### PR TITLE
fix GT4PY-41

### DIFF
--- a/src/gt4py/analysis/transformer.py
+++ b/src/gt4py/analysis/transformer.py
@@ -77,6 +77,7 @@ class IRTransformer:
             axis_splitters_var=None,
             externals=definition_ir.externals,
             sources=definition_ir.sources,
+            docstring=definition_ir.docstring,
         )
         self.transform_data = TransformData(
             definition_ir=definition_ir, implementation_ir=implementation_ir, options=options

--- a/src/gt4py/backend/concepts.py
+++ b/src/gt4py/backend/concepts.py
@@ -365,6 +365,7 @@ class BaseModuleGenerator(abc.ABC):
             module_members=module_members,
             class_name=self.stencil_class_name,
             class_members=class_members,
+            docstring=implementation_ir.docstring,
             gt_backend=self.backend_name,
             gt_source=sources,
             gt_domain_info=domain_info,

--- a/src/gt4py/backend/templates/stencil_module.py.in
+++ b/src/gt4py/backend/templates/stencil_module.py.in
@@ -39,6 +39,32 @@ from gt4py.stencil_object import AccessKind, Boundary, DomainInfo, FieldInfo, Pa
 {{ module_members }}
 
 class {{ class_name }}(StencilObject):
+    """
+    {{ docstring | indent(4)}}
+
+    Default Parameters
+    ------------------
+    domain : `Sequence` of `int`, optional
+        Shape of the computation domain. If `None`, it will be used the
+        largest feasible domain according to the provided input fields
+        and origin values (`None` by default).
+
+    origin :  `[int * ndims]` or `{'field_name': [int * ndims]}`, optional
+        If a single offset is passed, it will be used for all fields.
+        If a `dict` is passed, there could be an entry for each field.
+        A special key *'_all_'* will represent the value to be used for all
+        the fields not explicitly defined. If `None` is passed or it is
+        not possible to assign a value to some field according to the
+        previous rule, the value will be inferred from the global boundaries
+        of the field. Note that the function checks if the origin values
+        are at least equal to the `global_border` attribute of that field,
+        so a 0-based origin will only be acceptable for fields with
+        a 0-area support region.
+
+    exec_info : `dict`, optional
+        Dictionary used to store information about the stencil execution.
+        (`None` by default).
+    """
 
 {%- filter indent(width=4) %}
 {{- class_members }}

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -707,6 +707,7 @@ class StencilDefinition(Node):
     computations = attribute(of=ListOf[ComputationBlock])
     externals = attribute(of=DictOf[str, Any], optional=True)
     sources = attribute(of=DictOf[str, str], optional=True)
+    docstring = attribute(of=str)
 
 
 # ---- Implementation IR (IIR) ----
@@ -800,6 +801,7 @@ class StencilImplementation(IIRNode):
     axis_splitters_var = attribute(of=str, optional=True)
     externals = attribute(of=DictOf[str, Any], optional=True)
     sources = attribute(of=DictOf[str, str], optional=True)
+    docstring = attribute(of=str)
 
     @property
     def arg_fields(self):

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -45,11 +45,11 @@ class StencilObject(abc.ABC):
     def __str__(self):
         result = """
 <StencilObject: {name}> [backend="{backend}"]
-    - I/O fields: {fields} 
-    - Parameters: {params} 
-    - Constants: {constants} 
+    - I/O fields: {fields}
+    - Parameters: {params}
+    - Constants: {constants}
     - Definition ({func}):
-{source} 
+{source}
         """.format(
             name=self.options["module"] + "." + self.options["name"],
             version=self._gt_id_,

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -210,6 +210,7 @@ class TestHorizontalDiffusion(gt_testing.StencilTestSuite):
 
 @gtscript.function
 def lap_op(u):
+    """Laplacian operator."""
     return 4.0 * u[0, 0, 0] - (u[1, 0, 0] + u[-1, 0, 0] + u[0, 1, 0] + u[0, -1, 0])
 
 
@@ -341,6 +342,15 @@ class TestHorizontalDiffusionSubroutines3(gt_testing.StencilTestSuite):
     )
 
     def definition(u, diffusion, *, weight):
+        """
+        Horizontal diffusion stencil.
+
+        Parameters
+        ----------
+        u : 3D float field, input
+        diffusion : 3D float field, output
+        weight : diffusion coefficient
+        """
         from __externals__ import fwd_diff, BRANCH
 
         with computation(PARALLEL), interval(...):
@@ -418,6 +428,7 @@ class TestRuntimeIfNested(gt_testing.StencilTestSuite):
 
 @gtscript.function
 def add_one(field_in):
+    """Add 1 to each element of `field_in`."""
     return field_in + 1
 
 


### PR DESCRIPTION
* skip docstrings in stencil definitions while parsing
* skip pure string expressions inside with interval()
	in order to allow subroutine docstrings
* add stencil docstring to stencil class template
* add stencil docstring to fingerprint for ID