### PR TITLE
GTC: GTIR flatten vertical loop

### DIFF
--- a/src/gt4py/backend/gtc_backend/defir_to_gtir.py
+++ b/src/gt4py/backend/gtc_backend/defir_to_gtir.py
@@ -96,10 +96,11 @@ class DefIRToGTIR(IRNodeVisitor):
     def visit_ComputationBlock(self, node: ComputationBlock) -> List[gtir.VerticalLoop]:
         assigns = [s for s in self.visit(node.body)]
         start, end = self.visit(node.interval)
-        vertical_intervals = [gtir.VerticalInterval(body=assigns, start=start, end=end)]
+        vertical_interval = gtir.Interval(start=start, end=end)
         return gtir.VerticalLoop(
+            vertical_interval=vertical_interval,
             loop_order=self.GT4PY_ITERATIONORDER_TO_GTIR_LOOPORDER[node.iteration_order],
-            vertical_intervals=vertical_intervals,
+            body=assigns,
         )
 
     def visit_BlockStmt(self, node: BlockStmt) -> List[gtir.Stmt]:

--- a/src/gt4py/backend/gtc_backend/defir_to_gtir.py
+++ b/src/gt4py/backend/gtc_backend/defir_to_gtir.py
@@ -96,9 +96,9 @@ class DefIRToGTIR(IRNodeVisitor):
     def visit_ComputationBlock(self, node: ComputationBlock) -> List[gtir.VerticalLoop]:
         assigns = [s for s in self.visit(node.body)]
         start, end = self.visit(node.interval)
-        vertical_interval = gtir.Interval(start=start, end=end)
+        interval = gtir.Interval(start=start, end=end)
         return gtir.VerticalLoop(
-            vertical_interval=vertical_interval,
+            interval=interval,
             loop_order=self.GT4PY_ITERATIONORDER_TO_GTIR_LOOPORDER[node.iteration_order],
             body=assigns,
         )

--- a/src/gt4py/gtc/gtir.py
+++ b/src/gt4py/gtc/gtir.py
@@ -160,17 +160,15 @@ class AxisBound(Node):
         return cls.from_end(0)
 
 
-class VerticalInterval(LocNode):
-    body: List[Stmt]
+class Interval(LocNode):
     start: AxisBound
     end: AxisBound
 
 
 class VerticalLoop(LocNode):
-    vertical_intervals: List[VerticalInterval]
+    interval: Interval
     loop_order: common.LoopOrder
-
-    # TODO validate that intervals are contiguous
+    body: List[Stmt]
 
 
 @enum.unique

--- a/src/gt4py/gtc/python/python_naive_codegen.py
+++ b/src/gt4py/gtc/python/python_naive_codegen.py
@@ -17,16 +17,13 @@ def run({{', '.join(_this_node.param_names)}}, _domain_=None):
 """
     )
 
-    VerticalLoop = MakoTemplate(
+    VerticalLoop = JinjaTemplate(
         """
-${ '\\n'.join(vertical_intervals) }"""
-    )
-
-    VerticalInterval = JinjaTemplate(
-        """
-for K in range({{start}}, {{end}}):\
+for K in range({{interval}}):\
     {{'\\n'.join(body)|indent(4)}}"""
     )
+
+    Interval = FormatTemplate("{start}, {end}")
 
     ParAssignStmt = JinjaTemplate(
         """

--- a/tests/test_unittest/test_gtc/test_fields_metadata_pass.py
+++ b/tests/test_unittest/test_gtc/test_fields_metadata_pass.py
@@ -11,7 +11,7 @@ from gt4py.gtc.gtir import (
     FieldAccess,
     FieldBoundary,
     FieldDecl,
-    VerticalInterval,
+    Interval,
     VerticalLoop,
 )
 from gt4py.gtc.passes import FieldsMetadataPass
