### PR TITLE
Resolve VarRef data type error in NumPySourceGenerator

### DIFF
--- a/src/gt4py/backend/numpy_backend.py
+++ b/src/gt4py/backend/numpy_backend.py
@@ -233,13 +233,20 @@ class NumPySourceGenerator(PythonSourceGenerator):
 
             target = self.visit(stmt.target)
             value = self.visit(stmt.value)
+
+            data_type = (
+                self.block_info.symbols[target].data_type
+                if target in self.block_info.symbols
+                else stmt.target.data_type
+            )
+
             sources.append(
                 "{target} = vectorized_ternary_op(condition={condition}, then_expr={then_expr}, else_expr={else_expr}, dtype={np}.{dtype})".format(
                     condition=condition,
                     target=target,
                     then_expr=value,
                     else_expr=target,
-                    dtype=stmt.target.data_type.dtype.name,
+                    dtype=data_type.dtype.name,
                     np=self.numpy_prefix,
                 )
             )

--- a/src/gt4py/backend/python_generator.py
+++ b/src/gt4py/backend/python_generator.py
@@ -215,7 +215,7 @@ class PythonSourceGenerator(gt_ir.IRNodeVisitor):
     def visit_ApplyBlock(self, node: gt_ir.ApplyBlock):
         interval_definition = self.visit(node.interval)
         self.block_info.interval = interval_definition
-        self.block_info.symbols = set(node.local_symbols.keys())
+        self.block_info.symbols = node.local_symbols
         body_sources = self.visit(node.body)
 
         return interval_definition, body_sources

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -213,3 +213,15 @@ def horizontal_diffusion(in_field: Field3D, out_field: Field3D, coeff: Field3D):
 def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
     with computation(PARALLEL), interval(...):
         mask = in_field >= 0
+
+
+@register
+def set_inner_as_kord(a4_1: Field3D, a4_2: Field3D, a4_3: Field3D, extm: Field3D, qmin: float):
+    with computation(PARALLEL), interval(...):
+        diff_23 = 0.0
+        if extm and extm[0, 0, -1]:
+            a4_2 = a4_1
+        elif extm and extm[0, 0, 1]:
+            a4_3 = a4_1
+        else:
+            diff_23 = a4_2 - a4_3


### PR DESCRIPTION
## Description

This PR resolves an issue in the `numpy` backend that occurs when the target of an `if` branch does not have a `data_type` member. This is true for `FieldRef` but not `VarRef` objects. The solution is to fetch the data type for each `VarRef` from the corresponding `VarDecl` in the `block_info.symbols` table.
