### PR TITLE
Add BOOL type to DATA_TYPE_TO_CPP map

### DIFF
--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -165,6 +165,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
     }
 
     DATA_TYPE_TO_CPP = {
+        gt_ir.DataType.BOOL: "bool",
         gt_ir.DataType.INT8: "int8_t",
         gt_ir.DataType.INT16: "int16_t",
         gt_ir.DataType.INT32: "int32_t",

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -206,3 +206,9 @@ def horizontal_diffusion(in_field: Field3D, out_field: Field3D, coeff: Field3D):
         out_field = in_field[0, 0, 0] - coeff[0, 0, 0] * (
             flx_field[0, 0, 0] - flx_field[-1, 0, 0] + fly_field[0, 0, 0] - fly_field[0, -1, 0]
         )
+
+
+@register
+def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
+    with computation(PARALLEL), interval(...):
+        mask = in_field >= 0


### PR DESCRIPTION
## Description

This PR adds `DataType.BOOL => bool` to the `DATA_TYPE_TO_CPP` map in `gt_backends.py`.

