### PR TITLE
Fixing demotion pass with self-assignment

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -1213,9 +1213,9 @@ class DemoteLocalTemporariesToVariablesPass(TransformPass):
             self.generic_visit(node, **kwargs)
 
         def visit_Assign(self, node: gt_ir.Assign, **kwargs: Any) -> None:
+            self.visit(node.value, **kwargs)
             if node.target.name in self.demotables:
                 self.demotables[node.target.name] = kwargs["stage_name"]
-            self.visit(node.value, **kwargs)
 
         def visit_FieldRef(self, node: gt_ir.FieldRef, **kwargs: Any) -> None:
             field_name = node.name


### PR DESCRIPTION
## Description
Found a small bug where self-assignments always allow for demotion

minimal reproducer for the error:
```
    with computation(PARALLEL), interval(...):
        tmp = 1
    with computation(FORWARD), interval(...):
        out_storage = in_storage
    with computation(PARALLEL), interval(...):
        tmp = tmp + 1
        out_storage = tmp + 1
```