### PR TITLE
Delay gtscript function symbol resolution until generation

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1131,15 +1131,14 @@ class GTScriptParser(ast.NodeVisitor):
         canonical_ast = gt_meta.ast_dump(definition)
 
         # Recursively annotate gtscript functions called
-        # Nonlocals
+        # nonlocals
         for name, symbol in nonlocal_symbols.items():
             if hasattr(symbol, "_gtscript_"):
-                # was marked as a function
                 cls.annotate_definition(symbol, externals=nonlocal_symbols)
-        # From externals
+
+        # externals
         for name in imported_symbols.keys():
             if name in externals and hasattr(externals[name], "_gtscript_"):
-                # was marked as a function
                 cls.annotate_definition(externals[name], externals=nonlocal_symbols)
 
         definition._gtscript_ = dict(

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1220,6 +1220,12 @@ class GTScriptParser(ast.NodeVisitor):
         resolved_imports = {**imported}
         resolved_values_list = list(nonlocals.items())
 
+        # Annotate gtscript functions that are called
+        for name, value in resolved_values_list:
+            if hasattr(value, "_gtscript_") and value._gtscript_ is None:
+                # was marked as a function
+                value = GTScriptParser.annotate_definition(value)
+
         # Collect all imported and inlined values recursively through all the external symbols
         while resolved_imports or resolved_values_list:
             new_imports = {}

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -110,7 +110,9 @@ def function(func):
 
     from gt4py.frontend import gtscript_frontend as gt_frontend
 
-    gt_frontend.GTScriptParser.annotate_definition(func)
+    # Mark as a gtscript function by adding the _gtscript_ attribute
+    func._gtscript_ = None
+
     return func
 
 


### PR DESCRIPTION
Changes `gtscript.function` to only add the `_gtscript_` attribute (and set to `None`), delaying the annotation until later.

Resolves #202.