### PR TITLE
GTC GridTools backends: gtc:gt:cpu_kfirst, gtc:gt:gpu

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Authors
 * Häuselmann, Rico. ETH Zurich - CSCS
 * Madonna, Alberto. ETH Zurich - CSCS
 * Mariotti, Kean. ETH Zurich - CSCS
+* Thaler, Felix. ETH Zurich - CSCS
 * Ubbiali, Stefano. ETH Zurich
 * Vogt, Hannes. ETH Zurich - CSCS
 * Wicky, Tobias. Vulcan Inc.

--- a/src/gt4py/backend/gtc_backend/__init__.py
+++ b/src/gt4py/backend/gtc_backend/__init__.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from .gtcpp.backend import GTCGTBackend
+from .gtcpp.backend import GTCGTCpuIfirstBackend, GTCGTCpuKfirstBackend, GTCGTGpuBackend
 
 
-__all__ = ["GTCGTBackend"]
+__all__ = ["GTCGTCpuIfirstBackend", "GTCGTCpuKfirstBackend", "GTCGTGpuBackend"]

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -26,6 +26,7 @@ from gt4py.backend.gt_backends import (
     cuda_is_compatible_type,
     cuda_layout,
     gtcpu_is_compatible_type,
+    GTCUDAPyModuleGenerator,
     make_mc_layout_map,
     make_x86_layout_map,
     mc_is_compatible_layout,
@@ -238,6 +239,7 @@ class GTCGTCpuKfirstBackend(GTCGTBaseBackend):
 class GTCGTGpuBackend(GTCGTBaseBackend):
     """GridTools python backend using gtc."""
 
+    MODULE_GENERATOR_CLASS = GTCUDAPyModuleGenerator
     name = "gtc:gt:gpu"
     GT_BACKEND_T = "gpu"
     languages = {"computation": "cuda", "bindings": ["python"]}

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -63,7 +63,7 @@ class GTCGTExtGenerator:
         bindings_ext = ".cu" if self.gt_backend_t == "gpu" else ".cpp"
         return {
             "computation": {"computation.hpp": implementation},
-            "bindings": {"bindings" + binding_ext: bindings},
+            "bindings": {"bindings" + bindings_ext: bindings},
         }
 
 

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
 
 from eve import codegen
 from eve.codegen import MakoTemplate as as_mako
@@ -171,7 +171,7 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
 
 
 class GTCGTBaseBackend(BaseGTBackend, CLIBackendMixin):
-    options: ClassVar[Dict[str, Any]] = {}
+    options = BaseGTBackend.GT_BACKEND_OPTS
     PYEXT_GENERATOR_CLASS = GTCGTExtGenerator  # type: ignore
 
     def _generate_extension(self, uses_cuda: bool) -> Tuple[str, str]:

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -22,11 +22,11 @@ from gt4py import backend as gt_backend
 from gt4py import gt_src_manager
 from gt4py.backend import BaseGTBackend, CLIBackendMixin
 from gt4py.backend.gt_backends import (
+    GTCUDAPyModuleGenerator,
     cuda_is_compatible_layout,
     cuda_is_compatible_type,
     cuda_layout,
     gtcpu_is_compatible_type,
-    GTCUDAPyModuleGenerator,
     make_mc_layout_map,
     make_x86_layout_map,
     mc_is_compatible_layout,

--- a/src/gt4py/gt_src_manager.py
+++ b/src/gt4py/gt_src_manager.py
@@ -22,7 +22,8 @@ from . import config as gt_config
 
 
 _DEFAULT_GRIDTOOLS_VERSION = 1
-_GRIDTOOLS_GIT_BRANCHES = {1: "release_v1.1", 2: "v2.0.0"}
+# TODO: GT2 release with CUDA SID adapter
+_GRIDTOOLS_GIT_BRANCHES = {1: "release_v1.1", 2: "master"}
 _GRIDTOOLS_INCLUDE_PATHS = {1: gt_config.GT_INCLUDE_PATH, 2: gt_config.GT2_INCLUDE_PATH}
 _GRIDTOOLS_REPO_DIRNAMES = {1: gt_config.GT_REPO_DIRNAME, 2: gt_config.GT2_REPO_DIRNAME}
 

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -171,14 +171,14 @@ class GTCppCodegen(codegen.TemplatedGenerator):
                 return multi_pass(${ ','.join(multi_stages) });
             };
 
-            run(${computation_name}, cpu_ifirst<>{} /* TODO */, grid, ${','.join(arguments)});
+            run(${computation_name}, ${gt_backend_t}<>{}, grid, ${','.join(arguments)});
         }
         %endif
         """
     )
 
     Program = as_mako(
-        """#include <gridtools/stencil/cpu_ifirst.hpp>
+        """#include <gridtools/stencil/${gt_backend_t}.hpp>
         #include <gridtools/stencil/cartesian.hpp>
 
         namespace ${ name }_impl_{
@@ -205,6 +205,8 @@ class GTCppCodegen(codegen.TemplatedGenerator):
     def apply(cls, root: LeafNode, **kwargs: Any) -> str:
         if not isinstance(root, gtcpp.Program):
             raise ValueError("apply() requires gtcpp.Progam root node")
+        if "gt_backend_t" not in kwargs:
+            raise TypeError("apply() missing 1 required keyword-only argument: 'gt_backend_t'")
         generated_code = super().apply(root, offset_limit=_offset_limit(root), **kwargs)
         formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
         return formatted_code

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -206,17 +206,6 @@ def horizontal_diffusion(in_field: Field3D, out_field: Field3D, coeff: Field3D):
 
 
 @register
-def large_k_interval(in_field: Field3D, out_field: Field3D):
-    with computation(PARALLEL):
-        with interval(0, 6):
-            out_field = in_field
-        with interval(6, -10):  # this stage will only run if field has more than 16 elements
-            out_field = in_field + 1
-        with interval(-10, None):
-            out_field = in_field
-
-
-@register
 def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
     with computation(PARALLEL), interval(...):
         mask = in_field >= 0

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -206,6 +206,17 @@ def horizontal_diffusion(in_field: Field3D, out_field: Field3D, coeff: Field3D):
 
 
 @register
+def large_k_interval(in_field: Field3D, out_field: Field3D):
+    with computation(PARALLEL):
+        with interval(0, 6):
+            out_field = in_field
+        with interval(6, -10):  # this stage will only run if field has more than 16 elements
+            out_field = in_field + 1
+        with interval(-10, None):
+            out_field = in_field
+
+
+@register
 def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
     with computation(PARALLEL), interval(...):
         mask = in_field >= 0

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -44,11 +44,12 @@ def test_generation_cpu(name, backend):
                 mask=gtscript.mask_from_axes(v.axes),
                 backend=backend,
                 shape=(23, 23, 23),
-                default_origin=(10, 10, 10),
+                default_origin=(10, 10, 5),
             )
         else:
             args[k] = v(1.5)
-    stencil(**args, origin=(10, 10, 10), domain=(3, 3, 3))
+    # vertical domain size >= 16 required for test_large_k_interval
+    stencil(**args, origin=(10, 10, 5), domain=(3, 3, 16))
 
 
 @pytest.mark.requires_gpu

--- a/tests/test_unittest/test_backend_api.py
+++ b/tests/test_unittest/test_backend_api.py
@@ -82,4 +82,5 @@ def test_generate_bindings(backend, tmp_path):
         else:
             result = builder.backend.generate_bindings("python")
         assert "init_1_src" in result
-        assert "bindings.cpp" in result["init_1_src"]
+        srcs = result["init_1_src"]
+        assert "bindings.cpp" in srcs or "bindings.cu" in srcs

--- a/tests/test_unittest/test_cli.py
+++ b/tests/test_unittest/test_cli.py
@@ -102,6 +102,8 @@ BACKEND_ROW_PATTERN_BY_NAME = {
     "gtmc": r"^\s*gtmc\s*c\+\+\s*python\s*Yes",
     "gtcuda": r"^\s*gtcuda\s*cuda\s*python\s*Yes",
     "gtc:gt:cpu_ifirst": r"^\s*gtc:gt:cpu_ifirst\s*c\+\+\s*python\s*Yes",
+    "gtc:gt:cpu_kfirst": r"^\s*gtc:gt:cpu_kfirst\s*c\+\+\s*python\s*Yes",
+    "gtc:gt:gpu": r"^\s*gtc:gt:gpu\s*c\+\+\s*python\s*Yes",
     "dawn:gtx86": r"^\s*dawn:gtx86\s*c\+\+\s*python\s*No",
     "dawn:gtmc": r"^\s*dawn:gtmc\s*c\+\+\s*python\s*No",
     "dawn:gtcuda": r"^\s*dawn:gtcuda\s*cuda\s*python\s*No",

--- a/tests/test_unittest/test_gtc/test_gtcpp_compilation.py
+++ b/tests/test_unittest/test_gtc/test_gtcpp_compilation.py
@@ -122,7 +122,7 @@ def make_compilation_input_and_expected():
 @pytest.mark.parametrize("gtcpp_program,expected_regex", make_compilation_input_and_expected())
 def test_program_compilation_succeeds(tmp_path, gtcpp_program, expected_regex):
     assert isinstance(gtcpp_program, Program)
-    code = GTCppCodegen.apply(gtcpp_program)
+    code = GTCppCodegen.apply(gtcpp_program, gt_backend_t="cpu_ifirst")
     print(code)
     match(code, expected_regex)
     build_gridtools_test(tmp_path, code)
@@ -163,4 +163,7 @@ def test_apply_method_compilation_succeeds(tmp_path, apply_method, expected_rege
     print(apply_method_code)
     match(apply_method_code, expected_regex)
 
-    build_gridtools_test(tmp_path, GTCppCodegen.apply(_embed_apply_method_in_program(apply_method)))
+    build_gridtools_test(
+        tmp_path,
+        GTCppCodegen.apply(_embed_apply_method_in_program(apply_method), gt_backend_t="cpu_ifirst"),
+    )


### PR DESCRIPTION
## Description

Adds two new GTC backends based on the GridTools cpu_kfirst and gpu stencil backends.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


