### PR TITLE
Allow empty computations from compile-time conds

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -339,7 +339,6 @@ class InitInfoPass(TransformPass):
             interval = next(iter(self.current_block_info.intervals))
             interval_block = IntervalBlockInfo(self.data.id_generator.new, interval)
 
-            # assert node.body.stmts  # non-empty computation
             stmt_infos = [
                 info for info in [self.visit(stmt) for stmt in node.body.stmts] if info is not None
             ]

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -339,7 +339,7 @@ class InitInfoPass(TransformPass):
             interval = next(iter(self.current_block_info.intervals))
             interval_block = IntervalBlockInfo(self.data.id_generator.new, interval)
 
-            assert node.body.stmts  # non-empty computation
+            # assert node.body.stmts  # non-empty computation
             stmt_infos = [
                 info for info in [self.visit(stmt) for stmt in node.body.stmts] if info is not None
             ]

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -277,6 +277,8 @@ def multibranch_param_conditional(
 
 @register(externals={"DO_SOMETHING": False})
 def allow_empty_computation(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
+    from __externals__ import DO_SOMETHING
+
     with computation(FORWARD), interval(...):
         out_field = in_field
     with computation(PARALLEL), interval(...):

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -273,3 +273,12 @@ def multibranch_param_conditional(
             out_field = in_field - in_field[1, 0, 0]
         else:
             out_field = in_field
+
+
+@register(externals={"DO_SOMETHING": False})
+def allow_empty_computation(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
+    with computation(FORWARD), interval(...):
+        out_field = in_field
+    with computation(PARALLEL), interval(...):
+        if __INLINED(DO_SOMETHING):
+            out_field = abs(in_field)


### PR DESCRIPTION
## Description

In lieu of being able to conditionally call other subroutines inside a stencil, I am inlining calls to other subroutines and masking all code inside a `if __INLINED(...):`. This occasionally results in empty computations depending on the conditional inputs. This change would allow this sort of behavior. Is this something we want to support?

Example here: https://github.com/VulcanClimateModeling/Riem-solver-c-miniapp/blob/main/riem_solver_c.py#L89

Relevant Fortran code:

```fortran
         enddo
      enddo
   enddo
      if ( a_imp > 0.5 ) then
           call SIM1_solver(dt, is1, ie1, js1, je1, isd, ied, jsd, jed, km, rdgas, gama, gm2, cp2, akap, pe2,  &
                            dm, pm2, pem, w2, dz2, pt, ws, p_fac)
      endif
    do k=2,km+1
      do j=js1,je1
         do i=is1, ie1

```

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [ ] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


