### PR TITLE
Workaround parallel multistage synchronization issue

### DIFF
--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -212,6 +212,12 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
         gt_ir.Builtin.TRUE: "true",
     }
 
+    ITERATION_ORDER_TO_GT_ORDER = {
+        gt_ir.IterationOrder.FORWARD: "forward",
+        gt_ir.IterationOrder.BACKWARD: "backward",
+        gt_ir.IterationOrder.PARALLEL: "forward",  # NOTE required for
+    }
+
     def __init__(self, class_name, module_name, gt_backend_t, options):
         self.class_name = class_name
         self.module_name = module_name
@@ -501,7 +507,13 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
         multi_stages = []
         for multi_stage in node.multi_stages:
             steps = [[stage.name for stage in group.stages] for group in multi_stage.groups]
-            multi_stages.append({"exec": str(multi_stage.iteration_order).lower(), "steps": steps})
+            ordering = self.ITERATION_ORDER_TO_GT_ORDER[multi_stage.iteration_order]
+            multi_stages.append(
+                {
+                    "exec": ordering,
+                    "steps": steps,
+                }
+            )
 
         template_args = dict(
             arg_fields=arg_fields,

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -215,7 +215,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
     ITERATION_ORDER_TO_GT_ORDER = {
         gt_ir.IterationOrder.FORWARD: "forward",
         gt_ir.IterationOrder.BACKWARD: "backward",
-        gt_ir.IterationOrder.PARALLEL: "forward",  # NOTE required for
+        gt_ir.IterationOrder.PARALLEL: "forward",  # NOTE requires sync between parallel mss
     }
 
     def __init__(self, class_name, module_name, gt_backend_t, options):

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -151,7 +151,7 @@ class GTCppCodegen(codegen.TemplatedGenerator):
 
     def visit_LoopOrder(self, looporder: LoopOrder, **kwargs: Any) -> str:
         return {
-            LoopOrder.PARALLEL: "parallel",
+            LoopOrder.PARALLEL: "forward",
             LoopOrder.FORWARD: "forward",
             LoopOrder.BACKWARD: "backward",
         }[looporder]


### PR DESCRIPTION
## Description

Quick fix for lack of synchronization between parallel multistages in GridTools C++. This converts all parallel computations into forward for code generation in GT backends.

This is overly aggressive because it changes every parallel multistage to forward, so perhaps in the long term this should be changed to detect data dependencies between pairs of parallel computations and flip one of them.