### PR TITLE
Dawn extent fix

### DIFF
--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -257,7 +257,6 @@ class SIRConverter(gt_ir.IRNodeVisitor):
         stencil_ast = sir_utils.make_ast(
             [self.visit(computation) for computation in node.computations]
         )
-
         name = node.name.split(".")[-1]
         stencils.append(sir_utils.make_stencil(name=name, ast=stencil_ast, fields=fields))
 

--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -54,8 +54,7 @@ class FieldInfoCollector(gt_ir.IRNodeVisitor):
 
     def __call__(self, definition_ir):
         self.field_info = collections.OrderedDict()
-        self.visit(definition_ir, compute_extent=gt_definitions.Extent.zeros(), in_write=False)
-
+        self.visit(definition_ir, write_field="")
         return self.field_info
 
     def visit_FieldDecl(self, node: gt_ir.FieldDecl, **kwargs):
@@ -63,35 +62,33 @@ class FieldInfoCollector(gt_ir.IRNodeVisitor):
         field_dimensions = sir_utils.make_field_dimensions_cartesian(
             [1 if ax in node.axes else 0 for ax in DOMAIN_AXES]
         )
-        is_temporary = not node.is_api
         self.field_info[node.name] = dict(
             field_decl=sir_utils.make_field(
-                name=node.name, dimensions=field_dimensions, is_temporary=is_temporary
+                name=node.name, dimensions=field_dimensions, is_temporary=not node.is_api
             ),
             access=None,
             extent=gt_definitions.Extent.zeros(),
+            inputs=set(),
         )
 
     def visit_FieldRef(self, node: gt_ir.FieldRef, **kwargs):
         field_name = node.name
-        if kwargs["in_write"]:
+        if len(kwargs["write_field"]) < 1:
             self.field_info[field_name]["access"] = gt_definitions.AccessKind.READ_WRITE
         elif self.field_info[field_name]["access"] is None:
             self.field_info[field_name]["access"] = gt_definitions.AccessKind.READ_ONLY
+            if kwargs["write_field"] in self.field_info:
+                self.field_info[kwargs["write_field"]]["inputs"].add(field_name)
 
         offset = tuple(node.offset.values())
-        extent = gt_definitions.Extent(
+        self.field_info[field_name]["extent"] |= gt_definitions.Extent(
             [(offset[0], offset[0]), (offset[1], offset[1]), (0, 0)]
         )  # exclude sequential axis
 
-        kwargs["compute_extent"] |= extent
-        accumulated_extent = kwargs["compute_extent"] + extent
-        self.field_info[field_name]["extent"] |= accumulated_extent
-
     def visit_Assign(self, node: gt_ir.Assign, **kwargs):
-        kwargs["in_write"] = True
+        kwargs["write_field"] = ""
         self.visit(node.target, **kwargs)
-        kwargs["in_write"] = False
+        kwargs["write_field"] = node.target.name
         self.visit(node.value, **kwargs)
 
 
@@ -126,6 +123,22 @@ class SIRConverter(gt_ir.IRNodeVisitor):
 
     def _make_operator(self, op: enum.Enum):
         return self.OP_TO_CPP.get(op, op.python_symbol)
+
+    def _update_field_extents(self, field_info: Dict[str, Any]):
+        out_fields = [
+            field
+            for field in field_info.values()
+            if field["access"] == gt_definitions.AccessKind.READ_WRITE
+        ]
+
+        compute_extent = gt_definitions.Extent.zeros()
+        for i in range(len(out_fields) - 1, -1, -1):
+            out_field = out_fields[i]
+            compute_extent |= out_field["extent"]
+            for input in out_field["inputs"]:
+                in_field = field_info[input]
+                accumulated_extent = compute_extent + in_field["extent"]
+                in_field["extent"] |= accumulated_extent
 
     def visit_BuiltinLiteral(self, node: gt_ir.BuiltinLiteral):
         if node.value == gt_ir.Builtin.TRUE:
@@ -218,7 +231,6 @@ class SIRConverter(gt_ir.IRNodeVisitor):
 
     def visit_ComputationBlock(self, node: gt_ir.ComputationBlock, **kwargs):
         interval = self.visit(node.interval)
-
         body_ast = sir_utils.make_ast(self.visit(node.body, make_block=False))
 
         loop_order = (
@@ -239,11 +251,13 @@ class SIRConverter(gt_ir.IRNodeVisitor):
         global_variables = self._make_global_variables(node.parameters, node.externals)
 
         field_info = FieldInfoCollector.apply(node)
+        self._update_field_extents(field_info)
         fields = [field_info[field_name]["field_decl"] for field_name in field_info]
 
         stencil_ast = sir_utils.make_ast(
             [self.visit(computation) for computation in node.computations]
         )
+
         name = node.name.split(".")[-1]
         stencils.append(sir_utils.make_stencil(name=name, ast=stencil_ast, fields=fields))
 

--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -231,6 +231,7 @@ class SIRConverter(gt_ir.IRNodeVisitor):
 
     def visit_ComputationBlock(self, node: gt_ir.ComputationBlock, **kwargs):
         interval = self.visit(node.interval)
+
         body_ast = sir_utils.make_ast(self.visit(node.body, make_block=False))
 
         loop_order = (

--- a/src/gt4py/testing/suites.py
+++ b/src/gt4py/testing/suites.py
@@ -398,10 +398,17 @@ class StencilTestSuite(metaclass=SuiteMeta):
         assert isinstance(implementation, StencilObject)
         assert implementation.backend == test["backend"]
 
-        assert all(
-            field_info.boundary >= cls.global_boundaries[name]
-            for name, field_info in implementation.field_info.items()
-        )
+        # Assert strict equality for Dawn backends
+        if implementation.backend.startswith("dawn"):
+            assert all(
+                field_info.boundary == cls.global_boundaries[name]
+                for name, field_info in implementation.field_info.items()
+            )
+        else:
+            assert all(
+                field_info.boundary >= cls.global_boundaries[name]
+                for name, field_info in implementation.field_info.items()
+            )
 
         test["implementations"].append(implementation)
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the field extent computations in the Dawn backends. The existing code is sufficient to pass the GT4Py test suite, but causes the compute domain to be too large for some FV3 stencils. The new generates more precise extents.
