### PR TITLE
Skip tox when [skip ci] present in commit msg

### DIFF
--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -150,7 +150,6 @@ def stencil(
     Examples
     --------
         TODO
-
     """
 
     from gt4py import loader as gt_loader


### PR DESCRIPTION
Workflow from [skip-based-on-commit-message](https://github.com/marketplace/actions/skip-based-on-commit-message). Skips the computationally heavy tox build when [skip ci] is in the commit message.