### PR TITLE
Add compiler env vars to tox

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,6 +6,7 @@ Authors
 
 * Benedicic, Lucas. ETH Zurich - CSCS
 * Cruz, Felipe. ETH Zurich - CSCS
+* Dahm, Johann. Vulcan Inc.
 * Ehrengruber, Till. ETH Zurich - CSCS
 * González Paredes, Enrique. ETH Zurich - CSCS
 * Groner, Linus. ETH Zurich - CSCS

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     cpu: pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
     !cpu: pytest -v {posargs}
 
-passenv = BOOST_ROOT BOOST_HOME CUDA_HOME CUDA_PATH
+passenv = BOOST_ROOT BOOST_HOME CUDA_HOME CUDA_PATH CXX CC
 
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
## Description

Trivial change to import environment variables CXX and CC into tox. Required if you have those set to a custom compiler for OpenMP support.