### PR TITLE
Add resolved_values_list to func_externals

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1470,7 +1470,9 @@ class GTScriptParser(ast.NodeVisitor):
 
         # Resolve function-like imports
         func_externals = {
-            key: value for key, value in context.items() if isinstance(value, types.FunctionType)
+            key: value
+            for key, value in itertools.chain(context.items(), resolved_values_list)
+            if isinstance(value, types.FunctionType)
         }
         for name, value in func_externals.items():
             if isinstance(value, types.FunctionType) and not hasattr(value, "_gtscript_"):


### PR DESCRIPTION
## Description

The earlier PR worked for functions that were themselves externals. I recently found out that imported externals in functions that are resolved implicitly (no explicit `from __externals__ import func`) are not included in the resolved externals (and hence the fingerprint of the stencil). This is a clear bug.

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [ ] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


