### PR TITLE
Remove and fix AugAssign, update dawn backend

### DIFF
--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -224,12 +224,6 @@ class SIRConverter(gt_ir.IRNodeVisitor):
         stmt = sir_utils.make_assignment_stmt(left, right, "=")
         return stmt
 
-    def visit_AugAssign(self, node: gt_ir.AugAssign) -> SIR.AssignmentExpr:
-        # ignore types due to attribclass problem
-        bin_op = gt_ir.BinOpExpr(lhs=node.target, op=node.op, rhs=node.value)  # type: ignore
-        assign = gt_ir.Assign(target=node.target, value=bin_op)  # type: ignore
-        return self.visit(assign)
-
     def visit_If(self, node: gt_ir.If, **kwargs: Any) -> SIR.IfStmt:
         cond = sir_utils.make_expr_stmt(self.visit(node.condition))
         then_part = self.visit(node.main_body)

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -855,7 +855,7 @@ class IRMaker(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call):
         native_fcn = gt_ir.NativeFunction.PYTHON_SYMBOL_TO_IR_OP[node.func.id]
 
-        args = [self.visit(arg) for arg in node.args]
+        args = [gt_ir.utils.make_expr(self.visit(arg)) for arg in node.args]
         if len(args) != native_fcn.arity:
             raise GTScriptSyntaxError(
                 "Invalid native function call", loc=gt_ir.Location.from_ast_node(node)

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -942,7 +942,7 @@ class IRMaker(ast.NodeVisitor):
     def visit_AugAssign(self, node: ast.AugAssign):
         """Implement left <op>= right in terms of left = left <op> right."""
         binary_operation = ast.BinOp(left=node.target, op=node.op, right=node.value)
-        assignment = ast.Assign(targets=[node.target], value=node.target)
+        assignment = ast.Assign(targets=[node.target], value=binary_operation)
         ast.copy_location(binary_operation, node)
         ast.copy_location(assignment, node)
         return self.visit_Assign(assignment)

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -629,14 +629,6 @@ class Assign(Statement):
 
 
 @attribclass
-class AugAssign(Statement):
-    target = attribute(of=Ref)
-    value = attribute(of=Expr)
-    op = attribute(of=BinaryOperator)
-    loc = attribute(of=Location, optional=True)
-
-
-@attribclass
 class If(Statement):
     condition = attribute(of=Expr)
     main_body = attribute(of=BlockStmt)

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -73,14 +73,16 @@ class TestAugAssign(gt_testing.StencilTestSuite):
 
     def definition(field_a, field_b):
         with computation(PARALLEL), interval(...):
+            field_a -= field_b
+            field_b -= field_a
             field_a += 1.0
             field_a *= 2.0
             field_b -= 1.0
             field_b /= 2.0
 
     def validation(field_a, field_b, domain=None, origin=None):
-        field_a = (field_a + 1.0) * 2.0
-        field_b = (field_b - 1.0) / 2.0
+        field_a = (field_a + 1.0) * 2.0 - field_b
+        field_b = (field_b - 1.0) / 2.0 - field_a
 
 
 # ---- Scale stencil ----

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -73,16 +73,14 @@ class TestAugAssign(gt_testing.StencilTestSuite):
 
     def definition(field_a, field_b):
         with computation(PARALLEL), interval(...):
-            field_a -= field_b
-            field_b -= field_a
             field_a += 1.0
             field_a *= 2.0
             field_b -= 1.0
             field_b /= 2.0
 
     def validation(field_a, field_b, domain=None, origin=None):
-        field_a = (field_a + 1.0) * 2.0 - field_b
-        field_b = (field_b - 1.0) / 2.0 - field_a
+        field_a = (field_a + 1.0) * 2.0
+        field_b = (field_b - 1.0) / 2.0
 
 
 # ---- Scale stencil ----

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -79,8 +79,8 @@ class TestAugAssign(gt_testing.StencilTestSuite):
             field_b /= 2.0
 
     def validation(field_a, field_b, domain=None, origin=None):
-        field_a = (field_a + 1.0) * 2.0
-        field_b = (field_b - 1.0) / 2.0
+        field_a[...] = (field_a[...] + 1.0) * 2.0
+        field_b[...] = (field_b[...] - 1.0) / 2.0
 
 
 # ---- Scale stencil ----


### PR DESCRIPTION
`AugAssign` was simply assigning the field to itself without performing the binary operation. This adds a test that fails without this change, fixes it, and removes the outdated broken code.

Resolves DSL-214.