### PR TITLE
Add GPUStorage.data property

### DIFF
--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -156,10 +156,6 @@ class Storage(np.ndarray):
         return self._backend
 
     @property
-    def data(self):
-        return super().data
-
-    @property
     def mask(self):
         """
         Iterable of booleans.
@@ -296,7 +292,7 @@ class GPUStorage(Storage):
 
     @property
     def data(self):
-        return cp.asarray(super().data)
+        return cp.asarray(self)
 
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -297,7 +297,7 @@ class GPUStorage(Storage):
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):
             gpu_view = storage_utils.gpu_view(self)
-            gpu_view[key] = value if isinstance(value, cp.ndarray) else cp.asarray(value.data)
+            gpu_view[key] = value.data
             cp.cuda.Device(0).synchronize()
             return value
         else:

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -305,7 +305,7 @@ class GPUStorage(Storage):
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):
             gpu_view = storage_utils.gpu_view(self)
-            gpu_view[key] = cp.asarray(value.data)
+            gpu_view[key] = value if isinstance(value, cp.ndarray) else cp.asarray(value.data)
             cp.cuda.Device(0).synchronize()
             return value
         else:

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -305,7 +305,7 @@ class GPUStorage(Storage):
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):
             gpu_view = storage_utils.gpu_view(self)
-            gpu_view[key] = value.data
+            gpu_view[key] = cp.asarray(value.data)
             cp.cuda.Device(0).synchronize()
             return value
         else:

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -165,6 +165,10 @@ class Storage(np.ndarray):
         return self._backend
 
     @property
+    def data(self):
+        return super().data
+
+    @property
     def mask(self):
         return self._mask
 
@@ -294,10 +298,14 @@ class GPUStorage(Storage):
     def gpu_view(self):
         return storage_utils.gpu_view(self)
 
+    @property
+    def data(self):
+        return cp.asarray(super().data)
+
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):
             gpu_view = storage_utils.gpu_view(self)
-            gpu_view[key] = cp.asarray(value.data)
+            gpu_view[key] = value.data
             cp.cuda.Device(0).synchronize()
             return value
         else:

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -906,3 +906,28 @@ def test_sum_gpu():
     )
 
     q1[i1 : i2 + 1, jslice, 0] = cp.sum(q2[i1 : i2 + 1, jslice, :], axis=2)
+
+
+@pytest.mark.requires_gpu
+def test_add_gpu_managed():
+    shape = (5, 5, 5)
+    q1 = gt_store.from_array(
+        cp.zeros(shape),
+        backend="gtcuda",
+        dtype=np.float64,
+        default_origin=(0, 0, 0),
+        shape=shape,
+        managed_memory=True,
+    )
+
+    q2 = gt_store.from_array(
+        cp.ones(shape),
+        backend="gtcuda",
+        dtype=np.float64,
+        default_origin=(0, 0, 0),
+        shape=shape,
+        managed_memory=True,
+    )
+
+    q3 = q1 + q2
+    q1[:] = q3


### PR DESCRIPTION
## Description

The purpose of this PR is to ensure that the `data` property of each `Storage` subclass is consistent and returns the appropriate NumPy or CuPy array object, i.e., `numpy.ndarray` for `CPUStorage`, and `cupy.ndarray` for `GPUStorage` and `ExplicitlySyncedGPUStorage`. Previously, `GPUStorage.data` returned a `memoryview` object.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [ ] All relevant documentation has been updated or added