@@ -39,16 +39,14 @@ def test_copy_shift(shift_offset: Tuple[CartesianOffset, FieldBoundary]) -> None
         vertical_loops=[
             VerticalLoop(
                 loop_order=LoopOrder.FORWARD,
-                vertical_intervals=[
-                    VerticalInterval(
-                        start=AxisBound(level=LevelMarker.START, offset=0),
-                        end=AxisBound(level=LevelMarker.END, offset=0),
-                        body=[
-                            ParAssignStmt(
-                                left=FieldAccess.centered(name="a"),
-                                right=FieldAccess(name="b", offset=offset),
-                            )
-                        ],
+                interval=Interval(
+                    start=AxisBound(level=LevelMarker.START, offset=0),
+                    end=AxisBound(level=LevelMarker.END, offset=0),
+                ),
+                body=[
+                    ParAssignStmt(
+                        left=FieldAccess.centered(name="a"),
+                        right=FieldAccess(name="b", offset=offset),
                     )
                 ],
             )

--- a/tests/test_unittest/test_gtc/test_gtir.py
+++ b/tests/test_unittest/test_gtc/test_gtir.py
@@ -22,7 +22,7 @@ from gt4py.gtc.gtir import (
     FieldAccess,
     FieldDecl,
     Stmt,
-    VerticalInterval,
+    Interval,
     VerticalLoop,
     ParAssignStmt,
     Expr,
@@ -48,21 +48,21 @@ def copy_assign():
 
 
 @pytest.fixture
-def copy_interval(copy_assign):
-    yield VerticalInterval(
+def interval(copy_assign):
+    yield Interval(
         loc=SourceLocation(line=2, column=11, source="copy_gtir"),
         start=AxisBound(level=LevelMarker.START, offset=0),
         end=AxisBound(level=LevelMarker.END, offset=0),
-        body=[copy_assign],
     )
 
 
 @pytest.fixture
-def copy_v_loop(copy_interval):
+def copy_v_loop(copy_assign, interval):
     yield VerticalLoop(
         loc=SourceLocation(line=2, column=1, source="copy_gtir"),
         loop_order=LoopOrder.FORWARD,
-        vertical_intervals=[copy_interval],
+        interval=interval,
+        body=[copy_assign],
     )
 
 
@@ -99,25 +99,21 @@ def test_naive_python_avg():
         vertical_loops=[
             VerticalLoop(
                 loop_order=LoopOrder.FORWARD,
-                vertical_intervals=[
-                    VerticalInterval(
-                        start=AxisBound(level=LevelMarker.START, offset=0),
-                        end=AxisBound(level=LevelMarker.END, offset=0),
-                        body=[
-                            ParAssignStmt(
-                                left=FieldAccess.centered(name="a"),
-                                right=BinaryOp(
-                                    left=FieldAccess(
-                                        name="b",
-                                        offset=CartesianOffset(i=-1, j=0, k=0),
-                                    ),
-                                    right=FieldAccess(
-                                        name="b", offset=CartesianOffset(i=1, j=0, k=0)
-                                    ),
-                                    op=ArithmeticOperator.ADD,
-                                ),
-                            )
-                        ],
+                interval=Interval(
+                    start=AxisBound(level=LevelMarker.START, offset=0),
+                    end=AxisBound(level=LevelMarker.END, offset=0),
+                ),
+                body=[
+                    ParAssignStmt(
+                        left=FieldAccess.centered(name="a"),
+                        right=BinaryOp(
+                            left=FieldAccess(
+                                name="b",
+                                offset=CartesianOffset(i=-1, j=0, k=0),
+                            ),
+                            right=FieldAccess(name="b", offset=CartesianOffset(i=1, j=0, k=0)),
+                            op=ArithmeticOperator.ADD,
+                        ),
                     )
                 ],
             )

--- a/tests/test_unittest/test_gtc/test_naive_python_gen.py
+++ b/tests/test_unittest/test_gtc/test_naive_python_gen.py
@@ -10,7 +10,7 @@ from gt4py.gtc.gtir import (
     BinaryOp,
     CartesianOffset,
     FieldAccess,
-    VerticalInterval,
+    Interval,
     ParAssignStmt,
     VerticalLoop,
 )
@@ -82,60 +82,21 @@ def test_binary_op(naive_codegen, binary_operator):
     assert isinstance(toplevel.value.op, GTIROP_TO_ASTOP[binary_operator])
 
 
-def test_vertical_interval(naive_codegen):
-    vertical_interval = VerticalInterval(
-        start=AxisBound.start(),
-        end=AxisBound.end(),
-        body=[
-            ParAssignStmt(
-                left=FieldAccess.centered(name="a"), right=FieldAccess.centered(name="b")
-            ),
-            ParAssignStmt(
-                left=FieldAccess.centered(name="b"), right=FieldAccess.centered(name="c")
-            ),
-        ],
-    )
-    print(naive_codegen.apply(vertical_interval))
-    source_tree = ast_parse(naive_codegen.apply(vertical_interval))
-    for_k = source_tree.body[0]
-    assert isinstance(for_k, ast.For)
-    assert for_k.target.id == "K"
-    assert isinstance(for_k.iter, ast.Call)
-    assert isinstance(for_k.iter.args[-1], ast.Subscript)
-    for_i = for_k.body[0]
-    assert isinstance(for_i, ast.For)
-    assert for_i.target.id == "I"
-    for_i = for_k.body[1]
-    assert isinstance(for_i, ast.For)
-    assert for_i.target.id == "I"
-
-
 def test_vertical_loop(naive_codegen, loop_order):
     vertical_loop = VerticalLoop(
         loop_order=loop_order,
-        vertical_intervals=[
-            VerticalInterval(
-                start=AxisBound.start(),
-                end=AxisBound.from_end(2),
-                body=[
-                    ParAssignStmt(
-                        left=FieldAccess.centered(name="a"),
-                        right=FieldAccess.centered(name="b"),
-                    )
-                ],
-            ),
-            VerticalInterval(
-                start=AxisBound.from_end(1),
-                end=AxisBound.end(),
-                body=[
-                    ParAssignStmt(
-                        left=FieldAccess.centered(name="a"),
-                        right=FieldAccess.centered(name="b"),
-                    )
-                ],
-            ),
+        interval=Interval(
+            start=AxisBound.start(),
+            end=AxisBound.from_end(2),
+        ),
+        body=[
+            ParAssignStmt(
+                left=FieldAccess.centered(name="a"),
+                right=FieldAccess.centered(name="b"),
+            )
         ],
     )
+
     source_tree = ast_parse(naive_codegen.apply(vertical_loop))
 
     for_k = source_tree.body[0]
@@ -146,14 +107,3 @@ def test_vertical_loop(naive_codegen, loop_order):
     assert isinstance(range_end, ast.BinOp)
     assert isinstance(range_end.op, ast.Sub)
     assert range_end.right.n == 2
-
-    for_k = source_tree.body[1]
-    assert isinstance(for_k, ast.For)
-    assert for_k.target.id == "K"
-    assert isinstance(for_k.iter, ast.Call)
-    range_start = for_k.iter.args[0]
-    range_end = for_k.iter.args[-1]
-    assert isinstance(range_start, ast.BinOp)
-    assert isinstance(range_end, ast.Subscript)
-    assert isinstance(range_start.op, ast.Sub)
-    assert range_start.right.n == 1


### PR DESCRIPTION
As discussed the extra nesting of `Stmt`s in `VerticalInterval` in `VerticalLoop` doesn't provide extra semantic information. Simplifies the IR and makes it compatible with the current Definition IR.