### PR TITLE
Rename 'VerticalRegionStmt' => 'VerticalRegionDeclStmt'

### DIFF
--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -250,7 +250,7 @@ class SIRConverter(gt_ir.IRNodeVisitor):
 
     def visit_ComputationBlock(
         self, node: gt_ir.ComputationBlock, **kwargs: Any
-    ) -> SIR.VerticalRegionStmt:
+    ) -> SIR.VerticalRegionDeclStmt:
         interval = self.visit(node.interval)
 
         body_ast = sir_utils.make_ast(self.visit(node.body, make_block=False))


### PR DESCRIPTION
## Description

This PR fixes a typo in `dawn_backends.py` where `VerticalRegionStmt` should be `VerticalRegionDeclStmt`, resulting in the following error:
```python
AttributeError: module 'dawn4py.serialization.SIR' has no attribute 'VerticalRegionStmt'
```