### PR TITLE
Fix 143

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,7 @@ repos:
           tests/test_unittest/test_call_interface.py |
           tests/test_unittest/test_gtscript_frontend.py |
           tests/test_unittest/test_storage.py |
+          tests/test_unittest/test_merge_blocks_pass.py |
           )$
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
           tests/test_unittest/test_call_interface.py |
           tests/test_unittest/test_gtscript_frontend.py |
           tests/test_unittest/test_storage.py |
-          tests/test_unittest/test_merge_blocks_pass.py |
+          tests/definition_setup.py |
           )$
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -491,7 +491,7 @@ class MultiStageMergingWrapper:
         cls, target: DomainBlockInfo, candidate: DomainBlockInfo, parent: TransformData
     ) -> bool:
         target = cls(target, parent)
-        candidate = cls(target, parent)
+        candidate = cls(candidate, parent)
         return target.can_merge_with(candidate)
 
     def can_merge_with(self, candidate: "MultiStageMergingWrapper") -> bool:
@@ -596,8 +596,8 @@ class StageMergingWrapper:
         parent: TransformData,
         parent_block: DomainBlockInfo,
     ) -> bool:
-        target = cls(target, transform_data, block)
-        candidate = cls(candidate, transform_data, block)
+        target = cls(target, parent, parent_block)
+        candidate = cls(candidate, parent, parent_block)
         return target.can_merge_with(candidate)
 
     def can_merge_with(self, candidate: "StageMergingWrapper") -> bool:

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -761,12 +761,6 @@ class MergeBlocksPass(TransformPass):
     def defaults(self):
         return self._DEFAULT_OPTIONS
 
