### PR TITLE
Replace HorizontalExecution Mask by MaskStmt in OIR

### DIFF
--- a/src/gtc/cuir/cuir.py
+++ b/src/gtc/cuir/cuir.py
@@ -79,6 +79,11 @@ class AssignStmt(
     _dtype_validation = common.assign_stmt_dtype_validation(strict=True)
 
 
+class IfStmt(Stmt):
+    mask: Expr
+    body: List[Stmt]
+
+
 class UnaryOp(common.UnaryOp[Expr], Expr):
     pass
 
@@ -175,7 +180,6 @@ class KCacheDecl(Decl):
 
 class HorizontalExecution(LocNode):
     body: List[Stmt]
-    mask: Optional[Expr]
     declarations: List[LocalScalar]
     extent: Optional[IJExtent]
 

--- a/src/gtc/cuir/cuir.py
+++ b/src/gtc/cuir/cuir.py
@@ -79,7 +79,7 @@ class AssignStmt(
     _dtype_validation = common.assign_stmt_dtype_validation(strict=True)
 
 
-class IfStmt(Stmt):
+class MaskStmt(Stmt):
     mask: Expr
     body: List[Stmt]
 

--- a/src/gtc/cuir/cuir_codegen.py
+++ b/src/gtc/cuir/cuir_codegen.py
@@ -36,6 +36,14 @@ class CUIRCodegen(codegen.TemplatedGenerator):
 
     AssignStmt = as_fmt("{left} = {right};")
 
+    IfStmt = as_mako(
+        """
+        if (${mask}) {
+            ${'\\n'.join(body)}
+        }
+        """
+    )
+
     FieldAccess = as_mako(
         "*${f'sid::multi_shifted<tag::{name}>({name}, m_strides, {offset})' if offset else name}"
     )
@@ -148,7 +156,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
     HorizontalExecution = as_mako(
         """
         // ${id_}
-        if (validator(${extent}())${' && ' + mask if _this_node.mask else ''}) {
+        if (validator(${extent}())) {
             ${'\\n'.join(declarations)}
             ${'\\n'.join(body)}
         }

--- a/src/gtc/cuir/cuir_codegen.py
+++ b/src/gtc/cuir/cuir_codegen.py
@@ -36,7 +36,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
 
     AssignStmt = as_fmt("{left} = {right};")
 
-    IfStmt = as_mako(
+    MaskStmt = as_mako(
         """
         if (${mask}) {
             ${'\\n'.join(body)}

--- a/src/gtc/cuir/extent_analysis.py
+++ b/src/gtc/cuir/extent_analysis.py
@@ -44,7 +44,6 @@ class ComputeExtents(NodeTranslator):
             horizontal_executions.append(
                 cuir.HorizontalExecution(
                     body=horizontal_execution.body,
-                    mask=horizontal_execution.mask,
                     declarations=horizontal_execution.declarations,
                     extent=extent,
                 )

--- a/src/gtc/cuir/oir_to_cuir.py
+++ b/src/gtc/cuir/oir_to_cuir.py
@@ -82,6 +82,11 @@ class OIRToCUIR(eve.NodeTranslator):
             left=self.visit(node.left, **kwargs), right=self.visit(node.right, **kwargs)
         )
 
+    def visit_IfStmt(self, node: oir.IfStmt, **kwargs: Any) -> cuir.IfStmt:
+        return cuir.IfStmt(
+            mask=self.visit(node.mask, **kwargs), body=self.visit(node.body, **kwargs)
+        )
+
     def visit_Cast(self, node: oir.Cast, **kwargs: Any) -> cuir.Cast:
         return cuir.Cast(dtype=node.dtype, expr=self.visit(node.expr, **kwargs))
 
@@ -103,7 +108,6 @@ class OIRToCUIR(eve.NodeTranslator):
     ) -> cuir.HorizontalExecution:
         return cuir.HorizontalExecution(
             body=self.visit(node.body, **kwargs),
-            mask=self.visit(node.mask, **kwargs),
             declarations=self.visit(node.declarations),
         )
 

--- a/src/gtc/cuir/oir_to_cuir.py
+++ b/src/gtc/cuir/oir_to_cuir.py
@@ -82,8 +82,8 @@ class OIRToCUIR(eve.NodeTranslator):
             left=self.visit(node.left, **kwargs), right=self.visit(node.right, **kwargs)
         )
 
-    def visit_IfStmt(self, node: oir.IfStmt, **kwargs: Any) -> cuir.IfStmt:
-        return cuir.IfStmt(
+    def visit_MaskStmt(self, node: oir.MaskStmt, **kwargs: Any) -> cuir.MaskStmt:
+        return cuir.MaskStmt(
             mask=self.visit(node.mask, **kwargs), body=self.visit(node.body, **kwargs)
         )
 

--- a/src/gtc/gtcpp/oir_to_gtcpp.py
+++ b/src/gtc/gtcpp/oir_to_gtcpp.py
@@ -161,6 +161,12 @@ class OIRToGTCpp(eve.NodeTranslator):
             left=self.visit(node.left, **kwargs), right=self.visit(node.right, **kwargs)
         )
 
+    def visit_IfStmt(self, node: oir.IfStmt, **kwargs: Any) -> gtcpp.IfStmt:
+        return gtcpp.IfStmt(
+            cond=self.visit(node.mask, **kwargs),
+            true_branch=gtcpp.BlockStmt(body=self.visit(node.body, **kwargs)),
+        )
+
     def visit_HorizontalExecution(
         self,
         node: oir.HorizontalExecution,
@@ -171,13 +177,9 @@ class OIRToGTCpp(eve.NodeTranslator):
         **kwargs: Any,
     ) -> gtcpp.GTStage:
         assert "stencil_symtable" in kwargs
-        body = self.visit(node.body, **kwargs)
-        mask = self.visit(node.mask, **kwargs)
-        if mask:
-            body = [gtcpp.IfStmt(cond=mask, true_branch=gtcpp.BlockStmt(body=body))]
         apply_method = gtcpp.GTApplyMethod(
             interval=self.visit(interval, **kwargs),
-            body=body,
+            body=self.visit(node.body, **kwargs),
             local_variables=self.visit(node.declarations, **kwargs),
         )
         accessors = _extract_accessors(apply_method)

--- a/src/gtc/gtcpp/oir_to_gtcpp.py
+++ b/src/gtc/gtcpp/oir_to_gtcpp.py
@@ -161,7 +161,7 @@ class OIRToGTCpp(eve.NodeTranslator):
             left=self.visit(node.left, **kwargs), right=self.visit(node.right, **kwargs)
         )
 
-    def visit_IfStmt(self, node: oir.IfStmt, **kwargs: Any) -> gtcpp.IfStmt:
+    def visit_MaskStmt(self, node: oir.MaskStmt, **kwargs: Any) -> gtcpp.IfStmt:
         return gtcpp.IfStmt(
             cond=self.visit(node.mask, **kwargs),
             true_branch=gtcpp.BlockStmt(body=self.visit(node.body, **kwargs)),

--- a/src/gtc/gtir_to_oir.py
+++ b/src/gtc/gtir_to_oir.py
@@ -70,10 +70,12 @@ class GTIRToOIR(NodeTranslator):
     def visit_ParAssignStmt(
         self, node: gtir.ParAssignStmt, *, mask: oir.Expr = None, ctx: Context, **kwargs: Any
     ) -> None:
+        body = [oir.AssignStmt(left=self.visit(node.left), right=self.visit(node.right))]
+        if mask is not None:
+            body = [oir.IfStmt(body=body, mask=mask)]
         ctx.add_horizontal_execution(
             oir.HorizontalExecution(
-                body=[oir.AssignStmt(left=self.visit(node.left), right=self.visit(node.right))],
-                mask=mask,
+                body=body,
                 declarations=[],
             ),
         )

--- a/src/gtc/gtir_to_oir.py
+++ b/src/gtc/gtir_to_oir.py
@@ -72,7 +72,7 @@ class GTIRToOIR(NodeTranslator):
     ) -> None:
         body = [oir.AssignStmt(left=self.visit(node.left), right=self.visit(node.right))]
         if mask is not None:
-            body = [oir.IfStmt(body=body, mask=mask)]
+            body = [oir.MaskStmt(body=body, mask=mask)]
         ctx.add_horizontal_execution(
             oir.HorizontalExecution(
                 body=body,

--- a/src/gtc/oir.py
+++ b/src/gtc/oir.py
@@ -72,13 +72,15 @@ class AssignStmt(common.AssignStmt[Union[ScalarAccess, FieldAccess], Expr], Stmt
     _dtype_validation = common.assign_stmt_dtype_validation(strict=True)
 
 
-# TODO(havogt) consider introducing BlockStmt
-# class BlockStmt(common.BlockStmt[Stmt], Stmt):
-#     pass
+class IfStmt(Stmt):
+    mask: Expr
+    body: List[Stmt]
 
-# TODO(havogt) should we have an IfStmt or is masking the final solution?
-# class IfStmt(common.IfStmt[List[Stmt], Expr], Stmt):  # TODO replace List[Stmt] by BlockStmt?
-#     pass
+    @validator("mask")
+    def mask_is_boolean_field_expr(cls, v: Expr) -> Expr:
+        if v.dtype != common.DataType.BOOL:
+            raise ValueError("Mask must be a boolean expression.")
+        return v
 
 
 class UnaryOp(common.UnaryOp[Expr], Expr):

--- a/src/gtc/oir.py
+++ b/src/gtc/oir.py
@@ -131,15 +131,7 @@ class Temporary(FieldDecl):
 
 class HorizontalExecution(LocNode):
     body: List[Stmt]
-    mask: Optional[Expr]
     declarations: List[LocalScalar]
-
-    @validator("mask")
-    def mask_is_boolean_field_expr(cls, v: Optional[Expr]) -> Optional[Expr]:
-        if v:
-            if v.dtype != common.DataType.BOOL:
-                raise ValueError("Mask must be a boolean expression.")
-        return v
 
 
 class Interval(LocNode):

--- a/src/gtc/oir.py
+++ b/src/gtc/oir.py
@@ -72,7 +72,7 @@ class AssignStmt(common.AssignStmt[Union[ScalarAccess, FieldAccess], Expr], Stmt
     _dtype_validation = common.assign_stmt_dtype_validation(strict=True)
 
 
-class IfStmt(Stmt):
+class MaskStmt(Stmt):
     mask: Expr
     body: List[Stmt]
 

--- a/src/gtc/passes/oir_optimizations/caches.py
+++ b/src/gtc/passes/oir_optimizations/caches.py
@@ -263,7 +263,6 @@ class FillFlushToLocalKCaches(NodeTranslator):
     ) -> oir.HorizontalExecution:
         return oir.HorizontalExecution(
             body=fills + self.visit(node.body, name_map=name_map, **kwargs) + flushes,
-            mask=self.visit(node.mask, name_map=name_map, **kwargs),
             declarations=node.declarations,
         )
 

--- a/src/gtc/passes/oir_optimizations/temporaries.py
+++ b/src/gtc/passes/oir_optimizations/temporaries.py
@@ -53,7 +53,6 @@ class TemporariesToScalarsBase(NodeTranslator):
 
         return oir.HorizontalExecution(
             body=self.visit(node.body, tmps_name_map=tmps_name_map, **kwargs),
-            mask=self.visit(node.mask, tmps_name_map=tmps_name_map, **kwargs),
             declarations=node.declarations
             + [
                 oir.LocalScalar(

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -62,15 +62,9 @@ class AccessCollector(NodeVisitor):
         self.visit(node.right, is_write=False, **kwargs)
         self.visit(node.left, is_write=True, **kwargs)
 
-    def visit_HorizontalExecution(
-        self,
-        node: oir.HorizontalExecution,
-        **kwargs: Any,
-    ) -> None:
-        if node.mask is not None:
-            self.visit(node.mask, is_write=False, **kwargs)
-        for stmt in node.body:
-            self.visit(stmt, **kwargs)
+    def visit_IfStmt(self, node: oir.IfStmt, **kwargs: Any) -> None:
+        self.visit(node.mask, is_write=False, **kwargs)
+        self.visit(node.body, **kwargs)
 
     @dataclass
     class Result:

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -62,7 +62,7 @@ class AccessCollector(NodeVisitor):
         self.visit(node.right, is_write=False, **kwargs)
         self.visit(node.left, is_write=True, **kwargs)
 
-    def visit_IfStmt(self, node: oir.IfStmt, **kwargs: Any) -> None:
+    def visit_MaskStmt(self, node: oir.MaskStmt, **kwargs: Any) -> None:
         self.visit(node.mask, is_write=False, **kwargs)
         self.visit(node.body, **kwargs)
 

--- a/tests/test_unittest/test_gtc/cuir_utils.py
+++ b/tests/test_unittest/test_gtc/cuir_utils.py
@@ -85,7 +85,6 @@ class HorizontalExecutionFactory(factory.Factory):
         model = cuir.HorizontalExecution
 
     body = factory.List([factory.SubFactory(AssignStmtFactory)])
-    mask = None
     declarations = factory.List([])
     extent = factory.SubFactory(IJExtentFactory)
 

--- a/tests/test_unittest/test_gtc/oir_utils.py
+++ b/tests/test_unittest/test_gtc/oir_utils.py
@@ -103,7 +103,6 @@ class HorizontalExecutionFactory(factory.Factory):
         model = oir.HorizontalExecution
 
     body = factory.List([factory.SubFactory(AssignStmtFactory)])
-    mask = None
     declarations: List[oir.LocalScalar] = []
 
 

--- a/tests/test_unittest/test_gtc/oir_utils.py
+++ b/tests/test_unittest/test_gtc/oir_utils.py
@@ -56,6 +56,14 @@ class AssignStmtFactory(factory.Factory):
     right = factory.SubFactory(FieldAccessFactory)
 
 
+class IfStmtFactory(factory.Factory):
+    class Meta:
+        model = oir.IfStmt
+
+    mask = factory.SubFactory(FieldAccessFactory, dtype=common.DataType.BOOL)
+    body = factory.List([factory.SubFactory(AssignStmtFactory)])
+
+
 class NativeFuncCallFactory(factory.Factory):
     class Meta:
         model = oir.NativeFuncCall

--- a/tests/test_unittest/test_gtc/oir_utils.py
+++ b/tests/test_unittest/test_gtc/oir_utils.py
@@ -56,9 +56,9 @@ class AssignStmtFactory(factory.Factory):
     right = factory.SubFactory(FieldAccessFactory)
 
 
-class IfStmtFactory(factory.Factory):
+class MaskStmtFactory(factory.Factory):
     class Meta:
-        model = oir.IfStmt
+        model = oir.MaskStmt
 
     mask = factory.SubFactory(FieldAccessFactory, dtype=common.DataType.BOOL)
     body = factory.List([factory.SubFactory(AssignStmtFactory)])

--- a/tests/test_unittest/test_gtc/test_oir.py
+++ b/tests/test_unittest/test_gtc/test_oir.py
@@ -19,7 +19,7 @@ from pydantic.error_wrappers import ValidationError
 
 from gtc.common import DataType
 
-from .oir_utils import AssignStmtFactory, FieldAccessFactory, IfStmtFactory
+from .oir_utils import AssignStmtFactory, FieldAccessFactory, MaskStmtFactory
 
 
 def test_no_horizontal_offset_allowed():
@@ -29,4 +29,4 @@ def test_no_horizontal_offset_allowed():
 
 def test_mask_must_be_bool():
     with pytest.raises(ValidationError, match=r".*must be.* bool.*"):
-        IfStmtFactory(mask=FieldAccessFactory(dtype=DataType.INT32))
+        MaskStmtFactory(mask=FieldAccessFactory(dtype=DataType.INT32))

--- a/tests/test_unittest/test_gtc/test_oir.py
+++ b/tests/test_unittest/test_gtc/test_oir.py
@@ -19,7 +19,7 @@ from pydantic.error_wrappers import ValidationError
 
 from gtc.common import DataType
 
-from .oir_utils import AssignStmtFactory, FieldAccessFactory, HorizontalExecutionFactory
+from .oir_utils import AssignStmtFactory, FieldAccessFactory, IfStmtFactory
 
 
 def test_no_horizontal_offset_allowed():
@@ -29,4 +29,4 @@ def test_no_horizontal_offset_allowed():
 
 def test_mask_must_be_bool():
     with pytest.raises(ValidationError, match=r".*must be.* bool.*"):
-        HorizontalExecutionFactory(mask=FieldAccessFactory(dtype=DataType.INT32))
+        IfStmtFactory(mask=FieldAccessFactory(dtype=DataType.INT32))

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -19,7 +19,6 @@ from gtc.passes.oir_optimizations.horizontal_execution_merging import GreedyMerg
 
 from ...oir_utils import (
     AssignStmtFactory,
-    FieldAccessFactory,
     HorizontalExecutionFactory,
     NativeFuncCallFactory,
     StencilFactory,
@@ -139,24 +138,6 @@ def test_on_the_fly_merging_with_offsets():
     assert transformed.iter_tree().if_isinstance(oir.FieldAccess).filter(
         lambda x: x.name == "foo"
     ).getattr("offset").map(lambda o: (o.i, o.j, o.k)).to_set() == {(1, 0, 0), (0, 1, 0)}
-
-
-def test_on_the_fly_merging_with_mask():
-    testee = StencilFactory(
-        vertical_loops__0__sections__0__horizontal_executions=[
-            HorizontalExecutionFactory(
-                body=[AssignStmtFactory(left__name="tmp")],
-                mask=FieldAccessFactory(name="mask", dtype=common.DataType.BOOL),
-            ),
-            HorizontalExecutionFactory(
-                body=[AssignStmtFactory(right__name="tmp")],
-            ),
-        ],
-        declarations=[TemporaryFactory(name="tmp")],
-    )
-    transformed = OnTheFlyMerging().visit(testee)
-    assert len(transformed.vertical_loops[0].sections[0].horizontal_executions) == 2
-    assert len(transformed.declarations) == 1
 
 
 def test_on_the_fly_merging_with_expensive_function():

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_utils.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_utils.py
@@ -21,6 +21,7 @@ from ...oir_utils import (
     AssignStmtFactory,
     FieldAccessFactory,
     HorizontalExecutionFactory,
+    IfStmtFactory,
     StencilFactory,
     TemporaryFactory,
 )
@@ -37,11 +38,21 @@ def test_access_collector():
             ),
             HorizontalExecutionFactory(
                 body=[
-                    AssignStmtFactory(left__name="baz", right__name="tmp", right__offset__j=1),
+                    IfStmtFactory(
+                        body=[
+                            AssignStmtFactory(
+                                left__name="baz", right__name="tmp", right__offset__j=1
+                            ),
+                        ],
+                        mask=FieldAccessFactory(
+                            name="mask",
+                            dtype=DataType.BOOL,
+                            offset__i=-1,
+                            offset__j=-1,
+                            offset__k=1,
+                        ),
+                    )
                 ],
-                mask=FieldAccessFactory(
-                    name="mask", dtype=DataType.BOOL, offset__i=-1, offset__j=-1, offset__k=1
-                ),
             ),
         ],
         declarations=[TemporaryFactory(name="tmp")],

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_utils.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_utils.py
@@ -21,7 +21,7 @@ from ...oir_utils import (
     AssignStmtFactory,
     FieldAccessFactory,
     HorizontalExecutionFactory,
-    IfStmtFactory,
+    MaskStmtFactory,
     StencilFactory,
     TemporaryFactory,
 )
@@ -38,7 +38,7 @@ def test_access_collector():
             ),
             HorizontalExecutionFactory(
                 body=[
-                    IfStmtFactory(
+                    MaskStmtFactory(
                         body=[
                             AssignStmtFactory(
                                 left__name="baz", right__name="tmp", right__offset__j=1


### PR DESCRIPTION
## Description

Replaces the mask in the horizontal execution in the OIR by mask-statements. This allows for merging several horizontal executions with masks which was previously impossible and proved to be an optimization bottleneck.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


