### PR TITLE
CUDA architecture determination fix

### DIFF
--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -55,7 +55,7 @@ def get_gt_pyext_build_opts(
         cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
         if not cuda_arch:
             raise RuntimeError("CUDA architecture could not be determined")
-        elif compute_capability and int(compute_capability) < int(cuda_arch):
+        elif compute_capability and int(compute_capability) < int(cuda_arch.replace("sm_", "")):
             raise RuntimeError(
                 f"CUDA architecture {cuda_arch} exceeds compute capability {compute_capability}"
             )

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -55,7 +55,9 @@ def get_gt_pyext_build_opts(
         cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
         if not cuda_arch:
             raise RuntimeError("CUDA architecture could not be determined")
-        elif compute_capability and int(compute_capability) < int(cuda_arch.replace("sm_", "")):
+        elif cuda_arch.startswith("sm_"):
+            cuda_arch = cuda_arch.replace("sm_", "")
+        if compute_capability and int(compute_capability) < int(cuda_arch):
             raise RuntimeError(
                 f"CUDA architecture {cuda_arch} exceeds compute capability {compute_capability}"
             )

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -55,7 +55,7 @@ def get_gt_pyext_build_opts(
         cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
         if not cuda_arch:
             raise RuntimeError("CUDA architecture could not be determined")
-        elif cuda_arch.startswith("sm_"):
+        if cuda_arch.startswith("sm_"):
             cuda_arch = cuda_arch.replace("sm_", "")
         if compute_capability and int(compute_capability) < int(cuda_arch):
             raise RuntimeError(


### PR DESCRIPTION
## Description

This PR modifies the `pyext_builder.get_gt_pyext_build_opts` method to remove leading "sm_" string from the `CUDA_ARCH` variable when determining the CUDA architecture version as there are scripts on Piz Daint that include the prefix in that variable.

