### PR TITLE
Make clang_format package optional

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     typing-extensions~=3.7
     # ---- eve / gtc ----
     boltons>=20.0
-    clang-format>=9.0
     cytoolz>=0.11
     devtools>=0.5
     mako>=1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,8 @@ cuda102 =
     cupy-cuda102
 dawn =
     dawn4py@git+https://github.com/MeteoSwiss-APN/dawn.git@0.0.2#subdirectory=dawn
+format =
+    clang-format>=9.0
 testing =
     hypothesis>=4.14
     pytest~=6.1

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -61,19 +61,9 @@ from .visitors import NodeVisitor
 
 def _get_clang_format() -> Optional[str]:
     """Return the clang-format executable, or None if not available."""
-    default_filename = "clang-format"
-    try:
-        import clang_format
-
-        del clang_format
-        return default_filename
-    except ImportError:
-        executable = os.getenv("CLANG_FORMAT_EXECUTABLE", default_filename)
-        ret = run([executable, "--version"])
-        if ret.returncode != 0:
-            return None
-        else:
-            return executable
+    executable = os.getenv("CLANG_FORMAT_EXECUTABLE", "clang-format")
+    ret = run([executable, "--version"])
+    return executable if ret.returncode == 0 else None
 
 
 _CLANG_FORMAT_EXECUTABLE = _get_clang_format()
@@ -160,7 +150,7 @@ if _CLANG_FORMAT_EXECUTABLE is not None:
         sort_includes: bool = False,
     ) -> str:
         """Format C++ source code using clang-format."""
-        args = [str(_CLANG_FORMAT_EXECUTABLE)]
+        args = [_CLANG_FORMAT_EXECUTABLE]
         if style:
             args.append(f"--style={style}")
         if fallback_style:

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -59,16 +59,6 @@ from .typingx import (
 from .visitors import NodeVisitor
 
 
-def _get_clang_format() -> Optional[str]:
-    """Return the clang-format executable, or None if not available."""
-    executable = os.getenv("CLANG_FORMAT_EXECUTABLE", "clang-format")
-    ret = run([executable, "--version"])
-    return executable if ret.returncode == 0 else None
-
-
-_CLANG_FORMAT_EXECUTABLE = _get_clang_format()
-
-
 SourceFormatter = Callable[[str], str]
 
 #: Global dict storing registered formatters.
@@ -137,6 +127,16 @@ def format_python_source(
     assert isinstance(formatted_source, str)
 
     return formatted_source
+
+
+def _get_clang_format() -> Optional[str]:
+    """Return the clang-format executable, or None if not available."""
+    executable = os.getenv("CLANG_FORMAT_EXECUTABLE", "clang-format")
+    ret = run([executable, "--version"], capture_output=True)
+    return executable if ret.returncode == 0 else None
+
+
+_CLANG_FORMAT_EXECUTABLE = _get_clang_format()
 
 
 if _CLANG_FORMAT_EXECUTABLE is not None:

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -150,6 +150,7 @@ if _CLANG_FORMAT_EXECUTABLE is not None:
         sort_includes: bool = False,
     ) -> str:
         """Format C++ source code using clang-format."""
+        assert isinstance(_CLANG_FORMAT_EXECUTABLE, str)
         args = [_CLANG_FORMAT_EXECUTABLE]
         if style:
             args.append(f"--style={style}")


### PR DESCRIPTION
## Description

The `clang-format` package is not supported on the Mac yet (see https://github.com/mgevaert/clang-format-wheel/issues/2). This PR makes it optional and adds a env var to set it.