### PR TITLE
Fix #115:  Emit warning and force explicit domain specification for stencils without an effect

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -19,6 +19,7 @@
 
 import itertools
 from typing import Optional, Set, Tuple, Union
+import warnings
 
 from gt4py import definitions as gt_definitions
 from gt4py import ir as gt_ir
@@ -795,6 +796,16 @@ class BuildIIRPass(TransformPass):
                 self.iir.parameters[name] = decl
             else:
                 self.iir.fields[name] = decl
+
+        # Emit warning if no api symbol (field or parameter) is used
+        if all(
+            not (symbol.in_use and symbol.is_api) for name, symbol in self.data.symbols.items()
+        ):
+            loc = self.data.definition_ir.loc
+            warnings.warn(
+                f"Stencil without effective computation specified at line {loc.line} (column {loc.column}).",
+                RuntimeWarning,
+            )
 
         # Create multistages
         for block in self.data.blocks:

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -18,8 +18,8 @@
 """
 
 import itertools
-from typing import Optional, Set, Tuple, Union
 import warnings
+from typing import Optional, Set, Tuple, Union
 
 from gt4py import definitions as gt_definitions
 from gt4py import ir as gt_ir

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -339,7 +339,6 @@ class InitInfoPass(TransformPass):
                 )
 
         def visit_StencilDefinition(self, node: gt_ir.StencilDefinition):
-            assert node.computations  # non-empty definition
             for computation, interval in zip(node.computations, self.computation_intervals):
                 self.current_block_info = DomainBlockInfo(
                     self.data.id_generator.new, computation.iteration_order, {interval}, []
@@ -458,6 +457,9 @@ class MergeBlocksPass(TransformPass):
         return self._DEFAULT_OPTIONS
 
     def apply(self, transform_data: TransformData):
+        if not transform_data.blocks:  # do not apply pass if empty stencil
+            return
+
         # Greedy strategy to merge multi-stages
         merged_blocks = [transform_data.blocks[0]]
         for candidate in transform_data.blocks[1:]:

--- a/src/gt4py/analysis/transformer.py
+++ b/src/gt4py/analysis/transformer.py
@@ -24,11 +24,11 @@ from gt4py.analysis import TransformData
 
 from .passes import (
     BuildIIRPass,
-    CleanUpPass,
     ComputeExtentsPass,
     ComputeUsedSymbolsPass,
     DataTypePass,
     DemoteLocalTemporariesToVariablesPass,
+    HousekeepingPass,
     InitInfoPass,
     MergeBlocksPass,
     NormalizeBlocksPass,
@@ -120,8 +120,8 @@ class IRTransformer:
         demote_local_temporaries_to_variables_pass.apply(self.transform_data)
 
         # prune some stages that don't have effect
-        cleanup_pass = CleanUpPass()
-        cleanup_pass.apply(self.transform_data)
+        housekeeping_pass = HousekeepingPass()
+        housekeeping_pass.apply(self.transform_data)
 
         if options.build_info is not None:
             options.build_info["def_ir"] = self.transform_data.definition_ir

--- a/src/gt4py/backend/base.py
+++ b/src/gt4py/backend/base.py
@@ -655,7 +655,7 @@ pyext_module = gt_utils.make_module_from_file(
         # only generate implementation if any multi_stages are present. e.g. if no statement in the
         # stencil has any effect on the API fields, this may not be the case since they could be
         # pruned.
-        if self.builder.implementation_ir.multi_stages:
+        if self.builder.implementation_ir.has_effect:
             source = """
 # Load or generate a GTComputation object for the current domain size
 pyext_module.run_computation(list(_domain_), {run_args}, exec_info)

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -526,7 +526,7 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
 
         pyext_module_name: Optional[str]
         pyext_file_path: Optional[str]
-        if implementation_ir.multi_stages:
+        if implementation_ir.has_effect:
             pyext_module_name, pyext_file_path = self.generate_extension()
         else:
             # if computation has no effect, there is no need to create an extension

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1406,6 +1406,7 @@ class GTScriptParser(ast.NodeVisitor):
             computations=computations,
             externals=self.resolved_externals,
             docstring=inspect.getdoc(self.definition) or "",
+            loc=gt_ir.Location.from_ast_node(self.ast_root.body[0]),
         )
 
         return self.definition_ir

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -834,6 +834,16 @@ class StencilImplementation(IIRNode):
     docstring = attribute(of=str)
 
     @property
+    def has_effect(self):
+        """
+        Determine whether the stencil modifies any of its arguments.
+
+        Note that the only guarantee of this function is that the stencil has no effect if it returns ``false``. It
+        might however return true in cases where the optimization passes were not able to deduce this.
+        """
+        return self.multi_stages and len(self.arg_fields) != len(self.unreferenced)
+
+    @property
     def arg_fields(self):
         result = [f.name for f in self.fields.values() if f.is_api]
         return result

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -841,7 +841,9 @@ class StencilImplementation(IIRNode):
         Note that the only guarantee of this function is that the stencil has no effect if it returns ``false``. It
         might however return true in cases where the optimization passes were not able to deduce this.
         """
-        return self.multi_stages and len(self.arg_fields) != len(self.unreferenced)
+        return self.multi_stages and not all(
+            arg_field in self.unreferenced for arg_field in self.arg_fields
+        )
 
     @property
     def arg_fields(self):

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -737,6 +737,7 @@ class StencilDefinition(Node):
     externals = attribute(of=DictOf[str, Any], optional=True)
     sources = attribute(of=DictOf[str, str], optional=True)
     docstring = attribute(of=str)
+    loc = attribute(of=Location, optional=True)
 
 
 # ---- Implementation IR (IIR) ----

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -132,7 +132,7 @@ class StencilObject(abc.ABC):
         -------
             `Shape`: the maximum domain size.
         """
