### PR TITLE
fix non-binary conditionals in frontend

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -753,21 +753,13 @@ class IRMaker(ast.NodeVisitor):
 
     def visit_BoolOp(self, node: ast.BoolOp) -> gt_ir.BinOpExpr:
         op = self.visit(node.op)
-        lhs = gt_ir.utils.make_expr(self.visit(node.values[0]))
-        args = [lhs]
-
-        assert len(node.values) >= 2
         rhs = gt_ir.utils.make_expr(self.visit(node.values[-1]))
-        args.append(rhs)
-
-        for i in range(len(node.values) - 2, 0, -1):
-            lhs = gt_ir.utils.make_expr(self.visit(node.values[i]))
+        for value in reversed(node.values[:-1]):
+            lhs = gt_ir.utils.make_expr(self.visit(value))
             rhs = gt_ir.BinOpExpr(op=op, lhs=lhs, rhs=rhs)
-            args.append(lhs)
+            res = rhs
 
-        result = gt_ir.BinOpExpr(op=op, lhs=lhs, rhs=rhs)
-
-        return result
+        return res
 
     def visit_Compare(self, node: ast.Compare) -> gt_ir.BinOpExpr:
         lhs = gt_ir.utils.make_expr(self.visit(node.left))

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -509,3 +509,51 @@ class TestTernaryOp(gt_testing.StencilTestSuite):
 
     def validation(infield, outfield, *, domain, origin, **kwargs):
         outfield[...] = np.choose(infield[:, :-1, :] > 0, [-infield[:, 1:, :], infield[:, :-1, :]])
+
+
+class TestThreeWayAnd(gt_testing.StencilTestSuite):
+
+    dtypes = (np.float_,)
+    domain_range = [(1, 15), (2, 15), (1, 15)]
+    backends = CPU_BACKENDS
+    symbols = dict(
+        outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
+        a=gt_testing.parameter(in_range=(-100, 100)),
+        b=gt_testing.parameter(in_range=(-100, 100)),
+        c=gt_testing.parameter(in_range=(-100, 100)),
+    )
+
+    def definition(outfield, *, a, b, c):
+
+        with computation(PARALLEL), interval(...):
+            if a > 0 and b > 0 and c > 0:
+                outfield = 1
+            else:
+                outfield = 0
+
+    def validation(outfield, *, a, b, c, domain, origin, **kwargs):
+        outfield[...] = 1 if a > 0 and b > 0 and c > 0 else 0
+
+
+class TestThreeWayOr(gt_testing.StencilTestSuite):
+
+    dtypes = (np.float_,)
+    domain_range = [(1, 15), (2, 15), (1, 15)]
+    backends = CPU_BACKENDS
+    symbols = dict(
+        outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
+        a=gt_testing.parameter(in_range=(-100, 100)),
+        b=gt_testing.parameter(in_range=(-100, 100)),
+        c=gt_testing.parameter(in_range=(-100, 100)),
+    )
+
+    def definition(outfield, *, a, b, c):
+
+        with computation(PARALLEL), interval(...):
+            if a > 0 or b > 0 or c > 0:
+                outfield = 1
+            else:
+                outfield = 0
+
+    def validation(outfield, *, a, b, c, domain, origin, **kwargs):
+        outfield[...] = 1 if a > 0 or b > 0 or c > 0 else 0


### PR DESCRIPTION
Fix for the issue described in #51 where the Definition for IR for ast.BoolOp's with more than 2 operands (e.g. of the form `a and b and c`) was not constructed correctly.

