### PR TITLE
fix linter errors introduced by #169 in combination with new checkers

### DIFF
--- a/tests/test_unittest/test_merge_blocks_pass.py
+++ b/tests/test_unittest/test_merge_blocks_pass.py
@@ -178,8 +178,10 @@ class _StatementPositionVisitor:
 
     def visit(self, transform_data: TransformData) -> List[SPTYPE]:
         """
-        Returns:
+        Collect statement coordinates.
 
+        Returns
+        -------
             counting is from zero
             * multi_stage: in which multi stage is the statement?
             * stage: in which stage is the statement?
@@ -217,8 +219,8 @@ def test_split_reorderable(merge_blocks_pass: PassType, ijk_domain: Domain) -> N
     """
     Statements separated by a write after read occurrence are split in separate multi stages.
 
-    Example:
-
+    Examples
+    --------
     .. code-block: python
 
         with computation(FORWARD):
@@ -271,8 +273,8 @@ def test_split_preordered(merge_blocks_pass: PassType, ijk_domain: Domain) -> No
     """
     Statements preordered to be on the same side of the write after read occurence can be merged.
 
-    Example:
-
+    Examples
+    --------
     .. code-block: python
 
         with computation(FORWARD):


### PR DESCRIPTION
## Description

Blocks all PRs until merged. #169 and #180 which passed CI separately lead to linter errors in combination.

This fixes those linter errors.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


