### PR TITLE
Fix capture of boolean literals

### DIFF
--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -972,7 +972,7 @@ class DataTypePass(TransformPass):
                 # cast all other args to this type
                 for index, arg in enumerate(node.args):
                     if arg.data_type != data_type:
-                        node.args[index] = gt_ir.Cast(dtype=data_type, expr=arg, loc=node.loc)
+                        node.args[index] = gt_ir.Cast(data_type=data_type, expr=arg, loc=node.loc)
 
             if node.func in (
                 gt_ir.NativeFunction.MIN,

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -322,7 +322,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
 
     def visit_Cast(self, node: gt_ir.Cast) -> str:
         expr = self.visit(node.expr)
-        dtype = self.DATA_TYPE_TO_CPP[node.dtype]
+        dtype = self.DATA_TYPE_TO_CPP[node.data_type]
         return f"static_cast<{dtype}>({expr})"
 
     def visit_BuiltinLiteral(self, node: gt_ir.BuiltinLiteral) -> str:

--- a/src/gt4py/backend/gtc_backend/defir_to_gtir.py
+++ b/src/gt4py/backend/gtc_backend/defir_to_gtir.py
@@ -209,7 +209,7 @@ class DefIRToGTIR(IRNodeVisitor):
         raise NotImplementedError(f"BuiltIn.{node.value} not implemented in lowering")
 
     def visit_Cast(self, node: Cast) -> gtir.Cast:
-        return gtir.Cast(dtype=common.DataType(node.dtype.value), expr=self.visit(node.expr))
+        return gtir.Cast(dtype=common.DataType(node.data_type.value), expr=self.visit(node.expr))
 
     def visit_NativeFuncCall(self, node: NativeFuncCall) -> gtir.NativeFuncCall:
         return gtir.NativeFuncCall(

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -259,13 +259,6 @@ class AxisIntervalParser(ast.NodeVisitor):
         else:
             return gt_ir.AxisBound(level=gt_ir.LevelMarker.END, offset=0, loc=self.loc)
 
-    def visit_NameConstant(self, node: ast.NameConstant) -> gt_ir.AxisBound:
-        """Python < 3.8 uses ast.NameConstant for 'None'."""
-        if node.value is not None:
-            raise self.interval_error
-        else:
-            return gt_ir.AxisBound(level=gt_ir.LevelMarker.END, offset=0, loc=self.loc)
-
     def visit_BinOp(self, node: ast.BinOp) -> gt_ir.AxisBound:
         left = self.visit(node.left)
         right = self.visit(node.right)

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1122,7 +1122,7 @@ class IRMaker(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call):
         native_fcn = gt_ir.NativeFunction.PYTHON_SYMBOL_TO_IR_OP[node.func.id]
 
-        args = [gt_ir.utils.make_expr(self.visit(arg)) for arg in node.args]
+        args = [self.visit(arg) for arg in node.args]
         if len(args) != native_fcn.arity:
             raise GTScriptSyntaxError(
                 "Invalid native function call", loc=gt_ir.Location.from_ast_node(node)
@@ -1202,7 +1202,7 @@ class IRMaker(ast.NodeVisitor):
 
             target.append(self.visit(t))
 
-        value = [gt_ir.utils.make_expr(item) for item in gt_utils.listify(self.visit(node.value))]
+        value = [item for item in gt_utils.listify(self.visit(node.value))]
 
         assert len(target) == len(value)
         for left, right in zip(target, value):

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1202,7 +1202,7 @@ class IRMaker(ast.NodeVisitor):
 
             target.append(self.visit(t))
 
-        value = [item for item in gt_utils.listify(self.visit(node.value))]
+        value = gt_utils.listify(self.visit(node.value))
 
         assert len(target) == len(value)
         for left, right in zip(target, value):

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -964,7 +964,10 @@ class IRMaker(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript):
         assert isinstance(node.ctx, (ast.Load, ast.Store))
-        index = [ast.literal_eval(n) for n in node.slice.value.elts]
+        index_asts = (
+            node.slice.value.elts if isinstance(node.slice.value, ast.Tuple) else node.slice.value
+        )
+        index = [ast.literal_eval(iast) for iast in gt_utils.listify(index_asts)]
         result = self.visit(node.value)
         if isinstance(result, gt_ir.VarRef):
             result.index = index[0]

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -964,7 +964,7 @@ class IRMaker(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript):
         assert isinstance(node.ctx, (ast.Load, ast.Store))
-        index = tuple(sl.value for sl in gt_utils.listify(self.visit(node.slice)))
+        index = [ast.literal_eval(n) for n in node.slice.value.elts]
         result = self.visit(node.value)
         if isinstance(result, gt_ir.VarRef):
             result.index = index[0]

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -403,7 +403,7 @@ class FieldRef(Ref):
 
 @attribclass
 class Cast(Expr):
-    dtype = attribute(of=DataType)
+    data_type = attribute(of=DataType)
     expr = attribute(of=Expr)
     loc = attribute(of=Location, optional=True)
 

--- a/src/gt4py/ir/utils.py
+++ b/src/gt4py/ir/utils.py
@@ -31,17 +31,6 @@ from .nodes import *
 DEFAULT_LAYOUT_ID = "_default_layout_id_"
 
 
-def make_expr(value):
-    if isinstance(value, Expr):
-        result = value
-    elif isinstance(value, numbers.Number):
-        data_type = DataType.from_dtype(np.dtype(type(value)))
-        result = ScalarLiteral(value=value, data_type=data_type)
-    else:
-        raise ValueError("Invalid expression value '{}'".format(value))
-    return result
-
-
 def make_field_decl(
     name: str,
     dtype=np.float_,

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -101,7 +101,7 @@ class TestInlinedExternals:
                         + GLOBAL_NESTED_CONSTANTS.A
                         + GLOBAL_VERY_NESTED_CONSTANTS.nested.A
                     )
-                    if GLOBAL_BOOL_CONSTANT
+                    if GLOBAL_BOOL_CONSTANT and inout_field < 1.0
                     else 0
                 )
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -101,7 +101,7 @@ class TestInlinedExternals:
                         + GLOBAL_NESTED_CONSTANTS.A
                         + GLOBAL_VERY_NESTED_CONSTANTS.nested.A
                     )
-                    if GLOBAL_BOOL_CONSTANT and inout_field < 1.0
+                    if GLOBAL_BOOL_CONSTANT
                     else 0
                 )
 


### PR DESCRIPTION
## Description

- Fixes problem where `DataTypePass` fails on `BuiltinLiteral`s in `BoolOp`s, since they do not have a `data_type` attribute.
- Fixes problem where `Cast` nodes also fail in the `DataTypePass`, since these used `dtype` instead of `data_type` for the attribute name.
- Tidying up: Removes all references to `ast.Num` and `ast.NameConstant` in `gtscript_frontend.py`.

This also replaces `visit_Num` and `visit_NameConstant` with `visit_Constant` in `IRMaker`, as we are now requiring at least Python 3.8.

I would have added a test for this, but the best place for this is in the pass unit tests, and we do not have the test infrastructure `TIfStmt` type yet to support this type of check.

This is a simple test that triggers it:
```python
something: bool = False
@stencil(backend, rebuild=True)
def func(a: Field[float], b: Field[float]):
    with computation(PARALLEL), interval(...):
        if a > 0 and something:
            b = 0.0
        else:
            b = a[-1, 0, 0]
```