### PR TITLE
Support compile-time assertions in functions and handle in CallInliner

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1639,11 +1639,11 @@ class GTScriptParser(ast.NodeVisitor):
         # Inline function calls
         CallInliner.apply(main_func_node, context=local_context)
 
-        AssertionChecker.apply(main_func_node, context=local_context, source=self.source)
-
         # Evaluate and inline compile-time conditionals
         CompiledIfInliner.apply(main_func_node, context=local_context)
         # Cleaner.apply(self.definition_ir)
+
+        AssertionChecker.apply(main_func_node, context=local_context, source=self.source)
 
         # Generate definition IR
         domain = gt_ir.Domain.LatLonGrid()

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -446,6 +446,10 @@ class CallInliner(ast.NodeTransformer):
             node.orelse = self._process_stmts(node.orelse)
         return node
 
+    def visit_Assert(self, node: ast.Assert):
+        """Assertions are removed in the AssertionChecker later."""
+        return node
+
     def visit_Assign(self, node: ast.Assign):
         if isinstance(node.value, ast.Call) and node.value.func.id not in gtscript.MATH_BUILTINS:
             assert len(node.targets) == 1
@@ -462,9 +466,6 @@ class CallInliner(ast.NodeTransformer):
         if call_name in gtscript.MATH_BUILTINS:
             # A math function -- visit arguments and return as-is.
             node.args = [self.visit(arg) for arg in node.args]
-            return node
-        elif call_name == "__INLINED":
-            # This node is either in an assertion or a compile-time if-then. Both cases are dealt with later.
             return node
         elif any(
             isinstance(arg, ast.Call) and arg.func.id not in gtscript.MATH_BUILTINS

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -71,6 +71,12 @@ GLOBAL_VERY_NESTED_CONSTANTS = types.SimpleNamespace(nested=types.SimpleNamespac
 
 
 @gtscript.function
+def assert_in_func(field):
+    assert __INLINED(GLOBAL_CONSTANT < 2), "An error occurred"
+    return field[0, 0, 0] + GLOBAL_CONSTANT
+
+
+@gtscript.function
 def add_external_const(a):
     return a + 10.0 + GLOBAL_CONSTANT
 
@@ -671,6 +677,14 @@ class TestCompileTimeAssertions:
 
         module = f"TestCompileTimeAssertions_test_module_{id_version}"
         compile_definition(definition, "test_assert_nested_attribute", module)
+
+    def test_inside_func(self, id_version):
+        def definition(inout_field: gtscript.Field[float]):
+            with computation(PARALLEL), interval(...):
+                inout_field = assert_in_func(inout_field)
+
+        module = f"TestCompileTimeAssertions_test_module_{id_version}"
+        compile_definition(definition, "test_inside_func", module)
 
     def test_runtime_error(self, id_version):
         def definition(inout_field: gtscript.Field[float]):


### PR DESCRIPTION
## Description

Supports parsing compile-time assertions inside the body of function calls, and fixes a minor bug in CallInliner.