### PR TITLE
Remove undecorated functions and recursively add nonlocals and imports

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1440,6 +1440,14 @@ class GTScriptParser(ast.NodeVisitor):
                         context,
                         gt_ir.Location.from_ast_node(name_nodes[collected_name][0]),
                     )
+                    if hasattr(nonlocal_symbols[collected_name], "_gtscript_"):
+                        # Recursively add nonlocals and imported symbols
+                        nonlocal_symbols.update(
+                            nonlocal_symbols[collected_name]._gtscript_["nonlocals"]
+                        )
+                        imported_symbols.update(
+                            nonlocal_symbols[collected_name]._gtscript_["imported"]
+                        )
                 elif root_name not in local_symbols and root_name in unbound:
                     raise GTScriptSymbolError(
                         name=collected_name,

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -1460,8 +1460,6 @@ class GTScriptParser(ast.NodeVisitor):
     def eval_external(name: str, context: dict, loc=None):
         try:
             value = eval(name, context)
-            if isinstance(value, types.FunctionType) and not hasattr(value, "_gtscript_"):
-                GTScriptParser.annotate_definition(value)
 
             assert (
                 value is None
@@ -1494,8 +1492,8 @@ class GTScriptParser(ast.NodeVisitor):
             if isinstance(value, types.FunctionType)
         }
         for name, value in func_externals.items():
-            if isinstance(value, types.FunctionType) and not hasattr(value, "_gtscript_"):
-                GTScriptParser.annotate_definition(value)
+            if not hasattr(value, "_gtscript_"):
+                raise TypeError(f"{value.__name__} is not a gtscript function")
             for imported_name, imported_value in value._gtscript_["imported"].items():
                 resolved_imports[imported_name] = imported_value
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -71,24 +71,8 @@ GLOBAL_VERY_NESTED_CONSTANTS = types.SimpleNamespace(nested=types.SimpleNamespac
 
 
 @gtscript.function
-def assert_in_func(field):
-    assert __INLINED(GLOBAL_CONSTANT < 2), "An error occurred"
-    return field[0, 0, 0] + GLOBAL_CONSTANT
-
-
-@gtscript.function
 def add_external_const(a):
     return a + 10.0 + GLOBAL_CONSTANT
-
-
-@gtscript.function
-def identity(field_in):
-    return field_in
-
-
-@gtscript.function
-def sinus(field_in):
-    return sin(field_in)
 
 
 class TestInlinedExternals:
@@ -141,83 +125,20 @@ class TestInlinedExternals:
                 definition_func, "test_missing_nested_symbol", module, externals=externals
             )
 
-    def test_undecorated_delay(self, id_version):
-        A = 0
-
-        def undecorated_function():
-            return A
-
-        module = f"TestInlinedExternals_test_undecorated_delay_{id_version}"
-        externals = {"func": undecorated_function}
-
-        A = 1
-
-        # Direct function
-        def definition_func(inout_field: gtscript.Field[float]):
-            from gt4py.__gtscript__ import PARALLEL, computation, interval
-
-            with computation(PARALLEL), interval(...):
-                inout_field = undecorated_function()
-
-        stencil_id, def_ir = compile_definition(
-            definition_func, "test_undecorated_delay", module, externals=externals
-        )
-
-        stmt = def_ir.computations[0].body.stmts[0]
-        assert isinstance(stmt.value, gt_ir.ScalarLiteral) and stmt.value.value == 1
-
-        # As external
-        def definition_func(inout_field: gtscript.Field[float]):
-            from gt4py.__externals__ import func
-            from gt4py.__gtscript__ import PARALLEL, computation, interval
-
-            with computation(PARALLEL), interval(...):
-                inout_field = func()
-
-        stencil_id, def_ir = compile_definition(
-            definition_func, "test_undecorated_delay", module, externals=externals
-        )
-
-        stmt = def_ir.computations[0].body.stmts[0]
-        assert isinstance(stmt.value, gt_ir.ScalarLiteral) and stmt.value.value == 1
-
-    def test_function_import(self, id_version):
+    def test_recursive_function_imports(self, id_version):
         module = f"TestInlinedExternals_test_recursive_imports_{id_version}"
 
-        def some_function():
-            from __externals__ import const
-
-            return const
-
-        def definition_func(inout_field: gtscript.Field[float]):
-            from __externals__ import some_call
-
-            with computation(PARALLEL), interval(...):
-                inout_field = some_call()
-
-        stencil_id, def_ir = compile_definition(
-            definition_func,
-            "test_recursive_imports",
-            module,
-            externals={"some_call": some_function, "const": GLOBAL_CONSTANT},
-        )
-        assert set(def_ir.externals.keys()) == {
-            "some_call",
-            "const",
-        }
-
-    def test_recursive_imports(self, id_version):
-        module = f"TestInlinedExternals_test_recursive_imports_{id_version}"
-
+        @gtscript.function
         def func_nest2():
             from __externals__ import const
 
             return const
 
+        @gtscript.function
         def func_nest1():
             from __externals__ import other
 
-            return other() + func_nest2()
+            return other()
 
         def definition_func(inout_field: gtscript.Field[float]):
             from __externals__ import some_call
@@ -236,18 +157,17 @@ class TestInlinedExternals:
             "const",
             "other",
             "func_nest1",
-            "tests.test_unittest.test_gtscript_frontend.func_nest1.func_nest2",
         }
 
     def test_decorated_freeze(self):
         A = 0
 
         @gtscript.function
