### PR TITLE
Refactored frontend parsing of `with` blocks

### DIFF
--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -51,11 +51,11 @@ def compile_definition(
     stencil_id = frontend.get_stencil_id(
         build_options.qualified_name, definition_func, externals, options_id
     )
-    gt_frontend.GTScriptParser(
+    definition_ir = gt_frontend.GTScriptParser(
         definition_func, externals=externals or {}, options=build_options
     ).run()
 
-    return stencil_id
+    return stencil_id, definition_ir
 
 
 # ---- Tests-----
@@ -485,3 +485,55 @@ class TestAssignmentSyntax:
                 in_field -= 0.5
                 in_field /= 0.5
                 in_field *= 4.0
+
+
+class TestNestedWithSyntax:
+    def test_nested_with(self):
+        @gtscript.stencil(backend="debug")
+        def definition(in_field: gtscript.Field[np.float_], out_field: gtscript.Field[np.float_]):
+            with computation(PARALLEL):
+                with interval(...):
+                    in_field = out_field
+
+    def test_nested_with_reordering(self):
+        def definition_fw(
+            in_field: gtscript.Field[np.float_], out_field: gtscript.Field[np.float_]
+        ):
+            from gt4py.__gtscript__ import computation, interval, FORWARD
+
+            with computation(FORWARD):
+                with interval(1, 2):
+                    in_field = out_field + 1
+                with interval(0, 1):
+                    in_field = out_field + 2
+
+        def definition_bw(
+            in_field: gtscript.Field[np.float_], out_field: gtscript.Field[np.float_]
+        ):
+            from gt4py.__gtscript__ import computation, interval, FORWARD
+
+            with computation(BACKWARD):
+                with interval(1, 2):
+                    in_field = out_field + 1
+                with interval(0, 1):
+                    in_field = out_field + 2
+
+        definitions = [
+            # name, expected axis bounds, definition
+            ("fw", [(0, 1), (1, 2)], definition_fw),
+            ("bw", [(1, 2), (0, 1)], definition_bw),
+        ]
+
+        for name, axis_bounds, definition in definitions:
+            # generate DIR
+            _, definition_ir = compile_definition(
+                definition,
+                f"test_nested_with_reordering_{name}",
+                f"TestImports_test_module_{id_version}",
+            )
+
+            # test for correct ordering
+            for i, axis_bound in enumerate(axis_bounds):
+                interval = definition_ir.computations[i].interval
+                assert interval.start.offset == axis_bound[0]
+                assert interval.end.offset == axis_bound[1]


### PR DESCRIPTION
## Description

Currently each `with computation(...), interval(...): ...` was canonicalized by rewriting the AST into nested `with` blocks of the form
```
with computation(...):
  with interval(...):
```
and a later two-stage processing into a single `ComputationBlock` DIR node. This is not only hard to maintain and deviates from the DIR, which should be close to the actual gtscript definition, but also hard to expand. In preperation of the addition of the location/cell type specification for non-cartesian grids this part was therefore refactored. Now each `with` block is parsed in a single method and `with computation(...): with interval(...)` blocks are rewritten into `with computation(...), interval(...): ...`.

~~Suggestions on the previous [reordering of nested `with interval(...)` blocks](https://github.com/GridTools/gt4py/pull/124/files#diff-743cd36dd5d087aed38740c7f13c9782L575) would be greatly appreciated. The current reordering doesn't look sound to me (it only considers the start of the interval) and it's usefulness is unclear. There are no tests covering this nor a requirement why this is needed in the first place. It is therefore currently just removed in the refactored version.~~

__Edit: clarifications on the reordering__ (excerpt from a comment in this PR)
```
the nested computation blocks need not to be specified in their order of execution, but the backends
expect them to the given in that order so sort them. The order of execution is such that the lowest
(highest) interval is processed first if the iteration order is forward (backward).
```

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


