### PR TITLE
Add datamodels

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ flake8-rst-docstrings>=0.0.14
 flakehell>=0.9
 hypothesis>=4.14
 isort~=5.1
+mypy>=0.800
 pre-commit~=1.18
 psutil>=5.0
 pygments>=2.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -181,7 +181,7 @@ lines_after_imports = 2
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = eve,gtc,gt4py,__externals__,__gtscript__
-known_third_party = attr,black,boltons,cached_property,click,dawn4py,devtools,factory,hypothesis,jinja2,mako,networkx,numpy,packaging,pkg_resources,pybind11,pydantic,pytest,setuptools,tabulate,tests,typing_extensions,typing_inspect,xxhash
+known_third_party = attr,black,boltons,cached_property,click,dawn4py,devtools,factory,hypothesis,jinja2,mako,networkx,numpy,packaging,pkg_resources,pybind11,pydantic,pytest,pytest_factoryboy,setuptools,tabulate,tests,typing_extensions,typing_inspect,xxhash
 
 
 #-- mypy --

--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -17,9 +17,6 @@
 """Eve: a stencil toolchain in pure Python."""
 
 
-# flake8: noqa  # disable flake8 because of non-used imports warnings
-from .version import __version__, __versioninfo__  # isort:skip
-
 # Internal dependencies between modules (each line depends on some of the previous ones):
 #
 #   - typingx  (no dependencies)
@@ -29,6 +26,11 @@ from .version import __version__, __versioninfo__  # isort:skip
 #   - traits, visitors
 #   - codegen
 #
