### PR TITLE
Allow overriding OpenMP compilation and link args

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -374,12 +374,11 @@ In this case, the symbol must further be imported from ``__externals__`` in the 
 System Setup
 ------------
 
-The following variables, found in `src/gt4py/config.py <https://github.com/GridTools/gt4py/blob/master/src/gt4py/config.py>`_
-control compilation settings:
+Compilation settings for GT4Py backends generating C++ or CUDA code might be modified when needed by updating the default values in the  `gt4py.config <https://github.com/GridTools/gt4py/blob/master/src/gt4py/config.py>`_ module. Note that most of the system dependent settings may be also modified  using the following environment variables:
 
 * ``BOOST_ROOT`` or ``BOOST_HOME``: root of the boost library headers.
 * ``CUDA_ROOT`` or ``CUDA_HOME``: installation prefix of the CUDA toolkit.
-* ``GT_INCLUDE_PATH``: path prefix to GridTools header files.
+* ``GT_INCLUDE_PATH``: path prefix to an alternative installation of GridTools header files.
 * ``OPENMP_CPPFLAGS``: preprocessor arguments for OpenMP support.
 * ``OPENMP_LDFLAGS``: arguments when linking executables with OpenMP support.
 
@@ -389,14 +388,14 @@ MacOS
 
 The clang compiler supplied with the MacOS Command Line Tools does not support the ``-fopenmp`` flag, but it does have
 support for OpenMP in the C preprocessor and can link with OpenMP support if the libomp package is installed using
