### PR TITLE
Fix nvcc compilation

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -17,8 +17,8 @@
 """Definitions and utilities used by all the analysis pipeline components.
 """
 
-import functools
 import itertools
+from typing import Optional, Set, Tuple, Union
 
 from gt4py import definitions as gt_definitions
 from gt4py.definitions import Extent
@@ -33,7 +33,6 @@ from gt4py.analysis import (
     TransformData,
     TransformPass,
 )
-from gt4py.utils import UniqueIdGenerator
 
 
 class IRSpecificationError(gt_definitions.GTSpecificationError):
@@ -55,9 +54,9 @@ class IntervalSpecificationError(IRSpecificationError):
             if loc is None:
                 message = "Invalid interval specification '{interval}' ".format(interval=interval)
             else:
-                message = "Invalid interval specification '{interval}' in '{scope}' (line: {line}, col: {col})".format(
-                    interval=interval, scope=loc.scope, line=loc.line, col=loc.column
-                )
+                message = "Invalid interval specification '{interval}' in '{scope}' ".format(
+                    interval=interval, scope=loc.scope
+                ) + "(line: {line}, col: {col})".format(line=loc.line, col=loc.column)
         super().__init__(message, loc=loc)
         self.interval = interval
 
@@ -309,7 +308,8 @@ class InitInfoPass(TransformPass):
                 if not group_outputs.isdisjoint(stmt_inputs_with_ij_offset):
                     assert interval_block.stmts
                     assert interval_block.outputs
-                    # If some output field is read with an offset it likely implies different compute extent
+                    # If some output field is read with an offset it likely implies different
+                    # compute extent
                     self.current_block_info.ij_blocks.append(
                         self._make_ij_block(interval, interval_block)
                     )
@@ -869,15 +869,15 @@ class BuildIIRPass(TransformPass):
 
 class DemoteLocalTemporariesToVariablesPass(TransformPass):
     class CollectDemotableSymbols(gt_ir.IRNodeVisitor):
-        def __call__(self, node):
+        def __call__(self, node: gt_ir.StencilImplementation) -> Set[str]:
             assert isinstance(node, gt_ir.StencilImplementation)
             self.demotables = set(node.temporary_fields)
-            self.seen_symbols = set()
-            self.stage_symbols = None
+            self.seen_symbols: Set[str] = set()
+            self.stage_symbols: Optional[Set[str]] = None
             self.visit(node)
             return self.demotables
 
-        def visit_Stage(self, node: gt_ir.Stage):
+        def visit_Stage(self, node: gt_ir.Stage) -> None:
             self.stage_symbols = set()
 
             self.generic_visit(node)
@@ -888,9 +888,10 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
                 self.seen_symbols.add(s)
             self.stage_symbols = None
 
-        def visit_FieldRef(self, node: gt_ir.FieldRef):
+        def visit_FieldRef(self, node: gt_ir.FieldRef) -> None:
             if any(v != 0 for v in node.offset.values()):
                 self.demotables.discard(node.name)
+            assert self.stage_symbols is not None
             self.stage_symbols.add(node.name)
 
     class DemoteSymbols(gt_ir.IRNodeMapper):
@@ -898,13 +899,15 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
             self.demotables = demotables
             self.local_symbols = None
 
-        def __call__(self, node):
+        def __call__(self, node: gt_ir.StencilImplementation) -> gt_ir.StencilImplementation:
             assert isinstance(node, gt_ir.StencilImplementation)
             self.fields = node.fields
             node = self.visit(node)
             return node
 
-        def visit_FieldAccessor(self, path, node_name, node):
+        def visit_FieldAccessor(
+            self, path: tuple, node_name: str, node: gt_ir.FieldAccessor
+        ) -> Tuple[bool, Optional[gt_ir.FieldAccessor]]:
             if node.symbol in self.demotables:
                 return False, None
             else:
@@ -912,7 +915,7 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
 
         def visit_StencilImplementation(
             self, path: tuple, node_name: str, node: gt_ir.StencilImplementation
-        ):
+        ) -> gt_ir.StencilImplementation:
             self.iir = node
             res = self.generic_visit(path, node_name, node)
             for f in self.demotables:
@@ -921,7 +924,9 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
                 node.fields_extents.pop(f)
             return res
 
-        def visit_ApplyBlock(self, path: tuple, node_name: str, node: gt_ir.ApplyBlock):
+        def visit_ApplyBlock(
+            self, path: tuple, node_name: str, node: gt_ir.ApplyBlock
+        ) -> Tuple[bool, gt_ir.ApplyBlock]:
             self.local_symbols = {}
 
             self.generic_visit(path, node_name, node)
@@ -930,7 +935,9 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
             self.local_symbols = None
             return True, node
 