-        max_domain = Shape([sys.maxsize] * self.domain_info.ndims)
+        max_domain = Shape([np.iinfo(np.uintc).max] * self.domain_info.ndims)
         shapes = {name: Shape(field.shape) for name, field in field_args.items()}
         for name, shape in shapes.items():
             upper_boundary = Index(self.field_info[name].boundary.upper_indices)
@@ -308,6 +308,10 @@ class StencilObject(abc.ABC):
         # Domain
         if domain is None:
             domain = self._get_max_domain(used_field_args, origin)
+            if any(axis_bound == np.iinfo(np.uintc).max for axis_bound in domain):
+                raise ValueError(
+                    f"Compute domain could not be deduced. Specifiy the domain explicitly or ensure you reference at least one field."
+                )
         else:
             domain = normalize_domain(domain)
 

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -128,8 +128,6 @@ def test_ignore_np_errstate():
 
 @pytest.mark.parametrize("backend", CPU_BACKENDS)
 def test_stencil_without_effect(backend):
-    from gt4py.frontend.gtscript_frontend import GTScriptSymbolError
-
     def definition1(field_in: gtscript.Field[np.float_]):
         with computation(PARALLEL), interval(...):
             tmp = 0.0

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -124,3 +124,35 @@ def test_ignore_np_errstate():
 
     with pytest.warns(RuntimeWarning, match="divide by zero encountered"):
         setup_and_run(backend="numpy", ignore_np_errstate=False)
+
+
+@pytest.mark.parametrize("backend", CPU_BACKENDS)
+def test_stencil_without_effect(backend):
+    from gt4py.frontend.gtscript_frontend import GTScriptSymbolError
+
+    def definition1(field_in: gtscript.Field[np.float_]):
+        with computation(PARALLEL), interval(...):
+            tmp = 0.0
+
+    def definition2(f_in: gtscript.Field[np.float_]):
+        from __gtscript__ import __INLINE
+        from __externals__ import flag
+
+        with computation(PARALLEL), interval(...):
+            if __INLINED(flag):
+                B = f_in
+
+    stencil1 = gtscript.stencil(backend, definition1)
+    stencil2 = gtscript.stencil(backend, definition2, externals={"flag": True})
+
+    field_in = gt_storage.ones(
+        dtype=np.float_, backend=backend, shape=(23, 23, 23), default_origin=(0, 0, 0)
+    )
+
+    # test with explicit domain specified
+    stencil1(field_in, domain=(3, 3, 3))
+    stencil2(field_in, domain=(3, 3, 3))
+
+    # test without domain specified
+    with pytest.raises(ValueError):
+        stencil1(field_in)

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -135,15 +135,15 @@ def test_stencil_without_effect(backend):
             tmp = 0.0
 
     def definition2(f_in: gtscript.Field[np.float_]):
-        from __gtscript__ import __INLINE
         from __externals__ import flag
+        from __gtscript__ import __INLINE
 
         with computation(PARALLEL), interval(...):
             if __INLINED(flag):
                 B = f_in
 
     stencil1 = gtscript.stencil(backend, definition1)
-    stencil2 = gtscript.stencil(backend, definition2, externals={"flag": True})
+    stencil2 = gtscript.stencil(backend, definition2, externals={"flag": False})
 
     field_in = gt_storage.ones(
         dtype=np.float_, backend=backend, shape=(23, 23, 23), default_origin=(0, 0, 0)


### PR DESCRIPTION
## Description

Defining a stencil without referencing any arguments currently breaks at multiple locations in the front- and backend. ~~After initially fixing most occasions I recognized that it is not possible to define a meaningful default domain and therefore simply added a check to forbid these kinds of stencils.~~

Example stencil as of #115:

```python
@gtscript.stencil
def stencil(f_in: gtscript.Field[float]):
    from __gtscript__ import computation, PARALLEL, interval
    with computation(PARALLEL), interval(...):
        tmp = 0.
```

__EDIT__

While the first example stencil appears non-sense by itself, such cases can occur easily if compile time conditionals are used.

```python
@gtscript.stencil
def test(f_in: dtype, f_out: dtype)
    from __externals__ import flag
    with computation(PARALLEL), interval(...):
        tmp = 1.
        if __INLINE(flag):
            f_out = tmp * f_in
```

Here an error is raised if the flag is `false`. Since this behavior is counter intuitive the respective templates were adopted to allow such stencils. As the domain can not be deduced if no fields are used in the computations the user is however forced to specify the domain explicitly. In any case a warning is emitted to make the user aware of having specified a stencil without any effect.

Note that this is not meant as a way to measure the overhead of a stencil call! The backend may just skip generating code.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [X] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [X] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [X] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


