### PR TITLE
Support All Data Types in All Backends

### DIFF
--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -100,16 +100,7 @@ class GTCCudaBindingsCodegen(codegen.TemplatedGenerator):
         return self._unique_index
 
     def visit_DataType(self, dtype: DataType, **kwargs):
-        if dtype == DataType.INT64:
-            return "long long"
-        elif dtype == DataType.FLOAT64:
-            return "double"
-        elif dtype == DataType.FLOAT32:
-            return "float"
-        elif dtype == DataType.BOOL:
-            return "bool"
-        else:
-            raise AssertionError(f"Invalid DataType value: {dtype}")
+        return cuir_codegen.CUIRCodegen().visit_DataType(dtype)
 
     def visit_FieldDecl(self, node: cuir.FieldDecl, **kwargs):
         if "external_arg" in kwargs:

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -102,16 +102,7 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
         return self._unique_index
 
     def visit_DataType(self, dtype: DataType, **kwargs):
-        if dtype == DataType.INT64:
-            return "long long"
-        elif dtype == DataType.FLOAT64:
-            return "double"
-        elif dtype == DataType.FLOAT32:
-            return "float"
-        elif dtype == DataType.BOOL:
-            return "bool"
-        else:
-            raise AssertionError(f"Invalid DataType value: {dtype}")
+        return gtcpp_codegen.GTCppCodegen().visit_DataType(dtype)
 
     def visit_FieldDecl(self, node: gtcpp.FieldDecl, **kwargs):
         assert "gt_backend_t" in kwargs

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -83,7 +83,18 @@ __externals__ = "Placeholder"
 __gtscript__ = "Placeholder"
 
 
-_VALID_DATA_TYPES = (bool, np.bool, int, np.int32, np.int64, float, np.float32, np.float64)
+_VALID_DATA_TYPES = (
+    bool,
+    np.bool,
+    int,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    float,
+    np.float32,
+    np.float64,
+)
 
 
 def _set_arg_dtypes(definition, dtypes):

--- a/src/gtc/cuir/cuir_codegen.py
+++ b/src/gtc/cuir/cuir_codegen.py
@@ -139,7 +139,9 @@ class CUIRCodegen(codegen.TemplatedGenerator):
         try:
             return self.DATA_TYPE_TO_CODE[dtype]
         except KeyError as error:
-            raise NotImplementedError("Not implemented NativeFunction encountered.") from error
+            raise NotImplementedError(
+                f"Not implemented DataType '{dtype.name}' encountered."
+            ) from error
 
     IJExtent = as_fmt("extent<{i[0]}, {i[1]}, {j[0]}, {j[1]}>")
 

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -127,25 +127,31 @@ class GTCppCodegen(codegen.TemplatedGenerator):
 
     NativeFuncCall = as_mako("${func}(${','.join(args)})")
 
-    def visit_DataType(self, dtype: DataType, **kwargs: Any) -> str:
-        if dtype == DataType.INT64:
-            return "long long"
-        elif dtype == DataType.FLOAT64:
-            return "double"
-        elif dtype == DataType.FLOAT32:
-            return "float"
-        elif dtype == DataType.BOOL:
-            return "bool"
-        raise NotImplementedError("Not implemented NativeFunction encountered.")
+    DATA_TYPE_TO_CODE = {
+        DataType.BOOL: "bool",
+        DataType.INT8: "std::int8_t",
+        DataType.INT16: "std::int16_t",
+        DataType.INT32: "std::int32_t",
+        DataType.INT64: "std::int64_t",
+        DataType.FLOAT32: "float",
+        DataType.FLOAT64: "double",
+    }
 
-    def visit_UnaryOperator(self, op: UnaryOperator, **kwargs: Any) -> str:
-        if op == UnaryOperator.NOT:
-            return "!"
-        elif op == UnaryOperator.NEG:
-            return "-"
-        elif op == UnaryOperator.POS:
-            return "+"
-        raise NotImplementedError("Not implemented UnaryOperator encountered.")
+    def visit_DataType(self, dtype: DataType, **kwargs: Any) -> str:
+        try:
+            return self.DATA_TYPE_TO_CODE[dtype]
+        except KeyError as error:
+            raise NotImplementedError(
+                f"Not implemented DataType '{dtype.name}' encountered."
+            ) from error
+
+    UNARY_OPERATOR_TO_CODE = {
+        UnaryOperator.NOT: "!",
+        UnaryOperator.NEG: "-",
+        UnaryOperator.POS: "+",
+    }
+
+    UnaryOp = as_fmt("({_this_generator.UNARY_OPERATOR_TO_CODE[_this_node.op]}{expr})")
 
     Arg = as_fmt("{name}")
 

--- a/tests/test_integration/stencil_definitions.py
+++ b/tests/test_integration/stencil_definitions.py
@@ -62,6 +62,32 @@ def arithmetic_ops(field_a: Field3D, field_b: Field3D):
 
 
 @register
+def data_types(
+    bool_field: gtscript.Field[bool],
+    npbool_field: gtscript.Field[np.bool],
+    int_field: gtscript.Field[int],
+    int8_field: gtscript.Field[np.int8],
+    int16_field: gtscript.Field[np.int16],
+    int32_field: gtscript.Field[np.int32],
+    int64_field: gtscript.Field[np.int64],
+    float_field: gtscript.Field[float],
+    float32_field: gtscript.Field[np.float32],
+    float64_field: gtscript.Field[np.float64],
+):
+    with computation(PARALLEL), interval(...):
+        bool_field = True
+        npbool_field = False
+        int_field = 2147483647
+        int8_field = 127
+        int16_field = 32767
+        int32_field = 2147483647
+        int64_field = 9223372036854775807
+        float_field = 37.5
+        float32_field = 37.5
+        float64_field = 37.5
+
+
+@register
 def native_functions(field_a: Field3D, field_b: Field3D):
     with computation(PARALLEL), interval(...):
         abs_res = abs(field_a)


### PR DESCRIPTION
## Description

- Enables backend-supported int8 and int16 dtypes in frontend.
- Introduces a test to check that all data types are supported.
- Fixes full dtype support in GTC-based backends (additionally requires fix in GridTools: https://github.com/GridTools/gridtools/pull/1632)

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