-        def undecorated_function():
+        def some_function():
             return A
 
         module = f"TestInlinedExternals_test_undecorated_delay_{id_version}"
-        externals = {"func": undecorated_function}
+        externals = {"func": some_function}
 
         A = 1
 
@@ -255,7 +175,7 @@ class TestInlinedExternals:
             from gt4py.__gtscript__ import PARALLEL, computation, interval
 
             with computation(PARALLEL), interval(...):
-                inout_field = undecorated_function()
+                inout_field = some_function()
 
         stencil_id, def_ir = compile_definition(
             definition_func, "test_decorated_freeze", module, externals=externals
@@ -279,6 +199,24 @@ class TestInlinedExternals:
 
         with pytest.raises(gt_frontend.GTScriptDefinitionError, match=r".*WRONG_VALUE_CONSTANT.*"):
             compile_definition(definition_func, "test_wrong_value", module, externals=externals)
+
+
+class TestFunction:
+    def test_error_invalid(self, id_version):
+        module = f"TestFunction_test_module_{id_version}"
+        externals = {}
+
+        def func():
+            return 1.0
+
+        def definition_func(inout_field: gtscript.Field[float]):
+            from gt4py.__gtscript__ import PARALLEL, computation, interval
+
+            with computation(PARALLEL), interval(...):
+                inout_field = func()
+
+        with pytest.raises(TypeError, match=r"func is not a gtscript function"):
+            compile_definition(definition_func, "test_error_invalid", module, externals=externals)
 
 
 class TestImportedExternals:
@@ -503,6 +441,10 @@ class TestExternalsWithSubroutines:
 
             return lap
 
+        @gtscript.function
+        def identity(field_in):
+            return field_in
+
         def definition_func(
             in_phi: gtscript.Field[np.float64],
             in_gamma: gtscript.Field[np.float64],
@@ -679,6 +621,11 @@ class TestCompileTimeAssertions:
         compile_definition(definition, "test_assert_nested_attribute", module)
 
     def test_inside_func(self, id_version):
+        @gtscript.function
+        def assert_in_func(field):
+            assert __INLINED(GLOBAL_CONSTANT < 2), "An error occurred"
+            return field[0, 0, 0] + GLOBAL_CONSTANT
+
         def definition(inout_field: gtscript.Field[float]):
             with computation(PARALLEL), interval(...):
                 inout_field = assert_in_func(inout_field)
@@ -1051,6 +998,10 @@ class TestNativeFunctions:
                 in_field += min(abs(sin(add_external_const(in_field))), -0.5)
 
     def test_native_in_function(self):
+        @gtscript.function
+        def sinus(field_in):
+            return sin(field_in)
+
         @gtscript.stencil(backend="debug")
         def func(in_field: gtscript.Field[np.float_]):
             with computation(PARALLEL), interval(...):


### PR DESCRIPTION
## Description

Recursively add nonlocals and imports from annotated functions. This fixes behavior both with decorated and undecorated functions. We can finally re-decorate all gtscript functions, because the original reason for introducing them is fixed.
