### PR TITLE
Fix Compilation Error in gtc:gt:* Backends Related to Wrong Offset Limits

### DIFF
--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -30,7 +30,7 @@ def _offset_limit(root: Node) -> int:
         .if_isinstance(gtcpp.GTLevel)
         .getattr("offset")
         .reduce(lambda state, cur: max(state, abs(cur)), init=0)
-    )
+    ) + 1
 
 
 class GTCppCodegen(codegen.TemplatedGenerator):

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -215,6 +215,12 @@ def large_k_interval(in_field: Field3D, out_field: Field3D):
 
 
 @register
+def single_level_with_offset(in_field: Field3D, out_field: Field3D):
+    with computation(PARALLEL), interval(1, 2):
+        out_field = in_field
+
+
+@register
 def form_land_mask(in_field: Field3D, mask: gtscript.Field[np.bool]):
     with computation(PARALLEL), interval(...):
         mask = in_field >= 0

--- a/tests/test_unittest/test_gtc/test_gtcpp_codegen.py
+++ b/tests/test_unittest/test_gtc/test_gtcpp_codegen.py
@@ -20,6 +20,6 @@ from gtc.gtcpp import gtcpp_codegen
 from gtc.gtcpp.gtcpp import GTLevel
 
 
-@pytest.mark.parametrize("root,expected", [(GTLevel(splitter=0, offset=5), 5)])
+@pytest.mark.parametrize("root,expected", [(GTLevel(splitter=0, offset=5), 6)])
 def test_offset_limit(root, expected):
     assert gtcpp_codegen._offset_limit(root) == expected


### PR DESCRIPTION
## Description

Fixes compilation errors using gtc:gt:* backends, sometimes specifying too small offsets limits. Issue reported by @huanglangwen.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


