### PR TITLE
More menaingful names for tests in test suites.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,6 @@ repos:
           tests/test_integration/stencil_definitions.py |
           tests/test_integration/test_code_generation.py |
           tests/test_integration/test_cpp_regression.py |
-          tests/test_integration/test_suites.py |
           tests/test_integration/utils.py |
           tests/test_unittest/test_call_interface.py |
           tests/test_unittest/test_dawn_backends.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,10 +67,6 @@ repos:
           src/gt4py/storage/__init__.py |
           src/gt4py/storage/storage.py |
           src/gt4py/storage/utils.py |
-          src/gt4py/testing/__init__.py |
-          src/gt4py/testing/input_strategies.py |
-          src/gt4py/testing/suites.py |
-          src/gt4py/testing/utils.py |
           src/gt4py/utils/__init__.py |
           src/gt4py/utils/base.py |
           src/gt4py/utils/attrib.py |

--- a/src/gt4py/testing/__init__.py
+++ b/src/gt4py/testing/__init__.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+__all__ = ["field", "global_name", "none", "parameter", "StencilTestSuite"]
 try:
     from .input_strategies import field, global_name, none, parameter
     from .suites import StencilTestSuite

--- a/src/gt4py/testing/input_strategies.py
+++ b/src/gt4py/testing/input_strategies.py
@@ -18,7 +18,6 @@ import collections
 import numbers
 import types
 
-import hypothesis as hyp
 import hypothesis.strategies as hyp_st
 import numpy as np
 from hypothesis.extra import numpy as hyp_np
@@ -37,7 +36,6 @@ class _SymbolValueTuple(types.SimpleNamespace):
 
 def global_name(*, singleton=None, symbol=None, one_of=None, in_range=None):
     """Define a *global* symbol."""
-
     if singleton is not None:
         assert symbol is None and one_of is None and in_range is None
         return _SymbolValueTuple(kind="singleton", boundary=None, values=(singleton,))
@@ -64,7 +62,7 @@ def global_name(*, singleton=None, symbol=None, one_of=None, in_range=None):
         )
 
     else:
-        assert False, "Missing value descriptor"
+        raise AssertionError("Missing value descriptor")
 
 
 def field(*, in_range, boundary=None, extent=None):
@@ -99,7 +97,7 @@ def parameter(*, one_of=None, in_range=None):
         )
 
     else:
-        assert False, "Missing value descriptor"
+        raise AssertionError("Missing value descriptor")
 
 
 def none():
@@ -136,12 +134,7 @@ def one_of_values_st(args):
 
 def ndarray_shape_st(sizes):
     """Hypothesis strategy for shapes of `ndims` dimensions and size within `size_range`."""
-    # assert len(size_range) == 2
-    # return hyp_np.array_shapes(
-    #     min_dims=ndims, max_dims=ndims, min_side=size_range[0], max_side=size_range[1]
-    # )
-    tmp = hyp_st.tuples(*[hyp_st.integers(min_size, max_size) for (min_size, max_size) in sizes])
-    return tmp
+    return hyp_st.tuples(*[hyp_st.integers(min_size, max_size) for (min_size, max_size) in sizes])
 
 
 def padded_shape_st(shape_st, extra):
@@ -167,7 +160,6 @@ def ndarray_st(dtype, shape_strategy, value_st_factory):
         elements=value_st_factory(dtype),
         fill=value_st_factory(dtype),
     )
-    # print(id(tmp), id(shape_st), id(value_st_factory))
     return tmp
 
 

--- a/src/gt4py/testing/suites.py
+++ b/src/gt4py/testing/suites.py
@@ -355,7 +355,7 @@ class SuiteMeta(type):
 
 
 class StencilTestSuite(metaclass=SuiteMeta):
-    r"""Base class for every *stencil test suite*.
+    """Base class for every *stencil test suite*.
 
     Every new test suite must inherit from this class and define proper
     attributes and methods to generate a valid set of testing strategies.
@@ -363,55 +363,63 @@ class StencilTestSuite(metaclass=SuiteMeta):
 
     Supported and required class attributes are:
 
+    Attributes
+    ----------
     dtypes : `dict` or `list`
+        Required class attribute.
         GlobalDecl suite dtypes dictionary.
         - ``label``: `list` of `dtype`.
         If this value is a `list`, it will be converted to a `dict` with the default
         `None` key assigned to its value. It is meant to be populated with labels representing
         groups of symbols that should have the same type.
