### PR TITLE
Fix for #48: Static splitters offset greater than 2

### DIFF
--- a/src/gt4py/ir/utils.py
+++ b/src/gt4py/ir/utils.py
@@ -69,7 +69,7 @@ def make_field_ref(name: str, offset=(0, 0, 0), *, axes_names=None):
     return FieldRef(name=name, offset=offset)
 
 
-def make_axis_interval(bounds: tuple, *, offset_limit: int = 2):
+def make_axis_interval(bounds: tuple):
     if isinstance(bounds[0], (VarRef, BinOpExpr)):
         # assuming: "var_name[index] + offset"
         if isinstance(bounds[0], VarRef):

--- a/src/gt4py/ir/utils.py
+++ b/src/gt4py/ir/utils.py
@@ -70,9 +70,6 @@ def make_field_ref(name: str, offset=(0, 0, 0), *, axes_names=None):
 
 
 def make_axis_interval(bounds: tuple, *, offset_limit: int = 2):
-    assert isinstance(bounds[0], (VarRef, UnaryOpExpr, BinOpExpr)) or (
-        isinstance(bounds[0], int) and abs(bounds[0]) <= offset_limit
-    )
     if isinstance(bounds[0], (VarRef, BinOpExpr)):
         # assuming: "var_name[index] + offset"
         if isinstance(bounds[0], VarRef):

--- a/tests/reference_cpp_regression/reference.cpp
+++ b/tests/reference_cpp_regression/reference.cpp
@@ -187,9 +187,28 @@ namespace horizontal_diffusion {
 
 } // namespace horizontal_diffusion
 
+namespace large_k_interval {
+
+    template <typename DType>
+    py::dict get(gt::uint_t d1, gt::uint_t d2, gt::uint_t d3) {
+        std::array<gt::uint_t, 3> zero_origin{0, 0, 0};
+
+        py::dict fields;
+        fields["in_field"] =
+            apply_function<DType>(d1, d2, d3, [](gt::int_t, gt::int_t, gt::int_t) { return 1.; }, zero_origin);
+        fields["out_field"] =
+            apply_function<DType>(d1, d2, d3, [](gt::int_t, gt::int_t, gt::int_t) { return 0; }, zero_origin);
+        fields["out_field_reference"] =
+            apply_function<DType>(d1, d2, d3, [d3](gt::int_t, gt::int_t, gt::int_t k) { return k >= 6 && k < d3-10 ? 2 : 1; }, zero_origin);
+        return fields;
+    }
+
+} // namespace tridiagonal_solver
+
 PYBIND11_MODULE(reference_cpp_regression, m) {
     m.def("tridiagonal_solver", &tridiagonal_solver::get<double>);
     m.def("vertical_advection_dycore", &vertical_advection_dycore::get<double>);
     m.def("vertical_advection_dycore_with_scalar_storage", &vertical_advection_dycore_with_scalar_storage::get<double>);
     m.def("horizontal_diffusion", &horizontal_diffusion::get<double>);
+    m.def("large_k_interval", &large_k_interval::get<double>);
 }

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -221,6 +221,17 @@ def horizontal_diffusion(in_field: Field3D, out_field: Field3D, coeff: Field3D):
 
 
 @register
+def large_k_interval(in_field: Field3D, out_field: Field3D):
+    with computation(PARALLEL):
+        with interval(0, 6):
+            out_field = in_field
+        with interval(6, -10):  # this stage will only run if field has more than 16 elements
+            out_field = in_field + 1
+        with interval(-10, None):
+            out_field = in_field
+
+
+@register
 def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
     with computation(PARALLEL), interval(...):
         mask = in_field >= 0

--- a/tests/test_integration/test_cpp_regression.py
+++ b/tests/test_integration/test_cpp_regression.py
@@ -228,7 +228,7 @@ def run_vertical_advection_dycore(backend, id_version, domain):
     )
 )
 def run_large_k_interval(backend, id_version, domain):
-
+    """Test stencils with large static and potentially zero-length intervals."""
     validate_field_names = ["out_field"]
     origins = {"in_field": (0, 0, 0), "out_field": (0, 0, 0)}
     shapes = {

--- a/tests/test_integration/test_cpp_regression.py
+++ b/tests/test_integration/test_cpp_regression.py
@@ -78,7 +78,10 @@ def run_horizontal_diffusion(backend, id_version, domain):
 
     validate_field_names = ["out_field"]
     origins = {"in_field": (2, 2, 0), "out_field": (0, 0, 0), "coeff": (0, 0, 0)}
-    shapes = {k: tuple(domain[i] + 2 * origins[k][i] for i in range(3)) for k in origins.keys()}
+    shapes = {
+        name: tuple(domain[i] + 2 * origin[i] for i in range(3))
+        for name, origin in origins.items()
+    }
     name = "horizontal_diffusion"
 
     arg_fields = get_reference(name, backend, domain, origins, shapes)
@@ -94,7 +97,6 @@ def run_horizontal_diffusion(backend, id_version, domain):
             arg_fields[k].host_to_device()
     testmodule.run(
         **arg_fields,
-        # **{k: v.view(np.ndarray) for k, v in arg_fields.items()},
         _domain_=domain,
         _origin_=origins,
         exec_info=None,
@@ -127,7 +129,10 @@ def run_tridiagonal_solver(backend, id_version, domain):
         "rhs": (0, 0, 0),
         "out": (0, 0, 0),
     }
-    shapes = {k: tuple(domain[i] + 2 * origins[k][i] for i in range(3)) for k in origins.keys()}
+    shapes = {
+        name: tuple(domain[i] + 2 * origin[i] for i in range(3))
+        for name, origin in origins.items()
+    }
     name = "tridiagonal_solver"
 
     arg_fields = get_reference(name, backend, domain, origins, shapes)
@@ -143,7 +148,6 @@ def run_tridiagonal_solver(backend, id_version, domain):
             arg_fields[k].host_to_device()
     testmodule.run(
         **arg_fields,
-        # **{k: v.view(np.ndarray) for k, v in arg_fields.items()},
         _domain_=domain,
         _origin_=origins,
         exec_info=None,
@@ -198,7 +202,6 @@ def run_vertical_advection_dycore(backend, id_version, domain):
             arg_fields[k].host_to_device()
     testmodule.run(
         **arg_fields,
-        # **{k: v.view(np.ndarray) for k, v in arg_fields.items()},
         _domain_=domain,
         _origin_=origins,
         # _origin_={
@@ -228,7 +231,10 @@ def run_large_k_interval(backend, id_version, domain):
 
     validate_field_names = ["out_field"]
     origins = {"in_field": (0, 0, 0), "out_field": (0, 0, 0)}
-    shapes = {k: tuple(domain[i] + 2 * origins[k][i] for i in range(3)) for k in origins.keys()}
+    shapes = {
+        name: tuple(domain[i] + 2 * origin[i] for i in range(3))
+        for name, origin in origins.items()
+    }
     name = "large_k_interval"
 
     arg_fields = get_reference(name, backend, domain, origins, shapes)
@@ -244,7 +250,6 @@ def run_large_k_interval(backend, id_version, domain):
             arg_fields[k].host_to_device()
     testmodule.run(
         **arg_fields,
-        # **{k: v.view(np.ndarray) for k, v in arg_fields.items()},
         _domain_=domain,
         _origin_=origins,
         exec_info=None,


### PR DESCRIPTION
## Description

Currently splitters with offset larger than 2 are prohibited (see #48). This PR removes this restriction and adds a test to verify correctness.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


