### PR TITLE
Enforce vertical interval specification in execution order (#201)

### DIFF
--- a/src/gt4py/backend/debug_backend.py
+++ b/src/gt4py/backend/debug_backend.py
@@ -96,9 +96,7 @@ class DebugSourceGenerator(PythonSourceGenerator):
 
         # Create K for-loop: computation body is split in different vertical regions
         source_lines = []
-        regions = sorted(regions)
-        if iteration_order == gt_ir.IterationOrder.BACKWARD:
-            regions = reversed(regions)
+        assert sorted(regions, reverse=iteration_order == gt_ir.IterationOrder.BACKWARD) == regions
 
         for bounds, body_sources in regions:
             region_lines = self._make_regional_computation(iteration_order, bounds)

--- a/src/gt4py/backend/numpy_backend.py
+++ b/src/gt4py/backend/numpy_backend.py
@@ -121,9 +121,7 @@ class NumPySourceGenerator(PythonSourceGenerator):
         source_lines = []
 
         # Computations body is split in different vertical regions
-        regions = sorted(regions)
-        if iteration_order == gt_ir.IterationOrder.BACKWARD:
-            regions = reversed(regions)
+        assert sorted(regions, reverse=iteration_order == gt_ir.IterationOrder.BACKWARD) == regions
 
         for bounds, body in regions:
             region_lines = self._make_regional_computation(iteration_order, bounds, body)

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -587,14 +587,15 @@ class IRMaker(ast.NodeVisitor):
         return compute_blocks == compute_blocks_sorted
 
     def _visit_iteration_order_node(self, node: ast.withitem, loc: gt_ir.Location):
+        syntax_error = GTScriptSyntaxError(
+            f"Invalid 'computation' specification at line {loc.line} (column {loc.column})",
+            loc=loc,
+        )
         comp_node = node.context_expr
         if len(comp_node.args) + len(comp_node.keywords) != 1 or any(
             keyword.arg not in ["order"] for keyword in comp_node.keywords
         ):
-            raise GTScriptSyntaxError(
-                f"Invalid 'computation' specification at line {loc.line} (column {loc.column})",
-                loc=loc,
-            )
+            raise syntax_error
 
         if comp_node.args:
             iteration_order_node = comp_node.args[0]

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -21,6 +21,7 @@ import inspect
 import itertools
 import numbers
 import types
+from typing import List
 
 import numpy as np
 
@@ -555,7 +556,7 @@ class IRMaker(ast.NodeVisitor):
 
         return result
 
-    def _are_blocks_sorted(self, compute_blocks):
+    def _are_blocks_sorted(self, compute_blocks: List[gt_ir.ComputationBlock]):
         def sort_blocks_key(comp_block):
             start = comp_block.interval.start
             assert isinstance(start.level, gt_ir.LevelMarker)
@@ -647,7 +648,7 @@ class IRMaker(ast.NodeVisitor):
 
         return interval
 
-    def _visit_computation_node(self, node: ast.With) -> list:
+    def _visit_computation_node(self, node: ast.With) -> List[gt_ir.ComputationBlock]:
         loc = gt_ir.Location.from_ast_node(node)
         syntax_error = GTScriptSyntaxError(
             f"Invalid 'computation' specification at line {loc.line} (column {loc.column})",
@@ -1003,7 +1004,7 @@ class IRMaker(ast.NodeVisitor):
 
                 compute_blocks.append(self._visit_computation_node(with_node))
 
-            # Ensure block specification order
+            # Validate block specification order
             #  the nested computation blocks must be specified in their order of execution. The order of execution is
             #  such that the lowest (highest) interval is processed first if the iteration order is forward (backward).
             if not self._are_blocks_sorted(compute_blocks):

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1009,7 +1009,7 @@ class IRMaker(ast.NodeVisitor):
             #  such that the lowest (highest) interval is processed first if the iteration order is forward (backward).
             if not self._are_blocks_sorted(compute_blocks):
                 raise GTScriptSyntaxError(
-                    "Invalid 'with' statement at line {loc.line} (column {loc.column}). Intervals must be specified in order of execution."
+                    f"Invalid 'with' statement at line {loc.line} (column {loc.column}). Intervals must be specified in order of execution."
                 )
 
             return compute_blocks

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -563,6 +563,9 @@ class IRMaker(ast.NodeVisitor):
             key += start.offset
             return key
 
+        if len(compute_blocks) < 1:
+            return True
+
         # validate invariant
         assert all(
             comp_block.iteration_order == compute_blocks[0].iteration_order

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -107,10 +107,10 @@ def tridiagonal_solver(inf: Field3D, diag: Field3D, sup: Field3D, rhs: Field3D, 
             sup = sup / (diag - sup[0, 0, -1] * inf)
             rhs = (rhs - inf * rhs[0, 0, -1]) / (diag - sup[0, 0, -1] * inf)
     with computation(BACKWARD):
-        with interval(0, -1):
-            out = rhs - sup * out[0, 0, 1]
         with interval(-1, None):
             out = rhs
+        with interval(0, -1):
+            out = rhs - sup * out[0, 0, 1]
 
 
 @register(externals={"BET_M": 0.5, "BET_P": 0.5})

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -502,7 +502,7 @@ class TestNestedWithSyntax:
                 with interval(...):
                     in_field = out_field
 
-    def test_nested_with_reordering(self):
+    def test_nested_with_ordering(self):
         def definition_fw(
             in_field: gtscript.Field[np.float_], out_field: gtscript.Field[np.float_]
         ):
@@ -528,15 +528,16 @@ class TestNestedWithSyntax:
         definitions = {"fw": definition_fw, "bw": definition_bw}
 
         for name, definition in definitions.items():
-            with pytest.raises(gt_frontend.GTScriptSyntaxError) as excinfo:
+            with pytest.raises(
+                gt_frontend.GTScriptSyntaxError,
+                match=r"(.*?)Intervals must be specified in order of execution(.*)",
+            ):
                 # generate DIR
                 _, definition_ir = compile_definition(
                     definition,
                     f"test_nested_with_reordering_{name}",
                     f"TestImports_test_module_{id_version}",
                 )
-
-                assert "Intervals must be specified in order of execution." in str(excinfo.value)
 
 
 class TestNativeFunctions:

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -520,30 +520,23 @@ class TestNestedWithSyntax:
             from gt4py.__gtscript__ import FORWARD, computation, interval
 
             with computation(BACKWARD):
-                with interval(1, 2):
-                    in_field = out_field + 1
                 with interval(0, 1):
                     in_field = out_field + 2
+                with interval(1, 2):
+                    in_field = out_field + 1
 
-        definitions = [
-            # name, expected axis bounds, definition
-            ("fw", [(0, 1), (1, 2)], definition_fw),
-            ("bw", [(1, 2), (0, 1)], definition_bw),
-        ]
+        definitions = {"fw": definition_fw, "bw": definition_bw}
 
-        for name, axis_bounds, definition in definitions:
-            # generate DIR
-            _, definition_ir = compile_definition(
-                definition,
-                f"test_nested_with_reordering_{name}",
-                f"TestImports_test_module_{id_version}",
-            )
+        for name, definition in definitions.items():
+            with pytest.raises(gt_frontend.GTScriptSyntaxError) as excinfo:
+                # generate DIR
+                _, definition_ir = compile_definition(
+                    definition,
+                    f"test_nested_with_reordering_{name}",
+                    f"TestImports_test_module_{id_version}",
+                )
 
-            # test for correct ordering
-            for i, axis_bound in enumerate(axis_bounds):
-                interval = definition_ir.computations[i].interval
-                assert interval.start.offset == axis_bound[0]
-                assert interval.end.offset == axis_bound[1]
+                assert "Intervals must be specified in order of execution." in str(excinfo.value)
 
 
 class TestNativeFunctions:


### PR DESCRIPTION
## Description

This PR removes all reordering of interval blocks in the frontend and instead forces the user to specify them in execution order.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


