### PR TITLE
Fix bugs and add features related to argument dtypes

### DIFF
--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -331,6 +331,7 @@ class DataType(enum.Enum):
 
 DataType.NATIVE_TYPE_TO_NUMPY = {
     DataType.DEFAULT: "float_",
+    DataType.BOOL: "bool",
     DataType.INT8: "int8",
     DataType.INT16: "int16",
     DataType.INT32: "int32",


### PR DESCRIPTION
- Fix bug where a different `dtype` for an argument was not triggering a rebuild
- Add a feature to allow the user to define the actual `dtypes` of the arguments at compilation time, by using string annotations for the arguments and pass to the compile call a `dtypes` dictionary with the actual types
- Minor fixes related to dtypes and GT exceptions