### PR TITLE
drop ci for python 3.6, 3.7 add 3.9

### DIFF
--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -37,5 +37,5 @@ jobs:
         run: |
           pyversion_no_dot="${{ matrix.python-version }}"
           pyversion_no_dot="${pyversion_no_dot/./}"
-          pip install tox
+          pip install tox clang-format
           tox -r -e py${pyversion_no_dot}-cpu

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ test py38:
   image: $CI_REGISTRY_IMAGE/gt4py-ci/image:$PYVERSION
   script: 
     - python -c "import cupy"
+    - pip install clang-format
     - tox --sitepackages -r -e $PYVERSION_PREFIX-cuda101
   variables:
     CRAY_CUDA_MPS: 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,9 @@
 include:
   - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.cscs.yml'
 
-.py36: &py36
-  PYVERSION_PREFIX: py36
-  PYVERSION: 3.6.12
-
-.py37: &py37
-  PYVERSION_PREFIX: py37
-  PYVERSION: 3.7.9
+.py39: &py39
+  PYVERSION_PREFIX: py39
+  PYVERSION: 3.9.1
 
 .py38: &py38
   PYVERSION_PREFIX: py38
@@ -42,15 +38,10 @@ build py38:
     - staging
     - trying
 
-build py37:
+build py39:
   extends: build py38
   variables:
-    <<: *py37
-
-build py36:
-  extends: build py38
-  variables:
-    <<: *py36
+    <<: *py39
 
 test py38:
   extends: .daint
@@ -72,17 +63,12 @@ test py38:
     SLURM_TIMELIMIT: 120
     <<: *py38
 
-test py37:
+test py39:
+  allow_failure: true
   extends: test py38
-  needs: ["build py37"]
+  needs: ["build py39"]
   variables:
-    <<: *py37
-
-test py36:
-  extends: test py38
-  needs: ["build py36"]
-  variables:
-    <<: *py36
+    <<: *py39
 
 notify_github_success:
   stage: cleanup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,7 @@ build py38:
     - trying
 
 build py39:
+  allow_failure: true
   extends: build py38
   variables:
     <<: *py39

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ whitelist_externals =
 
 extras =
     testing
+    format
     cuda: cuda
     cuda90: cuda90
     cuda91: cuda91

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 
 [tox]
 envlist =
-    py{36,37,38}-{cpu,cuda,cuda90,cuda91,cuda92,cuda100,cuda101}
-    py{36,37,38}-dawn-{cpu,cuda,cuda90,cuda91,cuda92,cuda100,cuda101}
+    py{38,39}-{cpu,cuda,cuda90,cuda91,cuda92,cuda100,cuda101}
+    py{38,39}-dawn-{cpu,cuda,cuda90,cuda91,cuda92,cuda100,cuda101}
 
 [testenv]
 install_command = python -m pip install --no-cache-dir {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ whitelist_externals =
 
 extras =
     testing
-    format
     cuda: cuda
     cuda90: cuda90
     cuda91: cuda91


### PR DESCRIPTION
## Description

Update gitlab-ci pipeline to run only on supported python versions.
* drop 3.6, 3.7
* add 3.9

### Current state of CI pipeline for Python 3.9.1

since 3.9 support is not completely there and no cupy-cudaXXX wheels seem to be available for 3.9 yet either, both the image build as well as the test stages for python 3.9 are allowed to fail.

## Requirements

Before submitting this PR, please make sure:

- [X] All relevant documentation has been updated or added
 


