### PR TITLE
Fix bug where _merge_extents fails for VarRefs used in a multi-branch conditional

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -402,7 +402,6 @@ class InitInfoPass(TransformPass):
 
         def _merge_extents(self, refs: list):
             result = {}
-            params = set()
 
             # Merge offsets for same symbol
             for name, extent in refs:

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -260,7 +260,7 @@ class InitInfoPass(TransformPass):
             return []
 
         def visit_VarRef(self, node: gt_ir.VarRef):
-            result = [(node.name, None)]
+            result = [(node.name, node.index)]
             return result
 
         def visit_FieldRef(self, node: gt_ir.FieldRef):
@@ -407,9 +407,9 @@ class InitInfoPass(TransformPass):
             # Merge offsets for same symbol
             for name, extent in refs:
                 if extent is None:
-                    assert name in params or name not in result
+                    assert name in params or result.get(name, Extent.zeros()) == Extent.zeros()
                     params |= {name}
-                    result.setdefault(name, Extent((0, 0), (0, 0), (0, 0)))
+                    result.setdefault(name, Extent.zeros())
                 else:
                     assert name not in params
                     if name in result:

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -260,7 +260,7 @@ class InitInfoPass(TransformPass):
             return []
 
         def visit_VarRef(self, node: gt_ir.VarRef):
-            result = [(node.name, node.index)]
+            result = [(node.name, None)]
             return result
 
         def visit_FieldRef(self, node: gt_ir.FieldRef):
@@ -406,16 +406,9 @@ class InitInfoPass(TransformPass):
 
             # Merge offsets for same symbol
             for name, extent in refs:
-                if extent is None:
-                    assert name in params or result.get(name, Extent.zeros()) == Extent.zeros()
-                    params |= {name}
-                    result.setdefault(name, Extent.zeros())
-                else:
-                    assert name not in params
-                    if name in result:
-                        result[name] |= extent
-                    else:
-                        result[name] = extent
+                extent = extent or Extent.zeros()
+                result.setdefault(name, Extent.zeros())
+                result[name] |= extent
 
             return result
 

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -260,3 +260,16 @@ def local_var_inside_nested_conditional(in_storage: Field3D, out_storage: Field3
             else:
                 mid_storage = 4
             out_storage[0, 0, 0] = local_var + mid_storage
+
+
+@register
+def multibranch_param_conditional(
+    in_field: gtscript.Field[float], out_field: gtscript.Field[float], c: float
+):
+    with computation(PARALLEL), interval(...):
+        if c > 0.0:
+            out_field = in_field + in_field[1, 0, 0]
+        elif c < -1.0:
+            out_field = in_field - in_field[1, 0, 0]
+        else:
+            out_field = in_field


### PR DESCRIPTION
## Description

Thanks to Yongqiang Sun from NOAA for catching this bug during our workshop this week!

```python
def test_stencil(in_field: gtscript.Field[float], out_field: gtscript.Field[float], c: float):
    with computation(PARALLEL), interval(...):
        if c > 0.0:
            out_field = in_field + in_field[1, 0, 0]
        elif c < -1.0:
            out_field = in_field - in_field[1, 0, 0]
        else:
            out_field = in_field
```

This stencil fails to compile without a fix like this because `name in result` and `result[name] = Extent.zeros()` since it has already executed the setdefaults line once.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


