### PR TITLE
Reduce stencil overhead

### DIFF
--- a/src/gt4py/backend/templates/stencil_module.py.in
+++ b/src/gt4py/backend/templates/stencil_module.py.in
@@ -112,7 +112,9 @@ class {{ class_name }}(StencilObject):
     def options(self) -> dict:
         return type(self)._gt_options_
 
-    def __call__(self, {{ stencil_signature }}, domain=None, origin=None, exec_info=None):
+    def __call__(
+        self, {{ stencil_signature }}, domain=None, origin=None, validate_args=True, exec_info=None
+    ):
         if exec_info is not None:
             exec_info["call_start_time"] = time.perf_counter()
         field_args=dict(
@@ -132,7 +134,8 @@ class {{ class_name }}(StencilObject):
             parameter_args=parameter_args,
             domain=domain,
             origin=origin,
-            exec_info=exec_info
+            validate_args=validate_args,
+            exec_info=exec_info,
         )
 
 {%- filter indent(width=8) %}

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -14,12 +14,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
 import multiprocessing
 import os
 
 from typing import Any, Dict
 
-GT4PY_INSTALLATION_PATH = os.path.dirname(os.path.abspath(__file__))
+# Debug flag (referenced from stencil objects)
+debug: bool = True
+
+GT4PY_INSTALLATION_PATH: str = os.path.dirname(os.path.abspath(__file__))
 
 # Default paths (taken from user's environment vars when possible)
 BOOST_ROOT: str = os.environ.get(

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -20,8 +20,10 @@ import os
 
 from typing import Any, Dict
 
-# If True, validates stencil input arguments (can be changed by user)
-validate_args: bool = True
+# Can change this setting in an application:
+#   import gt4py.config as gt_config
+#   gt_config.disable_stencil_argument_validation = True
+disable_stencil_argument_validation: bool = False
 
 GT4PY_INSTALLATION_PATH: str = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -20,8 +20,8 @@ import os
 
 from typing import Any, Dict
 
-# Debug flag (referenced from stencil objects)
-debug: bool = True
+# If True, validates stencil input arguments (can be changed by user)
+validate_args: bool = True
 
 GT4PY_INSTALLATION_PATH: str = os.path.dirname(os.path.abspath(__file__))
 

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -20,11 +20,6 @@ import os
 
 from typing import Any, Dict
 
-# Can change this setting in an application:
-#   import gt4py.config as gt_config
-#   gt_config.disable_stencil_argument_validation = True
-disable_stencil_argument_validation: bool = False
-
 GT4PY_INSTALLATION_PATH: str = os.path.dirname(os.path.abspath(__file__))
 
 # Default paths (taken from user's environment vars when possible)

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -19,7 +19,7 @@ from gt4py.definitions import (
     Index,
 )
 
-from gt4py.config import debug
+import gt4py.config as gt_config
 
 
 class StencilObject(abc.ABC):
@@ -278,7 +278,7 @@ class StencilObject(abc.ABC):
 
         for name, field in used_field_args.items():
             origin.setdefault(name, origin["_all_"] if "_all_" in origin else field.default_origin)
-
+        print(gt_config.debug)
         # Domain
         if domain is None:
             domain = Shape([sys.maxsize] * self.domain_info.ndims)
@@ -288,7 +288,7 @@ class StencilObject(abc.ABC):
         else:
             domain = normalize_domain(domain)
 
-        if debug:
+        if gt_config.debug:
             self._validate_args(used_field_args, used_param_args, domain, origin, exec_info)
 
         self.run(

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -278,7 +278,7 @@ class StencilObject(abc.ABC):
 
         for name, field in used_field_args.items():
             origin.setdefault(name, origin["_all_"] if "_all_" in origin else field.default_origin)
-        print(gt_config.debug)
+
         # Domain
         if domain is None:
             domain = Shape([sys.maxsize] * self.domain_info.ndims)

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -122,12 +122,6 @@ class StencilObject(abc.ABC):
         self, used_field_args, used_param_args, domain, origin, max_domain, exec_info=None
     ):
         """Validate input arguments to self._call_run."""
-        for name, field_info in self.field_info.items():
-            if field_info is not None and used_field_args[name] is None:
-                raise ValueError(f"Field '{name}' is None.")
-        for name, parameter_info in self.parameter_info.items():
-            if parameter_info is not None and used_param_args[name] is None:
-                raise ValueError(f"Parameter '{name}' is None.")
 
         # assert compatibility of fields with stencil
         for name, field in used_field_args.items():
@@ -263,13 +257,20 @@ class StencilObject(abc.ABC):
         used_field_args = {
             name: field
             for name, field in field_args.items()
-            if name in self.field_info and self.field_info[name] is not None
+            if self.field_info.get(name, None) is not None
         }
+        for name, field_info in self.field_info.items():
+            if field_info is not None and used_field_args[name] is None:
+                raise ValueError(f"Field '{name}' is None.")
+
         used_param_args = {
             name: param
             for name, param in parameter_args.items()
-            if name in self.parameter_info and self.parameter_info[name] is not None
+            if self.parameter_info.get(name, None) is not None
         }
+        for name, parameter_info in self.parameter_info.items():
+            if parameter_info is not None and used_param_args[name] is None:
+                raise ValueError(f"Parameter '{name}' is None.")
 
         # Origins
         if origin is None:

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -288,7 +288,7 @@ class StencilObject(abc.ABC):
         else:
             domain = normalize_domain(domain)
 
-        if gt_config.debug:
+        if not gt_config.disable_stencil_argument_validation:
             self._validate_args(used_field_args, used_param_args, domain, origin, exec_info)
 
         self.run(

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -19,6 +19,8 @@ from gt4py.definitions import (
     Index,
 )
 
+from gt4py.config import debug
+
 
 class StencilObject(abc.ABC):
     """Generic singleton implementation of a stencil function.
@@ -116,6 +118,94 @@ class StencilObject(abc.ABC):
     def __call__(self, *args, **kwargs):
         pass
 
+    def _validate_args(
+        self, used_field_args, used_param_args, domain, origin, max_domain, exec_info=None
+    ):
+        for name, field_info in self.field_info.items():
+            if field_info is not None and used_field_args[name] is None:
+                raise ValueError(f"Field '{name}' is None.")
+        for name, parameter_info in self.parameter_info.items():
+            if parameter_info is not None and used_param_args[name] is None:
+                raise ValueError(f"Parameter '{name}' is None.")
+
+        # assert compatibility of fields with stencil
+        for name, field in used_field_args.items():
+            if not gt_backend.from_name(self.backend).storage_info["is_compatible_layout"](field):
+                raise ValueError(
+                    f"The layout of the field {name} is not compatible with the backend."
+                )
+
+            if not gt_backend.from_name(self.backend).storage_info["is_compatible_type"](field):
+                raise ValueError(
+                    f"Field '{name}' has type '{type(field)}', which is not compatible with the '{self.backend}' backend."
+                )
+            elif type(field) is np.ndarray:
+                warnings.warn(
+                    "NumPy ndarray passed as field. This is discouraged and only works with constraints and only for certain backends.",
+                    RuntimeWarning,
+                )
+            if not field.dtype == self.field_info[name].dtype:
+                raise TypeError(
+                    f"The dtype of field '{name}' is '{field.dtype}' instead of '{self.field_info[name].dtype}'"
+                )
+            # ToDo: check if mask is correct: need mask info in stencil object.
+
+            if isinstance(field, gt_storage.storage.Storage):
+                if not field.is_stencil_view:
+                    raise ValueError(
+                        f"An incompatible view was passed for field {name} to the stencil. "
+                    )
+                for name_other, field_other in used_field_args.items():
+                    if field_other.mask == field.mask:
+                        if not field_other.shape == field.shape:
+                            raise ValueError(
+                                f"The fields {name} and {name_other} have the same mask but different shapes."
+                            )
+
+        # assert compatibility of parameters with stencil
+        for name, parameter in used_param_args.items():
+            if not type(parameter) == self.parameter_info[name].dtype:
+                raise TypeError(
+                    f"The type of parameter '{name}' is '{type(parameter)}' instead of '{self.parameter_info[name].dtype}'"
+                )
+
+        assert isinstance(used_field_args, dict) and isinstance(used_param_args, dict)
+
+        if len(domain) != self.domain_info.ndims:
+            raise ValueError(f"Invalid 'domain' value '{domain}'")
+
+        # check domain+halo vs field size
+        if not domain > Shape.zeros(self.domain_info.ndims):
+            raise ValueError(f"Compute domain contains zero sizes '{domain}')")
+
+        # determine maximum domain
+        max_domain = Shape([sys.maxsize] * self.domain_info.ndims)
+        shapes = {name: Shape(field.shape) for name, field in used_field_args.items()}
+        for name, shape in shapes.items():
+            upper_boundary = Index(self.field_info[name].boundary.upper_indices)
+            max_domain &= shape - (Index(origin[name]) + upper_boundary)
+
+        if not domain <= max_domain:
+            raise ValueError(
+                f"Compute domain too large (provided: {domain}, maximum: {max_domain})"
+            )
+        for name, field in used_field_args.items():
+            min_origin = self.field_info[name].boundary.lower_indices
+            if origin[name] < min_origin:
+                raise ValueError(
+                    f"Origin for field {name} too small. Must be at least {min_origin}, is {origin[name]}"
+                )
+            min_shape = tuple(
+                o + d + h
+                for o, d, h in zip(
+                    origin[name], domain, self.field_info[name].boundary.upper_indices
+                )
+            )
+            if min_shape > field.shape:
+                raise ValueError(
+                    f"Shape of field {name} is {field.shape} but must be at least {min_shape} for given domain and origin."
+                )
+
     def _call_run(self, field_args, parameter_args, domain, origin, exec_info=None):
         """Check and preprocess the provided arguments (called by :class:`StencilObject` subclasses).
 
@@ -167,118 +257,43 @@ class StencilObject(abc.ABC):
 
         if exec_info is not None:
             exec_info["call_run_start_time"] = time.perf_counter()
-        used_arg_fields = {
+
+        # Collect used arguments and parameters
+        used_field_args = {
             name: field
             for name, field in field_args.items()
             if name in self.field_info and self.field_info[name] is not None
         }
-        used_arg_params = {
+        used_param_args = {
             name: param
             for name, param in parameter_args.items()
             if name in self.parameter_info and self.parameter_info[name] is not None
         }
-        for name, field_info in self.field_info.items():
-            if field_info is not None and field_args[name] is None:
-                raise ValueError(f"Field '{name}' is None.")
-        for name, parameter_info in self.parameter_info.items():
-            if parameter_info is not None and parameter_args[name] is None:
-                raise ValueError(f"Parameter '{name}' is None.")
-        # assert compatibility of fields with stencil
-        for name, field in used_arg_fields.items():
-            if not gt_backend.from_name(self.backend).storage_info["is_compatible_layout"](field):
-                raise ValueError(
-                    f"The layout of the field {name} is not compatible with the backend."
-                )
 
-            if not gt_backend.from_name(self.backend).storage_info["is_compatible_type"](field):
-                raise ValueError(
-                    f"Field '{name}' has type '{type(field)}', which is not compatible with the '{self.backend}' backend."
-                )
-            elif type(field) is np.ndarray:
-                warnings.warn(
-                    "NumPy ndarray passed as field. This is discouraged and only works with constraints and only for certain backends.",
-                    RuntimeWarning,
-                )
-            if not field.dtype == self.field_info[name].dtype:
-                raise TypeError(
-                    f"The dtype of field '{name}' is '{field.dtype}' instead of '{self.field_info[name].dtype}'"
-                )
-            # ToDo: check if mask is correct: need mask info in stencil object.
-
-            if isinstance(field, gt_storage.storage.Storage):
-                if not field.is_stencil_view:
-                    raise ValueError(
-                        f"An incompatible view was passed for field {name} to the stencil. "
-                    )
-                for name_other, field_other in used_arg_fields.items():
-                    if field_other.mask == field.mask:
-                        if not field_other.shape == field.shape:
-                            raise ValueError(
-                                f"The fields {name} and {name_other} have the same mask but different shapes."
-                            )
-
-        # assert compatibility of parameters with stencil
-        for name, parameter in used_arg_params.items():
-            if not type(parameter) == self.parameter_info[name].dtype:
-                raise TypeError(
-                    f"The type of parameter '{name}' is '{type(parameter)}' instead of '{self.parameter_info[name].dtype}'"
-                )
-
-        assert isinstance(field_args, dict) and isinstance(parameter_args, dict)
-
-        # Shapes
-        shapes = {}
-
-        for name, field in used_arg_fields.items():
-            shapes[name] = Shape(field.shape)
         # Origins
         if origin is None:
             origin = {}
         else:
             origin = normalize_origin_mapping(origin)
-        for name, field in used_arg_fields.items():
+
+        for name, field in used_field_args.items():
             origin.setdefault(name, origin["_all_"] if "_all_" in origin else field.default_origin)
 
         # Domain
-        max_domain = Shape([sys.maxsize] * self.domain_info.ndims)
-        for name, shape in shapes.items():
-            upper_boundary = Index(self.field_info[name].boundary.upper_indices)
-            max_domain &= shape - (Index(origin[name]) + upper_boundary)
-
         if domain is None:
-            domain = max_domain
+            domain = Shape([sys.maxsize] * self.domain_info.ndims)
+            for name, field in used_field_args.items():
+                upper_boundary = Index(self.field_info[name].boundary.upper_indices)
+                domain &= Shape(field.shape) - (Index(origin[name]) + upper_boundary)
         else:
             domain = normalize_domain(domain)
-            if len(domain) != self.domain_info.ndims:
-                raise ValueError(f"Invalid 'domain' value '{domain}'")
 
-        # check domain+halo vs field size
-        if not domain > Shape.zeros(self.domain_info.ndims):
-            raise ValueError(f"Compute domain contains zero sizes '{domain}')")
-
-        if not domain <= max_domain:
-            raise ValueError(
-                f"Compute domain too large (provided: {domain}, maximum: {max_domain})"
-            )
-        for name, field in used_arg_fields.items():
-            min_origin = self.field_info[name].boundary.lower_indices
-            if origin[name] < min_origin:
-                raise ValueError(
-                    f"Origin for field {name} too small. Must be at least {min_origin}, is {origin[name]}"
-                )
-            min_shape = tuple(
-                o + d + h
-                for o, d, h in zip(
-                    origin[name], domain, self.field_info[name].boundary.upper_indices
-                )
-            )
-            if min_shape > field.shape:
-                raise ValueError(
-                    f"Shape of field {name} is {field.shape} but must be at least {min_shape} for given domain and origin."
-                )
+        if debug:
+            self._validate_args(used_field_args, used_param_args, domain, origin, exec_info)
 
         self.run(
             _domain_=domain, _origin_=origin, exec_info=exec_info, **field_args, **parameter_args
         )
+
         if exec_info is not None:
             exec_info["call_run_end_time"] = time.perf_counter()

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -19,8 +19,6 @@ from gt4py.definitions import (
     Index,
 )
 
-import gt4py.config as gt_config
-
 
 class StencilObject(abc.ABC):
     """Generic singleton implementation of a stencil function.

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -118,9 +118,7 @@ class StencilObject(abc.ABC):
     def __call__(self, *args, **kwargs):
         pass
 
-    def _validate_args(
-        self, used_field_args, used_param_args, domain, origin, max_domain, exec_info=None
-    ):
+    def _validate_args(self, used_field_args, used_param_args, domain, origin, exec_info=None):
         """Validate input arguments to self._call_run."""
 
         # assert compatibility of fields with stencil

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -121,6 +121,7 @@ class StencilObject(abc.ABC):
     def _validate_args(
         self, used_field_args, used_param_args, domain, origin, max_domain, exec_info=None
     ):
+        """Validate input arguments to self._call_run."""
         for name, field_info in self.field_info.items():
             if field_info is not None and used_field_args[name] is None:
                 raise ValueError(f"Field '{name}' is None.")


### PR DESCRIPTION
Create a global flag that when set to True skips the stencil call input validation. In this case the stencils have much less over overhead as possible.

The idea is to only have this set to False in benchmarking and "production" scenarios.

Usage:
```
import gt4py.config as gt_config
gt_config.disable_stencil_argument_validation = True
```


