### PR TITLE
Dawn GPU backends: Bug in code generation

### DIFF
--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -401,8 +401,12 @@ cupy.cuda.Device(0).synchronize()
         return ["import cupy"]
 
     def backend_pre_run(self) -> List[str]:
-        field_names = self.args_data["field_info"].keys()
-        return ["{name}.host_to_device()" for name in field_names]
+        field_names = [
+            key
+            for key in self.args_data["field_info"]
+            if self.args_data["field_info"][key] is not None
+        ]
+        return [f"{name}.host_to_device()" for name in field_names]
 
     def generate_post_run(self) -> str:
         output_field_names = [

--- a/src/gt4py/backend/dawn_backends.py
+++ b/src/gt4py/backend/dawn_backends.py
@@ -402,9 +402,7 @@ cupy.cuda.Device(0).synchronize()
 
     def backend_pre_run(self) -> List[str]:
         field_names = [
-            key
-            for key in self.args_data["field_info"]
-            if self.args_data["field_info"][key] is not None
+            key for key, value in self.args_data["field_info"].items() if value is not None
         ]
         return [f"{name}.host_to_device()" for name in field_names]
 

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -28,6 +28,9 @@ CPU_BACKENDS = [
 ]
 GPU_BACKENDS = list(set(ALL_BACKENDS) - set(CPU_BACKENDS))
 INTERNAL_BACKENDS = ["debug", "numpy"] + [name for name in ALL_BACKENDS if name.startswith("gt")]
+DAWN_BACKENDS = [name for name in ALL_BACKENDS if "dawn:" in name]
+DAWN_CPU_BACKENDS = [name for name in CPU_BACKENDS if "dawn:" in name]
+DAWN_GPU_BACKENDS = [name for name in GPU_BACKENDS if "dawn:" in name]
 
 
 @pytest.fixture()

--- a/tests/test_unittest/test_backend.py
+++ b/tests/test_unittest/test_backend.py
@@ -6,7 +6,7 @@ from gt4py.backend import REGISTRY as backend_registry
 from gt4py.gtscript import __INLINED, PARALLEL, Field, computation, interval
 from gt4py.stencil_builder import StencilBuilder
 
-from ..definitions import ALL_BACKENDS
+from ..definitions import ALL_BACKENDS, CPU_BACKENDS, DAWN_CPU_BACKENDS
 
 
 def stencil_def(
@@ -83,8 +83,9 @@ def test_generate_pre_run(backend_name, mode):
     module_generator.args_data = args_data
     source = module_generator.generate_pre_run()
 
-    if backend_cls.storage_info["device"] == "cpu":
-        assert source == ""
+    if backend_name in CPU_BACKENDS:
+        if backend_name not in DAWN_CPU_BACKENDS:
+            assert source == ""
     else:
         for key in field_info_val[mode]:
             assert f"{key}.host_to_device()" in source
@@ -104,7 +105,7 @@ def test_generate_post_run(backend_name, mode):
     module_generator.args_data = args_data
     source = module_generator.generate_post_run()
 
-    if backend_cls.storage_info["device"] == "cpu":
+    if backend_name in CPU_BACKENDS:
         assert source == ""
     else:
         assert source == "out._set_device_modified()"


### PR DESCRIPTION
## Description

In the `backend_pre_run` method of `DawnCUDAPyModuleGenerator`, the string within the list comprehension is converted to an f-string. Plus, along the lines of https://github.com/GridTools/gt4py/pull/217, a safety check is added to disregard unused optional fields.

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [ ] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