+
         Example:
+
         .. code-block:: python
 
                     {
                         'float_symbols' : (np.float32, np.float64),
-                        'int_symbols' : (int, np.int\_, np.int64)
-
+                        'int_symbols' : (int, np.int_, np.int64)
                     }
 
     domain_range : `Sequence` of pairs like `((int, int), (int, int) ... )`
-         CartesianSpace sizes for testing. Each item encodes the (min, max) range of sizes for every axis.
+        Required class attribute.
+        CartesianSpace sizes for testing. Each item encodes the (min, max) range of sizes for every axis.
     symbols : `dict`
+        Required class attribute.
         Definition of symbols (globals, parameters and inputs) used in this stencil.
         - ``name``: `utils._SymbolDescriptor`. It is recommended to use the convenience
         functions `global_name()`, `parameter()` and `field()`. These functions have similar
         and self-explanatory arguments. Note that `dtypes` could be a list of actual dtypes
         but it is usually assumed to be a label from the global suite dtypes dictionary.
     definition : `function`
+        Required class attribute.
         Stencil definition function.
     validation : `function`
+        Required class attribute.
         Stencil validation function. It should have exactly the same signature than
         arguments to access the actual values used in the current testing invocation.
         the ``definition`` function plus the extra ``_globals_``, ``_domain_``, and ``_origin_``
         It should always return a `list` of `numpy.ndarray` s, one per output, even if
         the function only defines one output value.
-
-    Automatically generated class members are:
-
     definition_strategies : `dict`
+        Automatically generated.
         Hypothesis strategies for the stencil parameters used at definition (externals)
         - ``constant_name``: Hypothesis strategy (`strategy`).
     validation_strategies : `dict`
+        Automatically generated.
         Hypothesis strategies for the stencil parameters used at run-time (fields and parameters)
         - ``field_name``: Hypothesis strategy (`strategy`).
         - ``parameter_name``: Hypothesis strategy (`strategy`).
     ndims : `int`
+        Automatically generated.
         Constant of dimensions (1-3). If the name of class ends in ["1D", "2D", "3D"],
         this attribute needs to match the name or an assertion error will be raised.
     global_boundaries : `dict`
+        Automatically generated.
         Expected global boundaries for the input fields.
         - ``field_name``: 'list' of ``ndim`` 'tuple`s  (``(lower_boundary, upper_boundary)``).
         Example (3D): `[(1, 3), (2, 2), (0, 0)]`
-
     """
 
     _skip_ = True  # Avoid processing of this empty test suite

--- a/src/gt4py/testing/suites.py
+++ b/src/gt4py/testing/suites.py
@@ -13,10 +13,10 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+import collections
 import inspect
 import sys
 import types
-from collections.abc import Mapping, Sequence
 from itertools import count, product
 
 import hypothesis as hyp
@@ -204,9 +204,7 @@ class SuiteMeta(type):
                     else ()
                 )
                 name = test["backend"]
-                name += "".join(
-                    "_{}_{}".format(key, value) for key, value in test["constants"].items()
-                )
+                name += "".join(f"_{key}_{value}" for key, value in test["constants"].items())
                 name += "".join(
                     "_{}_{}".format(key, value.name) for key, value in test["dtypes"].items()
                 )
@@ -236,7 +234,7 @@ class SuiteMeta(type):
                 else ()
             )
             name = test["backend"]
-            name += "".join("_{}_{}".format(key, value) for key, value in test["constants"].items())
+            name += "".join(f"_{key}_{value}" for key, value in test["constants"].items())
             name += "".join(
                 "_{}_{}".format(key, value.name) for key, value in test["dtypes"].items()
             )
@@ -269,7 +267,7 @@ class SuiteMeta(type):
         backends = cls_dict["backends"]
 
         # Create testing strategies
-        assert isinstance(cls_dict["symbols"], Mapping), "Invalid 'symbols' mapping"
+        assert isinstance(cls_dict["symbols"], collections.abc.Mapping), "Invalid 'symbols' mapping"
 
         # Check domain and ndims
         assert 1 <= len(domain_range) <= 3 and all(
@@ -283,11 +281,11 @@ class SuiteMeta(type):
 
         # Check dtypes
         assert isinstance(
-            cls_dict["dtypes"], (Sequence, Mapping)
+            cls_dict["dtypes"], (collections.abc.Sequence, collections.abc.Mapping)
         ), "'dtypes' must be a sequence or a mapping object"
 
         # Check backends
-        assert isinstance(backends, Sequence) and all(
+        assert isinstance(backends, collections.abc.Sequence) and all(
             isinstance(b, str) for b in backends
         ), "'backends' must be a sequence of strings"
         for b in backends:
@@ -315,7 +313,7 @@ class SuiteMeta(type):
                     break
 
         dtypes = cls_dict["dtypes"]
-        if isinstance(dtypes, Sequence):
+        if isinstance(dtypes, collections.abc.Sequence):
             dtypes = {tuple(cls_dict["symbols"].keys()): dtypes}
         cls_dict["dtypes"] = standardize_dtype_dict(dtypes)
         cls_dict["ndims"] = len(cls_dict["domain_range"])

--- a/src/gt4py/testing/utils.py
+++ b/src/gt4py/testing/utils.py
@@ -40,9 +40,11 @@ def annotate_function(function, dtypes):
 
 def standardize_dtype_dict(dtypes):
     """Standardizes the dtype dict as it can be specified for the stencil test suites.
