### PR TITLE
Insert string keys back in argument annotations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,5 +14,6 @@ Authors
 * Häuselmann, Rico. ETH Zurich - CSCS
 * Madonna, Alberto. ETH Zurich - CSCS
 * Mariotti, Kean. ETH Zurich - CSCS
+* Ubbiali, Stefano. ETH Zurich
 * Vogt, Hannes. ETH Zurich - CSCS
 * Wicky, Tobias. Vulcan Inc.

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -87,38 +87,20 @@ _VALID_DATA_TYPES = (bool, np.bool, int, np.int32, np.int64, float, np.float32, 
 def _set_arg_dtypes(definition, dtypes):
     assert isinstance(definition, types.FunctionType)
     annotations = getattr(definition, "__annotations__", {})
-    placeholders = {}
+    original_annotations = {**annotations}
     for arg, value in annotations.items():
         if isinstance(value, _FieldDescriptor) and isinstance(value.dtype, str):
             if value.dtype in dtypes:
                 annotations[arg] = _FieldDescriptor(dtypes[value.dtype], value.axes)
-                placeholders[arg] = value.dtype
             else:
                 raise ValueError(f"Missing '{value.dtype}' dtype definition for arg '{arg}'")
         elif isinstance(value, str):
             if value in dtypes:
                 annotations[arg] = dtypes[value]
-                placeholders[arg] = value
             else:
                 raise ValueError(f"Missing '{value}' dtype definition for arg '{arg}'")
 
-    return definition, placeholders
-
-
-def _reset_arg_dtypes(definition, placeholders):
-    assert isinstance(definition, types.FunctionType)
-    annotations = getattr(definition, "__annotations__", {})
-    for arg, value in annotations.items():
-        if arg in placeholders:
-            if isinstance(value, _FieldDescriptor):
-                try:
-                    annotations[arg] = _FieldDescriptor(placeholders[arg], value.axes)
-                except KeyError:
-                    annotations[arg] = _FieldDescriptor(placeholders[arg].type, value.axes)
-            else:
-                annotations[arg] = placeholders[arg]
-
-    return definition
+    return definition, original_annotations
 
 
 def function(func):
@@ -242,14 +224,14 @@ def stencil(
             elif callable(definition_func):  # General callable
                 definition_func = definition_func.__call__
 
-        _, placeholders = _set_arg_dtypes(definition_func, dtypes or {})
+        _, original_annotations = _set_arg_dtypes(definition_func, dtypes or {})
         out = gt_loader.gtscript_loader(
             definition_func,
             backend=backend,
             build_options=build_options,
             externals=externals or {},
         )
-        _reset_arg_dtypes(definition_func, placeholders)
+        setattr(definition_func, "__annotations__", original_annotations)
         return out
 
     if definition is None:

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -42,7 +42,7 @@ def compile_definition(
     rebuild=False,
     **kwargs,
 ):
-    gtscript._set_arg_dtypes(definition_func, dtypes=dtypes or {})
+    _, original_annotations = gtscript._set_arg_dtypes(definition_func, dtypes=dtypes or {})
     build_options = gt_definitions.BuildOptions(
         name=name, module=module, rebuild=rebuild, backend_opts=kwargs, build_info=None
     )
@@ -54,6 +54,8 @@ def compile_definition(
     definition_ir = gt_frontend.GTScriptParser(
         definition_func, externals=externals or {}, options=build_options
     ).run()
+
+    setattr(definition_func, "__annotations__", original_annotations)
 
     return stencil_id, definition_ir
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -598,3 +598,95 @@ class TestNativeFunctions:
         def func(in_field: gtscript.Field[np.float_]):
             with computation(PARALLEL), interval(...):
                 in_field = asin(in_field) + 1 if 1 < in_field else sin(in_field)
+
+
+class TestAnnotations:
+    @staticmethod
+    def sumdiff_defs(
+        in_a: gtscript.Field["dtype_in"],
+        in_b: gtscript.Field["dtype_in"],
+        out_c: gtscript.Field["dtype_out"],
+        out_d: gtscript.Field[float],
+        *,
+        wa: "dtype_scalar",
+        wb: int,
+    ):
+        with computation(PARALLEL), interval(...):
+            out_c = wa * in_a + wb * in_b
+            out_d = wa * in_a - wb * in_b
+
+    @pytest.mark.parametrize("dtype_in", [int, np.float32, np.float64])
+    @pytest.mark.parametrize("dtype_out", [int, np.float32, np.float64])
+    @pytest.mark.parametrize("dtype_scalar", [int, np.float32, np.float64])
+    def test_set_arg_dtypes(self, dtype_in, dtype_out, dtype_scalar):
+        definition = self.sumdiff_defs
+        dtypes = {"dtype_in": dtype_in, "dtype_out": dtype_out, "dtype_scalar": dtype_scalar}
+
+        definition, original_annotations = gtscript._set_arg_dtypes(definition, dtypes)
+
+        assert "in_a" in original_annotations
+        assert isinstance(original_annotations["in_a"], gtscript._FieldDescriptor)
+        assert original_annotations["in_a"].dtype == "dtype_in"
+        assert "in_b" in original_annotations
+        assert isinstance(original_annotations["in_b"], gtscript._FieldDescriptor)
+        assert original_annotations["in_b"].dtype == "dtype_in"
+        assert "out_c" in original_annotations
+        assert isinstance(original_annotations["out_c"], gtscript._FieldDescriptor)
+        assert original_annotations["out_c"].dtype == "dtype_out"
+        assert "out_d" in original_annotations
+        assert isinstance(original_annotations["out_d"], gtscript._FieldDescriptor)
+        assert original_annotations["out_d"].dtype == float
+        assert "wa" in original_annotations
+        assert original_annotations["wa"] == "dtype_scalar"
+        assert "wb" in original_annotations
+        assert original_annotations["wb"] == int
+        assert len(original_annotations) == 6
+
+        annotations = getattr(definition, "__annotations__", {})
+        assert "in_a" in annotations
+        assert isinstance(annotations["in_a"], gtscript._FieldDescriptor)
+        assert annotations["in_a"].dtype == dtype_in
+        assert "in_b" in annotations
+        assert isinstance(annotations["in_b"], gtscript._FieldDescriptor)
+        assert annotations["in_b"].dtype == dtype_in
+        assert "out_c" in annotations
+        assert isinstance(annotations["out_c"], gtscript._FieldDescriptor)
+        assert annotations["out_c"].dtype == dtype_out
+        assert "out_d" in annotations
+        assert isinstance(annotations["out_d"], gtscript._FieldDescriptor)
+        assert annotations["out_d"].dtype == float
+        assert "wa" in annotations
+        assert annotations["wa"] == dtype_scalar
+        assert "wb" in annotations
+        assert annotations["wb"] == int
+        assert len(annotations) == 6
+
+        setattr(definition, "__annotations__", original_annotations)
+
+    @pytest.mark.parametrize("dtype_in", [int, np.float32, np.float64])
+    @pytest.mark.parametrize("dtype_out", [int, np.float32, np.float64])
+    @pytest.mark.parametrize("dtype_scalar", [int, np.float32, np.float64])
+    def test_compilation(self, dtype_in, dtype_out, dtype_scalar):
+        definition = self.sumdiff_defs
+        dtypes = {"dtype_in": dtype_in, "dtype_out": dtype_out, "dtype_scalar": dtype_scalar}
+
+        sumdiff = gtscript.stencil("debug", definition, dtypes=dtypes)
+
+        annotations = getattr(definition, "__annotations__", {})
+        assert "in_a" in annotations
+        assert isinstance(annotations["in_a"], gtscript._FieldDescriptor)
+        assert annotations["in_a"].dtype == "dtype_in"
+        assert "in_b" in annotations
+        assert isinstance(annotations["in_b"], gtscript._FieldDescriptor)
+        assert annotations["in_b"].dtype == "dtype_in"
+        assert "out_c" in annotations
+        assert isinstance(annotations["out_c"], gtscript._FieldDescriptor)
+        assert annotations["out_c"].dtype == "dtype_out"
+        assert "out_d" in annotations
+        assert isinstance(annotations["out_d"], gtscript._FieldDescriptor)
+        assert annotations["out_d"].dtype == float
+        assert "wa" in annotations
+        assert annotations["wa"] == "dtype_scalar"
+        assert "wb" in annotations
+        assert annotations["wb"] == int
+        assert len(annotations) == 6


### PR DESCRIPTION
## Description

In the `gtscript.stencil` function, I propose to replace back the actual datatypes with their string placeholders in the argument annotations of the definition function before returning the `StencilObject`. This allows to properly compile multiple versions of the same stencil - each with a different specification of datatypes - inside a Python session. This is useful for tests parametrized in the fields datatype.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these 
new features
- [ ] All relevant documentation has been updated or added

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement, 
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated 
version of the AUTHORS.rst file included in the PR