### PR TITLE
Add Cast node and use for mixed dtypes in NativeFuncCalls

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -67,7 +67,7 @@ class IntervalSpecificationError(IRSpecificationError):
             if loc is None:
                 message = f"Invalid interval specification '{interval}' "
             else:
-                message = f"Invalid interval specification '{interval}' in '{loc.scope}' (line: {loc.line}, col: {loc.col})"
+                message = f"Invalid interval specification '{interval}' in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(message, loc=loc)
 
 
@@ -77,7 +77,7 @@ class DataTypeSpecificationError(IRSpecificationError):
             if loc is None:
                 message = f"Invalid data type specification '{data_type}'"
             else:
-                message = f"Invalid data type specification '{data_type}' in '{loc.scope}' (line: {loc.line}, col: {loc.col})"
+                message = f"Invalid data type specification '{data_type}' in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(message, loc=loc)
 
 

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -941,7 +941,7 @@ class DataTypePass(TransformPass):
                     data_type = float_type
                 else:
                     raise NotImplementedError(
-                        "Types of different size are used as arguments to a NativeFuncCall."
+                        "Incompatible data types encountered in NativeFuncCall."
                     )
 
             if node.func in (

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -918,7 +918,7 @@ class DataTypePass(TransformPass):
             elif len(dtypes_set) == 1:
                 data_type = dtypes_set.pop()
             else:
-                # get the "max" float type in the set
+                # get the "largest" data type in the set
                 data_type = gt_ir.DataType.merge(*dtypes_set)
                 # cast all other args to this type
                 for index, arg in enumerate(node.args):

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -920,7 +920,9 @@ class DataTypePass(TransformPass):
             )
 
             # If doing a NativeFuncCall between floats and ints, add a gt_ir.Cast node
-            if len(dtypes_set) == 1:
+            if len(dtypes_set) == 0:
+                data_type = gt_ir.DataType.DEFAULT
+            elif len(dtypes_set) == 1:
                 data_type = dtypes_set.pop() if len(dtypes_set) else gt_ir.DataType.DEFAULT
             else:
                 arg_is_float = [dtype in FLOAT_TYPES for dtype in dtypes_list]

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -915,9 +915,7 @@ class DataTypePass(TransformPass):
             self.generic_visit(node.args, **kwargs)
 
             dtypes_list = [arg.data_type for arg in node.args]
-            dtypes_set = set(
-                arg.data_type for arg in node.args if arg.data_type != gt_ir.DataType.DEFAULT
-            )
+            dtypes_set = set(dtypes_list) - {gt_ir.DataType.DEFAULT}
 
             if len(dtypes_set) == 0:
                 data_type = gt_ir.DataType.DEFAULT

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -831,9 +831,6 @@ class ComputeExtentsPass(TransformPass):
 
 
 class DataTypePass(TransformPass):
-    INT_TYPES = (gt_ir.DataType.INT8, gt_ir.DataType.INT32, gt_ir.DataType.INT64)
-    FLOAT_TYPES = (gt_ir.DataType.FLOAT32, gt_ir.DataType.FLOAT64)
-
     class CollectDataTypes(gt_ir.IRNodeVisitor):
         def __call__(self, node):
             assert isinstance(node, gt_ir.StencilImplementation)

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -922,7 +922,7 @@ class DataTypePass(TransformPass):
             if len(dtypes_set) == 0:
                 data_type = gt_ir.DataType.DEFAULT
             elif len(dtypes_set) == 1:
-                data_type = dtypes_set.pop() if len(dtypes_set) else gt_ir.DataType.DEFAULT
+                data_type = dtypes_set.pop()
             else:
                 arg_is_float = [dtype in FLOAT_TYPES for dtype in dtypes_list]
                 arg_is_int = [dtype in INT_TYPES for dtype in dtypes_list]

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -919,7 +919,6 @@ class DataTypePass(TransformPass):
                 arg.data_type for arg in node.args if arg.data_type != gt_ir.DataType.DEFAULT
             )
 
-            # If doing a NativeFuncCall between floats and ints, add a gt_ir.Cast node
             if len(dtypes_set) == 0:
                 data_type = gt_ir.DataType.DEFAULT
             elif len(dtypes_set) == 1:

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -311,6 +311,11 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
 
         return source
 
+    def visit_Cast(self, node: gt_ir.Cast) -> str:
+        expr = self.visit(node.expr)
+        dtype = self.DATA_TYPE_TO_CPP[node.dtype]
+        return f"static_cast<{dtype}>({expr})"
+
     def visit_NativeFuncCall(self, node: gt_ir.NativeFuncCall) -> str:
         call = self.NATIVE_FUNC_TO_CPP[node.func]
         if self.gt_backend_t != "cuda":

--- a/src/gt4py/backend/python_generator.py
+++ b/src/gt4py/backend/python_generator.py
@@ -133,6 +133,9 @@ class PythonSourceGenerator(gt_ir.IRNodeVisitor):
     def generic_visit(self, node: gt_ir.Node, **kwargs):
         raise RuntimeError("Invalid IR node: {}".format(node))
 
+    def visit_Cast(self, node: gt_ir.Cast):
+        return self.visit(node.expr)
+
     def visit_Decl(self, node: gt_ir.Decl):
         raise NotImplementedError()
 

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -395,6 +395,13 @@ class FieldRef(Ref):
     loc = attribute(of=Location, optional=True)
 
 
+@attribclass
+class Cast(Expr):
+    dtype = attribute(of=DataType)
+    expr = attribute(of=Expr)
+    loc = attribute(of=Location, optional=True)
+
+
 @enum.unique
 class NativeFunction(enum.Enum):
     ABS = 1

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -94,7 +94,9 @@ storing a reference to the piece of source code which originated the node.
 
     NativeFuncCall(func: NativeFunction, args: List[Expr], data_type: DataType)
 
-    Expr        = Literal | Ref | NativeFuncCall | CompositeExpr | InvalidBranch
+    Cast(dtype: DataType, expr: Expr)
+
+    Expr        = Literal | Ref | NativeFuncCall | Cast | CompositeExpr | InvalidBranch
 
     CompositeExpr   = UnaryOpExpr(op: UnaryOperator, arg: Expr)
                     | BinOpExpr(op: BinaryOperator, lhs: Expr, rhs: Expr)

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -64,7 +64,7 @@ def afunc(b):
 @register
 def native_functions(field_a: Field3D, field_b: Field3D):
     with computation(PARALLEL), interval(...):
-        field_a = min(afunc(field_b), field_b)
+        field_a = max(min(afunc(field_b), field_b), 1)
 
 
 @register


### PR DESCRIPTION
Add casts to be able to use NativeFuncCalls with mixed float/int types.

Co-authored-by: Tobias Wicky <tobiasw@vulcan.com>

## Description

Describe the content of the PR and links to related issues, bugs of features.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


