### PR TITLE
Enable usage of pow with new gtc backends

### DIFF
--- a/src/gt4py/backend/gtc_backend/defir_to_gtir.py
+++ b/src/gt4py/backend/gtc_backend/defir_to_gtir.py
@@ -188,7 +188,9 @@ class DefIRToGTIR(IRNodeVisitor):
 
     def visit_BinOpExpr(self, node: BinOpExpr) -> gtir.BinaryOp:
         if node.op == BinaryOperator.POW:
-            return gtir.NativeFuncCall(func=common.NativeFunction.POW, args=[self.visit(node.lhs), self.visit(node.rhs)])
+            return gtir.NativeFuncCall(
+                func=common.NativeFunction.POW, args=[self.visit(node.lhs), self.visit(node.rhs)]
+            )
 
         return gtir.BinaryOp(
             left=self.visit(node.lhs),

--- a/src/gt4py/backend/gtc_backend/defir_to_gtir.py
+++ b/src/gt4py/backend/gtc_backend/defir_to_gtir.py
@@ -187,6 +187,9 @@ class DefIRToGTIR(IRNodeVisitor):
         return gtir.UnaryOp(op=self.GT4PY_UNARYOP_TO_GTIR[node.op], expr=self.visit(node.arg))
 
     def visit_BinOpExpr(self, node: BinOpExpr) -> gtir.BinaryOp:
+        if node.op == BinaryOperator.POW:
+            return gtir.NativeFuncCall(func=common.NativeFunction.POW, args=[self.visit(node.lhs), self.visit(node.rhs)])
+
         return gtir.BinaryOp(
             left=self.visit(node.lhs),
             right=self.visit(node.rhs),

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -142,6 +142,7 @@ class NativeFunction(StrEnum):
     MIN = "min"
     MAX = "max"
     MOD = "mod"
+    POW = "pow"
 
     SIN = "sin"
     COS = "cos"
@@ -173,6 +174,7 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
     NativeFunction.MIN: 2,
     NativeFunction.MAX: 2,
     NativeFunction.MOD: 2,
+    NativeFunction.POW: 2,
     NativeFunction.SIN: 1,
     NativeFunction.COS: 1,
     NativeFunction.TAN: 1,

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -103,6 +103,8 @@ class GTCppCodegen(codegen.TemplatedGenerator):
             return "gridtools::math::min"
         elif func == NativeFunction.MAX:
             return "gridtools::math::max"
+        elif func == NativeFunction.POW:
+            return "gridtools::math::pow"
         raise NotImplementedError("Not implemented NativeFunction encountered.")
 
     NativeFuncCall = as_mako("${func}(${','.join(args)})")


### PR DESCRIPTION
## Description

Just the implementation using `gt_math::pow` (so no testing). Additional optimizations for integer exponents possible.

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [ ] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