+
     In the input dictionary, a selection of possible dtypes or just a single dtype can be specified for a set of fields
     or a single field. This function makes sure that all keys are tuples (by wrapping single field names and single
-    dtypes as 1-tuples)"""
+    dtypes as 1-tuples)
+    """
     assert isinstance(dtypes, collections.abc.Mapping)
     assert all(
         (isinstance(k, str) or gt_utils.is_iterable_of(k, str)) for k in dtypes.keys()
@@ -69,7 +71,7 @@ def standardize_dtype_dict(dtypes):
         result[key] = value
 
     for key, value in result.items():
-        result[key] = [np.dtype(dt) for dt in result[key]]
+        result[key] = [np.dtype(dt) for dt in value]
 
     keys = [k for t in result.keys() for k in t]
     if not len(keys) == len(set(keys)):

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -37,7 +37,7 @@ class TestIdentity(gt_testing.StencilTestSuite):
 
     dtypes = {("field_a",): (np.float64, np.float32)}
     domain_range = [(1, 25), (1, 25), (1, 25)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(field_a):
@@ -532,10 +532,9 @@ class TestOptionalField(gt_testing.StencilTestSuite):
     definition = optional_field
 
     def validation(in_field, out_field, dyn_tend, phys_tend=None, *, dt, domain, origin, **kwargs):
-        from __externals__ import PHYS_TEND
 
         out_field[...] = in_field + dt * dyn_tend
-        if PHYS_TEND:
+        if PHYS_TEND:  # noqa: F821
             out_field += dt * phys_tend
 
 
@@ -581,13 +580,12 @@ class TestTwoOptionalFields(gt_testing.StencilTestSuite):
         origin,
         **kwargs,
     ):
-        from __externals__ import PHYS_TEND_A, PHYS_TEND_B
 
         out_a[...] = in_a + dt * dyn_tend_a
         out_b[...] = in_b + dt * dyn_tend_b
-        if PHYS_TEND_A:
+        if PHYS_TEND_A:  # noqa: F821
             out_a += dt * phys_tend_a
-        if PHYS_TEND_B:
+        if PHYS_TEND_B:  # noqa: F821
             out_b += dt * phys_tend_b
 
 

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -171,9 +171,7 @@ class TestParametricMix(gt_testing.StencilTestSuite):
     def validation(
         field_a, field_b, field_c, field_out, *, weight, alpha_factor, domain, origin, **kwargs
     ):
-        from __externals__ import USE_ALPHA
-
-        if USE_ALPHA:
+        if USE_ALPHA:  # noqa: F821
             factor = alpha_factor
         else:
             factor = 1.0

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -21,13 +21,7 @@ from gt4py import gtscript
 from gt4py import testing as gt_testing
 from gt4py.gtscript import PARALLEL, computation, interval
 
-from ..definitions import (
-    ALL_BACKENDS,
-    CPU_BACKENDS,
-    DAWN_BACKENDS,
-    DAWN_GPU_BACKENDS,
-    INTERNAL_BACKENDS,
-)
+from ..definitions import ALL_BACKENDS, DAWN_BACKENDS, DAWN_GPU_BACKENDS, INTERNAL_BACKENDS
 from .stencil_definitions import optional_field, two_optional_fields
 
 
@@ -42,7 +36,8 @@ class TestIdentity(gt_testing.StencilTestSuite):
 
     def definition(field_a):
         with computation(PARALLEL), interval(...):
-            field_a = field_a  # TODO need 'pass'
+            tmp = field_a
+            field_a = tmp
 
     def validation(field_a, domain=None, origin=None):
         pass
@@ -54,7 +49,7 @@ class TestCopy(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 25), (1, 25), (1, 25)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         field_b=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -73,7 +68,7 @@ class TestAugAssign(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 25), (1, 25), (1, 25)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         field_b=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -97,7 +92,7 @@ class TestGlobalScale(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         SCALE_FACTOR=gt_testing.global_name(one_of=(1.0, 1e3, 1e6)),
         field_a=gt_testing.field(in_range=(-1, 1), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -119,7 +114,7 @@ class TestParametricScale(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         scale=gt_testing.parameter(in_range=(-100, 100)),
@@ -144,7 +139,7 @@ class TestParametricMix(gt_testing.StencilTestSuite):
         ("weight", "alpha_factor"): np.float_,
     }
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = list(set(CPU_BACKENDS) & set(INTERNAL_BACKENDS))
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         USE_ALPHA=gt_testing.global_name(one_of=(True, False)),
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -183,7 +178,7 @@ class TestParametricMix(gt_testing.StencilTestSuite):
 class TestHeatEquation_FTCS_3D(gt_testing.StencilTestSuite):
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         u=gt_testing.field(in_range=(-10, 10), extent=[(-1, 1), (0, 0), (0, 0)]),
         v=gt_testing.field(in_range=(-10, 10), extent=[(0, 0), (-1, 1), (0, 0)]),
@@ -208,7 +203,7 @@ class TestHorizontalDiffusion(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         u=gt_testing.field(in_range=(-10, 10), boundary=[(2, 2), (2, 2), (0, 0)]),
         diffusion=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -271,7 +266,7 @@ class TestHorizontalDiffusionSubroutines(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         fwd_diff=gt_testing.global_name(singleton=wrap1arg2return),
         u=gt_testing.field(in_range=(-10, 10), boundary=[(2, 2), (2, 2), (0, 0)]),
@@ -305,7 +300,7 @@ class TestHorizontalDiffusionSubroutines2(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         fwd_diff=gt_testing.global_name(singleton=fwd_diff_op_xy),
         BRANCH=gt_testing.global_name(one_of=(True, False)),
@@ -345,7 +340,7 @@ class TestRuntimeIfFlat(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(outfield):
@@ -366,7 +361,7 @@ class TestRuntimeIfNested(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(outfield):
@@ -415,7 +410,7 @@ class TestRuntimeIfNestedDataDependent(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(3, 3), (3, 3), (3, 3)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         factor=gt_testing.parameter(in_range=(-100, 100)),
         field_a=gt_testing.field(in_range=(-1, 1), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -451,7 +446,7 @@ class TestTernaryOp(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         infield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 1), (0, 0)]),
         outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -472,7 +467,7 @@ class TestThreeWayAnd(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         a=gt_testing.parameter(in_range=(-100, 100)),
@@ -496,7 +491,7 @@ class TestThreeWayOr(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]
-    backends = CPU_BACKENDS
+    backends = INTERNAL_BACKENDS
     symbols = dict(
         outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         a=gt_testing.parameter(in_range=(-100, 100)),

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -57,7 +57,7 @@ class TestCopy(gt_testing.StencilTestSuite):
 
     def definition(field_a, field_b):
         with computation(PARALLEL), interval(...):
-            field_b = field_a  # noqa: F841
+            field_b = field_a  # noqa: F841  # Local name is assigned to but never used
 
     def validation(field_a, field_b, domain=None, origin=None):
         field_b[...] = field_a
@@ -105,7 +105,7 @@ class TestGlobalScale(gt_testing.StencilTestSuite):
             field_a = SCALE_FACTOR * field_a[0, 0, 0]
 
     def validation(field_a, domain, origin, **kwargs):
-        field_a[...] = SCALE_FACTOR * field_a  # noqa: F821
+        field_a[...] = SCALE_FACTOR * field_a  # noqa: F821  # Undefined name
 
 
 # ---- Parametric scale stencil -----
@@ -159,14 +159,14 @@ class TestParametricMix(gt_testing.StencilTestSuite):
                 factor = alpha_factor
             else:
                 factor = 1.0
-            field_out = factor * field_a[0, 0, 0] - (1 - factor) * (  # noqa: F841
-                field_b[0, 0, 0] - weight * field_c[0, 0, 0]
-            )
+            field_out = factor * field_a[  # noqa: F841 # Local name is assigned to but never used
+                0, 0, 0
+            ] - (1 - factor) * (field_b[0, 0, 0] - weight * field_c[0, 0, 0])
 
     def validation(
         field_a, field_b, field_c, field_out, *, weight, alpha_factor, domain, origin, **kwargs
     ):
-        if USE_ALPHA:  # noqa: F821
+        if USE_ALPHA:  # noqa: F821  # Undefined name
             factor = alpha_factor
         else:
             factor = 1.0
@@ -190,8 +190,12 @@ class TestHeatEquation_FTCS_3D(gt_testing.StencilTestSuite):
 
     def definition(u, v, u_new, v_new, *, ru, rv):
         with computation(PARALLEL), interval(...):
-            u_new = u[0, 0, 0] + ru * (u[1, 0, 0] - 2 * u[0, 0, 0] + u[-1, 0, 0])  # noqa: F841
-            v_new = v[0, 0, 0] + rv * (v[0, 1, 0] - 2 * v[0, 0, 0] + v[0, -1, 0])  # noqa: F841
+            u_new = u[0, 0, 0] + ru * (  # noqa: F841 # Local name is assigned to but never used
+                u[1, 0, 0] - 2 * u[0, 0, 0] + u[-1, 0, 0]
+            )
+            v_new = v[0, 0, 0] + rv * (  # noqa: F841 # Local name is assigned to but never used
+                v[0, 1, 0] - 2 * v[0, 0, 0] + v[0, -1, 0]
+            )
 
     def validation(u, v, u_new, v_new, *, ru, rv, domain, origin, **kwargs):
         u_new[...] = u[1:-1, :, :] + ru * (u[2:, :, :] - 2 * u[1:-1, :, :] + u[:-2, :, :])
@@ -215,9 +219,9 @@ class TestHorizontalDiffusion(gt_testing.StencilTestSuite):
             laplacian = 4.0 * u[0, 0, 0] - (u[1, 0, 0] + u[-1, 0, 0] + u[0, 1, 0] + u[0, -1, 0])
             flux_i = laplacian[1, 0, 0] - laplacian[0, 0, 0]
             flux_j = laplacian[0, 1, 0] - laplacian[0, 0, 0]
-            diffusion = u[0, 0, 0] - weight * (  # noqa: F841
-                flux_i[0, 0, 0] - flux_i[-1, 0, 0] + flux_j[0, 0, 0] - flux_j[0, -1, 0]
-            )
+            diffusion = u[  # noqa: F841 # Local name is assigned to but never used
+                0, 0, 0
+            ] - weight * (flux_i[0, 0, 0] - flux_i[-1, 0, 0] + flux_j[0, 0, 0] - flux_j[0, -1, 0])
 
     def validation(u, diffusion, *, weight, domain, origin, **kwargs):
         laplacian = 4.0 * u[1:-1, 1:-1, :] - (
@@ -280,9 +284,9 @@ class TestHorizontalDiffusionSubroutines(gt_testing.StencilTestSuite):
         with computation(PARALLEL), interval(...):
             laplacian = lap_op(u=u)
             flux_i, flux_j = fwd_diff(field=laplacian)
-            diffusion = u[0, 0, 0] - weight * (  # noqa: F841
-                flux_i[0, 0, 0] - flux_i[-1, 0, 0] + flux_j[0, 0, 0] - flux_j[0, -1, 0]
-            )
+            diffusion = u[  # noqa: F841 # Local name is assigned to but never used
+                0, 0, 0
+            ] - weight * (flux_i[0, 0, 0] - flux_i[-1, 0, 0] + flux_j[0, 0, 0] - flux_j[0, -1, 0])
 
     def validation(u, diffusion, *, weight, domain, origin, **kwargs):
         laplacian = 4.0 * u[1:-1, 1:-1, :] - (
@@ -320,9 +324,9 @@ class TestHorizontalDiffusionSubroutines2(gt_testing.StencilTestSuite):
                 flux_j = fwd_diff_op_y(field=laplacian)
             else:
                 flux_i, flux_j = fwd_diff_op_xy(field=laplacian)
-            diffusion = u[0, 0, 0] - weight * (  # noqa: F841
-                flux_i[0, 0, 0] - flux_i[-1, 0, 0] + flux_j[0, 0, 0] - flux_j[0, -1, 0]
-            )
+            diffusion = u[  # noqa: F841 # Local name is assigned to but never used
+                0, 0, 0
+            ] - weight * (flux_i[0, 0, 0] - flux_i[-1, 0, 0] + flux_j[0, 0, 0] - flux_j[0, -1, 0])
 
     def validation(u, diffusion, *, weight, domain, origin, **kwargs):
         laplacian = 4.0 * u[1:-1, 1:-1, :] - (
@@ -350,7 +354,7 @@ class TestRuntimeIfFlat(gt_testing.StencilTestSuite):
             if True:
                 outfield = 1
             else:
-                outfield = 2  # noqa: F841
+                outfield = 2  # noqa: F841  # Local name is assigned to but never used
 
     def validation(outfield, *, domain, origin, **kwargs):
         outfield[...] = 1
@@ -424,12 +428,12 @@ class TestRuntimeIfNestedDataDependent(gt_testing.StencilTestSuite):
                 if field_a < 0:
                     field_b = -field_a
                 else:
-                    field_b = field_a  # noqa: F841
+                    field_b = field_a  # noqa: F841  # Local name is assigned to but never used
             else:
                 if field_a < 0:
                     field_c = -field_a
                 else:
-                    field_c = field_a  # noqa: F841
+                    field_c = field_a  # noqa: F841  # Local name is assigned to but never used
 
             field_a = add_one(field_a)
 
@@ -455,9 +459,9 @@ class TestTernaryOp(gt_testing.StencilTestSuite):
     def definition(infield, outfield):
 
         with computation(PARALLEL), interval(...):
-            outfield = (infield > 0.0) * infield + (infield <= 0.0) * (  # noqa: F841
-                -infield[0, 1, 0]
-            )
+            outfield = (  # noqa: F841 # Local name is assigned to but never used
+                infield > 0.0
+            ) * infield + (infield <= 0.0) * (-infield[0, 1, 0])
 
     def validation(infield, outfield, *, domain, origin, **kwargs):
         outfield[...] = np.choose(infield[:, :-1, :] > 0, [-infield[:, 1:, :], infield[:, :-1, :]])
@@ -481,7 +485,7 @@ class TestThreeWayAnd(gt_testing.StencilTestSuite):
             if a > 0 and b > 0 and c > 0:
                 outfield = 1
             else:
-                outfield = 0  # noqa: F841
+                outfield = 0  # noqa: F841  # Local name is assigned to but never used
 
     def validation(outfield, *, a, b, c, domain, origin, **kwargs):
         outfield[...] = 1 if a > 0 and b > 0 and c > 0 else 0
@@ -505,7 +509,7 @@ class TestThreeWayOr(gt_testing.StencilTestSuite):
             if a > 0 or b > 0 or c > 0:
                 outfield = 1
             else:
-                outfield = 0  # noqa: F841
+                outfield = 0  # noqa: F841  # Local name is assigned to but never used
 
     def validation(outfield, *, a, b, c, domain, origin, **kwargs):
         outfield[...] = 1 if a > 0 or b > 0 or c > 0 else 0
@@ -529,7 +533,7 @@ class TestOptionalField(gt_testing.StencilTestSuite):
     def validation(in_field, out_field, dyn_tend, phys_tend=None, *, dt, domain, origin, **kwargs):
 
         out_field[...] = in_field + dt * dyn_tend
-        if PHYS_TEND:  # noqa: F821
+        if PHYS_TEND:  # noqa: F821  # Undefined name
             out_field += dt * phys_tend
 
 
@@ -578,9 +582,9 @@ class TestTwoOptionalFields(gt_testing.StencilTestSuite):
 
         out_a[...] = in_a + dt * dyn_tend_a
         out_b[...] = in_b + dt * dyn_tend_b
-        if PHYS_TEND_A:  # noqa: F821
+        if PHYS_TEND_A:  # noqa: F821  # Undefined name
             out_a += dt * phys_tend_a
-        if PHYS_TEND_B:  # noqa: F821
+        if PHYS_TEND_B:  # noqa: F821  # Undefined name
             out_b += dt * phys_tend_b
 
 


### PR DESCRIPTION
This PR
* adds a unique name based on backend, dtypes and global parameter values to the individual tests of a test suite, s.t. it is possible to e.g. filter tests based on backend names. I.e. `pytest -k gtc` etc.   
* removes the gt4py.testing direcotry and test_suites.py file from flake8 ignores and fixes conflicts