### PR TITLE
More aggressive temporary demoting

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -1122,7 +1122,7 @@ class FieldRefCollector(gt_ir.IRNodeVisitor):
         return collector(node)
 
     def __init__(self, domain: gt_ir.Domain):
-        self._domain = domain
+        self.domain = domain
         self.read_field_info: Set[Tuple[str, bool]] = None
         self.written_field_info: Set[Tuple[str, bool]] = None
         self._field_info: Set[Tuple[str, bool]] = None
@@ -1143,9 +1143,8 @@ class FieldRefCollector(gt_ir.IRNodeVisitor):
         self.read_field_info |= self._field_info
 
     def visit_FieldRef(self, node: gt_ir.FieldRef) -> None:
-        parallel_offset = any(node.offset[ax.name] != 0 for ax in self._domain.parallel_axes)
-        sequential_offset = node.offset[self._domain.sequential_axis.name] != 0
-        self._field_info.add((node.name, parallel_offset, sequential_offset))
+        offset = any(node.offset[ax] != 0 for ax in self.domain.axes_names)
+        self._field_info.add((node.name, offset))
 
 
 class DemoteLocalTemporariesToVariablesPass(TransformPass):

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -1175,6 +1175,7 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
             for name, access_with_offset in read_field_info:
                 if access_with_offset:
                     self.demotables.discard(name)
+                seen_symbols_stage.add(name)
 
             for name, access_with_offset in written_field_info:
                 if name in self.seen_symbols:

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -1141,7 +1141,7 @@ class FieldRefCollector(gt_ir.IRNodeVisitor):
         self.field_info = self.written_field_info
         self.visit(node.target)
 
-        # Reset field_info to read_field_info
+        # Also used in further visit_FieldRef calls
         self.field_info = self.read_field_info
         self.visit(node.value)
 

--- a/src/gt4py/analysis/transformer.py
+++ b/src/gt4py/analysis/transformer.py
@@ -114,8 +114,9 @@ class IRTransformer:
         data_type_pass = DataTypePass()
         data_type_pass.apply(self.transform_data)
 
-        # turn temporary fields that are only written and read within the same function
-        # into local scalars
+        # turn temporary fields into local scalars if possible. A few scenarios:
+        # - read and written in same stage
+        # - written once and read at [0, 0, 0] 1+ time (possibly in multiple stages)
         demote_local_temporaries_to_variables_pass = DemoteLocalTemporariesToVariablesPass()
         demote_local_temporaries_to_variables_pass.apply(self.transform_data)
 


### PR DESCRIPTION
## Description

Increase the scope of temporary demoting to those fields that are accessed in multiple stages, but only at `[0, 0, 0]`.

To do:
- [ ] Increase the scope of testing demotion pass
- [ ] Verify that the demotion is done correctly

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [ ] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


