### PR TITLE
Skip visiting None values in IRNodeMapper

### DIFF
--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -966,11 +966,12 @@ class IRNodeMapper:
 
         del_items = []
         for key, old_value in items:
-            keep_item, new_value = self._visit((*path, node_name), key, old_value)
-            if not keep_item:
-                del_items.append(key)
-            elif new_value != old_value:
-                setattr_op(node, key, new_value)
+            if old_value:
+                keep_item, new_value = self._visit((*path, node_name), key, old_value)
+                if not keep_item:
+                    del_items.append(key)
+                elif new_value != old_value:
+                    setattr_op(node, key, new_value)
         for key in reversed(del_items):  # reversed, so that keys remain valid in sequences
             delattr_op(node, key)
 


### PR DESCRIPTION
## Description

IRNodeMapper fails if the node attribute is optional and the value is None.