-    @staticmethod
-    def _unwrap(
-        wrappers: Sequence[MergeableType],
-    ) -> Union[List[DomainBlockInfo], List[IJBlockInfo]]:
-        return [wrapper.wrapped for wrapper in wrappers]
-
     def apply(self, transform_data: TransformData) -> TransformData:
         merged_blocks = greedy_merging_with_wrapper(
             transform_data.blocks, MultiStageMergingWrapper, parent=transform_data

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -458,42 +458,6 @@ class MergeBlocksPass(TransformPass):
     def defaults(self):
         return self._DEFAULT_OPTIONS
 
-    # def apply(self, transform_data: TransformData):
-    #    # Greedy strategy to merge multi-stages
-    #    merged_blocks = [transform_data.blocks[0]]
-    #    for candidate in transform_data.blocks[1:]:
-    #        merged = merged_blocks[-1]
-    #        if self._are_compatible_multi_stages(
-    #            merged, candidate, transform_data.has_sequential_axis
-    #        ):
-    #            merged.id = transform_data.id_generator.new
-    #            self._merge_domain_blocks(merged, candidate)
-    #        else:
-    #            merged_blocks.append(candidate)
-
-    #    # Greedy strategy to merge stages
-    #    # assert transform_data.has_sequential_axis
-    #    for block in merged_blocks:
-    #        merged_ijs = [block.ij_blocks[0]]
-    #        for ij_candidate in block.ij_blocks[1:]:
-    #            merged = merged_ijs[-1]
-    #            if self._are_compatible_stages(
-    #                merged,
-    #                ij_candidate,
-    #                transform_data.min_k_interval_sizes,
-    #                block.iteration_order,
-    #            ):
-    #                merged.id = transform_data.id_generator.new
-    #                self._merge_ij_blocks(merged, ij_candidate, transform_data)
-    #            else:
-    #                merged_ijs.append(ij_candidate)
-
-    #        block.ij_blocks = merged_ijs
-
-    #    transform_data.blocks = merged_blocks
-
-    #    return transform_data
-
     def _greedy_merging(
         self,
         items: Sequence[T],
@@ -691,19 +655,6 @@ class MergeBlocksPass(TransformPass):
         # Check that there are not data dependencies between stages
         if self._stages_have_data_dependencies(candidate, target, min_k_interval_sizes):
             return False
-        # for input, extent in candidate.inputs.items():
-        #    if input in target.outputs:
-        #        read_interval = (
-        #            next(iter(candidate.intervals)).as_tuple(min_k_interval_sizes) + extent[-2]
-        #        )
-        #        for merged_interval_block in target.interval_blocks:
-        #            merged_interval = merged_interval_block.interval
-        #            if merged_interval.as_tuple(
-        #                min_k_interval_sizes
-        #            ) != read_interval and merged_interval.overlaps(
-        #                read_interval, min_k_interval_sizes
-        #            ):
-        #                return False
         return True
 
     def _merge_domain_blocks(self, target, candidate):

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -38,13 +38,9 @@ from gt4py.definitions import Extent
 class IRSpecificationError(gt_definitions.GTSpecificationError):
     def __init__(self, message=None, *, loc=None):
         if message is None:
-            if loc is None:
-                message = "Invalid specification"
-            else:
-                message = (
-                    f"Invalid specification in '{loc.scope}' (line: {loc.line}, col: {loc.col})"
-                )
-        super().__init__(message, loc=loc)
+            message = "Invalid specification"
+        message = f"{message} in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
+        super().__init__(message)
 
 
 class IntervalSpecificationError(IRSpecificationError):

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -655,7 +655,7 @@ class StageMergingWrapper:
                 merged_int_block.outputs |= candidate_int_block.outputs
 
             else:
-                target.interval_blocks.append(candidate_int_block)
+                self.interval_blocks.append(candidate_int_block)
 
         self._stage.intervals |= candidate.intervals
         self._stage.outputs |= candidate.outputs

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -18,6 +18,7 @@
 """
 
 import itertools
+import warnings
 from typing import (
     Any,
     Callable,

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -645,7 +645,7 @@ class MergeBlocksPass(TransformPass):
     ) -> bool:
         if interval_a == interval_b:
             return False
-        elif interval_a.overlaps(interval_b, min_k_interval_sizes, iteration_order):
+        elif interval_a.overlaps(interval_b, min_k_interval_sizes):
             return True
         return False
 

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -748,6 +748,8 @@ class StageMergingWrapper:
 
 
 def greedy_merging(items: Sequence[MergeableType]) -> List[MergeableType]:
+    if len(items) < 2:
+        return items
     merged_items = [items[0]]
     for candidate in items[1:]:
         target = merged_items[-1]

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -122,14 +122,13 @@ storing a reference to the piece of source code which originated the node.
         # start is included
         # end is excluded
 
-    ComputationBlock(interval: AxisInterval, order: IterationOrder, body: BlockStmt)
+    ComputationBlock(interval: AxisInterval, iteration_order: IterationOrder, body: BlockStmt)
 
     ArgumentInfo(name: str, is_keyword: bool, [default: Any])
 
     StencilDefinition(name: str,
                       domain: Domain,
                       api_signature: List[ArgumentInfo],
-                      domain: Domain,
                       api_fields: List[FieldDecl],
                       parameters: List[VarDecl],
                       computations: List[ComputationBlock],
@@ -736,7 +735,7 @@ class StencilDefinition(Node):
     computations = attribute(of=ListOf[ComputationBlock])
     externals = attribute(of=DictOf[str, Any], optional=True)
     sources = attribute(of=DictOf[str, str], optional=True)
-    docstring = attribute(of=str)
+    docstring = attribute(of=str, default="")
 
 
 # ---- Implementation IR (IIR) ----

--- a/tests/analysis_setup.py
+++ b/tests/analysis_setup.py
@@ -1,0 +1,44 @@
+from copy import deepcopy
+from typing import Callable, Iterator
+
+import pytest
+
+from gt4py.analysis import TransformData
+from gt4py.analysis.passes import (
+    ComputeExtentsPass,
+    InitInfoPass,
+    MergeBlocksPass,
+    NormalizeBlocksPass,
+)
+
+
+PassType = Callable[[TransformData], TransformData]
+
+
+@pytest.fixture()
+def init_pass() -> Iterator[PassType]:
+    yield InitInfoPass().apply
+
+
+@pytest.fixture()
+def normalize_blocks_pass(init_pass: PassType) -> Iterator[PassType]:
+    def inner(data: TransformData):
+        return NormalizeBlocksPass().apply(init_pass(deepcopy(data)))
+
+    yield inner
+
+
+@pytest.fixture()
+def compute_extents_pass(normalize_blocks_pass: PassType) -> Iterator[PassType]:
+    def inner(data: TransformData):
+        return ComputeExtentsPass().apply(normalize_blocks_pass(deepcopy(data)))
+
+    yield inner
+
+
+@pytest.fixture()
+def merge_blocks_pass(compute_extents_pass: PassType) -> Iterator[PassType]:
+    def inner(data: TransformData):
+        return MergeBlocksPass().apply(compute_extents_pass(deepcopy(data)))
+
+    yield inner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,20 @@ import pytest
 
 from gt4py import config as gt_config
 
+from .analysis_setup import (
+    compute_extents_pass,
+    init_pass,
+    merge_blocks_pass,
+    normalize_blocks_pass,
+)
+from .definition_setup import (
+    ij_offset,
+    ijk_domain,
+    iteration_order,
+    make_transform_data,
+    non_parallel_iteration_order,
+)
+
 
 # Delete cache folder
 shutil.rmtree(

--- a/tests/definition_setup.py
+++ b/tests/definition_setup.py
@@ -97,7 +97,10 @@ def make_definition(
                 ),
                 iteration_order=iteration_order,
                 body=BlockStmt(
-                    stmts=[make_assign(*assign, loc_line=i) for i, assign in enumerate(body)]
+                    stmts=[
+                        make_assign(*assign, loc_scope=name, loc_line=i)
+                        for i, assign in enumerate(body)
+                    ]
                 ),
             )
         ],

--- a/tests/definition_setup.py
+++ b/tests/definition_setup.py
@@ -1,0 +1,136 @@
+from functools import partial
+from typing import Iterator, List, Tuple
+
+import pytest
+
+from gt4py.analysis import TransformData
+from gt4py.definitions import BuildOptions
+from gt4py.ir.nodes import (
+    ArgumentInfo,
+    Assign,
+    Axis,
+    AxisBound,
+    AxisInterval,
+    BlockStmt,
+    ComputationBlock,
+    DataType,
+    Domain,
+    FieldDecl,
+    FieldRef,
+    IterationOrder,
+    LevelMarker,
+    Location,
+    StencilDefinition,
+    StencilImplementation,
+)
+
+
+BodyType = List[Tuple[str, str, Tuple[int, int, int]]]
+
+
+@pytest.fixture()
+def ijk_domain() -> Domain:
+    axes = [Axis(name=idx) for idx in ["I", "J", "K"]]
+    return Domain(parallel_axes=axes[:2], sequential_axis=axes[2])
+
+
+@pytest.fixture(params=[IterationOrder.FORWARD, IterationOrder.BACKWARD, IterationOrder.PARALLEL])
+def iteration_order(request) -> Iterator[IterationOrder]:
+    return request.param
+
+
+@pytest.fixture(params=[IterationOrder.FORWARD, IterationOrder.BACKWARD])
+def non_parallel_iteration_order(request) -> Iterator[IterationOrder]:
+    return request.param
+
+
+@pytest.fixture(params=[(-1, 0, 0), (0, 1, 0), (-1, 2, 0)])
+def ij_offset(request):
+    yield request.param
+
+
+def make_offset(offset: Tuple[int, int, int]):
+    return {"I": offset[0], "J": offset[1], "K": offset[2]}
+
+
+def make_assign(
+    target: str,
+    value: str,
+    offset: Tuple[int, int, int] = (0, 0, 0),
+    loc_line=0,
+    loc_scope="unnamed",
+):
+    make_loc = partial(Location, scope=loc_scope)
+    return Assign(
+        target=FieldRef(
+            name=target, offset=make_offset((0, 0, 0)), loc=make_loc(line=loc_line, column=0)
+        ),
+        value=FieldRef(
+            name=value, offset=make_offset(offset), loc=make_loc(line=loc_line, column=2)
+        ),
+        loc=make_loc(line=loc_line, column=1),
+    )
+
+
+def make_definition(
+    name: str, fields: List[str], domain: Domain, body: BodyType, iteration_order: IterationOrder
+) -> StencilDefinition:
+    api_signature = [ArgumentInfo(name=n, is_keyword=False) for n in fields]
+    tmp_fields = {i[0] for i in body}.union({i[1] for i in body}).difference(fields)
+    api_fields = [
+        FieldDecl(name=n, data_type=DataType.AUTO, axes=domain.axes_names, is_api=True)
+        for n in fields
+    ] + [
+        FieldDecl(name=n, data_type=DataType.AUTO, axes=domain.axes_names, is_api=False)
+        for n in tmp_fields
+    ]
+    return StencilDefinition(
+        name=name,
+        domain=domain,
+        api_signature=api_signature,
+        api_fields=api_fields,
+        parameters=[],
+        computations=[
+            ComputationBlock(
+                interval=AxisInterval(
+                    start=AxisBound(level=LevelMarker.START), end=AxisBound(level=LevelMarker.END)
+                ),
+                iteration_order=iteration_order,
+                body=BlockStmt(stmts=[make_assign(*assign) for assign in body]),
+            )
+        ],
+        docstring="",
+    )
+
+
+def init_implementation_from_definition(definition: StencilDefinition) -> StencilImplementation:
+    return StencilImplementation(
+        name=definition.name,
+        api_signature=[],
+        domain=definition.domain,
+        fields={},
+        parameters={},
+        multi_stages=[],
+        fields_extents={},
+        unreferenced=[],
+        axis_splitters_var=None,
+        externals=definition.externals,
+        sources=definition.sources,
+        docstring=definition.docstring,
+    )
+
+
+def make_transform_data(
+    *,
+    name: str,
+    domain: Domain,
+    fields: List[str],
+    body: BodyType,
+    iteration_order: IterationOrder,
+) -> TransformData:
+    definition = make_definition(name, fields, domain, body, iteration_order)
+    return TransformData(
+        definition_ir=definition,
+        implementation_ir=init_implementation_from_definition(definition),
+        options=BuildOptions(name=name, module=__name__),
+    )

--- a/tests/definition_setup.py
+++ b/tests/definition_setup.py
@@ -96,7 +96,9 @@ def make_definition(
                     start=AxisBound(level=LevelMarker.START), end=AxisBound(level=LevelMarker.END)
                 ),
                 iteration_order=iteration_order,
-                body=BlockStmt(stmts=[make_assign(*assign) for assign in body]),
+                body=BlockStmt(
+                    stmts=[make_assign(*assign, loc_line=i) for i, assign in enumerate(body)]
+                ),
             )
         ],
         docstring="",

--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -1,368 +1,86 @@
-from typing import Dict, Iterator, List, Optional
+from typing import Tuple
 
-import pytest
+from gt4py.ir.nodes import Domain, IterationOrder
 
-from gt4py.analysis import TransformData
-from gt4py.analysis.passes import (
-    ComputeExtentsPass,
-    InitInfoPass,
-    MergeBlocksPass,
-    NormalizeBlocksPass,
-)
-from gt4py.definitions import BuildOptions
-from gt4py.ir.nodes import (
-    ArgumentInfo,
-    Assign,
-    Axis,
-    AxisBound,
-    AxisInterval,
-    BlockStmt,
-    ComputationBlock,
-    DataType,
-    Domain,
-    FieldDecl,
-    FieldRef,
-    IterationOrder,
-    LevelMarker,
-    Location,
-    StencilDefinition,
-    StencilImplementation,
-)
+from ..analysis_setup import PassType
+from ..definition_setup import make_transform_data
 
 
-@pytest.fixture(params=["extended", "offset", "allowed_offset"])
-def case(request):
-    yield request.param
-
-
-@pytest.fixture()
-def length() -> Iterator[int]:
-    yield 10
-
-
-@pytest.fixture()
-def axis_names() -> Iterator[List[str]]:
-    yield ["I", "J", "K"]
-
-
-@pytest.fixture()
-def axes(axis_names: List[str]) -> Iterator[List[Axis]]:
-    yield [Axis(name=idx) for idx in axis_names]
-
-
-@pytest.fixture()
-def domain(axes: List[Axis]) -> Iterator[Domain]:
-    yield Domain(parallel_axes=axes[:2], sequential_axis=axes[2])
-
-
-@pytest.fixture()
-def param_names() -> Iterator[List[str]]:
-    yield ["in", "out", "inout"]
-
-
-@pytest.fixture()
-def api_signature(param_names: List[str]) -> Iterator[List[ArgumentInfo]]:
-    yield [ArgumentInfo(name=n, is_keyword=False) for n in param_names]
-
-
-@pytest.fixture()
-def api_fields(param_names: List[str], axis_names: List[str]) -> Iterator[List[FieldDecl]]:
-    yield (
-        [
-            FieldDecl(name=n, data_type=DataType.AUTO, axes=axis_names, is_api=True)
-            for n in param_names
-        ]
-        + [FieldDecl(name="tmp", data_type=DataType.AUTO, axes=axis_names, is_api=False)]
+def test_merge_write_after_read_ij_extended(
+    merge_blocks_pass: PassType,
+    iteration_order: IterationOrder,
+    ij_offset: Tuple[int, int, int],
+    ijk_domain: Domain,
+) -> None:
+    transform_data = make_transform_data(
+        name="ij_extended",
+        domain=ijk_domain,
+        fields=["out", "in", "inout"],
+        body=[("tmp", "inout", (0, 0, 0)), ("out", "tmp", ij_offset), ("inout", "in", (0, 0, 0))],
+        iteration_order=iteration_order,
     )
+    transform_data = merge_blocks_pass(transform_data)
+    assert len(transform_data.blocks) == 2
+    assert len(transform_data.blocks[0].ij_blocks) == 2
+    assert len(transform_data.blocks[1].ij_blocks) == 1
 
 
-@pytest.fixture()
-def no_offset(axis_names: List[str]) -> Iterator[Dict[str, int]]:
-    yield {idx: 0 for idx in axis_names}
-
-
-@pytest.fixture()
-def offset_by_one(axis_names: List[str]) -> Iterator[Dict[str, int]]:
-    yield {idx: -1 if idx == "I" else 0 for idx in axis_names}
-
-
-@pytest.fixture()
-def computations_extended(
-    no_offset: Dict[str, int], offset_by_one: Dict[str, int]
-) -> Iterator[List[ComputationBlock]]:
-    """
-    Build stencil definition body for write after read with extended compute domain.
-
-    equivalent to
-    .. code-block: python
-
-        with computation(PARALLEL), interval(...):
-            tmp = inout
-            out = tmp[-1, 0, 0]
-            inout = in
-    """
-    yield [
-        ComputationBlock(
-            interval=AxisInterval(
-                start=AxisBound(level=LevelMarker.START), end=AxisBound(level=LevelMarker.END)
-            ),
-            iteration_order=IterationOrder.PARALLEL,
-            body=BlockStmt(
-                stmts=[
-                    Assign(
-                        target=FieldRef(
-                            name="tmp",
-                            offset=no_offset,
-                            loc=Location(scope="war_extended_compute", line=0, column=0),
-                        ),
-                        value=FieldRef(
-                            name="inout",
-                            offset=no_offset,
-                            loc=Location(scope="war_extended_compute", line=0, column=2),
-                        ),
-                        loc=Location(scope="war_extended_compute", line=0, column=1),
-                    ),
-                    Assign(
-                        target=FieldRef(
-                            name="out",
-                            offset=no_offset,
-                            loc=Location(scope="war_extended_compute", line=1, column=0),
-                        ),
-                        value=FieldRef(
-                            name="tmp",
-                            offset=offset_by_one,
-                            loc=Location(scope="war_extended_compute", line=1, column=2),
-                        ),
-                        loc=Location(scope="war_extended_compute", line=1, column=1),
-                    ),
-                    Assign(
-                        target=FieldRef(
-                            name="inout",
-                            offset=no_offset,
-                            loc=Location(scope="war_extended_compute", line=2, column=0),
-                        ),
-                        value=FieldRef(
-                            name="in",
-                            offset=no_offset,
-                            loc=Location(scope="war_extended_compute", line=2, column=2),
-                        ),
-                        loc=Location(scope="war_extended_compute", line=2, column=1),
-                    ),
-                ]
-            ),
-        )
-    ]
-
-
-@pytest.fixture()
-def computations_offset(
-    no_offset: Dict[str, int], offset_by_one: Dict[str, int]
-) -> Iterator[List[ComputationBlock]]:
-    """
-    Build stencil definition body for write after read with read offset.
-
-    equivalent to
-    .. code-block: python
-
-        with computation(PARALLEL), interval(...):
-            out = inout[-1, 0, 0]
-            inout = in
-    """
-    yield [
-        ComputationBlock(
-            interval=AxisInterval(
-                start=AxisBound(level=LevelMarker.START), end=AxisBound(level=LevelMarker.END)
-            ),
-            iteration_order=IterationOrder.PARALLEL,
-            body=BlockStmt(
-                stmts=[
-                    Assign(
-                        target=FieldRef(
-                            name="out",
-                            offset=no_offset,
-                            loc=Location(scope="war_offset", line=0, column=0),
-                        ),
-                        value=FieldRef(
-                            name="inout",
-                            offset=offset_by_one,
-                            loc=Location(scope="war_offset", line=0, column=2),
-                        ),
-                        loc=Location(scope="war_offset", line=0, column=1),
-                    ),
-                    Assign(
-                        target=FieldRef(
-                            name="inout",
-                            offset=no_offset,
-                            loc=Location(scope="war_offset", line=1, column=0),
-                        ),
-                        value=FieldRef(
-                            name="in",
-                            offset=offset_by_one,
-                            loc=Location(scope="war_offset", line=1, column=2),
-                        ),
-                        loc=Location(scope="war_offset", line=1, column=1),
-                    ),
-                ]
-            ),
-        )
-    ]
-
-
-@pytest.fixture()
-def computations_allowed_offset(
-    no_offset: Dict[str, int], offset_by_one: Dict[str, int]
-) -> Iterator[List[ComputationBlock]]:
-    """
-    Build stencil definition body writing to x after reading y with offset.
-
-    equivalent to
-    .. code-block: python
-
-        with computation(PARALLEL), interval(...):
-            out = in[-1, 0, 0]
-            inout = in
-    """
-    yield [
-        ComputationBlock(
-            interval=AxisInterval(
-                start=AxisBound(level=LevelMarker.START), end=AxisBound(level=LevelMarker.END)
-            ),
-            iteration_order=IterationOrder.PARALLEL,
-            body=BlockStmt(
-                stmts=[
-                    Assign(
-                        target=FieldRef(
-                            name="out",
-                            offset=no_offset,
-                            loc=Location(scope="allowed_offset", line=0, column=0),
-                        ),
-                        value=FieldRef(
-                            name="in",
-                            offset=offset_by_one,
-                            loc=Location(scope="allowed_offset", line=0, column=2),
-                        ),
-                        loc=Location(scope="allowed_offset", line=0, column=1),
-                    ),
-                    Assign(
-                        target=FieldRef(
-                            name="inout",
-                            offset=no_offset,
-                            loc=Location(scope="allowed_offset", line=1, column=0),
-                        ),
-                        value=FieldRef(
-                            name="in",
-                            offset=no_offset,
-                            loc=Location(scope="allowed_offset", line=1, column=2),
-                        ),
-                        loc=Location(scope="allowed_offset", line=1, column=1),
-                    ),
-                ]
-            ),
-        )
-    ]
-
-
-@pytest.fixture()
-def computations(
-    case: str,
-    computations_extended: List[ComputationBlock],
-    computations_offset: List[ComputationBlock],
-    computations_allowed_offset: List[ComputationBlock],
-) -> Iterator[Optional[List[ComputationBlock]]]:
-    comps = None
-    if case == "extended":
-        comps = computations_extended
-    elif case == "offset":
-        comps = computations_offset
-    elif case == "allowed_offset":
-        comps = computations_allowed_offset
-    yield comps
-
-
-@pytest.fixture()
-def expected_nblocks(case: str) -> Iterator[Optional[int]]:
-    nblocks = None
-    if case == "extended":
-        nblocks = 2
-    elif case == "offset":
-        nblocks = 2
-    elif case == "allowed_offset":
-        nblocks = 1
-    yield nblocks
-
-
-@pytest.fixture()
-def definition(
-    case: str,
-    domain: Domain,
-    api_signature: List[ArgumentInfo],
-    api_fields: List[FieldDecl],
-    computations: List[ComputationBlock],
-) -> StencilDefinition:
-    yield StencilDefinition(
-        name=case,
-        domain=domain,
-        api_signature=api_signature,
-        api_fields=api_fields,
-        parameters=[],
-        computations=computations,
-        docstring="",
+def test_merge_write_after_read_ij_offset(
+    merge_blocks_pass: PassType,
+    iteration_order: IterationOrder,
+    ij_offset: Tuple[int, int, int],
+    ijk_domain: Domain,
+) -> None:
+    transform_data = make_transform_data(
+        name="ij_offset",
+        domain=ijk_domain,
+        fields=["out", "inout", "in"],
+        body=[("out", "inout", ij_offset), ("inout", "in", (0, 0, 0))],
+        iteration_order=iteration_order,
     )
+    transform_data = merge_blocks_pass(transform_data)
+    assert len(transform_data.blocks) == 2
+    assert len(transform_data.blocks[0].ij_blocks) == 1
+    assert len(transform_data.blocks[1].ij_blocks) == 1
 
 
-def init_implementation_from_definition(definition: StencilDefinition) -> StencilImplementation:
-    return StencilImplementation(
-        name=definition.name,
-        api_signature=[],
-        domain=definition.domain,
-        fields={},
-        parameters={},
-        multi_stages=[],
-        fields_extents={},
-        unreferenced=[],
-        axis_splitters_var=None,
-        externals=definition.externals,
-        sources=definition.sources,
-        docstring=definition.docstring,
+def test_merge_read_after_read_ij_offset(
+    merge_blocks_pass: PassType,
+    iteration_order: IterationOrder,
+    ij_offset: Tuple[int, int, int],
+    ijk_domain: Domain,
+) -> None:
+    transform_data = make_transform_data(
+        name="ij_offset_readonly",
+        domain=ijk_domain,
+        fields=["out", "in", "inout"],
+        body=[("out", "in", ij_offset), ("inout", "in", (0, 0, 0))],
+        iteration_order=iteration_order,
     )
+    assert len(transform_data.blocks) == 1
 
 
-@pytest.fixture()
-def transform_data(
-    case: str,
-    definition: StencilDefinition,
-) -> TransformData:
-    yield TransformData(
-        definition_ir=definition,
-        implementation_ir=init_implementation_from_definition(definition),
-        options=BuildOptions(name=case, module=__name__),
+def test_merge_write_after_read_k(
+    merge_blocks_pass: PassType, non_parallel_iteration_order: IterationOrder, ijk_domain: Domain
+) -> None:
+    transform_data = make_transform_data(
+        name="k_offset_nonparallel",
+        domain=ijk_domain,
+        fields=["out", "inout", "in"],
+        body=[("out", "inout", (0, 0, -1)), ("inout", "in", (0, 0, 0))],
+        iteration_order=non_parallel_iteration_order,
     )
+    transform_data = merge_blocks_pass(transform_data)
+    assert len(transform_data.blocks) == 1
 
 
-@pytest.fixture()
-def transform_data_after_init_pass(transform_data: TransformData):
-    init_pass = InitInfoPass()
-    yield init_pass.apply(transform_data)
-
-
-@pytest.fixture()
-def transform_data_after_normalize_blocks_pass(transform_data_after_init_pass: TransformData):
-    normalize_blocks_pass = NormalizeBlocksPass()
-    yield normalize_blocks_pass.apply(transform_data_after_init_pass)
-
-
-@pytest.fixture()
-def transform_data_after_compute_extents_pass(
-    transform_data_after_normalize_blocks_pass: TransformData,
-):
-    compute_extents_pass = ComputeExtentsPass()
-    yield compute_extents_pass.apply(transform_data_after_normalize_blocks_pass)
-
-
-def test_merge_write_after_read(
-    transform_data_after_compute_extents_pass: TransformData, expected_nblocks
-):
-    merge_blocks_pass = MergeBlocksPass()
-    data = merge_blocks_pass.apply(transform_data_after_compute_extents_pass)
-
-    assert len(data.blocks) == expected_nblocks
+def test_merge_write_after_read_k_parallel(merge_blocks_pass, ijk_domain):
+    transform_data = make_transform_data(
+        name="k_offset_parallel",
+        domain=ijk_domain,
+        fields=["out", "inout", "in"],
+        body=[("out", "inout", (0, 0, -1)), ("inout", "in", (0, 0, 0))],
+        iteration_order=IterationOrder.PARALLEL,
+    )
+    transform_data = merge_blocks_pass(transform_data)
+    assert len(transform_data.blocks) == 2

--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -1,6 +1,8 @@
 from typing import Tuple
 
-from gt4py.ir.nodes import Domain, IterationOrder
+import pytest
+
+from gt4py.ir.nodes import Axis, Domain, IterationOrder
 
 from ..analysis_setup import PassType
 from ..definition_setup import make_transform_data
@@ -20,6 +22,8 @@ def test_merge_write_after_read_ij_extended(
         iteration_order=iteration_order,
     )
     transform_data = merge_blocks_pass(transform_data)
+    # not allowed to be merged: race condition independent of iteration order
+    # write after read with extended compute domain
     assert len(transform_data.blocks) == 2
     assert len(transform_data.blocks[0].ij_blocks) == 2
     assert len(transform_data.blocks[1].ij_blocks) == 1
@@ -39,6 +43,8 @@ def test_merge_write_after_read_ij_offset(
         iteration_order=iteration_order,
     )
     transform_data = merge_blocks_pass(transform_data)
+    # not allowed to be merged: race condition independent of iteration order
+    # write after read: no input with offset allowed
     assert len(transform_data.blocks) == 2
     assert len(transform_data.blocks[0].ij_blocks) == 1
     assert len(transform_data.blocks[1].ij_blocks) == 1
@@ -58,6 +64,7 @@ def test_merge_read_after_read_ij_offset(
         iteration_order=iteration_order,
     )
     transform_data = merge_blocks_pass(transform_data)
+    #  allowed to be merged: no write to "in"
     assert len(transform_data.blocks) == 1
 
 
@@ -72,10 +79,13 @@ def test_merge_write_after_read_k(
         iteration_order=non_parallel_iteration_order,
     )
     transform_data = merge_blocks_pass(transform_data)
+    # allowed to be merged: order is sequential -> no race condition on k-offsets
     assert len(transform_data.blocks) == 1
 
 
-def test_merge_write_after_read_k_parallel(merge_blocks_pass, ijk_domain):
+def test_merge_write_after_read_k_parallel(
+    merge_blocks_pass: PassType, ijk_domain: Domain
+) -> None:
     transform_data = make_transform_data(
         name="k_offset_parallel",
         domain=ijk_domain,
@@ -84,4 +94,64 @@ def test_merge_write_after_read_k_parallel(merge_blocks_pass, ijk_domain):
         iteration_order=IterationOrder.PARALLEL,
     )
     transform_data = merge_blocks_pass(transform_data)
+    # not allowed to be merged: order is PARALLEL -> race condition even on k-offsets
     assert len(transform_data.blocks) == 2
+
+
+def test_merge_write_after_read_k_extended_sequential(
+    merge_blocks_pass: PassType, non_parallel_iteration_order: IterationOrder, ijk_domain: Domain
+) -> None:
+    transform_data = make_transform_data(
+        name="k_extended",
+        domain=ijk_domain,
+        fields=["out", "in", "inout"],
+        body=[("tmp", "inout", (0, 0, 0)), ("out", "tmp", (0, 0, 1)), ("inout", "in", (0, 0, 0))],
+        iteration_order=non_parallel_iteration_order,
+    )
+    transform_data = merge_blocks_pass(transform_data)
+    # should be merged, since k-offset in sequential order does not extend compute domain
+    assert len(transform_data.blocks) == 1
+
+
+def test_merge_read_after_write_k_parallel_seq(
+    merge_blocks_pass: PassType, ijk_domain: Domain
+) -> None:
+    transform_data = make_transform_data(
+        name="read_after_write_forbidden",
+        domain=ijk_domain,
+        fields=["out", "in"],
+        body=[("tmp", "in", (0, 0, 0)), ("out", "tmp", (0, 0, -1))],
+        iteration_order=IterationOrder.PARALLEL,
+    )
+    transform_data = merge_blocks_pass(transform_data)
+    # not allowed to be merged, because PARALLEL and k-axis is sequential
+    assert len(transform_data.blocks) == 2
+
+
+@pytest.mark.skip(reason="ComputeExtentsPass fails if no sequential axis")
+def test_merge_read_after_write_k_parallel_noseq(merge_blocks_pass: PassType) -> None:
+    transform_data = make_transform_data(
+        name="read_after_write_forbidden",
+        domain=Domain(parallel_axes=[Axis(name=idx) for idx in ["I", "J", "K"]]),
+        fields=["out", "in"],
+        body=[("tmp", "in", (0, 0, 0)), ("out", "tmp", (0, 0, -1))],
+        iteration_order=IterationOrder.PARALLEL,
+    )
+    transform_data = merge_blocks_pass(transform_data)
+    # allowed to be merged, because k-axis is not sequential
+    assert len(transform_data.blocks) == 1
+
+
+def test_merge_read_after_write_k_sequential(
+    merge_blocks_pass: PassType, ijk_domain: Domain, non_parallel_iteration_order: IterationOrder
+) -> None:
+    transform_data = make_transform_data(
+        name="read_after_write_forbidden",
+        domain=ijk_domain,
+        fields=["out", "in"],
+        body=[("tmp", "in", (0, 0, 0)), ("out", "tmp", (0, 0, -1))],
+        iteration_order=non_parallel_iteration_order,
+    )
+    transform_data = merge_blocks_pass(transform_data)
+    # allowed to be merged, because order is not PARALLEL
+    assert len(transform_data.blocks) == 1

--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -283,7 +283,7 @@ def computations(
 def expected_nblocks(case: str) -> Iterator[Optional[int]]:
     nblocks = None
     if case == "extended":
-        nblocks = 3
+        nblocks = 2
     elif case == "offset":
         nblocks = 2
     elif case == "allowed_offset":

--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -254,7 +254,6 @@ def test_split_reorderable(merge_blocks_pass: PassType, ijk_domain: Domain) -> N
     # third is merged with fourth
     statement_pos = _StatementPositionVisitor().visit(transform_data)
     statement_pos = [statement_pos[i] for i in stmt_to_line]  # convert from lineno to stmt #
-    print(statement_pos)
     assert len(transform_data.blocks) == 2
     # first multi stage contains stmts 0 and 1 in order
     assert statement_pos[0].multi_stage == 0
@@ -308,7 +307,6 @@ def test_split_preordered(merge_blocks_pass: PassType, ijk_domain: Domain) -> No
     # fourth stands alone
     statement_pos = _StatementPositionVisitor().visit(transform_data)
     statement_pos = [statement_pos[i] for i in stmt_to_line]  # convert from lineno to stmt #
-    print(statement_pos)
     assert len(transform_data.blocks) == 2
     # first multi stage contains stmt 0, 3 and 1 in order
     assert statement_pos[0].multi_stage == 0

--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -57,6 +57,7 @@ def test_merge_read_after_read_ij_offset(
         body=[("out", "in", ij_offset), ("inout", "in", (0, 0, 0))],
         iteration_order=iteration_order,
     )
+    transform_data = merge_blocks_pass(transform_data)
     assert len(transform_data.blocks) == 1
 
 

--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -132,7 +132,8 @@ def test_merge_read_after_write_k_parallel_seq(
 def test_merge_read_after_write_k_parallel_noseq(merge_blocks_pass: PassType) -> None:
     transform_data = make_transform_data(
         name="read_after_write_forbidden",
-        domain=Domain(parallel_axes=[Axis(name=idx) for idx in ["I", "J", "K"]]),
+        # type ignore is due to attribclass
+        domain=Domain(parallel_axes=[Axis(name=idx) for idx in ["I", "J", "K"]]),  # type: ignore
         fields=["out", "in"],
         body=[("tmp", "in", (0, 0, 0)), ("out", "tmp", (0, 0, -1))],
         iteration_order=IterationOrder.PARALLEL,

--- a/tests/test_unittest/test_normalize_blocks_pass.py
+++ b/tests/test_unittest/test_normalize_blocks_pass.py
@@ -36,4 +36,5 @@ def test_write_after_read_ij_offset(
         body=[("out", "in", ij_offset), ("inout", "in", (0, 0, 0))],
         iteration_order=iteration_order,
     )
+    transform_data = normalize_blocks_pass(transform_data)
     assert len(transform_data.blocks) == 2

--- a/tests/test_unittest/test_normalize_blocks_pass.py
+++ b/tests/test_unittest/test_normalize_blocks_pass.py
@@ -1,0 +1,39 @@
+from typing import Tuple
+
+from gt4py.ir.nodes import Domain, IterationOrder
+
+from ..analysis_setup import PassType
+from ..definition_setup import make_transform_data
+
+
+def test_write_after_read_ij_extended(
+    normalize_blocks_pass: PassType,
+    iteration_order: IterationOrder,
+    ij_offset: Tuple[int, int, int],
+    ijk_domain: Domain,
+) -> None:
+    transform_data = make_transform_data(
+        name="ij_extended",
+        domain=ijk_domain,
+        fields=["out", "in", "inout"],
+        body=[("tmp", "inout", (0, 0, 0)), ("out", "tmp", ij_offset), ("inout", "in", (0, 0, 0))],
+        iteration_order=iteration_order,
+    )
+    transform_data = normalize_blocks_pass(transform_data)
+    assert len(transform_data.blocks) == 3
+
+
+def test_write_after_read_ij_offset(
+    normalize_blocks_pass: PassType,
+    iteration_order: IterationOrder,
+    ij_offset: Tuple[int, int, int],
+    ijk_domain: Domain,
+) -> None:
+    transform_data = make_transform_data(
+        name="ij_offset_readonly",
+        domain=ijk_domain,
+        fields=["out", "in", "inout"],
+        body=[("out", "in", ij_offset), ("inout", "in", (0, 0, 0))],
+        iteration_order=iteration_order,
+    )
+    assert len(transform_data.blocks) == 2


### PR DESCRIPTION
## Description

fix #143: allow merging of write-after-read statements only when allowed by the GridTools parallel model.

### Added:
* test setup: helpers for definition IR tree creation
* test setup: fixtures for common definition IR subtrees
* complete unit test suite for `MergeBlocksPass`
* punctual unit tests for `NormalizeBlocksPass`

### Changed:
* reduced complexity of `MergeBlocksPass.apply` and `NormalizeBlocksPass.apply`
  - complexity measured with `flake8-cognitive-complexity`
  - split merging algorithm from predicates and merge handlers
  - split complex predicates
  - replace deeply nested for loops with generators
  - added and adapted predicates to pass the test suite

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