-        def visit_FieldRef(self, path: tuple, node_name: str, node: gt_ir.FieldRef):
+        def visit_FieldRef(
+            self, path: tuple, node_name: str, node: gt_ir.FieldRef
+        ) -> Tuple[bool, Union[gt_ir.FieldRef, gt_ir.VarRef]]:
             if node.name in self.demotables:
                 if node.name not in self.local_symbols:
                     field_decl = self.fields[node.name]
@@ -946,7 +953,7 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
             else:
                 return True, node
 
-    def apply(self, transform_data: TransformData):
+    def apply(self, transform_data: TransformData) -> TransformData:
         collect_demotable_symbols = self.CollectDemotableSymbols()
         demotables = collect_demotable_symbols(transform_data.implementation_ir)
 
@@ -958,11 +965,13 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
 
 class CleanUpPass(TransformPass):
     class PruneEmptyNodes(gt_ir.IRNodeMapper):
-        def __call__(self, node):
+        def __call__(self, node: gt_ir.StencilImplementation) -> None:
             assert isinstance(node, gt_ir.StencilImplementation)
             self.visit(node)
 
-        def visit_Stage(self, path: tuple, node_name: str, node: gt_ir.Stage):
+        def visit_Stage(
+            self, path: tuple, node_name: str, node: gt_ir.Stage
+        ) -> Tuple[bool, Optional[gt_ir.Stage]]:
             self.generic_visit(path, node_name, node)
 
             if any(
@@ -973,7 +982,9 @@ class CleanUpPass(TransformPass):
             else:
                 return False, None
 
-        def visit_StageGroup(self, path: tuple, node_name: str, node: gt_ir.StageGroup):
+        def visit_StageGroup(
+            self, path: tuple, node_name: str, node: gt_ir.StageGroup
+        ) -> Tuple[bool, Optional[gt_ir.StageGroup]]:
             self.generic_visit(path, node_name, node)
 
             if node.stages:
@@ -981,7 +992,9 @@ class CleanUpPass(TransformPass):
             else:
                 return False, None
 
-        def visit_MultiStage(self, path: tuple, node_name: str, node: gt_ir.MultiStage):
+        def visit_MultiStage(
+            self, path: tuple, node_name: str, node: gt_ir.MultiStage
+        ) -> Tuple[bool, Optional[gt_ir.MultiStage]]:
             self.generic_visit(path, node_name, node)
 
             if node.groups:
@@ -989,7 +1002,7 @@ class CleanUpPass(TransformPass):
             else:
                 return False, None
 
-    def apply(self, transform_data: TransformData):
+    def apply(self, transform_data: TransformData) -> TransformData:
 
         prune_emtpy_nodes = self.PruneEmptyNodes()
         prune_emtpy_nodes(transform_data.implementation_ir)

--- a/src/gt4py/analysis/transformer.py
+++ b/src/gt4py/analysis/transformer.py
@@ -22,13 +22,15 @@ import pprint
 from gt4py import ir as gt_ir
 from gt4py.analysis import TransformData
 from .passes import (
-    InitInfoPass,
-    NormalizeBlocksPass,
-    MergeBlocksPass,
-    ComputeExtentsPass,
     BuildIIRPass,
-    DataTypePass,
+    CleanUpPass,
+    ComputeExtentsPass,
     ComputeUsedSymbolsPass,
+    DataTypePass,
+    DemoteLocalTemporariesToVariablesPass,
+    InitInfoPass,
+    MergeBlocksPass,
+    NormalizeBlocksPass,
 )
 
 
@@ -110,6 +112,15 @@ class IRTransformer:
         # Fill in missing dtypes
         data_type_pass = DataTypePass()
         data_type_pass.apply(self.transform_data)
+
+        # turn temporary fields that are only written and read within the same function
+        # into local scalars
+        demote_local_temporaries_to_variables_pass = DemoteLocalTemporariesToVariablesPass()
+        demote_local_temporaries_to_variables_pass.apply(self.transform_data)
+
+        # prune some stages that don't have effect
+        cleanup_pass = CleanUpPass()
+        cleanup_pass.apply(self.transform_data)
 
         if options.build_info is not None:
             options.build_info["def_ir"] = self.transform_data.definition_ir

--- a/src/gt4py/backend/base.py
+++ b/src/gt4py/backend/base.py
@@ -898,6 +898,9 @@ pyext_module = gt_utils.make_module_from_file(
                 if arg.name in api_fields:
                     args.append("list(_origin_['{}'])".format(arg.name))
 
+        # only generate implementation if any multi_stages are present. e.g. if no statement in the
+        # stencil has any effect on the API fields, this may not be the case since they could be
+        # pruned.
         if self.implementation_ir.multi_stages:
             source = """
 # Load or generate a GTComputation object for the current domain size

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -510,6 +510,7 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
             generator_options["pyext_file_path"] = pyext_file_path
 
         else:
+            # if no computation has effect, there is no need to create an extension
             pyext_module_name, pyext_file_path = None, None
         # Generate and return the Python wrapper class
         return cls._generate_module(

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -496,15 +496,21 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
 
         cls._check_options(options)
 
-        # Generate the Python binary extension (checking if GridTools sources are installed)
-        if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
-            raise RuntimeError("Missing GridTools sources.")
-
         implementation_ir = gt_analysis.transform(definition_ir, options)
-        pyext_module_name, pyext_file_path = cls.generate_extension(
-            stencil_id, definition_ir, options, implementation_ir=implementation_ir
-        )
 
+        generator_options = options.as_dict()
+        if implementation_ir.multi_stages:
+            # Generate the Python binary extension (checking if GridTools sources are installed)
+            if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
+                raise RuntimeError("Missing GridTools sources.")
+
+            pyext_module_name, pyext_file_path = cls.generate_extension(
+                stencil_id, definition_ir, options, implementation_ir=implementation_ir
+            )
+            generator_options["pyext_file_path"] = pyext_file_path
+
+        else:
+            pyext_module_name, pyext_file_path = None, None
         # Generate and return the Python wrapper class
         return cls._generate_module(
             stencil_id,

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -82,6 +82,7 @@ def get_gt_pyext_build_opts(
             "-DBOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL",
             "-DBOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE",
             "--expt-relaxed-constexpr",
+            "--disable-warnings",  # workaround for 'catastrophic failure' error in nvcc
             "--compiler-options",
             "-fvisibility=hidden",
             "--compiler-options",

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -82,7 +82,6 @@ def get_gt_pyext_build_opts(
             "-DBOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL",
             "-DBOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE",
             "--expt-relaxed-constexpr",
-            "--disable-warnings",  # workaround for 'catastrophic failure' error in nvcc
             "--compiler-options",
             "-fvisibility=hidden",
             "--compiler-options",

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -47,7 +47,14 @@ build_settings: Dict[str, Any] = {
     "gt_include_path": os.environ.get("GT_INCLUDE_PATH", GT_INCLUDE_PATH),
     "openmp_cppflags": os.environ.get("OPENMP_CPPFLAGS", "-fopenmp").split(),
     "openmp_ldflags": os.environ.get("OPENMP_LDFLAGS", "-fopenmp").split(),
-    "extra_compile_args": {"cxx": [], "nvcc": []},
+    "extra_compile_args": {
+        "cxx": [],
+        "nvcc": [
+            # disable warnings in nvcc as a workaround for
+            # 'catastrophic failure' error in nvcc < 11
+            "--disable-warnings",
+        ],
+    },
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),
 }

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -932,12 +932,15 @@ class IRNodeMapper:
         else:
             return True, node
 
+        del_items = []
         for key, old_value in items:
             keep_item, new_value = self._visit((*path, node_name), key, old_value)
             if not keep_item:
-                delattr_op(node, key)
+                del_items.append(key)
             elif new_value != old_value:
                 setattr_op(node, key, new_value)
+        for key in reversed(del_items):  # reversed, so that keys remain valid in sequences
+            delattr_op(node, key)
 
         return True, node
 

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -90,14 +90,8 @@ def test_temporary_field_declared_in_if_raises():
                 field_a = field_b
 
 
-@pytest.mark.parametrize(
-    "backend",
-    [
-        name
-        for name in gt_backend.REGISTRY.names
-        if gt_backend.from_name(name).storage_info["device"] == "cpu"
-    ],
-)
+@pytest.mark.requires_gpu
+@pytest.mark.parametrize("backend", CPU_BACKENDS)
 def test_stage_without_effect(backend):
     @gtscript.stencil(backend=backend)
     def definition(field_a: gtscript.Field[np.float_]):

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -88,3 +88,18 @@ def test_temporary_field_declared_in_if_raises():
                 else:
                     field_b = field_a
                 field_a = field_b
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        name
+        for name in gt_backend.REGISTRY.names
+        if gt_backend.from_name(name).storage_info["device"] == "cpu"
+    ],
+)
+def test_stage_without_effect(backend):
+    @gtscript.stencil(backend=backend)
+    def definition(field_a: gtscript.Field[np.float_]):
+        with computation(PARALLEL), interval(...):
+            field_c = 0.0


### PR DESCRIPTION
This PR addresses some issues that were observed when compiling tasmania with nvcc, due to bugs in nvcc.
* added a pass in the analysis for internal backends that will turn temporaries into local variables in some cases, this reduces the maximum symbol size in the ptx assembly
* disabled all warnings in nvcc which caused a catastrophic failure in nvcc due to a different bug in nvcc