+
+# flake8: noqa  # disable flake8 because of non-used imports warnings
+
+from __future__ import annotations  # isort:skip
+from .version import __version__, __versioninfo__  # isort:skip
 
 from .concepts import (
     FieldKind,

--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -14,22 +14,22 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Eve: a stencil toolchain in pure Python."""
+"""Eve framework to support development of DSL toolchains in pure Python.
 
+The internal dependencies between modules are the following (each line depends
+on some of the previous ones):
 
-# Internal dependencies between modules (each line depends on some of the previous ones):
-#
-#   - typingx  (no dependencies)
-#   - exceptions, type_definitions
-#   - utils
-#   - concepts <-> iterators  (circular dependency only inside methods, it should be safe)
-#   - traits, visitors
-#   - codegen
-#
+  - typingx  (no dependencies)
+  - exceptions, type_definitions
+  - utils
+  - concepts <-> iterators  (circular dependency only inside methods, it should be safe)
+  - traits, visitors
+  - codegen
 
-# flake8: noqa  # disable flake8 because of non-used imports warnings
+"""
 
 from __future__ import annotations  # isort:skip
+
 from .version import __version__, __versioninfo__  # isort:skip
 
 from .concepts import (
@@ -64,3 +64,39 @@ from .type_definitions import (
     SymbolRef,
 )
 from .visitors import NodeMutator, NodeTranslator, NodeVisitor
+
+
+__all__ = [
+    "__version__",
+    "__versioninfo__",
+    "Bool",
+    "Enum",
+    "Float",
+    "Int",
+    "IntEnum",
+    "FieldKind",
+    "FrozenModel",
+    "FrozenNode",
+    "GenericNode",
+    "Model",
+    "NegativeFloat",
+    "NegativeInt",
+    "NOTHING",
+    "Node",
+    "NodeMutator",
+    "NodeTranslator",
+    "NodeVisitor",
+    "PositiveFloat",
+    "PositiveInt",
+    "SourceLocation",
+    "Str",
+    "StrEnum",
+    "SymbolName",
+    "SymbolRef",
+    "SymbolTableTrait",
+    "VType",
+    "field",
+    "iter_tree",
+    "in_field",
+    "out_field",
+]

--- a/src/eve/datamodels.py
+++ b/src/eve/datamodels.py
@@ -183,11 +183,24 @@ class GenericDataModelAlias(typing._GenericAlias, _root=True):  # type: ignore[c
         >>> @datamodel
         ... class Model(Generic[T]):
         ...     value: T
+        ...
+        >>> print(Model.__parameters__)
+        (~T,)
+        >>> hasattr(Model, '__args__')
+        False
+
         >>> assert isinstance(Model[int], GenericDataModelAlias)
         >>> assert issubclass(get_origin(Model[int]), Model)
         >>> assert Model[int].__class__ is get_origin(Model[int])
         >>> print(Model[int].__class__.__name__)
         Model__int
+
+        >>> print(Model[int].__parameters__)
+        ()
+        >>> hasattr(Model[int], '__args__')
+        True
+        >>> print(Model[int].__args__)
+        (<class 'int'>,)
 
     Notes:
         For the full picture check also related PEPs:
@@ -394,9 +407,7 @@ def strict_type_attrs_validator(
         return type_hint.__type_validator__()
 
     # Non-generic types
-    if isinstance(type_hint, type) and type_hint is not type(  # noqa: E721  # use isinstance()
-        None
-    ):
+    if isinstance(type_hint, type) and type_hint is not type(None):  # noqa: E721  # use isinstance
         assert not type_args
         if type_hint is int:
             return instance_of_int_attrs_validator()
@@ -1211,7 +1222,8 @@ def datamodel(
         unsafe_hash: If ``False``, a ``__hash__()`` method is generated in a safe way
             according to how ``eq`` and ``frozen`` are set, or set to ``None`` (disabled)
             otherwise. If ``True``, a ``__hash__()`` method is generated anyway
-            (use with care). See :func:`dataclasses.dataclass` for the complete explanation.
+            (use with care). See :func:`dataclasses.dataclass` for the complete explanation
+            (or other sources like: `<https://hynek.me/articles/hashes-and-equality/>`_).
         frozen: If ``True``, assigning to fields will generate an exception.
             This emulates read-only frozen instances. The ``__setattr__()`` and
             ``__delattr__()`` methods should not be defined in the class.

--- a/src/eve/datamodels.py
+++ b/src/eve/datamodels.py
@@ -1,0 +1,1190 @@
+# -*- coding: utf-8 -*-
+#
+# Eve Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-l directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Data Model class and related utils.
+
+Data Models can be considered as an extension to ``dataclasses`` providing
+run-time validation utils for fields. Values assigned to fields at
+initialization are validated with automatic type checkings using the
+field type definition. Custom field validation methods can also be added with
+the :func:`validator` decorator, and global instance validation methods with
+:func:`root_validator`.
+
+The datamodels API is intentionally copying ``dataclasses`` API as close as
+possible. Actually, Data Model classes are also ``dataclasses``, so all functions
+dealing with ``dataclasses`` should also work with Data Models.
+
+Notes:
+    Since the current implementation uses `attrs <https://www.attrs.org/>`_ internally,
+    Data Model classes are also ``attrs`` classes.
+
+Examples:
+    >>> @datamodel
+    ... class SampleModel:
+    ...     name: str
+    ...     value: int
+    ...
+    ...     @validator('name')
+    ...     def _name_validator(self, attribute, value):
+    ...         if len(value) < 5:
+    ...             raise ValueError(
+    ...                 f"Provided value '{value}' for '{attribute.name}' field is too short."
+    ...             )
+
+
+    >>> class AnotherSampleModel(DataModel):
+    ...     name: str
+    ...     friends: List[str]
+    ...
+    ...     @root_validator
+    ...     def _root_validator(cls, instance):
+    ...         if instace.name in instance.friends:
+    ...             raise ValueError("'name' value cannot appear in 'friends' list.")
+"""
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import sys
+import typing
+import warnings
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generator,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+
+import attr
+
+from eve.typingx import NonDataDescriptor
+
+from . import utils
+from .concepts import NOTHING
+
+
+# Typing
+T = TypeVar("T")
+V = TypeVar("V")
+
+
+class _AttrClassLike(Protocol):
+    __attrs_attrs__: ClassVar[Tuple[attr.Attribute, ...]]
+
+
+class _DataClassLike(Protocol):
+    __dataclass_fields__: ClassVar[Tuple[dataclasses.Field, ...]]
+
+    def __post_init__(self) -> None:
+        ...
+
+
+class _DevToolsPrettyPrintable(Protocol):
+    def __pretty__(self, fmt: Callable[[Any], Any], **kwargs: Any) -> Generator[Any, None, None]:
+        ...
+
+
+class DataModelLike(_AttrClassLike, _DataClassLike, _DevToolsPrettyPrintable, Protocol):
+    __datamodel_fields__: ClassVar[utils.FrozenNamespace]
+    __datamodel_params__: ClassVar[utils.FrozenNamespace]
+    __datamodel_validators__: ClassVar[
+        Tuple[NonDataDescriptor[DataModelLike, BoundRootValidator], ...]
+    ]
+
+
+class GenericDataModelLike(DataModelLike):
+    __args__: ClassVar[Tuple[Union[Type, TypeVar]]]
+    __parameters__: ClassVar[Tuple[TypeVar]]
+
+    @classmethod
+    def __class_getitem__(
+        cls: Type[GenericDataModelLike], args: Union[Type, Tuple[Type]]
+    ) -> GenericDataModelAlias:
+        ...
+
+
+ValidatorFunc = Callable[[DataModelLike, attr.Attribute, T], None]
+BoundValidator = Callable[[attr.Attribute, T], None]
+
+RootValidatorFunc = Callable[[Type[DataModelLike], DataModelLike], None]
+BoundRootValidator = Callable[[DataModelLike], None]
+
+
+class GenericDataModelAlias(typing._GenericAlias, _root=True):  # type: ignore  # typing._GenericAlias is not visible for mypy
+    """Custom class alias compatible with aliases created by ``typing.Generic``.
+
+    This class emulates the :class:`typing._GenericAlias` behavior, to be
+    compatible with the mechanism of the :mod:`typing` module for ``Generic``
+    types. Basically, a :class:`typing._GenericAlias` instance is a class
+    proxy which stores a reference to the original class (``__origin__``),
+    the generic type parameters (``__parameters__``) and the concrete
+    types passed at creation (``__args__``).
+
+    Both :class:`typing._GenericAlias` and this class implement a
+    ``__mro__entries__()`` method (PEP 560) and, therefore, when
+    instances of these classes are found in the list of bases of
+    a new class, they are automatically substituted by the original
+    Python class, and the new type is created as usual.
+
+    Instances of this class work exactly in the same way, but also
+    create new actual Data Model classes during the `concretization`
+    of generic models, which are stored instead of the original
+    generic models in the ``__origin__`` attribute.
+
+    The new concrete class can be accessed as usual using
+    :class:`typing.get_origin` or by using the custom :attr:`__class__`
+    shortcut provided by this class.
+
+    Examples:
+        >>> from typing import Generic, get_origin
+        >>> @datamodel
+        ... class Model(Generic[T]):
+        ...     value: T
+        >>> assert isinstance(Model[int], GenericDataModelAlias)
+        >>> assert issubclass(get_origin(Model[int]), Model)
+        >>> assert Model[int].__class__ is get_origin(Model[int])
+        >>> print(Model[int].__class__.__name__)
+        Model__int
+
+    Notes:
+        For the full picture check also related PEPs:
+
+            - https://www.python.org/dev/peps/pep-0526/
+            - https://www.python.org/dev/peps/pep-0560/
+    """
+
+    __origin__: Type[GenericDataModelLike]
+
+    def __getitem__(self, args: Union[Type, Tuple[Type]]) -> GenericDataModelAlias:
+        origin_model: Type[GenericDataModelLike] = self.__origin__
+        assert isinstance(origin_model, type) and is_generic(origin_model)
+        return origin_model.__class_getitem__(args)  # equivalent to: self.__origin__[args]
+
+    @property  # type: ignore  # Read-only property cannot override read-write property
+    def __class__(self) -> Type:
+        """Return the concrete class represented by this instance."""
+        assert isinstance(self.__origin__, type)
+        return self.__origin__
+
+
+# Implementation
+_FIELD_VALIDATOR_TAG = "_FIELD_VALIDATOR_TAG"
+_MODEL_FIELDS = "__datamodel_fields__"
+_MODEL_PARAMS = "__datamodel_params__"
+_ROOT_VALIDATOR_TAG = "__ROOT_VALIDATOR_TAG"
+_ROOT_VALIDATORS = "__datamodel_validators__"
+
+
+class _SENTINEL:
+    ...
+
+
+# -- Validators --
+class _TupleValidator:
+    """Implementation of attr.s type validator for Tuple typings."""
+
+    validators: Tuple[attr._ValidatorType, ...]
+    tuple_type: Type[Tuple]
+
+    def __init__(
+        self, validators: Tuple[attr._ValidatorType, ...], tuple_type: Type[Tuple]
+    ) -> None:
+        self.validators = validators
+        self.tuple_type = tuple_type
+
+    def __call__(self, instance: _AttrClassLike, attribute: attr.Attribute, value: Any) -> None:
+        if not isinstance(value, self.tuple_type):
+            raise TypeError(
+                f"In '{attribute.name}' validation, got '{value}' that is a {type(value)} instead of {self.tuple_type}."
+            )
+        if len(value) != len(self.validators):
+            raise TypeError(
+                f"In '{attribute.name}' validation, got '{value}' tuple which contains {len(value)} elements instead of {len(self.validators)}."
+            )
+
+        _i = None
+        item_value = ""
+        try:
+            for _i, (item_value, item_validator) in enumerate(zip(value, self.validators)):
+                item_validator(instance, attribute, item_value)
+        except Exception as e:
+            raise TypeError(
+                f"In '{attribute.name}' validation, tuple '{value}' contains invalid value '{item_value}' at position {_i}."
+            ) from e
+
+
+class _OrValidator:
+    """Implementation of attr.s validator composing multiple validators together using OR."""
+
+    validators: Tuple[attr._ValidatorType, ...]
+    error_type: Type[Exception]
+
+    def __init__(
+        self, validators: Tuple[attr._ValidatorType, ...], error_type: Type[Exception]
+    ) -> None:
+        self.validators = validators
+        self.error_type = error_type
+
+    def __call__(self, instance: _AttrClassLike, attribute: attr.Attribute, value: Any) -> None:
+        passed = False
+        for v in self.validators:
+            try:
+                v(instance, attribute, value)
+                passed = True
+                break
+            except Exception:
+                pass
+
+        if not passed:
+            raise self.error_type(
+                f"In '{attribute.name}' validation, provided value '{value}' fails for all the possible validators."
+            )
+
+
+class _LiteralValidator:
+    """Implementation of attr.s type validator for Literal typings."""
+
+    literal: Any
+
+    def __init__(self, literal: Any) -> None:
+        self.literal = literal
+
+    def __call__(self, instance: _AttrClassLike, attribute: attr.Attribute, value: Any) -> None:
+        if isinstance(self.literal, bool):
+            valid = value is self.literal
+        else:
+            valid = value == self.literal
+        if not valid:
+            raise ValueError(
+                f"Provided value '{value}' field does not match {self.literal} during '{attribute.name}' validation."
+            )
+
+
+def empty_attrs_validator() -> attr._ValidatorType:
+    """Create an attr.s empty validator which always succeeds."""
+
+    def _empty_validator(instance: _AttrClassLike, attribute: attr.Attribute, value: Any) -> None:
+        pass
+
+    return _empty_validator
+
+
+def instance_of_int_attrs_validator() -> attr._ValidatorType:
+    """Create an attr.s validator for `int` values which fails with `bool` values."""
+
+    def _int_validator(instance: _AttrClassLike, attribute: attr.Attribute, value: Any) -> None:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise TypeError(
+                f"'{attribute.name}' must be {int} (got '{value}' that is a {type(value)})."
+            )
+
+    return _int_validator
+
+
+def or_attrs_validator(
+    *validators: attr._ValidatorType, error_type: Type[Exception]
+) -> attr._ValidatorType:
+    """Create an attr.s validator combinator where only one of the validators needs to pass."""
+    if len(validators) == 1:
+        return validators[0]
+    else:
+        return _OrValidator(validators, error_type=error_type)
+
+
+def literal_type_attrs_validator(*type_args: Type) -> attr._ValidatorType:
+    """Create an attr.s strict type validator for Literal typings."""
+    return or_attrs_validator(*(_LiteralValidator(t) for t in type_args), error_type=ValueError)
+
+
+def tuple_type_attrs_validator(*type_args: Type, tuple_type: Type = tuple) -> attr._ValidatorType:
+    """Create an attr.s strict type validator for Tuple typings."""
+    if len(type_args) == 2 and (type_args[1] is Ellipsis):
+        # Tuple as an immutable sequence type: Tuple[int, ...]
+        if not issubclass(tuple_type, tuple):
+            raise TypeError(f"Invalid 'tuple' subclass '{tuple_type}'.")
+        member_type_hint = type_args[0]
+        return attr.validators.deep_iterable(
+            member_validator=strict_type_attrs_validator(member_type_hint),
+            iterable_validator=attr.validators.instance_of(tuple_type),
+        )
+    else:
+        # Tuple as a heterogeneous container: Tuple[int, float]
+        return _TupleValidator(tuple(strict_type_attrs_validator(t) for t in type_args), tuple_type)
+
+
+def union_type_attrs_validator(*type_args: Type) -> attr._ValidatorType:
+    """Create an attr.s strict type validator for Union typings."""
+    if len(type_args) == 2 and (type_args[1] is type(None)):  # noqa: E721  # use isinstance()
+        non_optional_validator = strict_type_attrs_validator(type_args[0])
+        return attr.validators.optional(non_optional_validator)
+    else:
+        return or_attrs_validator(
+            *(strict_type_attrs_validator(t) for t in type_args), error_type=TypeError
+        )
+
+
+def strict_type_attrs_validator(type_hint: Type) -> attr._ValidatorType:
+    """Create an attr.s strict type validator for a specific typing hint."""
+    origin_type = typing.get_origin(type_hint)
+    type_args = typing.get_args(type_hint)
+
+    if isinstance(type_hint, type) and type_hint is not type(  # noqa: E721  # use isinstance()
+        None
+    ):
+        assert not type_args
+        if type_hint is int:
+            return instance_of_int_attrs_validator()
+        else:
+            return attr.validators.instance_of(type_hint)
+    elif isinstance(type_hint, typing.TypeVar):
+        if type_hint.__bound__:
+            return attr.validators.instance_of(type_hint.__bound__)
+        else:
+            return empty_attrs_validator()
+    elif type_hint is Any:
+        return empty_attrs_validator()
+    elif origin_type is typing.Literal:
+        return literal_type_attrs_validator(*type_args)
+    elif origin_type is typing.Union:
+        return union_type_attrs_validator(*type_args)
+    elif isinstance(origin_type, type):
+        # Deal with generic collections
+        if issubclass(origin_type, tuple):
+            return tuple_type_attrs_validator(*type_args, tuple_type=origin_type)
+        elif issubclass(origin_type, (collections.abc.Sequence, collections.abc.Set)):
+            assert len(type_args) == 1
+            member_type_hint = type_args[0]
+            return attr.validators.deep_iterable(
+                member_validator=strict_type_attrs_validator(member_type_hint),
+                iterable_validator=attr.validators.instance_of(origin_type),
+            )
+        elif issubclass(origin_type, collections.abc.Mapping):
+            assert len(type_args) == 2
+            key_type_hint, value_type_hint = type_args
+            return attr.validators.deep_mapping(
+                key_validator=strict_type_attrs_validator(key_type_hint),
+                value_validator=strict_type_attrs_validator(value_type_hint),
+                mapping_validator=attr.validators.instance_of(origin_type),
+            )
+    else:
+        raise TypeError(f"Type description '{type_hint}' is not supported.")
+
+    assert False  # noqa
+
+
+# -- DataModel --
+def _collect_field_validators(cls: Type, *, delete_tag: bool = True) -> Dict[str, ValidatorFunc]:
+    result = {}
+    for member in cls.__dict__.values():
+        if hasattr(member, _FIELD_VALIDATOR_TAG):
+            field_name = getattr(member, _FIELD_VALIDATOR_TAG)
+            result[field_name] = member
+            if delete_tag:
+                delattr(member, _FIELD_VALIDATOR_TAG)
+
+    return result
+
+
+def _collect_root_validators(cls: Type, *, delete_tag: bool = True) -> List[RootValidatorFunc]:
+    result = []
+    for base in reversed(cls.__mro__[1:]):
+        for validator in getattr(base, _ROOT_VALIDATORS, []):
+            if validator not in result:
+                result.append(validator)
+
+    for member in cls.__dict__.values():
+        if hasattr(member, _ROOT_VALIDATOR_TAG):
+            result.append(member)
+            if delete_tag:
+                delattr(member, _ROOT_VALIDATOR_TAG)
+
+    return result
+
+
+def _get_attribute_from_bases(
+    name: str, mro: Tuple[Type, ...], annotations: Optional[Dict[str, Any]] = None
+) -> Optional[attr.Attribute]:
+    for base in mro:
+        for base_field_attrib in getattr(base, "__attrs_attrs__", []):
+            if base_field_attrib.name == name:
+                if annotations is not None:
+                    annotations[name] = base.__annotations__[name]
+                return typing.cast(attr.Attribute, base_field_attrib)
+
+    return None
+
+
+def _substitute_typevars(
+    type_hint: Type, type_params_map: Mapping[TypeVar, Union[Type, TypeVar]]
+) -> Tuple[Union[Type, TypeVar], bool]:
+    if isinstance(type_hint, typing.TypeVar):
+        assert type_hint in type_params_map
+        return type_params_map[type_hint], True
+    elif getattr(type_hint, "__parameters__", []):
+        return type_hint[tuple(type_params_map[tp] for tp in type_hint.__parameters__)], True
+    else:
+        return type_hint, False
+
+
+def _make_counting_attr_from_attribute(
+    field_attrib: attr.Attribute, *, include_type: bool = False, **kwargs: Any
+) -> Any:  # attr.s lies on purpose in some typings
+    members = [
+        "default",
+        "validator",
+        "repr",
+        "eq",
+        "order",
+        "hash",
+        "init",
+        "metadata",
+        "converter",
+        "kw_only",
+        "on_setattr",
+    ]
+    if include_type:
+        members.append("type")
+
+    return attr.ib(**{key: getattr(field_attrib, key) for key in members}, **kwargs)  # type: ignore  # too hard for mypy
+
+
+def _make_dataclass_field_from_attr(field_attrib: attr.Attribute) -> dataclasses.Field:
+    MISSING = getattr(dataclasses, "MISSING", NOTHING)
+    default = MISSING
+    default_factory = MISSING
+    if isinstance(field_attrib.default, attr.Factory):  # type: ignore  # attr.s lies on purpose in some typings
+        default_factory = field_attrib.default.factory  # type: ignore  # attr.s lies on purpose in some typings
+    elif field_attrib.default is not attr.NOTHING:
+        default = field_attrib.default
+
+    assert field_attrib.eq == field_attrib.order  # dataclasses.compare == (attr.eq and attr.order)
+
+    dataclasses_field = dataclasses.Field(  # type: ignore  # dataclasses.Field signature seems invisible to mypy
+        default=default,
+        default_factory=default_factory,
+        init=field_attrib.init,
+        repr=field_attrib.repr if not callable(field_attrib.repr) else None,
+        hash=field_attrib.hash,
+        compare=field_attrib.eq,
+        metadata=field_attrib.metadata,
+    )
+    dataclasses_field.name = field_attrib.name
+    assert field_attrib.type is not None
+    dataclasses_field.type = field_attrib.type
+    dataclasses_field._field_type = dataclasses._FIELD  # type: ignore  #dataclasses._FIELD seems invisible to mypy
+
+    return dataclasses_field
+
+
+def _make_non_instantiable_init() -> Callable[..., None]:
+    def __init__(self: DataModelLike, *args: Any, **kwargs: Any) -> None:
+        raise TypeError(f"Trying to instantiate '{type(self).__name__}' abstract class.")
+
+    return __init__
+
+
+def _make_post_init(has_post_init: bool) -> Callable[[DataModelLike], None]:
+    # Duplicated code to facilitate the source inspection of the generated `__init__()` method
+    if has_post_init:
+
+        def __attrs_post_init__(self: DataModelLike) -> None:
+            if attr._config._run_validators is True:  # type: ignore  # attr._config is not visible for mypy
+                for validator in type(self).__datamodel_validators__:
+                    validator.__get__(self)(self)
+                self.__post_init__()
+
+    else:
+
+        def __attrs_post_init__(self: DataModelLike) -> None:
+            if attr._config._run_validators is True:  # type: ignore  # attr._config is not visible for mypy
+                for validator in type(self).__datamodel_validators__:
+                    validator.__get__(self)(self)
+
+    return __attrs_post_init__
+
+
+def _make_devtools_pretty() -> Callable[
+    [DataModelLike, Callable[[Any], Any]], Generator[Any, None, None]
+]:
+    def __pretty__(
+        self: DataModelLike, fmt: Callable[[Any], Any], **kwargs: Any
+    ) -> Generator[Any, None, None]:
+        """Used by `devtools <https://python-devtools.helpmanual.io/>` to provide a human readable representation.
+
+        Note:
+            Adapted from `pydantic <https://github.com/samuelcolvin/pydantic>`.
+        """
+        yield self.__class__.__name__ + "("
+        yield 1
+        for name in self.__datamodel_fields__.keys():
+            yield name + "="
+            yield fmt(getattr(self, name))
+            yield ","
+            yield 0
+        yield -1
+        yield ")"
+
+    return __pretty__
+
+
+def _make_data_model_class_getitem() -> classmethod:
+    def __class_getitem__(
+        cls: Type[GenericDataModelLike], args: Union[Type, Tuple[Type]]
+    ) -> GenericDataModelAlias:
+        """Return an instance compatible with aliases created by the `typing` module for `typing.Generic`s.
+
+        See :class:`GenericDataModelAlias` for further information.
+        """
+        type_args: Tuple[Type] = args if isinstance(args, tuple) else (args,)
+        concrete_cls = concretize(cls, *type_args)
+        return GenericDataModelAlias(concrete_cls, type_args)
+
+    return classmethod(__class_getitem__)
+
+
+def _make_datamodel(
+    cls: Type,
+    *,
+    repr: bool,  # noqa: A002   # shadowing 'repr' python builtin
+    eq: bool,
+    order: bool,
+    unsafe_hash: bool,
+    frozen: bool,
+    instantiable: bool,
+) -> Type:
+    """Actual implementation of the Data Model creation.
+
+    See :func:`datamodel` for the description of the parameters.
+    """
+    if "__annotations__" not in cls.__dict__:
+        cls.__annotations__ = {}
+    annotations = cls.__dict__["__annotations__"]
+    mro_bases: Tuple[Type, ...] = cls.__mro__[1:]
+    resolved_annotations = typing.get_type_hints(cls)
+
+    # Create attrib definitions with automatic type validators (and converters)
+    # for the annotated fields. The original annotations are used for iteration
+    # since the resolved annotations may also contain superclasses' annotations
+    for key in annotations:
+        type_hint = resolved_annotations[key]
+        if typing.get_origin(type_hint) is not ClassVar:
+            type_validator = strict_type_attrs_validator(type_hint)
+            if key not in cls.__dict__:
+                setattr(cls, key, attr.ib(validator=type_validator))
+            elif not isinstance(cls.__dict__[key], attr._make._CountingAttr):  # type: ignore  # attr._make is not visible for mypy
+                setattr(cls, key, attr.ib(default=cls.__dict__[key], validator=type_validator))
+            else:
+                # A field() function has been used to customize the definition:
+                # prepend the type validator to the list of provided validators (if any)
+                cls.__dict__[key]._validator = (
+                    type_validator
+                    if cls.__dict__[key]._validator is None
+                    else attr._make.and_(type_validator, cls.__dict__[key]._validator)  # type: ignore  # attr._make is not visible for mypy
+                )
+
+                # TODO(egparedes): implement type coercing
+                # if cls.__dict__[key].converter is True:
+                #     cls.__dict__[key].converter = _make_type_coercer(type_hint)
+
+    # All fields should be annotated with type hints
+    for key, value in cls.__dict__.items():
+        if isinstance(value, attr._make._CountingAttr) and (  # type: ignore  # attr._make is not visible for mypy
+            key not in annotations or typing.get_origin(resolved_annotations[key]) is ClassVar
+        ):
+            raise TypeError(f"Missing type annotation in '{key}' field.")
+
+    root_validators = _collect_root_validators(cls)
+    field_validators = _collect_field_validators(cls)
+
+    # Add collected field validators
+    for field_name, field_validator in field_validators.items():
+        field_c_attr = cls.__dict__.get(field_name, None)
+        if not field_c_attr:
+            # Field has not been defined in the current class namespace,
+            # look for field definition in the base classes.
+            base_field_attr = _get_attribute_from_bases(field_name, mro_bases, annotations)
+            if base_field_attr:
+                # Create a new field in the current class cloning the existing
+                # definition and add the new validator (attrs recommendation)
+                field_c_attr = _make_counting_attr_from_attribute(
+                    base_field_attr,
+                )
+                setattr(cls, field_name, field_c_attr)
+            else:
+                raise TypeError(f"Validator assigned to non existing '{field_name}' field.")
+
+        # Add field validator using field_attr.validator
+        assert isinstance(field_c_attr, attr._make._CountingAttr)  # type: ignore  # attr._make is not visible for mypy
+        field_c_attr.validator(field_validator)
+
+    setattr(cls, _ROOT_VALIDATORS, tuple(root_validators))
+
+    # Update class with attr.s features
+    if "__init__" in cls.__dict__:
+        raise TypeError(
+            "datamodel(init=True) is incompatible with custom '__init__' methods, use '__post_init__' instead."
+        )
+
+    if not instantiable:
+        cls.__init__ = _make_non_instantiable_init()
+    else:
+        # For dataclasses emulation, __attrs_post_init__ calls __post_init__ (if it exists)
+        cls.__attrs_post_init__ = _make_post_init(has_post_init="__post_init__" in cls.__dict__)
+
+    cls.__class_getitem__ = _make_data_model_class_getitem()
+
+    attr_settings = {"auto_attribs": True, "slots": False, "kw_only": True}
+    hash_arg = None if not unsafe_hash else True
+    new_cls = attr.define(  # type: ignore  # attr.define is not visible for mypy
+        **attr_settings,
+        init=instantiable,
+        repr=repr,
+        eq=eq,
+        order=order,
+        frozen=frozen,
+        hash=hash_arg,
+    )(cls)
+    assert new_cls is cls
+
+    # Final postprocessing
+    cls.__pretty__ = _make_devtools_pretty()
+    setattr(
+        cls,
+        _MODEL_PARAMS,
+        utils.FrozenNamespace(
+            init=True,
+            repr=repr,
+            eq=eq,
+            order=order,
+            unsafe_hash=unsafe_hash,
+            frozen=frozen,
+            instantiable=instantiable,
+        ),
+    )
+    setattr(
+        cls,
+        _MODEL_FIELDS,
+        utils.FrozenNamespace(
+            **{field_attr.name: field_attr for field_attr in cls.__attrs_attrs__}
+        ),
+    )
+    cls.__dataclass_fields__ = {  # dataclasses emulation
+        field_attr.name: _make_dataclass_field_from_attr(field_attr)
+        for field_attr in cls.__attrs_attrs__
+    }
+
+    return cls
+
+
+@utils.optional_lru_cache(maxsize=None, typed=True)
+def _make_concrete_with_cache(
+    datamodel_cls: Type[GenericDataModelLike],
+    *type_args: Type,
+    class_name: Optional[str] = None,
+    module: Optional[str] = None,
+) -> Type[DataModelLike]:
+    if not is_generic(datamodel_cls):
+        raise TypeError(f"'{datamodel_cls.__name__}' is not a generic model class.")
+    for t in type_args:
+        if not (isinstance(t, (type, type(None))) or getattr(t, "__module__", None) == "typing"):
+            raise TypeError(
+                f"Only 'type' and 'typing' definitions can be passed as arguments "
+                f"to instantiate a generic model class (received: {type_args})."
+            )
+    if len(type_args) != len(datamodel_cls.__parameters__):
+        raise TypeError(
+            f"Instantiating '{datamodel_cls.__name__}' generic model with a wrong number of parameters "
+            f"({len(type_args)} used, {len(datamodel_cls.__parameters__)} expected)."
+        )
+
+    # Replace field definitions with the new actual types for generic fields
+    type_params_map = dict(zip(datamodel_cls.__parameters__, type_args))
+    model_fields = getattr(datamodel_cls, _MODEL_FIELDS)
+    new_annotations = {}
+    new_field_c_attrs = {}
+    for field_name, field_type in typing.get_type_hints(datamodel_cls).items():
+        new_annotation, replaced = _substitute_typevars(field_type, type_params_map)
+        if replaced:
+            new_annotations[field_name] = new_annotation
+            field_attrib = getattr(model_fields, field_name)
+            new_field_c_attrs[field_name] = _make_counting_attr_from_attribute(field_attrib)
+
+    # Create new concrete class
+    if not class_name:
+        arg_names = []
+        for tp_var in datamodel_cls.__parameters__:
+            arg_string = tp_var.__name__
+            if tp_var in type_params_map:
+                concrete_arg = type_params_map[tp_var]
+                if isinstance(concrete_arg, type):
+                    arg_string = concrete_arg.__name__
+                else:
+                    arg_string = utils.slugify(
+                        str(concrete_arg).replace("typing.", "").replace("...", "ellipsis")
+                    )
+
+            arg_names.append(arg_string)
+
+        class_name = f"{datamodel_cls.__name__}__{'_'.join(arg_names)}"
+
+    namespace = {
+        "__annotations__": new_annotations,
+        "__module__": module if module else datamodel_cls.__module__,
+        **new_field_c_attrs,
+    }
+
+    concrete_cls = type(class_name, (datamodel_cls,), namespace)
+    assert concrete_cls.__module__ == module or not module
+
+    if _MODEL_FIELDS not in concrete_cls.__dict__:
+        # If original model does not inherit from GenericModel,
+        # _make_datamodel() hasn't been called yet, so call it now
+        params = getattr(datamodel_cls, _MODEL_PARAMS)
+        concrete_cls = _make_datamodel(
+            concrete_cls,
+            **{
+                name: getattr(params, name)
+                for name in ("repr", "eq", "order", "unsafe_hash", "frozen", "instantiable")
+            },
+        )
+
+    return concrete_cls
+
+
+def is_datamodel(obj: Any) -> bool:
+    """Returns True if `obj` is a Data Model class or an instance of a Data Model."""
+    cls = obj if isinstance(obj, type) else obj.__class__
+    return hasattr(cls, _MODEL_FIELDS)
+
+
+def is_generic(model: Union[DataModelLike, Type[DataModelLike]]) -> bool:
+    """Returns True if `model` is a generic Data Model class or an instance of a generic Data Model."""
+    if not is_datamodel(model):
+        raise TypeError(f"Invalid datamodel instance or class: '{model}'.")
+
+    return len(getattr(model, "__parameters__", [])) > 0
+
+
+def is_instantiable(model: Type[DataModelLike]) -> bool:
+    """Returns True if `model` is a instantiable Data Model class or an instance of a instantiable Data Model."""
+    if not is_datamodel(model):
+        raise TypeError(f"Invalid datamodel instance or class: '{model}'.")
+
+    params = getattr(model, _MODEL_PARAMS)
+    assert hasattr(params, "instantiable") and isinstance(params.instantiable, bool)
+    return params.instantiable
+
+
+@typing.overload
+def get_fields(
+    model: Union[DataModelLike, Type[DataModelLike]], *, as_dataclass: Literal[False] = False
+) -> utils.FrozenNamespace:
+    ...
+
+
+@typing.overload
+def get_fields(
+    model: Union[DataModelLike, Type[DataModelLike]], *, as_dataclass: Literal[True]
+) -> Tuple[dataclasses.Field, ...]:
+    ...
+
+
+def get_fields(
+    model: Union[DataModelLike, Type[DataModelLike]], *, as_dataclass: bool = False
+) -> Union[utils.FrozenNamespace, Tuple[dataclasses.Field, ...]]:
+    """Return the field meta-information of a Data Model.
+
+    Arguments:
+        model: A Data Model class or instance.
+
+    Keyword Arguments:
+        as_dataclass: If ``True`` (the default is ``False``), field information is returned
+            as :class:`dataclass.Field` instances instead of :class:`attr.Attribute`.
+
+    Examples:
+        >>> from typing import List
+        >>> @datamodel
+        ... class Model:
+        ...     amount: int = 1
+        ...     name: str
+        ...     numbers: List[float]
+        >>> fields(Model)  # doctest:+ELLIPSIS
+        FrozenNamespace(amount=Attribute(name='amount', default=1, ...),\
+ name=Attribute(name='name', default=NOTHING, ...),\
+ numbers=Attribute(name='numbers', default=NOTHING, ...))
+        >>> fields(Model, as_dataclass=True)  # doctest:+ELLIPSIS
+        (Field(name='amount',type='int',default=1,default_factory=...),\
+ Field(name='name',type='str',default=...),\
+ Field(name='numbers',type='List[float]',default=...))
+    """
+    if not is_datamodel(model):
+        raise TypeError(f"Invalid datamodel instance or class: '{model}'.")
+    if not isinstance(model, type):
+        model = model.__class__
+
+    if as_dataclass:
+        return dataclasses.fields(model)
+    else:
+        ns = getattr(model, _MODEL_FIELDS)
+        assert isinstance(ns, utils.FrozenNamespace)
+        return ns
+
+
+fields = get_fields
+
+
+def asdict(
+    instance: DataModelLike,
+    *,
+    dict_factory: Type[Mapping[Any, Any]] = dict,
+    retain_collection_types: bool = False,
+) -> Dict[str, Any]:
+    """Return the contents of a Data Model instance as a new mapping from field names to values.
+
+    Arguments:
+        instance: Data Model instance.
+
+    Keyword Arguments:
+        dict_factory: A callable to produce ``dict`` instances from.
+        retain_collection_types: Do not convert to ``list`` when encountering an
+            attribute whose type is ``tuple`` or ``set``.
+
+    Examples:
+        >>> @datamodel
+        ... class C:
+        ...     x: int
+        ...     y: int
+        >>> c = C(x=1, y=2)
+        >>> assert asdict(c) == {'x': 1, 'y': 2}
+    """
+    if not is_datamodel(instance) or isinstance(instance, type):
+        raise TypeError(f"Invalid datamodel instance: '{instance}'.")
+    return attr.asdict(
+        instance,
+        dict_factory=dict_factory,
+        recurse=True,
+        retain_collection_types=retain_collection_types,
+    )
+
+
+def astuple(
+    instance: DataModelLike,
+    *,
+    tuple_factory: Type[Sequence[Any]] = tuple,
+    retain_collection_types: bool = False,
+) -> Tuple[Any, ...]:
+    """Return the contents of a Data Model instance as a new tuple of field values.
+
+    Arguments:
+        instance: Data Model instance.
+
+    Keyword Arguments:
+        tuple_factory: A callable to produce ``tuple`` instances from.
+        retain_collection_types: Do not convert to ``list`` or ``dict`` when
+            encountering an attribute which type is ``tuple``, ``dict``
+            or ``set``.
+
+    Examples:
+        >>> @datamodel
+        ... class C:
+        ...     x: int
+        ...     y: int
+        >>> c = C(x=1, y=2)
+        >>> assert astuple(c) == (1, 2)
+    """
+    if not is_datamodel(instance) or isinstance(instance, type):
+        raise TypeError(f"Invalid datamodel instance: '{instance}'.")
+    return attr.astuple(
+        instance,
+        tuple_factory=tuple_factory,
+        recurse=True,
+        retain_collection_types=retain_collection_types,
+    )
+
+
+def concretize(
+    datamodel_cls: Type[GenericDataModelLike],
+    /,
+    *type_args: Type,
+    class_name: Optional[str] = None,
+    module: Optional[str] = None,
+    support_pickling: bool = True,
+    overwrite_definition: bool = True,
+) -> Type[DataModelLike]:
+    """Generate a new concrete subclass of a generic Data Model.
+
+    Arguments:
+        datamodel_cls: Generic Data Model to be subclassed.
+        type_args: Type defintitions replacing the `TypeVars` in
+            ``datamodel_cls.__parameters__``.
+
+    Keyword Arguments:
+        class_name: Name of the new concrete class. The default value is the
+            same of the generic Data Model replacing the `TypeVars` by the provided
+            `type_args` in the name.
+        module: Value of the ``__module__`` attribute of the new class.
+            The default value is the name of the module containing the generic Data Model.
+        support_pickling: If ``True``, support for pickling will be added
+            by actually inserting the new class into the target `module`.
+        overwrite_definition: If ``True``, a previous definition of the class in
+            the target module will be overwritten.
+    """
+    concrete_cls = _make_concrete_with_cache(
+        datamodel_cls, *type_args, class_name=class_name, module=module
+    )
+    assert isinstance(concrete_cls, type) and is_datamodel(concrete_cls)
+
+    # For pickling to work, the new class has to be added to the proper module
+    if support_pickling:
+        class_name = concrete_cls.__name__
+        reference_module_globals = sys.modules[concrete_cls.__module__].__dict__
+        if reference_module_globals.get(class_name, None) is not concrete_cls:
+            if class_name in reference_module_globals and not overwrite_definition:
+                warnings.warn(
+                    f"Existing '{class_name}' symbol in module '{module}' contains a reference"
+                    "to a different object.",
+                    RuntimeWarning,
+                )
+            else:
+                reference_module_globals[class_name] = concrete_cls
+
+    return concrete_cls
+
+
+def validator(name: str) -> Callable[[Callable], Callable]:
+    """Decorator to define a custom field validator for a specific field.
+
+    Arguments:
+        name: Name of the field to be validated by the decorated function.
+
+    The decorated functions should have the following signature:
+    ``def _validator_function(self, attribute, value):`` where
+    ``self`` will be the model instance being validated, ``attribute``
+    the definition information of the attribute (the value of
+    ``__datamodel_fields__.field_name``) and ``value`` the actual value
+    received for this field.
+    """
+    assert isinstance(name, str)
+
+    def _field_validator_maker(func: Callable) -> Callable:
+        setattr(func, _FIELD_VALIDATOR_TAG, name)
+        return func
+
+    return _field_validator_maker
+
+
+def root_validator(func: Callable, /) -> classmethod:
+    """Decorator to define a custom root validator.
+
+    The decorated functions should have the following signature:
+    ``def _root_validator_function(cls, instance):`` where ``cls`` will
+    be the class of the model and ``instance`` the actual instance being
+    validated.
+    """
+
+    cls_method = classmethod(func)
+    setattr(cls_method, _ROOT_VALIDATOR_TAG, None)
+    return cls_method
+
+
+def field(
+    *,
+    default: Any = NOTHING,
+    default_factory: Callable[[None], Any] = NOTHING,
+    init: bool = True,
+    repr: bool = True,  # noqa: A002   # shadowing 'repr' python builtin
+    hash: Optional[bool] = None,  # noqa: A002   # shadowing 'hash' python builtin
+    compare: bool = True,
+    metadata: Optional[Mapping[Any, Any]] = None,
+) -> Any:  # attr.s lies on purpose in some typings
+    """Define a new attribute on a class with advanced options.
+
+    Keyword Arguments:
+        default: If provided, this will be the default value for this field.
+            This is needed because the ``field()`` call itself replaces the
+            normal position of the default value.
+        default_factory: If provided, it must be a zero-argument callable that will
+            be called when a default value is needed for this field. Among other
+            purposes, this can be used to specify fields with mutable default values.
+            It is an error to specify both `default` and `default_factory`.
+        init: If ``True``, this field is included as a parameter to the
+            generated ``__init__()`` method.
+        repr: If ``True``, this field is included in the string returned
+            by the generated ``__repr__()`` method.
+        hash: This can be a ``bool`` or ``None``. If ``True``, this field is included
+            in the generated ``__hash__()`` method. If ``None``, use the value of
+            `compare`, which would normally be the expected behavior: a field
+            should be considered in the `hash` if it’s used for comparisons.
+            Setting this value to anything other than ``None`` is `discouraged`.
+        compare: If ``True``, this field is included in the generated equality and
+            comparison methods (__eq__(), __gt__(), et al.).
+        metadata: An arbitrary mapping, not used at all by Data Models, and provided
+            only as a third-party extension mechanism. Multiple third-parties can each
+            have their own key, to use as a namespace in the metadata.
+
+    Examples:
+        >>> from typing import List
+        >>> @datamodel
+        ... class C:
+        ...     mylist: List[int] = field(default_factory=lambda : [1, 2, 3])
+        >>> c = C()
+        >>> c.mylist
+        [1, 2, 3]
+
+    Note:
+        Currently implemented using :func:`attr.ib` from `attrs <https://www.attrs.org/>`_
+    """
+
+    defaults_kwargs = {}
+    if default is not NOTHING and default_factory is not NOTHING:
+        raise ValueError("Cannot specify both default and default_factory.")
+
+    if default is not NOTHING:
+        defaults_kwargs["default"] = default
+    if default_factory is not NOTHING:
+        defaults_kwargs["factory"] = default_factory
+
+    return attr.ib(  # type: ignore  # attr.s lies on purpose in some typings
+        **defaults_kwargs,
+        init=init,
+        repr=repr,
+        hash=hash,
+        eq=compare,
+        order=compare,
+        metadata=metadata,
+    )
+
+
+def datamodel(
+    cls: Type = None,
+    /,
+    *,
+    repr: bool = True,  # noqa: A002   # shadowing 'repr' python builtin
+    eq: bool = True,
+    order: bool = False,
+    unsafe_hash: bool = False,
+    frozen: bool = False,
+    instantiable: bool = True,
+) -> Union[Type, Callable[[Type], Type]]:
+    """A class decorator to add generated special methods to classes according to the specified attributes.
+
+    Examines PEP 526 ``__annotations__`` to determine field types and creates
+    strict type validation functions for the fields.
+
+    Arguments:
+        cls: Original class definition.
+
+    Keyword Arguments:
+        repr: If ``True``, a ``__repr__()`` method will be generated.
+            If the class already defines ``__repr__()``, it will be overwritten.
+        eq: If ``True``, ``__eq__()`` and ``__ne__()`` methods will be generated.
+            This method compares the class as if it were a tuple of its fields.
+            Both instances in the comparison must be of identical type.
+        order:  If ``True``, add ``__lt__()``, ``__le__()``, ``__gt__()``,
+            and ``__ge__()`` methods that behave like `eq` above and allow instances
+            to be ordered. If ``None`` mirror value of `eq`.
+        unsafe_hash: If ``False``, a ``__hash__()`` method is generated in a safe way
+            according to how ``eq`` and ``frozen`` are set, or set to ``None`` (disabled)
+            otherwise. If ``True``, a ``__hash__()`` method is generated anyway
+            (use with care). See :func:`dataclasses.dataclass` for the complete explanation.
+        frozen: If ``True``, assigning to fields will generate an exception.
+            This emulates read-only frozen instances. The ``__setattr__()`` and
+            ``__delattr__()`` methods should not be defined in the class.
+        instantiable: If ``False`` the class will contain an invalid ``__init__()``
+            method that raises an exception.
+
+    Note:
+        Currently implemented using :func:`attr.s` from `attrs <https://www.attrs.org/>`_
+    """
+
+    def _decorator(cls: Type) -> Type:
+        return _make_datamodel(
+            cls,
+            repr=repr,
+            eq=eq,
+            order=order,
+            unsafe_hash=unsafe_hash,
+            frozen=frozen,
+            instantiable=instantiable,
+        )
+
+    # This works for both @datamodel or @datamodel() decorations
+    return _decorator(cls) if cls is not None else _decorator
+
+
+class DataModel:
+    """Base class to automatically convert any subclass into a Data Model.
+
+    Inheriting from this class is equivalent to apply the :func:`datamodel`
+    decorator to a class, except that all descendants will be also converted
+    automatically in Data Models (which does not happen when explicitly
+    applying the decorator).
+
+    See :func:`datamodel` for the description of the parameters.
+    """
+
+    @classmethod
+    def __init_subclass__(
+        cls,
+        /,
+        *,
+        repr: bool = True,  # noqa: A002   # shadowing 'repr' python builtin
+        eq: bool = True,
+        order: bool = False,
+        unsafe_hash: bool = False,
+        frozen: bool = False,
+        instantiable: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init_subclass__(**kwargs)  # type: ignore  # super() does not need to be object
+        _make_datamodel(
+            cls,
+            repr=repr,
+            eq=eq,
+            order=order,
+            unsafe_hash=unsafe_hash,
+            frozen=frozen,
+            instantiable=instantiable,
+        )
+
+
+# TODO(egparedes): implement type coercing
+# def _make_type_coercer(type_hint: Type[T]) -> Callable[[Any], T]:
+#     return type_hint if isinstance(type_hint, type) else lambda x: x  # type: ignore
+
+
+# TODO(egparedes): implement full instance freezing
+# def _frozen_setattr(instance, attribute, value):
+#     raise attr.exceptions.FrozenAttributeError(
+#         f"Trying to modify immutable '{attribute.name}' attribute in '{type(instance).__name__}' instance."
+#     )
+
+
+# TODO(egparedes): implement validation on attribute assignment
+# def _valid_setattr(instance, attribute, value):
+#     print("SET", attribute, value)

--- a/src/eve/datamodels.py
+++ b/src/eve/datamodels.py
@@ -150,7 +150,7 @@ class TypeWithAttrValidatorTp(Protocol):
     @classmethod
     @abc.abstractmethod
     def __type_validator__(self) -> ValidatorType:
-        ...
+        raise NotImplementedError()
 
 
 class GenericDataModelAlias(typing._GenericAlias, _root=True):  # type: ignore[call-arg,name-defined]  # typing._GenericAlias not visible
@@ -1005,7 +1005,7 @@ def update_forward_refs(
         for field_name in fields:
             field_attr = getattr(datamodel_fields_ns, field_name)
             if "ForwardRef(" in repr(field_attr.type):
-                actual_type = typingx.resolve_forward_ref(
+                actual_type = typingx.resolve_type(
                     field_attr.type,
                     sys.modules[model.__module__].__dict__,
                     local_ns,

--- a/src/eve/datamodels.py
+++ b/src/eve/datamodels.py
@@ -884,9 +884,10 @@ def get_fields(
  numbers=Attribute(name='numbers', default=NOTHING, ...))
 
         >>> fields(Model, as_dataclass=True)  # doctest:+ELLIPSIS
-        (Field(name='amount',type='int',default=1,default_factory=...),\
- Field(name='name',type='str',default=...),\
- Field(name='numbers',type='List[float]',default=...))
+        (Field(name='amount',type=<class 'int'>,default=1,default_factory=...),\
+ Field(name='name',type=<class 'str'>,default=...),\
+ Field(name='numbers',type=typing.List[float],default=...))
+
     """  # noqa: RST201  # doctest conventions confuse RST validator
     if not is_datamodel(model):
         raise TypeError(f"Invalid datamodel instance or class: '{model}'.")

--- a/src/eve/datamodels.py
+++ b/src/eve/datamodels.py
@@ -189,8 +189,8 @@ class GenericDataModelAlias(typing._GenericAlias, _root=True):  # type: ignore[c
     Notes:
         For the full picture check also related PEPs:
 
-            - https://www.python.org/dev/peps/pep-0526/
-            - https://www.python.org/dev/peps/pep-0560/
+            - `PEP 526 - Syntax for Variable Annotations <https://www.python.org/dev/peps/pep-0526>`_
+            - `PEP 560 - Core support for typing module and generic types <https://www.python.org/dev/peps/pep-0560>`_
     """
 
     __origin__: Type[GenericDataModelTp]
@@ -579,10 +579,10 @@ def _make_devtools_pretty() -> Callable[
     def __pretty__(
         self: DataModelTp, fmt: Callable[[Any], Any], **kwargs: Any
     ) -> Generator[Any, None, None]:
-        """Provide a human readable representation for `devtools <https://python-devtools.helpmanual.io/>`.
+        """Provide a human readable representation for `devtools <https://python-devtools.helpmanual.io/>`_.
 
         Note:
-            Adapted from `pydantic <https://github.com/samuelcolvin/pydantic>`.
+            Adapted from `pydantic <https://github.com/samuelcolvin/pydantic>`_.
         """
         yield self.__class__.__name__ + "("
         yield 1

--- a/src/eve/datamodels.py
+++ b/src/eve/datamodels.py
@@ -110,6 +110,9 @@ class _DevToolsPrettyPrintable(Protocol):
 
 
 class DataModelLike(_AttrClassLike, _DataClassLike, _DevToolsPrettyPrintable, Protocol):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        ...
+
     __datamodel_fields__: ClassVar[utils.FrozenNamespace]
     __datamodel_params__: ClassVar[utils.FrozenNamespace]
     __datamodel_validators__: ClassVar[
@@ -120,6 +123,7 @@ class DataModelLike(_AttrClassLike, _DataClassLike, _DevToolsPrettyPrintable, Pr
 class GenericDataModelLike(DataModelLike, Protocol):
     __args__: ClassVar[Tuple[Union[Type, TypeVar]]]
     __parameters__: ClassVar[Tuple[TypeVar]]
+    __class__: ClassVar[DataModelLike]  # type: ignore[assignment]
 
     @classmethod
     def __class_getitem__(
@@ -938,7 +942,7 @@ def concretize(
     *type_args: Type,
     class_name: Optional[str] = None,
     module: Optional[str] = None,
-    support_pickling: bool = True,
+    support_pickling: bool = True,  # noqa
     overwrite_definition: bool = True,
 ) -> Type[DataModelLike]:
     """Generate a new concrete subclass of a generic Data Model.
@@ -1141,7 +1145,7 @@ def datamodel(
     return _decorator(cls) if cls is not None else _decorator
 
 
-class DataModel:
+class DataModel(DataModelLike):
     """Base class to automatically convert any subclass into a Data Model.
 
     Inheriting from this class is equivalent to apply the :func:`datamodel`

--- a/src/eve/iterators.py
+++ b/src/eve/iterators.py
@@ -27,9 +27,11 @@ from .typingx import Any, Generator, Iterable, List, Optional, Tuple, Union
 
 
 try:
+    # For perfomance reasons, try to use cytoolz when possible (using cython)
     import cytoolz as toolz
 except ModuleNotFoundError:
-    import toolz  # noqa
+    # Fall back to pure Python toolz
+    import toolz
 
 
 KeyValue = Tuple[Union[int, str], Any]

--- a/src/eve/iterators.py
+++ b/src/eve/iterators.py
@@ -31,7 +31,7 @@ try:
     import cytoolz as toolz
 except ModuleNotFoundError:
     # Fall back to pure Python toolz
-    import toolz
+    import toolz  # noqa: F401  # imported but unused
 
 
 KeyValue = Tuple[Union[int, str], Any]

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -57,7 +57,7 @@ RootValidatorValuesType = Dict[str, Any]
 RootValidatorType = Callable[[Type, RootValidatorValuesType], RootValidatorValuesType]
 
 
-def canonicalize_forward_ref(type_hint: Union[Type, ForwardRef]) -> Union[Type, ForwardRef]:
+def canonicalize_forward_ref(type_hint: Union[str, Type, ForwardRef]) -> Union[Type, ForwardRef]:
     """Return the original type hint or a ``ForwardRef``s without nested ``ForwardRef``s.
 
     Examples:
@@ -88,7 +88,6 @@ def canonicalize_forward_ref(type_hint: Union[Type, ForwardRef]) -> Union[Type, 
                             nested -= 1
                     elif c == "(":
                         nested += 1
-
                 content = (new_hint[start + offset : end]).strip(" \n\r\t\"'")
                 new_hint = new_hint[:start] + content + new_hint[end + 1 :]
 
@@ -99,7 +98,6 @@ def canonicalize_forward_ref(type_hint: Union[Type, ForwardRef]) -> Union[Type, 
 
     assert isinstance(type_hint, typing._GenericAlias)  # type: ignore[attr-defined]  # typing._GenericAlias is not public
     new_type_args = tuple(canonicalize_forward_ref(t) for t in type_args)
-    # print(f"{type_hint=}, {new_type_args=}")
     if not any(isinstance(t, ForwardRef) for t in new_type_args):
         return type_hint
 

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -210,6 +210,7 @@ def resolve_type(
         except Exception as e:
             if allow_partial:
                 actual_type = canonicalize_forward_ref(actual_type)
+                break
             else:
                 raise e
 

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -16,26 +16,40 @@
 
 """Python version independent typings."""
 
-# flake8: noqa
-from typing import *  # isort:skip
 
-import sys  # isort:skip
+# flake8: noqa
+
+from __future__ import annotations
+
 from typing import *
 from typing import IO, BinaryIO, TextIO
 
+from typing_extensions import *  # type: ignore
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Final, Literal, Protocol, TypedDict, runtime_checkable
-
-del sys
-
-
-T = TypeVar("T")
-FrozenList = Tuple[T, ...]
 
 AnyCallable = Callable[..., Any]
 AnyNoneCallable = Callable[..., None]
 AnyNoArgCallable = Callable[[], Any]
+
+
+T = TypeVar("T")
+V = TypeVar("V")
+
+
+class NonDataDescriptor(Protocol[T, V]):  # type: ignore
+    @overload
+    def __get__(self, _instance: None, _owner_type: Type[T]) -> NonDataDescriptor:
+        ...
+
+    @overload
+    def __get__(self, _instance: T, _owner_type: Optional[Type[T]] = None) -> V:
+        ...
+
+
+class DataDescriptor(NonDataDescriptor[T, V], Protocol):  # type: ignore
+    def __set__(self, _instance: T, _value: V) -> None:
+        ...
+
 
 RootValidatorValuesType = Dict[str, Any]
 RootValidatorType = Callable[[Type, RootValidatorValuesType], RootValidatorValuesType]

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -147,8 +147,8 @@ def get_canonical_type_hints(cls: Type) -> Dict[str, Union[Type, ForwardRef]]:
 
 
 @typing.overload
-def resolve_forward_ref(
-    type_int: Any,
+def resolve_type(
+    type_hint: Any,
     global_ns: Optional[Dict[str, Any]] = None,
     local_ns: Optional[Dict[str, Any]] = None,
     *,
@@ -158,8 +158,8 @@ def resolve_forward_ref(
 
 
 @typing.overload
-def resolve_forward_ref(
-    type_int: Any,
+def resolve_type(
+    type_hint: Any,
     global_ns: Optional[Dict[str, Any]] = None,
     local_ns: Optional[Dict[str, Any]] = None,
     *,
@@ -168,8 +168,8 @@ def resolve_forward_ref(
     ...
 
 
-def resolve_forward_ref(
-    type_int: Any,
+def resolve_type(
+    type_hint: Any,
     global_ns: Optional[Dict[str, Any]] = None,
     local_ns: Optional[Dict[str, Any]] = None,
     *,
@@ -187,11 +187,13 @@ def resolve_forward_ref(
 
     Examples:
         >>> import typing
-        >>> resolve_forward_ref(typing.ForwardRef('typing.List[int]'))
-        typing.List[int]
+        >>> resolve_type(
+        ...     typing.Dict[typing.ForwardRef('str'), 'typing.Tuple["int", typing.ForwardRef("float")]']
+        ... )
+        typing.Dict[str, typing.Tuple[int, float]]
 
     """
-    actual_type = ForwardRef(type_int) if isinstance(type_int, str) else type_int
+    actual_type = ForwardRef(type_hint) if isinstance(type_hint, str) else type_hint
     while "ForwardRef(" in repr(actual_type):
         try:
             if local_ns:

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -1380,7 +1380,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             >>> list(it.reduceby(lambda nvowels, name: nvowels + sum(i in 'aeiou' for i in name), len, init=0))
             [(5, 4), (3, 2), (7, 3)]
 
-        """  # noqa: RST203  # sphinx.napoleon conventions confuse RST validator
+        """  # noqa: RST203, RST301  # sphinx.napoleon conventions confuse RST validator
         if (not callable(key) and not isinstance(key, (int, str, list))) or not all(
             isinstance(i, str) for i in attr_keys
         ):

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -52,6 +52,7 @@ from .typingx import (
     Callable,
     Collection,
     Dict,
+    Generic,
     Iterable,
     Iterator,
     List,
@@ -71,6 +72,8 @@ try:
 except ModuleNotFoundError:
     # Fall back to pure Python toolz
     import toolz  # noqa: F401  # imported but unused
+
+T = TypeVar("T")
 
 
 def isinstancechecker(type_info: Union[Type, Iterable[Type]]) -> Callable[[Any], bool]:
@@ -418,7 +421,7 @@ class CaseStyleConverter:
         return name.split("-")
 
 
-class FrozenNamespace(types.SimpleNamespace):
+class FrozenNamespace(types.SimpleNamespace, Generic[T]):
     """An immutable `types.SimpleNamespace`-like class.
 
     Examples:
@@ -435,16 +438,16 @@ class FrozenNamespace(types.SimpleNamespace):
         [('a', 10), ('b', 'hello')]
     """
 
-    def __setattr__(self, _name: str, _value: Any) -> None:
+    def __setattr__(self, _name: str, _value: T) -> None:
         raise TypeError(f"Trying to modify immutable '{self.__class__.__name__}' instance.")
 
-    def items(self) -> Iterable[Tuple[str, Any]]:
+    def items(self) -> Iterable[Tuple[str, T]]:
         return self.__dict__.items()
 
     def keys(self) -> Iterable[str]:
         return self.__dict__.keys()
 
-    def values(self) -> Iterable[Any]:
+    def values(self) -> Iterable[T]:
         return self.__dict__.values()
 
 
@@ -487,7 +490,6 @@ class UIDGenerator:
 
 
 # -- Iterators --
-T = TypeVar("T")
 S = TypeVar("S")
 K = TypeVar("K")
 

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -70,7 +70,7 @@ try:
     import cytoolz as toolz
 except ModuleNotFoundError:
     # Fall back to pure Python toolz
-    import toolz
+    import toolz  # noqa: F401  # imported but unused
 
 
 def isinstancechecker(type_info: Union[Type, Iterable[Type]]) -> Callable[[Any], bool]:
@@ -218,8 +218,7 @@ def itemgetter_(key: Any, default: Any = NOTHING) -> Callable[[Any], Any]:
 def optional_lru_cache(
     func: Callable = None, *, maxsize: Optional[int] = 128, typed: bool = False
 ) -> Union[Callable, Callable[[Callable], Callable]]:
-    """Wrapper around :func:`functools.lru_cache` calling the original function
-    when arguments are not hashable.
+    """Wrap :func:`functools.lru_cache` to fall back to the original function if arguments are not hashable.
 
     Examples:
         >>> @optional_lru_cache(typed=True)
@@ -241,7 +240,6 @@ def optional_lru_cache(
 
     Notes:
         Based on :func:`typing._tp_cache`.
-
     """
 
     def _decorator(func: Callable) -> Callable:
@@ -1382,7 +1380,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             >>> list(it.reduceby(lambda nvowels, name: nvowels + sum(i in 'aeiou' for i in name), len, init=0))
             [(5, 4), (3, 2), (7, 3)]
 
-        """  # noqa: RST203  # sphinx.napoleon conventions confuses RST validator
+        """  # noqa: RST203  # sphinx.napoleon conventions confuse RST validator
         if (not callable(key) and not isinstance(key, (int, str, list))) or not all(
             isinstance(i, str) for i in attr_keys
         ):

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -294,7 +294,7 @@ def shash(*args: Any, hash_algorithm: Optional[Any] = None) -> str:
     interpreter reboots) and it does not use hash customizations on user
     classes (it uses `pickle` internally to get a byte stream).
 
-    Args:
+    Arguments:
         hash_algorithm: object implementing the `hash algorithm` interface
             from :mod:`hashlib` or canonical name (`str`) of the
             hash algorithm as defined in :mod:`hashlib`.

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -121,7 +121,7 @@ class GenericModelFactory(factory.Factory):
 
 
 @pytest.fixture(params=example_model_factories)
-def example_model_factory(request) -> datamodels.DataModelLike:
+def example_model_factory(request) -> datamodels.DataModelTp:
     return request.param
 
 
@@ -502,7 +502,7 @@ class ChildModelWithRootValidators(ModelWithRootValidators):
 
 
 @pytest.mark.parametrize("model_class", [ModelWithRootValidators, ChildModelWithRootValidators])
-def test_root_validators(model_class: Type[datamodels.DataModelLike]):
+def test_root_validators(model_class: Type[datamodels.DataModelTp]):
     model_class(int_value=0, float_value=1.1, str_value="")
     with pytest.raises(ValueError, match="float_value"):
         model_class(int_value=1, float_value=1.0, str_value="")
@@ -661,11 +661,11 @@ def test_info_functions():
     [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
 )
 def test_generic_model_instantiation_name(concrete_type: Type):
-    Model = datamodels.concretize(GenericModel, concrete_type)  # type: ignore  # GenericModel is not detected as GenericDataModelLike
+    Model = datamodels.concretize(GenericModel, concrete_type)  # type: ignore[misc]  # GenericModel is not detected as GenericDataModelTp
     assert Model.__name__.startswith(GenericModel.__name__)
     assert Model.__name__ != GenericModel.__name__
 
-    Model = datamodels.concretize(GenericModel, concrete_type, class_name="MyNewConcreteClass")  # type: ignore  # GenericModel is not detected as GenericDataModelLike
+    Model = datamodels.concretize(GenericModel, concrete_type, class_name="MyNewConcreteClass")  # type: ignore[misc]  # GenericModel is not detected as GenericDataModelTp
     assert Model.__name__ == "MyNewConcreteClass"
 
 
@@ -674,12 +674,12 @@ def test_generic_model_instantiation_name(concrete_type: Type):
     [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
 )
 def test_generic_model_alias(concrete_type: Type):
-    Model = datamodels.concretize(GenericModel, concrete_type)  # type: ignore  # GenericModel is not detected as GenericDataModelLike
+    Model = datamodels.concretize(GenericModel, concrete_type)  # type: ignore[misc]  # GenericModel is not detected as GenericDataModelTp
 
-    assert GenericModel[concrete_type].__class__ is Model  # type: ignore  # using run-time type on purpose
-    assert typing.get_origin(GenericModel[concrete_type]) is Model  # type: ignore  # using run-time type on purpose
+    assert GenericModel[concrete_type].__class__ is Model  # type: ignore[valid-type]  # using run-time type on purpose
+    assert typing.get_origin(GenericModel[concrete_type]) is Model  # type: ignore[valid-type]  # using run-time type on purpose
 
-    class SubModel(GenericModel[concrete_type]):  # type: ignore  # using run-time type on purpose
+    class SubModel(GenericModel[concrete_type]):  # type: ignore[valid-type]  # using run-time type on purpose
         ...
 
     assert SubModel.__base__ is Model
@@ -731,7 +731,7 @@ def test_concrete_field_type_validation(
     type_hint: str, valid_values: Sequence[Any], wrong_values: Sequence[Any]
 ):
     concrete_type: Type = eval(type_hint)
-    Model: Type[datamodels.DataModelLike] = GenericModel[concrete_type].__class__  # type: ignore[valid-type,assignment]
+    Model: Type[datamodels.DataModelTp] = GenericModel[concrete_type].__class__  # type: ignore[valid-type,assignment]
 
     for value in valid_values:
         Model(value=value)

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -254,8 +254,8 @@ sample_type_data = [
 
 
 @pytest.mark.parametrize(["type_hint", "valid_values", "wrong_values"], sample_type_data)
-def test_field_type_hint(type_hint: Type, valid_values: Sequence[Any], wrong_values: Sequence[Any]):
-    context = {}
+def test_field_type_hint(type_hint: str, valid_values: Sequence[Any], wrong_values: Sequence[Any]):
+    context: Dict[str, Any] = {}
     exec(
         f"""
 @datamodels.datamodel
@@ -397,7 +397,7 @@ class ChildModelWithValidators(ModelWithValidators):
 
 
 @pytest.mark.parametrize("model_class", [ModelWithValidators, ChildModelWithValidators])
-def test_field_validators(model_class: datamodels.DataModelLike):
+def test_field_validators(model_class: Type[Union[ModelWithValidators, ChildModelWithValidators]]):
 
     with pytest.raises(ValueError, match="int_value"):
         model_class(int_value=-1)
@@ -500,7 +500,7 @@ class ChildModelWithRootValidators(ModelWithRootValidators):
 
 
 @pytest.mark.parametrize("model_class", [ModelWithRootValidators, ChildModelWithRootValidators])
-def test_root_validators(model_class: datamodels.DataModelLike):
+def test_root_validators(model_class: Type[datamodels.DataModelLike]):
     model_class(int_value=0, float_value=1.1, str_value="")
     with pytest.raises(ValueError, match="float_value"):
         model_class(int_value=1, float_value=1.0, str_value="")

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -266,7 +266,10 @@ class Model:
     )
     Model = context["Model"]
 
-    assert eval(Model.__datamodel_fields__.value.type) == eval(type_hint)
+    field_type = Model.__datamodel_fields__.value.type
+    if isinstance(field_type, str):
+        field_type = eval(field_type)
+    assert field_type == eval(type_hint)
 
     for value in valid_values:
         Model(value=value)

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-
 from __future__ import annotations
 
 import dataclasses
@@ -122,7 +121,7 @@ class GenericModelFactory(factory.Factory):
 
 
 @pytest.fixture(params=example_model_factories)
-def example_model_factory(request) -> datamodels.DataModelLike:  # type: ignore
+def example_model_factory(request) -> datamodels.DataModelLike:
     return request.param
 
 
@@ -321,7 +320,7 @@ def test_field_redefinition():
 
     # Redefinition with different type
     class ChildModel2(Model):
-        value: float = 2.2
+        value: float = 2.2  # type: ignore  # redefining value as float on purpose
 
     assert ChildModel2().value == 2.2
 
@@ -659,11 +658,11 @@ def test_info_functions():
     [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
 )
 def test_generic_model_instantiation_name(concrete_type: Type):
-    Model = datamodels.concretize(GenericModel, concrete_type)
+    Model = datamodels.concretize(GenericModel, concrete_type)  # type: ignore  # GenericModel is not detected as GenericDataModelLike
     assert Model.__name__.startswith(GenericModel.__name__)
     assert Model.__name__ != GenericModel.__name__
 
-    Model = datamodels.concretize(GenericModel, concrete_type, class_name="MyNewConcreteClass")
+    Model = datamodels.concretize(GenericModel, concrete_type, class_name="MyNewConcreteClass")  # type: ignore  # GenericModel is not detected as GenericDataModelLike
     assert Model.__name__ == "MyNewConcreteClass"
 
 
@@ -672,12 +671,12 @@ def test_generic_model_instantiation_name(concrete_type: Type):
     [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
 )
 def test_generic_model_alias(concrete_type: Type):
-    Model = datamodels.concretize(GenericModel, concrete_type)
+    Model = datamodels.concretize(GenericModel, concrete_type)  # type: ignore  # GenericModel is not detected as GenericDataModelLike
 
-    assert GenericModel[concrete_type].__class__ is Model
-    assert typing.get_origin(GenericModel[concrete_type]) is Model
+    assert GenericModel[concrete_type].__class__ is Model  # type: ignore  # using run-time type on purpose
+    assert typing.get_origin(GenericModel[concrete_type]) is Model  # type: ignore  # using run-time type on purpose
 
-    class SubModel(GenericModel[concrete_type]):
+    class SubModel(GenericModel[concrete_type]):  # type: ignore  # using run-time type on purpose
         ...
 
     assert SubModel.__base__ is Model
@@ -726,9 +725,10 @@ def test_basic_generic_field_type_validation():
 # Reuse sample_type_data from test_field_type_hint
 @pytest.mark.parametrize(["type_hint", "valid_values", "wrong_values"], sample_type_data)
 def test_concrete_field_type_validation(
-    type_hint: Type, valid_values: Sequence[Any], wrong_values: Sequence[Any]
+    type_hint: str, valid_values: Sequence[Any], wrong_values: Sequence[Any]
 ):
-    Model = GenericModel[eval(type_hint)].__class__
+    concrete_type: Type = eval(type_hint)
+    Model: Type[datamodels.DataModelLike] = GenericModel[concrete_type].__class__  # type: ignore[valid-type,assignment]
 
     for value in valid_values:
         Model(value=value)

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -1,0 +1,738 @@
+# -*- coding: utf-8 -*-
+#
+# Eve Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import types
+import typing
+from typing import Set  # noqa: F401  # imported but unused (used in exec() context)
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generic,
+    List,
+    MutableSequence,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+
+import devtools
+import factory
+import pytest
+import pytest_factoryboy as pytfboy
+
+from eve import datamodels, utils
+
+
+T = TypeVar("T")
+
+
+example_model_factories: List[factory.Factory] = []
+
+
+def register_factory(
+    factory_class: Optional[factory.Factory] = None,
+    *,
+    model_fixture: Optional[str] = None,
+    collection: Optional[MutableSequence[factory.Factory]] = None,
+) -> Union[factory.Factory, Callable[[factory.Factory], factory.Factory]]:
+    def _decorator(factory: factory.Factory) -> factory.Factory:
+        if collection is not None:
+            collection.append(factory)
+        return pytfboy.register(factory, model_fixture)
+
+    return _decorator(factory_class) if factory_class is not None else _decorator
+
+
+class SampleEnum(enum.Enum):
+    FOO = "foo"
+    BLA = "bla"
+
+
+class SampleClass:
+    pass
+
+
+class EmptyModel(datamodels.DataModel):
+    pass
+
+
+@register_factory(collection=example_model_factories)
+class EmptyModelFactory(factory.Factory):
+    class Meta:
+        model = EmptyModel
+
+
+class IntModel(datamodels.DataModel):
+    value: int
+
+
+@register_factory(collection=example_model_factories)
+class IntModelFactory(factory.Factory):
+    class Meta:
+        model = IntModel
+
+    value = 1
+
+
+class AnyModel(datamodels.DataModel):
+    value: Any
+
+
+@register_factory(collection=example_model_factories)
+class AnyModelFactory(factory.Factory):
+    class Meta:
+        model = AnyModel
+
+    value = ("any", "value")
+
+
+class GenericModel(datamodels.DataModel, Generic[T]):
+    value: T
+
+
+@register_factory(collection=example_model_factories)
+class GenericModelFactory(factory.Factory):
+    class Meta:
+        model = GenericModel
+
+    value = "generic value"
+
+
+@pytest.fixture(params=example_model_factories)
+def example_model_factory(request) -> datamodels.DataModelLike:  # type: ignore
+    return request.param
+
+
+# --- Tests ---
+# Test generated members
+def test_datamodel_class_members(example_model_factory):
+    model = example_model_factory()
+    model_class = model.__class__
+
+    assert hasattr(model_class, "__init__")
+    assert hasattr(model_class, "__datamodel_fields__")
+    assert isinstance(model_class.__datamodel_fields__, utils.FrozenNamespace)
+    assert hasattr(model_class, "__datamodel_params__")
+    assert isinstance(model_class.__datamodel_params__, utils.FrozenNamespace)
+    assert hasattr(model_class, "__datamodel_validators__")
+    assert isinstance(model_class.__datamodel_validators__, tuple)
+
+
+def test_devtools_compatibility(example_model_factory):
+    model = example_model_factory()
+    model_class = model.__class__
+    formatted_string = devtools.pformat(model)
+
+    assert hasattr(model_class, "__pretty__")
+    assert callable(model_class.__pretty__)
+    assert f"{model_class.__name__}(" in formatted_string
+    for name in model_class.__datamodel_fields__.keys():
+        assert f"{name}=" in formatted_string
+
+
+def test_dataclass_compatibility(example_model_factory):
+    model = example_model_factory()
+    model_class = model.__class__
+
+    assert hasattr(model_class, "__dataclass_fields__") and isinstance(
+        model_class.__dataclass_fields__, dict
+    )
+    assert set(model_class.__datamodel_fields__.keys()) == set(
+        model_class.__dataclass_fields__.keys()
+    )
+    assert dataclasses.is_dataclass(model_class)
+    field_names = set(model_class.__datamodel_fields__.keys())
+    assert all(f.name in field_names for f in dataclasses.fields(model))
+
+
+def test_init():
+    @datamodels.datamodel
+    class Model:
+        value: int
+        enum_value: SampleEnum
+        list_value: List[int]
+
+    model = Model(value=1, enum_value=SampleEnum.FOO, list_value=[1, 2, 3])
+    assert model.value == 1
+    assert model.enum_value == SampleEnum.FOO
+    assert model.list_value == [1, 2, 3]
+
+
+def test_default_values():
+    @datamodels.datamodel
+    class Model:
+        bool_value: bool = True
+        int_value: int
+        enum_value: SampleEnum = SampleEnum.FOO
+        any_value: Any = datamodels.field(default="ANY")
+
+    model = Model(int_value=1)
+    with pytest.raises(TypeError, match="'int_value'"):
+        Model()
+
+    assert model.bool_value is True
+    assert model.int_value == 1
+    assert model.enum_value == SampleEnum.FOO
+    assert model.any_value == "ANY"
+
+    @datamodels.datamodel
+    class WrongModel:
+        bool_value: bool = 1
+
+    with pytest.raises(TypeError, match="'bool_value'"):
+        WrongModel()
+
+
+def test_default_factories():
+    @datamodels.datamodel
+    class Model:
+        list_value: List[int] = datamodels.field(default_factory=list)
+        dict_value: Dict[str, int] = datamodels.field(default_factory=lambda: {"one": 1})
+
+    model = Model()
+
+    assert model.list_value == []
+    assert model.dict_value == {"one": 1}
+
+    @datamodels.datamodel
+    class WrongModel:
+        list_value: List[int] = datamodels.field(default_factory=tuple)
+
+    with pytest.raises(TypeError, match="'list_value'"):
+        WrongModel()
+
+
+# Test field specification
+sample_type_data = [
+    ("bool", [True, False], [1, "True"]),
+    ("int", [1, -1], [1.0, True, "1"]),
+    ("float", [1.0], [1, "1.0"]),
+    ("str", ["", "one"], [1, ("one",)]),
+    ("complex", [1j], [1, 1.0, "1j"]),
+    ("bytes", [b"bytes", b""], ["string", ["a"]]),
+    ("typing.Any", ["any"], tuple()),
+    ("typing.Literal[1, 1.0, True]", [1, 1.0, True], [False]),
+    ("typing.Tuple[int, str]", [(3, "three")], [(), (3, 3)]),
+    ("typing.Tuple[int, ...]", [(1, 2, 3), ()], [3, (3, "three")]),
+    ("typing.List[int]", ([1, 2, 3], []), (1, [1.0])),
+    ("typing.Set[int]", ({1, 2, 3}, set()), (1, [1], (1,), {1: None})),
+    ("typing.Dict[int, str]", ({}, {3: "three"}), ([(3, "three")], 3, "three", [])),
+    ("typing.Sequence[int]", ([1, 2, 3], [], (1, 2, 3), tuple()), (1, [1.0], {1})),
+    ("typing.MutableSequence[int]", ([1, 2, 3], []), ((1, 2, 3), tuple(), 1, [1.0], {1})),
+    ("typing.Set[int]", ({1, 2, 3}, set()), (1, [1], (1,), {1: None})),
+    ("typing.Union[int, float, str]", [1, 3.0, "one"], [[1], [], 1j]),
+    ("typing.Optional[int]", [1, None], [[1], [], 1j]),
+    (
+        "typing.Dict[Union[int, float, str], Union[Tuple[int, Optional[float]], Set[int]]]",
+        [{1: (2, 3.0)}, {1.0: (2, None)}, {"1": {1, 2}}],
+        [{(1, 1.0, "1"): set()}, {1: [1]}, {"1": (1,)}],
+    ),
+]
+
+
+@pytest.mark.parametrize(["type_hint", "valid_values", "wrong_values"], sample_type_data)
+def test_field_type_hint(type_hint: Type, valid_values: Sequence[Any], wrong_values: Sequence[Any]):
+    context = {}
+    exec(
+        f"""
+@datamodels.datamodel
+class Model:
+    value: {type_hint}
+""",
+        globals(),
+        context,
+    )
+    Model = context["Model"]
+
+    assert eval(Model.__datamodel_fields__.value.type) == eval(type_hint)
+
+    for value in valid_values:
+        Model(value=value)
+
+    for value in wrong_values:
+        with pytest.raises((TypeError, ValueError), match="'value'"):
+            Model(value=value)
+
+
+def test_custom_class_type_hint():
+    @datamodels.datamodel
+    class Model1:
+        value: SampleEnum
+
+    Model1(value=SampleEnum.FOO)
+
+    class SampleClassChild(SampleClass):
+        pass
+
+    class SampleClassGrandChild(SampleClassChild):
+        pass
+
+    @datamodels.datamodel
+    class Model2:
+        value: SampleClass
+
+    Model2(value=SampleClass())
+    Model2(value=SampleClassChild())
+    Model2(value=SampleClassGrandChild())
+
+    class AnotherClass:
+        pass
+
+    with pytest.raises(TypeError, match="value"):
+        Model1(value=AnotherClass())
+    with pytest.raises(TypeError, match="value"):
+        Model2(value=AnotherClass())
+
+
+def test_field_redefinition():
+    class Model(datamodels.DataModel):
+        value: int = 0
+
+    assert Model().value == 0
+
+    # Redefinition with same type
+    class ChildModel1(Model):
+        value: int = 1
+
+    assert ChildModel1().value == 1
+
+    # Redefinition with different type
+    class ChildModel2(Model):
+        value: float = 2.2
+
+    assert ChildModel2().value == 2.2
+
+    with pytest.raises(TypeError, match="value"):
+        assert ChildModel2(value=2)
+
+
+def test_class_vars():
+    @datamodels.datamodel
+    class Model:
+        value: Any
+        default_value: Any = None
+
+        class_var: ClassVar[int] = 0
+
+    field_names = set(Model.__datamodel_fields__.keys())
+    assert field_names == {"value", "default_value"}
+    assert hasattr(Model, "class_var")
+    assert Model.class_var == 0
+
+
+def test_missing_annotations():
+    with pytest.raises(TypeError, match="other_value"):
+
+        class Model(datamodels.DataModel):
+            other_value = datamodels.field(default=None)
+
+
+# Test custom validators
+class ModelWithValidators(datamodels.DataModel):
+    bool_value: bool = False
+    int_value: int = 0
+    even_int_value: int = 2
+    float_value: float = 0.0
+    str_value: str = ""
+    extra_value: Optional[Any] = None
+
+    @datamodels.validator("bool_value")
+    def _bool_value_validator(self, attribute, value):
+        assert isinstance(self, ModelWithValidators)
+
+    @datamodels.validator("int_value")
+    def _int_value_validator(self, attribute, value):
+        if value < 0:
+            raise ValueError(f"'{attribute.name}' must be larger or equal to 0")
+
+    @datamodels.validator("even_int_value")
+    def _even_int_value_validator(self, attribute, value):
+        if value % 2:
+            raise ValueError(f"'{attribute.name}' must be an even number")
+
+    @datamodels.validator("float_value")
+    def _float_value_validator(self, attribute, value):
+        if value > 3.14159:
+            raise ValueError(f"'{attribute.name}' must be lower or equal to 3.14159")
+
+    @datamodels.validator("str_value")
+    def _str_value_validator(self, attribute, value):
+        # This kind of validation should arguably happen in a root_validator, but
+        # since float_value is defined before str_value, it should have been
+        # already validated at this point
+        if value == str(self.float_value):
+            raise ValueError(f"'{attribute.name}' must be different to 'float_value'")
+
+    @datamodels.validator("extra_value")
+    def _extra_value_validator(self, attribute, value):
+        if bool(value):
+            raise ValueError(f"'{attribute.name}' must be equivalent to False")
+
+
+class ChildModelWithValidators(ModelWithValidators):
+    pass
+
+
+@pytest.mark.parametrize("model_class", [ModelWithValidators, ChildModelWithValidators])
+def test_field_validators(model_class: datamodels.DataModelLike):
+
+    with pytest.raises(ValueError, match="int_value"):
+        model_class(int_value=-1)
+
+    model_class(even_int_value=-2)
+    with pytest.raises(ValueError, match="even_int_value"):
+        model_class(even_int_value=1)
+
+    model_class(float_value=-2.0)
+    with pytest.raises(ValueError, match="float_value"):
+        model_class(float_value=4.0)
+
+    with pytest.raises(ValueError, match="str_value"):
+        model_class(float_value=1.0, str_value="1.0")
+
+    with pytest.raises(ValueError, match="extra_value"):
+        model_class(extra_value=1)
+
+    model_class(extra_value=False)
+    model_class(extra_value=0)
+    model_class(extra_value="")
+    model_class(extra_value=[])
+    with pytest.raises(ValueError, match="extra_value"):
+        model_class(extra_value=1)
+
+
+def test_new_field_validators_in_subclass():
+    class ChildModelWithValidators(ModelWithValidators):
+        @datamodels.validator("int_value")
+        def _int_value_validator(self, attribute, value):
+            if value > 10:
+                raise ValueError(f"'{attribute.name}' must be lower or equal to 10")
+
+    ChildModelWithValidators(int_value=1)
+    with pytest.raises(ValueError, match="int_value"):
+        ChildModelWithValidators(int_value=-1)
+    with pytest.raises(ValueError, match="int_value"):
+        ChildModelWithValidators(int_value=11)
+
+
+def test_field_validators_in_overwritten_field_in_subclass():
+    class ChildModelWithValidators(ModelWithValidators):
+        int_value: int = 0
+
+        @datamodels.validator("int_value")
+        def _int_value_validator(self, attribute, value):
+            if value > 10:
+                raise ValueError(f"'{attribute.name}' must be lower or equal to 10")
+
+    ChildModelWithValidators(int_value=1)
+    ChildModelWithValidators(int_value=-1)  # Test new field definition
+    with pytest.raises(ValueError, match="int_value"):
+        ChildModelWithValidators(int_value=11)
+
+    # Overwrite field definition with a new type
+    class AnotherChildModelWithValidators(ModelWithValidators):
+        extra_value: float
+
+        @datamodels.validator("extra_value")
+        def _extra_value_validator(self, attribute, value):
+            if value < 0.0:
+                raise ValueError(f"'{attribute.name}' must be a positive number")
+
+    AnotherChildModelWithValidators(extra_value=0.0)
+    AnotherChildModelWithValidators(extra_value=1.0)
+    with pytest.raises(ValueError, match="extra_value"):
+        AnotherChildModelWithValidators(extra_value=-1.0)
+
+
+class ModelWithRootValidators(datamodels.DataModel):
+    int_value: int
+    float_value: float
+    str_value: str
+
+    class_counter: ClassVar[int] = 0
+
+    @datamodels.root_validator
+    def _root_validator(cls, instance):
+        assert cls is type(instance)
+        assert issubclass(cls, ModelWithRootValidators)
+        assert isinstance(instance, ModelWithRootValidators)
+        cls.class_counter = 0
+
+    @datamodels.root_validator
+    def _another_root_validator(cls, instance):
+        assert cls.class_counter == 0
+        cls.class_counter += 1
+
+    @datamodels.root_validator
+    def _final_root_validator(cls, instance):
+        assert cls.class_counter == 1
+        cls.class_counter += 1
+
+        if instance.int_value == instance.float_value:
+            raise ValueError("'int_value' and 'float_value' must be different")
+
+
+class ChildModelWithRootValidators(ModelWithRootValidators):
+    pass
+
+
+@pytest.mark.parametrize("model_class", [ModelWithRootValidators, ChildModelWithRootValidators])
+def test_root_validators(model_class: datamodels.DataModelLike):
+    model_class(int_value=0, float_value=1.1, str_value="")
+    with pytest.raises(ValueError, match="float_value"):
+        model_class(int_value=1, float_value=1.0, str_value="")
+
+
+def test_root_validators_in_subclasses():
+    class Model(ModelWithRootValidators):
+        @datamodels.root_validator
+        def _root_validator(cls, instance):
+            assert cls.class_counter == 2
+            cls.class_counter += 10
+
+        @datamodels.root_validator
+        def _another_root_validator(cls, instance):
+            assert cls.class_counter == 12
+            cls.class_counter += 10
+
+        @datamodels.root_validator
+        def _final_root_validator(cls, instance):
+            assert cls.class_counter == 22
+            if str(instance.int_value) == instance.str_value:
+                raise ValueError("'int_value' and 'str_value' must be different")
+
+    with pytest.raises(ValueError, match="str_value"):
+        Model(int_value=1, float_value=0.0, str_value="1")
+    with pytest.raises(ValueError, match="float_value"):
+        Model(int_value=1, float_value=1.0, str_value="1")
+    with pytest.raises(ValueError, match="float_value"):
+        Model(int_value=1, float_value=1.0, str_value="1")
+
+
+# Test field options
+def test_field_init():
+    @datamodels.datamodel
+    class Model:
+        hidden_value: int = datamodels.field(init=False)
+        value: int
+        hidden_value_with_default: int = datamodels.field(default=10, init=False)
+
+    model = Model(value=1)
+    assert model.value == 1
+    assert model.hidden_value_with_default == 10
+
+    model.hidden_value = -1
+    assert model.hidden_value == -1
+
+
+def test_field_metadata():
+    @datamodels.datamodel
+    class Model:
+        value: int = datamodels.field(metadata={"my_metadata": "META"})
+
+    assert isinstance(Model.__datamodel_fields__.value.metadata, types.MappingProxyType)
+    assert Model.__datamodel_fields__.value.metadata["my_metadata"] == "META"
+
+
+# Test datamodel options
+def test_frozen():
+    import attr
+
+    @datamodels.datamodel(frozen=True)
+    class FrozenModel:
+        value: Any = None
+
+    assert FrozenModel.__datamodel_params__.frozen is True
+    with pytest.raises(attr.exceptions.FrozenInstanceError):
+        FrozenModel().value = 1
+
+    class FrozenModel2(datamodels.DataModel, frozen=True):
+        value: Any = None
+
+    assert FrozenModel2.__datamodel_params__.frozen is True
+    with pytest.raises(attr.exceptions.FrozenInstanceError):
+        FrozenModel2().value = 1
+
+
+def test_hash():
+    string_value = "this is a really long string to avoid string interning 1234567890 +:?.!"
+
+    # Safe mutable case: no hash
+    @datamodels.datamodel
+    class MutableModel:
+        value: Any = None
+
+    with pytest.raises(TypeError, match="unhashable type"):
+        hash(MutableModel(value=string_value))
+
+    # Unsafe mutable case: mutable hash
+    @datamodels.datamodel(unsafe_hash=True)
+    class MutableModelWithHash:
+        value: Any = None
+
+    mutable_model = MutableModelWithHash(value=string_value)
+    hash_value = hash(mutable_model)
+    assert hash_value == hash(MutableModelWithHash(value=string_value))
+
+    # This is the (expected) wrong behaviour with a 'unsafe_hash=True',
+    # because hash value should not change during lifetime of an object
+    mutable_model.value = 42
+    assert hash_value != hash(mutable_model)
+
+    # Safe frozen case: proper hash
+    @datamodels.datamodel(frozen=True)
+    class FrozenModel:
+        value: Any = None
+
+    assert hash(MutableModelWithHash(value=string_value)) == hash(
+        MutableModelWithHash(value=string_value)
+    )
+
+
+def test_non_instantiable():
+    @datamodels.datamodel(instantiable=False)
+    class NonInstantiableModel:
+        value: Any
+
+    assert NonInstantiableModel.__datamodel_params__.instantiable is False
+    with pytest.raises(TypeError, match="Trying to instantiate"):
+        NonInstantiableModel()
+
+    class NonInstantiableModel2(datamodels.DataModel, instantiable=False):
+        value: Any
+
+    assert NonInstantiableModel2.__datamodel_params__.instantiable is False
+    with pytest.raises(TypeError, match="Trying to instantiate"):
+        NonInstantiableModel2()
+
+
+# Test module functions
+def test_info_functions():
+    @datamodels.datamodel
+    class Model:
+        int_value: int
+        float_value: float
+        str_value: str
+        class_counter: ClassVar[int] = 0
+
+    fields_info = datamodels.fields(Model)
+    fields_info_keys = set(fields_info.keys())
+
+    assert isinstance(fields_info, utils.FrozenNamespace)
+    assert fields_info_keys == {"int_value", "float_value", "str_value"}
+    assert datamodels.get_fields(Model) == fields_info
+    assert datamodels.fields(Model, as_dataclass=True) == dataclasses.fields(Model)
+
+    model = Model(int_value=1, float_value=2.0, str_value="string")
+
+    assert fields_info == datamodels.fields(model)
+    assert datamodels.asdict(model) == {"int_value": 1, "float_value": 2.0, "str_value": "string"}
+    assert datamodels.astuple(model) == (1, 2.0, "string")
+
+
+# Test generic models
+@pytest.mark.parametrize(
+    "concrete_type",
+    [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
+)
+def test_generic_model_instantiation_name(concrete_type: Type):
+    Model = datamodels.concretize(GenericModel, concrete_type)
+    assert Model.__name__.startswith(GenericModel.__name__)
+    assert Model.__name__ != GenericModel.__name__
+
+    Model = datamodels.concretize(GenericModel, concrete_type, class_name="MyNewConcreteClass")
+    assert Model.__name__ == "MyNewConcreteClass"
+
+
+@pytest.mark.parametrize(
+    "concrete_type",
+    [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
+)
+def test_generic_model_alias(concrete_type: Type):
+    Model = datamodels.concretize(GenericModel, concrete_type)
+
+    assert GenericModel[concrete_type].__class__ is Model
+    assert typing.get_origin(GenericModel[concrete_type]) is Model
+
+    class SubModel(GenericModel[concrete_type]):
+        ...
+
+    assert SubModel.__base__ is Model
+
+
+@pytest.mark.parametrize(
+    "concrete_type",
+    [int, List[float], Tuple[int, ...], Optional[int], Union[int, float]],
+)
+def test_generic_model_instantiation_cache(concrete_type):
+    Model1 = datamodels.concretize(GenericModel, concrete_type)
+    Model2 = datamodels.concretize(GenericModel, concrete_type)
+    Model3 = datamodels.concretize(GenericModel, concrete_type)
+
+    assert (
+        Model1 is Model2
+        and Model2 is Model3
+        and Model3 is datamodels.concretize(GenericModel, concrete_type)
+    )
+
+
+def test_basic_generic_field_type_validation():
+    class GenericModel(datamodels.DataModel, Generic[T]):
+        value: T
+
+    GenericModel(value=1)
+    GenericModel(value="value")
+    GenericModel(value=(1.0, "value"))
+    GenericModel(value=None)
+
+    class PartialGenericModel(datamodels.DataModel, Generic[T]):
+        value: List[T]
+
+    PartialGenericModel(value=[])
+    PartialGenericModel(value=[1])
+    PartialGenericModel(value=["value"])
+    PartialGenericModel(value=[1.0, "value"])
+    PartialGenericModel(value=[(1.0, "value")])
+    PartialGenericModel(value=[None])
+    with pytest.raises(TypeError, match="'value'"):
+        PartialGenericModel(value=1)
+    with pytest.raises(TypeError, match="'value'"):
+        PartialGenericModel(value=(1, 2))
+
+
+# Reuse sample_type_data from test_field_type_hint
+@pytest.mark.parametrize(["type_hint", "valid_values", "wrong_values"], sample_type_data)
+def test_concrete_field_type_validation(
+    type_hint: Type, valid_values: Sequence[Any], wrong_values: Sequence[Any]
+):
+    Model = GenericModel[eval(type_hint)].__class__
+
+    for value in valid_values:
+        Model(value=value)
+
+    for value in wrong_values:
+        with pytest.raises((TypeError, ValueError), match="'value'"):
+            Model(value=value)

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -347,12 +347,14 @@ class GlobalRecursiveModel:
 def test_deferred_class_type_hint():
     # Model defined in a module global context
     assert isinstance(GlobalRecursiveModel.__datamodel_fields__.value.type, ForwardRef)
-    datamodels.update_forward_refs(GlobalRecursiveModel)
-    assert GlobalRecursiveModel.__datamodel_fields__.value.type.__args__[0] == GlobalRecursiveModel
 
     m1 = GlobalRecursiveModel()
     m2 = GlobalRecursiveModel(value=m1)
     GlobalRecursiveModel(value=m2)
+
+    with pytest.raises(TypeError, match="value"):
+        GlobalRecursiveModel(value="wrong_value")
+    assert GlobalRecursiveModel.__datamodel_fields__.value.type.__args__[0] == GlobalRecursiveModel
 
     # Models defined in a non-global context
     @datamodels.datamodel


### PR DESCRIPTION
## Description

Add a new eve.datamodels module to replace pydantic.Models in the short future.

Main changes:
- Add eve.datamodels module with unit tests
- Add new typing manipulation utils to eve.typingx
- Add new minor utils to eve.utils
- Very minor fixes to imports and docs in some eve modules
