### PR TITLE
Support Power Operator (**) and More Native Functions in gtc:gt: Backends

### DIFF
--- a/src/gt4py/backend/gtc_backend/defir_to_gtir.py
+++ b/src/gt4py/backend/gtc_backend/defir_to_gtir.py
@@ -186,7 +186,11 @@ class DefIRToGTIR(IRNodeVisitor):
     def visit_UnaryOpExpr(self, node: UnaryOpExpr) -> gtir.UnaryOp:
         return gtir.UnaryOp(op=self.GT4PY_UNARYOP_TO_GTIR[node.op], expr=self.visit(node.arg))
 
-    def visit_BinOpExpr(self, node: BinOpExpr) -> gtir.BinaryOp:
+    def visit_BinOpExpr(self, node: BinOpExpr) -> Union[gtir.BinaryOp, gtir.NativeFuncCall]:
+        if node.op == BinaryOperator.POW:
+            return gtir.NativeFuncCall(
+                func=common.NativeFunction.POW, args=[self.visit(node.lhs), self.visit(node.rhs)]
+            )
         return gtir.BinaryOp(
             left=self.visit(node.lhs),
             right=self.visit(node.rhs),

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -151,6 +151,7 @@ class NativeFunction(StrEnum):
     ARCTAN = "arctan"
 
     SQRT = "sqrt"
+    POW = "pow"
     EXP = "exp"
     LOG = "log"
 
@@ -180,6 +181,7 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
     NativeFunction.ARCCOS: 1,
     NativeFunction.ARCTAN: 1,
     NativeFunction.SQRT: 1,
+    NativeFunction.POW: 2,
     NativeFunction.EXP: 1,
     NativeFunction.LOG: 1,
     NativeFunction.ISFINITE: 1,

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -97,12 +97,26 @@ class GTCppCodegen(codegen.TemplatedGenerator):
     Literal = as_mako("static_cast<${dtype}>(${value})")
 
     def visit_NativeFunction(self, func: NativeFunction, **kwargs: Any) -> str:
+        if func == NativeFunction.ABS:
+            return "gridtools::math::abs"
+        if func == NativeFunction.MIN:
+            return "gridtools::math::min"
+        if func == NativeFunction.MAX:
+            return "gridtools::math::max"
+        if func == NativeFunction.MOD:
+            return "gridtools::math::fmod"
         if func == NativeFunction.SQRT:
             return "gridtools::math::sqrt"
-        elif func == NativeFunction.MIN:
-            return "gridtools::math::min"
-        elif func == NativeFunction.MAX:
-            return "gridtools::math::max"
+        if func == NativeFunction.POW:
+            return "gridtools::math::pow"
+        if func == NativeFunction.EXP:
+            return "gridtools::math::exp"
+        if func == NativeFunction.EXP:
+            return "gridtools::math::exp"
+        if func == NativeFunction.LOG:
+            return "gridtools::math::log"
+        if func == NativeFunction.TRUNC:
+            return "gridtools::math::trunc"
         raise NotImplementedError("Not implemented NativeFunction encountered.")
 
     NativeFuncCall = as_mako("${func}(${','.join(args)})")

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -97,25 +97,20 @@ class GTCppCodegen(codegen.TemplatedGenerator):
     Literal = as_mako("static_cast<${dtype}>(${value})")
 
     def visit_NativeFunction(self, func: NativeFunction, **kwargs: Any) -> str:
-        if func == NativeFunction.ABS:
-            return "gridtools::math::abs"
-        if func == NativeFunction.MIN:
-            return "gridtools::math::min"
-        if func == NativeFunction.MAX:
-            return "gridtools::math::max"
-        if func == NativeFunction.MOD:
-            return "gridtools::math::fmod"
-        if func == NativeFunction.SQRT:
-            return "gridtools::math::sqrt"
-        if func == NativeFunction.POW:
-            return "gridtools::math::pow"
-        if func == NativeFunction.EXP:
-            return "gridtools::math::exp"
-        if func == NativeFunction.LOG:
-            return "gridtools::math::log"
-        if func == NativeFunction.TRUNC:
-            return "gridtools::math::trunc"
-        raise NotImplementedError("Not implemented NativeFunction encountered.")
+        try:
+            return {
+                NativeFunction.ABS: "gridtools::math::abs",
+                NativeFunction.MIN: "gridtools::math::min",
+                NativeFunction.MAX: "gridtools::math::max",
+                NativeFunction.MOD: "gridtools::math::fmod",
+                NativeFunction.SQRT: "gridtools::math::sqrt",
+                NativeFunction.POW: "gridtools::math::pow",
+                NativeFunction.EXP: "gridtools::math::exp",
+                NativeFunction.LOG: "gridtools::math::log",
+                NativeFunction.TRUNC: "gridtools::math::trunc",
+            }[func]
+        except KeyError as error:
+            raise NotImplementedError("Not implemented NativeFunction encountered.") from error
 
     NativeFuncCall = as_mako("${func}(${','.join(args)})")
 

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -111,8 +111,6 @@ class GTCppCodegen(codegen.TemplatedGenerator):
             return "gridtools::math::pow"
         if func == NativeFunction.EXP:
             return "gridtools::math::exp"
-        if func == NativeFunction.EXP:
-            return "gridtools::math::exp"
         if func == NativeFunction.LOG:
             return "gridtools::math::log"
         if func == NativeFunction.TRUNC:

--- a/tests/test_unittest/test_gtc_backend/test_defir_to_gtir.py
+++ b/tests/test_unittest/test_gtc_backend/test_defir_to_gtir.py
@@ -100,6 +100,16 @@ def test_bin_op_expr(defir_to_gtir):
     bin_op = defir_to_gtir.visit_BinOpExpr(bin_op_expr)
     assert isinstance(bin_op, gtir.BinaryOp)
 
+    bin_op_expr = BinOpExpr(
+        op=BinaryOperator.POW, lhs=TFieldRef(name="a").build(), rhs=TFieldRef(name="b").build()
+    )
+    native_func_call = defir_to_gtir.visit_BinOpExpr(bin_op_expr)
+    assert isinstance(native_func_call, gtir.NativeFuncCall)
+    assert native_func_call.func == common.NativeFunction.POW
+    assert len(native_func_call.args) == 2
+    assert native_func_call.args[0].name == "a"
+    assert native_func_call.args[1].name == "b"
+
 
 def test_field_ref(defir_to_gtir):
     field_ref = TFieldRef(name="a", offset=(-1, 3, 0)).build()


### PR DESCRIPTION
## Description

Added lowering of power operator (**) and the following native functions for floating point input: abs, mod, pow, exp, log, trunc.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


