### PR TITLE
Remove Unneeded Temporary Assignment in Vertical Advection

### DIFF
--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -181,12 +181,10 @@ def vertical_advection_dycore(
     with computation(BACKWARD):
         with interval(-1, None):
             datacol = dcol[0, 0, 0]
-            data_col = datacol
             utens_stage = dtr_stage * (datacol - u_pos[0, 0, 0])
 
         with interval(0, -1):
-            datacol = dcol[0, 0, 0] - ccol[0, 0, 0] * data_col[0, 0, 1]
-            data_col = datacol
+            datacol = dcol[0, 0, 0] - ccol[0, 0, 0] * datacol[0, 0, 1]
             utens_stage = dtr_stage * (datacol - u_pos[0, 0, 0])
 
 


### PR DESCRIPTION
## Description

The vertical advection stencil definition contained a strange duplication of the datacol variable, namely datacol and data_col, this is removed.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


