### PR TITLE
Adjusted assertions to Python 3.8's ast

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -470,7 +470,7 @@ class IRMaker(ast.NodeVisitor):
     def __call__(self, ast_root: ast.AST):
         assert (
             isinstance(ast_root, ast.Module)
-            and ast_root._fields == ("body",)
+            and "body" in ast_root._fields
             and len(ast_root.body) == 1
             and isinstance(ast_root.body[0], ast.FunctionDef)
         )
@@ -1156,7 +1156,7 @@ class GTScriptParser(ast.NodeVisitor):
     def run(self):
         assert (
             isinstance(self.ast_root, ast.Module)
-            and self.ast_root._fields == ("body",)
+            and "body" in self.ast_root._fields
             and len(self.ast_root.body) == 1
             and isinstance(self.ast_root.body[0], ast.FunctionDef)
         )


### PR DESCRIPTION
Python 3.8 saw a minor change for its `Module` class.

Before: `Module(stmt* body)`
https://docs.python.org/3.7/library/ast.html
Since Python 3.8: `Module(stmt* body, type_ignore *type_ignores)`
https://docs.python.org/3.8/library/ast.html

This breaks two assertions in `gtscript_frontend.py`. I think this fix should be backwards compatible.