### PR TITLE
Fix K-Caching Issues

### DIFF
--- a/src/gtc/passes/oir_optimizations/caches.py
+++ b/src/gtc/passes/oir_optimizations/caches.py
@@ -105,6 +105,9 @@ class KCacheDetection(NodeTranslator):
     max_cacheable_offset: int = 5
 
     def visit_VerticalLoop(self, node: oir.VerticalLoop, **kwargs: Any) -> oir.VerticalLoop:
+        # k-caches are restricted to loops with a single horizontal region as all regions without
+        # horizontal offsets should be merged before anyway and this restriction allows for easier
+        # conversion of fill and flush caches to local caches later
         if node.loop_order == common.LoopOrder.PARALLEL or any(
             len(section.horizontal_executions) != 1 for section in node.sections
         ):

--- a/src/gtc/passes/oir_optimizations/caches.py
+++ b/src/gtc/passes/oir_optimizations/caches.py
@@ -105,7 +105,9 @@ class KCacheDetection(NodeTranslator):
     max_cacheable_offset: int = 5
 
     def visit_VerticalLoop(self, node: oir.VerticalLoop, **kwargs: Any) -> oir.VerticalLoop:
-        if node.loop_order == common.LoopOrder.PARALLEL:
+        if node.loop_order == common.LoopOrder.PARALLEL or any(
+            len(section.horizontal_executions) != 1 for section in node.sections
+        ):
             return self.generic_visit(node, **kwargs)
 
         def accessed_more_than_once(offsets: Set[Any]) -> bool:

--- a/src/gtc/passes/oir_optimizations/caches.py
+++ b/src/gtc/passes/oir_optimizations/caches.py
@@ -330,6 +330,8 @@ class FillFlushToLocalKCaches(NodeTranslator):
 
         class FixSymbolNameClashes(NodeTranslator):
             def visit_ScalarAccess(self, node: oir.ScalarAccess) -> oir.ScalarAccess:
+                if node.name not in decls_map:
+                    return node
                 return oir.ScalarAccess(name=decls_map[node.name], dtype=node.dtype)
 
             def visit_LocalScalar(self, node: oir.LocalScalar) -> oir.LocalScalar:

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_caches.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_caches.py
@@ -30,6 +30,7 @@ from ...oir_utils import (
     IJCacheFactory,
     IntervalFactory,
     KCacheFactory,
+    LocalScalarFactory,
     StencilFactory,
     TemporaryFactory,
     VerticalLoopFactory,
@@ -382,13 +383,18 @@ def test_fill_to_local_k_caches_section_splitting_forward():
                 sections=[
                     VerticalLoopSectionFactory(
                         interval=IntervalFactory(end=AxisBound(level=LevelMarker.END, offset=-1)),
-                        horizontal_executions__0__body=[
-                            AssignStmtFactory(
-                                left__name="foo", right__name="foo", right__offset__k=0
-                            ),
-                            AssignStmtFactory(
-                                left__name="foo", right__name="foo", right__offset__k=1
-                            ),
+                        horizontal_executions=[
+                            HorizontalExecutionFactory(
+                                body=[
+                                    AssignStmtFactory(
+                                        left__name="foo", right__name="foo", right__offset__k=0
+                                    ),
+                                    AssignStmtFactory(
+                                        left__name="foo", right__name="foo", right__offset__k=1
+                                    ),
+                                ],
+                                declarations=[LocalScalarFactory()],
+                            )
                         ],
                     ),
                     VerticalLoopSectionFactory(


### PR DESCRIPTION
## Description

Fixes two issues of k-Caches as reported by @huanglangwen:
- Limit k-caches to vertical loop sections with a single horizontal execution.
- Fix possible symbol name duplication during the splitting of a vertical loop section when local scalars are present.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


