### PR TITLE
Fix temporary error to ignore nested math funcs

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -464,7 +464,10 @@ class CallInliner(ast.NodeTransformer):
         if call_name in gtscript.MATH_BUILTINS:
             node.args = [self.visit(arg) for arg in node.args]
             return node
-        elif any(isinstance(arg, ast.Call) for arg in node.args):
+        elif any(
+            isinstance(arg, ast.Call) and arg.func.id not in gtscript.MATH_BUILTINS
+            for arg in node.args
+        ):
             raise GTScriptSyntaxError(
                 "Function calls are not supported in arguments to function calls",
                 loc=gt_ir.Location.from_ast_node(node),


### PR DESCRIPTION
## Description

This fixes a silly error I introduced in a previous PR. That PR makes a temporary error until we can fix function calls in arguments to functions. For now we need to ignore math functions in these, since they are mapped as IR nodes.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


