### PR TITLE
Expose iteration index with index(...)

### DIFF
--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -70,6 +70,7 @@ builtins = {
     "Sequence",
     "externals",
     "computation",
+    "index",
     "interval",
     "__gtscript__",
     "__externals__",
@@ -485,6 +486,11 @@ class _ComputationContextManager:
 def computation(order):
     """Define the computation."""
     return _ComputationContextManager()
+
+
+def index(*axes):
+    """Return current index along axes as a tuple."""
+    pass
 
 
 def interval(*args):

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -96,7 +96,9 @@ storing a reference to the piece of source code which originated the node.
 
     Cast(dtype: DataType, expr: Expr)
 
-    Expr        = Literal | Ref | NativeFuncCall | Cast | CompositeExpr | InvalidBranch
+    AxisIndex(axis: str)
+
+    Expr        = Literal | Ref | NativeFuncCall | Cast | CompositeExpr | AxisIndex | InvalidBranch
 
     CompositeExpr   = UnaryOpExpr(op: UnaryOperator, arg: Expr)
                     | BinOpExpr(op: BinaryOperator, lhs: Expr, rhs: Expr)
@@ -402,6 +404,11 @@ class Cast(Expr):
     dtype = attribute(of=DataType)
     expr = attribute(of=Expr)
     loc = attribute(of=Location, optional=True)
+
+
+@attribclass
+class AxisIndex(Expr):
+    axis = attribute(of=str)
 
 
 @enum.unique

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -497,6 +497,18 @@ class TestExternalsWithSubroutines:
             )
 
 
+class TestIndex:
+    def test_single(self, id_version):
+        def definition(inout_field: gtscript.Field[float]):
+            with computation(PARALLEL), interval(...):
+                i_index = index(I)
+                inout_field = i_index
+
+        module = f"TestIndex_test_single_{id_version}"
+        stencil_id, def_ir = compile_definition(definition, "test_single", module)
+        pass
+
+
 class TestCompileTimeAssertions:
     def test_nomsg(self, id_version):
         def definition(inout_field: gtscript.Field[float]):


### PR DESCRIPTION
## Description

This was discussed at the [gtscript workshop](https://hackmd.io/9MHp3vuPRVGy1Zf7VILBvw#DiscussionEnhancement-Expose-the-iteration-index-positional-computations). Exposes the current (I, J, K) index e.g. with `k_index = index(K)` to be used later in the stencil as a scalar variable. Note that this means it cannot be used to index fields.

To do:
- [ ] Finish lowering to IIR
- [ ] Add IR tests
- [ ] Add codegen support
- [ ] Add to an end-to-end test

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [ ] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


