### PR TITLE
fix numpy backend for local variables inside conditionals

### DIFF
--- a/src/gt4py/backend/numpy_backend.py
+++ b/src/gt4py/backend/numpy_backend.py
@@ -273,13 +273,11 @@ class NumPySourceGenerator(PythonSourceGenerator):
             )
 
             sources.append(
-                "{target} = vectorized_ternary_op(condition={condition}, then_expr={then_expr}, else_expr={else_expr}, dtype={np}.{dtype})".format(
+                "{target} = np.where({condition}, {then_expr}, {else_expr})".format(
                     condition=condition,
                     target=target,
+                    else_expr=target if not isinstance(stmt.target, gt_ir.VarRef) else "np.nan",
                     then_expr=value,
-                    else_expr=target,
-                    dtype=data_type.dtype.name,
-                    np=self.numpy_prefix,
                 )
             )
         else:


### PR DESCRIPTION
## Description

If temporary variables were used inside a conditional the old implementation raised an `UnboundLocalError: local variable 'VAR' referenced before assignment` error. This fixes that issue

Co-authored-by: @eddie-c-davis  <eddied@vulcan.com>
