### PR TITLE
Upped sphinx version requirement to fix broken documentation with python 3.9

### DIFF
--- a/.github/workflows/gt4py-sphinx.yml
+++ b/.github/workflows/gt4py-sphinx.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,6 @@ isort~=5.1
 pre-commit~=1.18
 setuptools>=40.8.0
 seed-isort-config~=2.1
-sphinx~=2.0
+sphinx~=3.1
 sphinx_rtd_theme~=0.4
 tox~=3.14

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -100,22 +100,12 @@ class Storage(np.ndarray):
     """
     Storage class based on a numpy (CPU) or cupy (GPU) array, taking care of proper memory alignment, with additional
     information that is required by the backends.
-
-
-    Attributes
-    ----------
-    In addition to the attributes inherited, Storages have the following attributes:
-
-    backend: the backend identifier string of the storage
-
-    mask:iterable of booleans. Dimensions where the corresponding entry is `False` are ignored.
     """
 
     __array_subok__ = True
 
     def __new__(cls, shape, dtype, backend, default_origin, mask=None):
-        """ "
-
+        """
         Parameters
         ----------
 
@@ -162,10 +152,16 @@ class Storage(np.ndarray):
 
     @property
     def backend(self):
+        """The backend identifier string of the storage."""
         return self._backend
 
     @property
     def mask(self):
+        """
+        Iterable of booleans.
+
+        Dimensions where the corresponding entry is `False` are ignored.
+        """
         return self._mask
 
     @property


### PR DESCRIPTION
## Description

Creating the documentation with python 3.9 fails for Sphinx versions below 3.1. This became apparent when the CI started using python 3.9 and the documentation action failing thereafter. This PR simply increases the sphinx version requirement to 3.1. This version also works with at least python 3.8.

Example error before 3.1:

```
WARNING: error while formatting arguments for gt4py.stencil_builder.StencilBuilder.with_externals: type object 'dict' has no attribute '_special'
```

__Edit__:

The new sphinx version additionally warns if a property or method is documented twice. This leads to the unexpected behavior that

```python
class Example:
  """
  Something

  Attributes:
  -------------
  some_property: Something
  """

  # ...

  @property
  def some_property():
    # ...
```

throws a warning even though `some_property` itself does not contain a docstring:

```
.../gt4py/src/gt4py/storage/storage.py:docstring of gt4py.storage.storage.Storage.backend:1: WARNING: duplicate object description of gt4py.storage.storage.Storage.backend, other instance in _source/gt4py.storage, use :noindex: for one of them
```

Apparently the attributes section is only ment for documenting attributes, which are not defined in the class body, but for example by assignment inside of methods. Hence documentation for them should be made using regular docstrings there, i.e.

```python
class Example:
  """
  Something
  """

  # ...

  @property
  def some_property():
    """Something"""
    # ...
```

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