-homebrew. Then set the following environment variables:
+``homebrew`` (https://brew.sh/). Then set the following environment variables:
 
 .. code:: bash
 
     export OPENMP_CPPFLAGS="-Xpreprocessor -fopenmp"
     export OPENMP_LDFLAGS="$(brew --prefix libomp)/lib/libomp.a"
 
-Similarly, boost headers are most easily installed using homebrew. Then set the corresponding environment variable:
+Similarly, boost headers are most easily installed using ``homebrew``. Then set the corresponding environment variable:
 
 .. code:: bash
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -374,7 +374,9 @@ In this case, the symbol must further be imported from ``__externals__`` in the 
 System Setup
 ------------
 
-Compilation settings for GT4Py backends generating C++ or CUDA code might be modified when needed by updating the default values in the  `gt4py.config <https://github.com/GridTools/gt4py/blob/master/src/gt4py/config.py>`_ module. Note that most of the system dependent settings may be also modified  using the following environment variables:
+Compilation settings for GT4Py backends generating C++ or CUDA code might be modified when needed by updating
+the default values in the `gt4py.config <https://github.com/GridTools/gt4py/blob/master/src/gt4py/config.py>`_ module.
+Note that most of the system dependent settings may be also modified using the following environment variables:
 
 * ``BOOST_ROOT`` or ``BOOST_HOME``: root of the boost library headers.
 * ``CUDA_ROOT`` or ``CUDA_HOME``: installation prefix of the CUDA toolkit.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -374,7 +374,8 @@ In this case, the symbol must further be imported from ``__externals__`` in the 
 System Setup
 ------------
 
-The following variables, found in `src/gt4py/config.py` control compilation settings
+The following variables, found in `src/gt4py/config.py <https://github.com/GridTools/gt4py/blob/master/src/gt4py/config.py>`_
+control compilation settings:
 
 * ``BOOST_ROOT`` or ``BOOST_HOME``: root of the boost library headers.
 * ``CUDA_ROOT`` or ``CUDA_HOME``: installation prefix of the CUDA toolkit.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -369,3 +369,34 @@ In this case, the symbol must further be imported from ``__externals__`` in the 
             with computation(PARALLEL), interval(...):
                 result = field_a[0, 0, 0] - (field_b[0, 0, 0] - weight * field_c[0, 0, 0])
 
+
+------------
+System Setup
+------------
+
+The following variables, found in `src/gt4py/config.py` control compilation settings
+
+* ``BOOST_ROOT`` or ``BOOST_HOME``: root of the boost library headers.
+* ``CUDA_ROOT`` or ``CUDA_HOME``: installation prefix of the CUDA toolkit.
+* ``GT_INCLUDE_PATH``: path prefix to GridTools header files.
+* ``OPENMP_CPPFLAGS``: preprocessor arguments for OpenMP support.
+* ``OPENMP_LDFLAGS``: arguments when linking executables with OpenMP support.
+
+
+MacOS
+-----
+
+The clang compiler supplied with the MacOS Command Line Tools does not support the ``-fopenmp`` flag, but it does have
+support for OpenMP in the C preprocessor and can link with OpenMP support if the libomp package is installed using
+homebrew. Then set the following environment variables:
+
+.. code:: bash
+
+    export OPENMP_CPPFLAGS="-Xpreprocessor -fopenmp"
+    export OPENMP_LDFLAGS="$(brew --prefix libomp)/lib/libomp.a"
+
+Similarly, boost headers are most easily installed using homebrew. Then set the corresponding environment variable:
+
+.. code:: bash
+
+    export BOOST_ROOT=/usr/local/opt/boost

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -97,7 +97,7 @@ def get_gt_pyext_build_opts(
         for opts_arg, settings_arg in zip(
             ("extra_compile_args", "extra_link_args"), ("openmp_cppflags", "openmp_ldflags")
         ):
-            setting = gt_config.build_settings[compile_arg]
+            setting = gt_config.build_settings[settings_arg]
             if setting:
                 build_opts[opts_arg].append(setting)
 

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -94,12 +94,13 @@ def get_gt_pyext_build_opts(
         )
 
     if uses_openmp:
-        for opts_arg, settings_arg in zip(
-            ("extra_compile_args", "extra_link_args"), ("openmp_cppflags", "openmp_ldflags")
-        ):
-            setting = gt_config.build_settings[settings_arg]
-            if setting:
-                build_opts[opts_arg].append(setting)
+        cpp_flags = gt_config.build_settings["openmp_cppflags"]
+        if cpp_flags:
+            build_opts["extra_compile_args"].append(cpp_flags)
+
+        ld_flags = gt_config.build_settings["openmp_ldflags"]
+        if ld_flags:
+            build_opts["extra_compile_args"].append(ld_flags)
 
     return build_opts
 

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -100,7 +100,7 @@ def get_gt_pyext_build_opts(
 
         ld_flags = gt_config.build_settings["openmp_ldflags"]
         if ld_flags:
-            build_opts["extra_compile_args"].append(ld_flags)
+            build_opts["extra_link_args"].append(ld_flags)
 
     return build_opts
 

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -44,7 +44,7 @@ build_settings: Dict[str, Any] = {
     "cuda_library_path": os.path.join(CUDA_ROOT, "lib64"),
     "gt_include_path": os.environ.get("GT_INCLUDE_PATH", GT_INCLUDE_PATH),
     "openmp_cppflags": os.environ.get("OPENMP_CPPFLAGS", "-fopenmp"),
-    "openmp_ldflags": os.environ.get("OPENMP_LDFLAGS", ""),
+    "openmp_ldflags": os.environ.get("OPENMP_LDFLAGS", "-fopenmp"),
     "extra_compile_args": {"cxx": [], "nvcc": []},
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -36,10 +36,6 @@ GT_REPO_PATH: str = os.path.abspath(
 
 GT_INCLUDE_PATH: str = os.path.abspath(os.path.join(GT_REPO_PATH, "include"))
 
-# OpenMP preprocessor and link flags
-OPENMP_CPPFLAGS: str = os.environ.get("OPENMP_CPPFLAGS", "-fopenmp")
-OPENMP_LDFLAGS: str = os.environ.get("OPENMP_LDFLAGS", "")
-
 # Settings dict
 build_settings: Dict[str, Any] = {
     "boost_include_path": os.path.join(BOOST_ROOT, "include"),
@@ -47,8 +43,8 @@ build_settings: Dict[str, Any] = {
     "cuda_include_path": os.path.join(CUDA_ROOT, "include"),
     "cuda_library_path": os.path.join(CUDA_ROOT, "lib64"),
     "gt_include_path": os.environ.get("GT_INCLUDE_PATH", GT_INCLUDE_PATH),
-    "openmp_cppflags": OPENMP_CPPFLAGS,
-    "openmp_ldflags": OPENMP_LDFLAGS,
+    "openmp_cppflags": os.environ.get("OPENMP_CPPFLAGS", "-fopenmp"),
+    "openmp_ldflags": os.environ.get("OPENMP_LDFLAGS", ""),
     "extra_compile_args": {"cxx": [], "nvcc": []},
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -36,6 +36,10 @@ GT_REPO_PATH: str = os.path.abspath(
 
 GT_INCLUDE_PATH: str = os.path.abspath(os.path.join(GT_REPO_PATH, "include"))
 
+# OpenMP preprocessor and link flags
+OPENMP_CPPFLAGS: str = os.environ.get("OPENMP_CPPFLAGS", "-fopenmp")
+OPENMP_LDFLAGS: str = os.environ.get("OPENMP_LDFLAGS", "")
+
 # Settings dict
 build_settings: Dict[str, Any] = {
     "boost_include_path": os.path.join(BOOST_ROOT, "include"),
@@ -43,6 +47,8 @@ build_settings: Dict[str, Any] = {
     "cuda_include_path": os.path.join(CUDA_ROOT, "include"),
     "cuda_library_path": os.path.join(CUDA_ROOT, "lib64"),
     "gt_include_path": os.environ.get("GT_INCLUDE_PATH", GT_INCLUDE_PATH),
+    "openmp_cppflags": OPENMP_CPPFLAGS,
+    "openmp_ldflags": OPENMP_LDFLAGS,
     "extra_compile_args": {"cxx": [], "nvcc": []},
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     cpu: pytest -v -k "not requires_gpu and not requires_cudatoolkit" {posargs}
     !cpu: pytest -v {posargs}
 
-passenv = BOOST_ROOT BOOST_HOME CUDA_HOME CUDA_PATH CXX CC
+passenv = BOOST_ROOT BOOST_HOME CUDA_HOME CUDA_PATH CXX CC OPENMP_CPPFLAGS OPENMP_LDFLAGS
 
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
## Description

Only certain compilers support OpenMP via `-fopenmp` flag. On the Mac using an interpreter compiled with Apple's version of Clang, OpenMP support is only in the pre-processor, so the flag needs to be `-Xpreprocessor -fopenmp`, and the library needs to be linked in manually. This allows for that as well as the flexibility for other implementations.

For anyone interested, on MacOS I use [direnv](https://direnv.net/) with the following `gt4py/.envrc` file:
```
export BOOST_ROOT=/usr/local/opt/boost
export OPENMP_CPPFLAGS="-Xpreprocessor -fopenmp"
export OPENMP_LDFLAGS="$(brew --prefix libomp)/lib/libomp.a"
```

This requires the Apple Command Line Tools and Boost and OpenMP installed via [homebrew](https://brew.sh/):
```
$ brew install boost libomp
```

Also resolves #66.