### PR TITLE
Fix tox tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ _local_
 ### GridTools ####
 src/gt4py/_external_src/gridtools
 .gt_cache/
-src/gt4py/_external_src
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/src/gt4py/__init__.py
+++ b/src/gt4py/__init__.py
@@ -20,16 +20,20 @@ __copyright__ = "ETH Zurich"
 __license__ = "gpl3"
 
 
-# from . import config
-# from . import utils
-# from . import definitions
-#
-# from . import backend
-# from . import gtscript
-# from . import ir
-# from . import loader
-# from . import storage
-# from . import testing
+from . import config
+from . import utils
+
+from . import definitions
+from . import gtscript
+
+from . import ir
+from . import analysis
+from . import frontend
+from . import backend
+from . import stencil_object
+from . import loader
+from . import storage
+from . import testing
 
 from .definitions import (
     AccessKind,
@@ -41,10 +45,6 @@ from .definitions import (
     CartesianSpace,
 )
 from .stencil_object import StencilObject
-
-from . import config
-from . import gtscript
-from . import storage
 
 from pkg_resources import get_distribution, DistributionNotFound
 

--- a/src/gt4py/_external_src/__init__.py
+++ b/src/gt4py/_external_src/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# GT4Py - GridTools4Py - GridTools for Python
+#
+# Copyright (c) 2014-2019, ETH Zurich
+# All rights reserved.
+#
+# This file is part the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/src/gt4py/backend/gt_cuda_backend.py
+++ b/src/gt4py/backend/gt_cuda_backend.py
@@ -19,7 +19,6 @@ import os
 import numpy as np
 
 from gt4py import backend as gt_backend
-from gt4py import storage as gt_storage
 from . import pyext_builder
 
 
@@ -49,7 +48,10 @@ def cuda_is_compatible_layout(field):
 
 
 def cuda_is_compatible_type(field):
-    return isinstance(field, gt_storage.storage.GPUStorage)
+    # ToDo: find a better way to remove the import cycle
+    from gt4py.storage.storage import GPUStorage
+
+    return isinstance(field, GPUStorage)
 
 
 @gt_backend.register

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -129,10 +129,10 @@ def build_gtcpu_ext(
     build_path: str,
     target_path: str,
     *,
-    verbose=False,
-    clean=False,
-    debug_mode=False,
-    add_profile_info=False,
+    verbose: bool = False,
+    clean: bool = False,
+    debug_mode: bool = False,
+    add_profile_info: bool = False,
     extra_include_dirs: list = None,
 ):
     include_dirs = [gt_config.build_settings["boost_include_path"]]
@@ -221,15 +221,18 @@ def build_gtcuda_ext(
     build_path: str,
     target_path: str,
     *,
-    verbose=False,
-    clean=False,
-    debug_mode=False,
-    add_profile_info=False,
+    verbose: bool = False,
+    clean: bool = False,
+    debug_mode: bool = False,
+    add_profile_info: bool = False,
+    extra_include_dirs: list = None,
 ):
     include_dirs = [
         gt_config.build_settings["boost_include_path"],
         gt_config.build_settings["cuda_include_path"],
     ]
+    if extra_include_dirs:
+        include_dirs.extend(extra_include_dirs)
 
     library_dirs = [gt_config.build_settings["cuda_library_path"]]
     libraries = ["cudart"]
@@ -293,7 +296,7 @@ def build_gtcuda_ext(
         sources,
         build_path,
         target_path,
-        verbose=True,
+        verbose=verbose,
         clean=clean,
         include_dirs=include_dirs,
         library_dirs=library_dirs,

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -133,8 +133,11 @@ def build_gtcpu_ext(
     clean=False,
     debug_mode=False,
     add_profile_info=False,
+    extra_include_dirs: list = None,
 ):
     include_dirs = [gt_config.build_settings["boost_include_path"]]
+    if extra_include_dirs:
+        include_dirs.extend(extra_include_dirs)
     extra_compile_args_from_config = gt_config.build_settings["extra_compile_args"]
     if isinstance(extra_compile_args_from_config, dict):
         extra_compile_args_from_config = extra_compile_args_from_config["cxx"]

--- a/src/gt4py/definitions.py
+++ b/src/gt4py/definitions.py
@@ -15,16 +15,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import abc
 import collections
 import enum
 import numbers
 import operator
-import sys
-import time
-import warnings
 
-import gt4py as gt
 from gt4py import utils as gt_utils
 from gt4py.utils.attrib import (
     attribute,

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import copy
 import numpy as np
 
 try:

--- a/src/gt4py/storage/utils.py
+++ b/src/gt4py/storage/utils.py
@@ -18,7 +18,6 @@ import math
 import numbers
 import numpy as np
 import gt4py.utils as gt_util
-import collections
 
 try:
     import cupy as cp

--- a/tests/reference_cpp_regression/build.py
+++ b/tests/reference_cpp_regression/build.py
@@ -14,9 +14,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import inspect
 import os
 
+import gt4py
 import gt4py.utils as gt_utils
+
+
+GT4PY_INSTALLATION_PATH = os.path.dirname(inspect.getabsfile(gt4py))
+
+EXTERNAL_SRC_PATH = os.path.join(GT4PY_INSTALLATION_PATH, "_external_src")
 
 
 def compile_reference():
@@ -30,5 +37,6 @@ def compile_reference():
         current_dir,
         verbose=False,
         clean=False,
+        extra_include_dirs=[EXTERNAL_SRC_PATH],
     )
     return gt_utils.make_module_from_file(*reference_names)

--- a/tests/reference_cpp_regression/reference.cpp
+++ b/tests/reference_cpp_regression/reference.cpp
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include "../../src/gt4py/_external_src/gridtools/regression/horizontal_diffusion_repository.hpp"
-#include "../../src/gt4py/_external_src/gridtools/regression/vertical_advection_repository.hpp"
+#include "gridtools/regression/horizontal_diffusion_repository.hpp"
+#include "gridtools/regression/vertical_advection_repository.hpp"
 #include <iostream>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>

--- a/tox.ini
+++ b/tox.ini
@@ -2,41 +2,24 @@
 # Read more under https://tox.readthedocs.org/
 
 [tox]
-envlist = py36-cuda,py37-cuda
+envlist = py{36,37}-{cpu,cuda,cuda90,cuda91,cuda92,cuda100,cuda101}
 
 [testenv]
 commands_pre = python setup.py install_gt_sources
-commands = pytest -v {posargs}
+commands =
+    cpu: pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
+    !cpu: pytest -v {posargs}
 passenv = BOOST_ROOT BOOST_HOME CUDA_HOME CUDA_PATH
 whitelist_externals = make
                       /bin/bash
                       gcc
                       g++
                       ldd
+extras =
+    cuda: cuda
+    cuda90: cuda90
+    cuda91: cuda91
+    cuda92: cuda92
+    cuda100: cuda100
+    cuda101: cuda101
 
-[testenv:py36-cpu]
-commands = pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
-
-[testenv:py37-cpu]
-commands = pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
-
-[testenv:py36-cuda]
-extras = cuda
-
-[testenv:py37-cuda]
-extras = cuda
-
-[testenv:py36-cuda101]
-extras = cuda101
-
-[testenv:py37-cuda100]
-extras = cuda100
-
-[testenv:py37-cuda92]
-extras = cuda92
-
-[testenv:py37-cuda91]
-extras = cuda91
-
-[testenv:py37-cuda90]
-extras = cuda90

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,41 @@
 # Read more under https://tox.readthedocs.org/
 
 [tox]
-envlist = py36,py37
+envlist = py36-cuda,py37-cuda
 
 [testenv]
 commands_pre = python setup.py install_gt_sources
 commands = pytest -v {posargs}
+passenv = BOOST_ROOT BOOST_HOME CUDA_HOME CUDA_PATH
 whitelist_externals = make
                       /bin/bash
                       gcc
                       g++
                       ldd
+
+[testenv:py36-cpu]
+commands = pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
+
+[testenv:py37-cpu]
+commands = pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
+
+[testenv:py36-cuda]
+extras = cuda
+
+[testenv:py37-cuda]
+extras = cuda
+
+[testenv:py36-cuda101]
+extras = cuda101
+
+[testenv:py37-cuda100]
+extras = cuda100
+
+[testenv:py37-cuda92]
+extras = cuda92
+
+[testenv:py37-cuda91]
+extras = cuda91
+
+[testenv:py37-cuda90]
+extras = cuda90


### PR DESCRIPTION
This PR fixes errors in the tox configuration which prevented the full test suite to be executed successfully when installing gt4py in non-editable mode.

Additional enhancements addressed in the PR are:

- New fine-grained tox environments for cpu-only and cuda specific versions (to select the environments use `-e`. Example: `tox -e py36-cuda101 ./tests`)
- Fix import cycles found during the tests fixing