### PR TITLE
Support calling gtscript functions as module.func

### DIFF
--- a/src/gt4py/utils/meta.py
+++ b/src/gt4py/utils/meta.py
@@ -249,18 +249,6 @@ class ASTTransformPass(ASTPass):
         return node
 
 
-def get_qualified_name(base_node: Union[ast.Name, ast.Attribute]):
-    node = base_node.body if isinstance(base_node, ast.Expression) else base_node
-    if isinstance(node, ast.Name):
-        return node.id
-    elif isinstance(node, ast.Attribute):
-        return get_qualified_name(node.value) + "." + node.attr
-    else:
-        raise ValueError(
-            f"Expected a node of type Union[ast.Name, ast.Attribute], but got {type(node)}"
-        )
-
-
 class ASTEvaluator(ASTPass):
     AST_OP_TO_OP = {
         # Arithmetic operations
@@ -336,7 +324,7 @@ class ASTEvaluator(ASTPass):
         return condition
 
     def visit_Attribute(self, node: ast.Attribute):
-        qualified_name = get_qualified_name(node)
+        qualified_name = get_qualified_name_from_node(node)
         if qualified_name not in self.context:
             raise ValueError(f"{qualified_name} not found in context")
         return self.context[qualified_name]

--- a/tests/test_unittest/test_meta.py
+++ b/tests/test_unittest/test_meta.py
@@ -22,10 +22,15 @@ import gt4py.utils as gt_util
 class TestGetQualifiedName:
     def test_name_only(self):
         name = "simple_name"
-        expr = ast.parse(name, mode="eval")
-        assert gt_util.meta.get_qualified_name(expr) == name
+        expr = ast.parse(name, mode="eval").body
+        assert gt_util.meta.get_qualified_name_from_node(expr) == name
 
     def test_nested_attribute(self):
         name = "module.submodule.name"
-        expr = ast.parse(name, mode="eval")
-        assert gt_util.meta.get_qualified_name(expr) == name
+        expr = ast.parse(name, mode="eval").body
+        assert gt_util.meta.get_qualified_name_from_node(expr) == name
+        assert gt_util.meta.get_qualified_name_from_node(expr, as_list=True) == [
+            "module",
+            "submodule",
+            "name",
+        ]


### PR DESCRIPTION
## Description

Uses `gt_meta.get_qualified_name_from_node` to allow for gtscript functions in other modules to be called.

* Removes duplicate functionality in `IRMaker._get_qualified_name` and `gt_meta.get_qualified_name`
* Adds tests for `gt_meta.get_qualified_name_from_node`