### PR TITLE
Fix XIterator.reduceby Type Declarations of Overloads

### DIFF
--- a/src/gtc/gtcpp/oir_to_gtcpp.py
+++ b/src/gtc/gtcpp/oir_to_gtcpp.py
@@ -15,12 +15,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from dataclasses import dataclass, field
-from typing import Any, List, Set, Tuple, Union
+from typing import Any, List, Set, Union
 
 from devtools import debug  # noqa: F401
 
 import eve
-from eve.utils import XIterator
 from gtc import common, oir
 from gtc.common import CartesianOffset
 from gtc.gtcpp import gtcpp
@@ -33,7 +32,7 @@ from gtc.gtcpp import gtcpp
 
 
 def _extract_accessors(node: eve.Node) -> List[gtcpp.GTAccessor]:
-    extents: XIterator[Tuple[str, gtcpp.GTExtent]] = (
+    extents = (
         node.iter_tree()
         .if_isinstance(gtcpp.AccessorRef)
         .reduceby(


### PR DESCRIPTION
## Description

Proper type hints for XIterator.reduceby such that Mypy can correctly derive the return type from the given arguments.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


