### PR TITLE
Remove GTC Node id_

### DIFF
--- a/src/eve/concepts.py
+++ b/src/eve/concepts.py
@@ -36,7 +36,6 @@ from .typingx import (
     Optional,
     Set,
     Tuple,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -185,18 +184,6 @@ class BaseNode(pydantic.BaseModel, metaclass=NodeMetaclass):
 
     __node_impl_fields__: ClassVar[NodeImplFieldMetadataDict]
     __node_children__: ClassVar[NodeChildrenMetadataDict]
-
-    # Node fields
-    #: Unique node-id (implementation field)
-    id_: Optional[Str] = None
-
-    @pydantic.validator("id_", pre=True, always=True)
-    def _id_validator(cls: Type[AnyNode], v: Optional[str]) -> str:  # type: ignore  # validators are classmethods
-        if v is None:
-            v = utils.UIDGenerator.sequential_id(prefix=cls.__qualname__)
-        if not isinstance(v, str):
-            raise TypeError(f"id_ is not an 'str' instance ({type(v)})")
-        return v
 
     def iter_impl_fields(self) -> Generator[Tuple[str, Any], None, None]:
         for name, _ in self.__fields__.items():

--- a/src/gtc/cuir/cuir_codegen.py
+++ b/src/gtc/cuir/cuir_codegen.py
@@ -147,7 +147,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
 
     HorizontalExecution = as_mako(
         """
-        // ${id_}
+        // HorizontalExecution ${id(_this_node)}
         if (validator(${extent}())${' && ' + mask if _this_node.mask else ''}) {
             ${'\\n'.join(declarations)}
             ${'\\n'.join(body)}
@@ -196,7 +196,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
                 ${dst} = ${src};
             % endfor
         </%def>
-        // ${id_}
+        // VerticalLoopSection ${id(_this_node)}
         % if order == cuir.LoopOrder.FORWARD:
             for (int _k_block = ${start}; _k_block < ${end}; ++_k_block) {
                 ${'\\n__syncthreads();\\n'.join(horizontal_executions)}
@@ -251,7 +251,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
     VerticalLoop = as_mako(
         """
         template <class Sid>
-        struct loop_${id_}_f {
+        struct loop_${id(_this_node)}_f {
             sid::ptr_holder_type<Sid> m_ptr_holder;
             sid::strides_type<Sid> m_strides;
             int k_size;
@@ -306,10 +306,10 @@ class CUIRCodegen(codegen.TemplatedGenerator):
             ${vertical_loop}
         % endfor
 
-        template <${', '.join(f'class Loop{vl.id_}' for vl in _this_node.vertical_loops)}>
-        struct kernel_${id_}_f {
+        template <${', '.join(f'class Loop{id(vl)}' for vl in _this_node.vertical_loops)}>
+        struct kernel_${id(_this_node)}_f {
             % for vertical_loop in _this_node.vertical_loops:
-                Loop${vertical_loop.id_} m_${vertical_loop.id_};
+                Loop${id(vertical_loop)} m_${id(vertical_loop)};
             % endfor
 
             template <class Validator>
@@ -317,7 +317,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
                                                const int _j_block,
                                                Validator validator) const {
                 % for vertical_loop in _this_node.vertical_loops:
-                    m_${vertical_loop.id_}(_i_block, _j_block, validator);
+                    m_${id(vertical_loop)}(_i_block, _j_block, validator);
                 % endfor
             }
         };
@@ -426,19 +426,19 @@ class CUIRCodegen(codegen.TemplatedGenerator):
 
                     % for kernel in _this_node.kernels:
 
-                        // kernel ${kernel.id_}
-                        gpu_backend::shared_allocator shared_alloc_${kernel.id_};
+                        // kernel ${id(kernel)}
+                        gpu_backend::shared_allocator shared_alloc_${id(kernel)};
 
                         % for vertical_loop in kernel.vertical_loops:
-                            // vertical loop ${vertical_loop.id_}
+                            // vertical loop ${id(vertical_loop)}
 
                             assert((${loop_start(vertical_loop)}) >= 0 &&
                                    (${loop_start(vertical_loop)}) < k_size);
-                            auto offset_${vertical_loop.id_} = tuple_util::make<hymap::keys<dim::k>::values>(
+                            auto offset_${id(vertical_loop)} = tuple_util::make<hymap::keys<dim::k>::values>(
                                 ${loop_start(vertical_loop)}
                             );
 
-                            auto composite_${vertical_loop.id_} = sid::composite::make<
+                            auto composite_${id(vertical_loop)} = sid::composite::make<
                                     ${', '.join(f'tag::{field}' for field in loop_fields(vertical_loop))}
                                 >(
 
@@ -446,28 +446,28 @@ class CUIRCodegen(codegen.TemplatedGenerator):
                                 % if field in params:
                                     block(sid::shift_sid_origin(
                                         ${field},
-                                        offset_${vertical_loop.id_}
+                                        offset_${id(vertical_loop)}
                                     ))
                                 % else:
                                     sid::shift_sid_origin(
                                         ${field},
-                                        offset_${vertical_loop.id_}
+                                        offset_${id(vertical_loop)}
                                     )
                                 % endif
                                 ${'' if loop.last else ','}
                             % endfor
                             );
-                            using composite_${vertical_loop.id_}_t = decltype(composite_${vertical_loop.id_});
-                            loop_${vertical_loop.id_}_f<composite_${vertical_loop.id_}_t> loop_${vertical_loop.id_}{
-                                sid::get_origin(composite_${vertical_loop.id_}),
-                                sid::get_strides(composite_${vertical_loop.id_}),
+                            using composite_${id(vertical_loop)}_t = decltype(composite_${id(vertical_loop)});
+                            loop_${id(vertical_loop)}_f<composite_${id(vertical_loop)}_t> loop_${id(vertical_loop)}{
+                                sid::get_origin(composite_${id(vertical_loop)}),
+                                sid::get_strides(composite_${id(vertical_loop)}),
                                 k_size
                             };
 
                         % endfor
 
-                        kernel_${kernel.id_}_f<${', '.join(f'decltype(loop_{vl.id_})' for vl in kernel.vertical_loops)}> kernel_${kernel.id_}{
-                            ${', '.join(f'loop_{vl.id_}' for vl in kernel.vertical_loops)}
+                        kernel_${id(kernel)}_f<${', '.join(f'decltype(loop_{id(vl)})' for vl in kernel.vertical_loops)}> kernel_${id(kernel)}{
+                            ${', '.join(f'loop_{id(vl)}' for vl in kernel.vertical_loops)}
                         };
                         gpu_backend::launch_kernel<${max_extent},
                             i_block_size_t::value, j_block_size_t::value>(
@@ -478,8 +478,8 @@ class CUIRCodegen(codegen.TemplatedGenerator):
                             % else:
                                 1,
                             %endif
-                            kernel_${kernel.id_},
-                            shared_alloc_${kernel.id_}.size());
+                            kernel_${id(kernel)},
+                            shared_alloc_${id(kernel)}.size());
                     % endfor
 
                     GT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -190,7 +190,8 @@ class GTCppCodegen(codegen.TemplatedGenerator):
     def visit_GTComputationCall(
         self, node: gtcpp.GTComputationCall, **kwargs: Any
     ) -> Union[str, Collection[str]]:
-        return self.generic_visit(node, computation_name=node.id_, **kwargs)
+        computation_name = type(node).__name__ + str(id(node))
+        return self.generic_visit(node, computation_name=computation_name, **kwargs)
 
     GTComputationCall = as_mako(
         """

--- a/src/gtc/gtcpp/oir_to_gtcpp.py
+++ b/src/gtc/gtcpp/oir_to_gtcpp.py
@@ -191,15 +191,16 @@ class OIRToGTCpp(eve.NodeTranslator):
             }
         )
 
+        functor_name = type(node).__name__ + str(id(node))
         prog_ctx.add_functor(
             gtcpp.GTFunctor(
-                name=node.id_,
+                name=functor_name,
                 applies=[apply_method],
                 param_list=gtcpp.GTParamList(accessors=accessors),
             )
         ),
 
-        return gtcpp.GTStage(functor=node.id_, args=stage_args)
+        return gtcpp.GTStage(functor=functor_name, args=stage_args)
 
     def visit_VerticalLoop(
         self,

--- a/src/gtc/gtir_to_oir.py
+++ b/src/gtc/gtir_to_oir.py
@@ -117,7 +117,7 @@ class GTIRToOIR(NodeTranslator):
     def visit_FieldIfStmt(
         self, node: gtir.FieldIfStmt, *, mask: oir.Expr = None, ctx: Context, **kwargs: Any
     ) -> None:
-        mask_field_decl = _create_mask(ctx, f"mask_{node.id_}", self.visit(node.cond))
+        mask_field_decl = _create_mask(ctx, f"mask_{id(node)}", self.visit(node.cond))
         current_mask = oir.FieldAccess(
             name=mask_field_decl.name, offset=CartesianOffset.zero(), dtype=mask_field_decl.dtype
         )

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -32,7 +32,7 @@ class LegacyExtentsVisitor(NodeVisitor):
 
     @dataclass
     class StencilContext:
-        assign_conditions: Dict[str, List[gtir.FieldAccess]] = field(default_factory=dict)
+        assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
     def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> FIELD_EXT_T:
         field_extents = {name: Extent.zeros() for name in _iter_field_names(node)}
@@ -54,7 +54,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         left_extent = field_extents.setdefault(node.left.name, Extent.zeros())
         pa_ctx = self.AssignContext(left_extent=left_extent)
         self.visit(
-            ctx.assign_conditions.get(str(node.id_), []),
+            ctx.assign_conditions.get(id(node), []),
             field_extents=field_extents,
             pa_ctx=pa_ctx,
             **kwargs,
@@ -66,7 +66,7 @@ class LegacyExtentsVisitor(NodeVisitor):
     def visit_FieldIfStmt(
         self, node: gtir.FieldIfStmt, *, ctx: StencilContext, **kwargs: Any
     ) -> None:
-        for assign_id in node.iter_tree().if_isinstance(gtir.ParAssignStmt).getattr("id_"):
+        for assign_id in node.iter_tree().if_isinstance(gtir.ParAssignStmt).map(id):
             ctx.assign_conditions.setdefault(assign_id, []).extend(
                 node.cond.iter_tree().if_isinstance(gtir.FieldAccess).to_list()
             )

--- a/src/gtc_unstructured/irs/gtir_to_nir.py
+++ b/src/gtc_unstructured/irs/gtir_to_nir.py
@@ -118,7 +118,7 @@ class GtirToNir(eve.NodeTranslator):
         **kwargs,
     ):
         location_ref_deref = symtable[node.location_ref.name]
-        name = node.id_
+        name = type(node).__name__ + str(id(node))
         hloop_ctx.add_declaration(
             nir.LocalFieldVar(
                 name=name,
@@ -174,7 +174,7 @@ class GtirToNir(eve.NodeTranslator):
     ):
         connectivity_deref: gtir.Connectivity = kwargs["symtable"][node.neighbors.of.name]
 
-        reduce_var_name = "local" + str(node.id_)
+        reduce_var_name = "local" + str(id(node))
         hloop_ctx.add_declaration(
             nir.LocalVar(
                 name=reduce_var_name,

--- a/src/gtc_unstructured/irs/nir_passes/field_dependency_graph.py
+++ b/src/gtc_unstructured/irs/nir_passes/field_dependency_graph.py
@@ -72,9 +72,9 @@ class _FieldWriteDependencyGraph(NodeVisitor):
             self.graph.add_edge(source, kwargs["current_write"], extent=has_extent)
 
     def visit_AssignStmt(self, node: AssignStmt, **kwargs):
-        self.graph.add_node(node.left.id_)  # make IR nodes hashable?
-        self.visit(node.right, current_write=node.left.id_, **kwargs)
-        self.last_write_access[node.left.name] = node.left.id_
+        self.graph.add_node(id(node.left))  # make IR nodes hashable?
+        self.visit(node.right, current_write=id(node.left), **kwargs)
+        self.last_write_access[node.left.name] = id(node.left)
 
 
 def generate_dependency_graph(loops: List[HorizontalLoop]) -> nx.DiGraph:

--- a/src/gtc_unstructured/irs/nir_to_usid.py
+++ b/src/gtc_unstructured/irs/nir_to_usid.py
@@ -237,7 +237,7 @@ class NirToUsid(eve.NodeTranslator):
             usid.SidComposite(name=name, entries=entries) for name, entries in composites.items()
         ]
 
-        kernel_name = "kernel_" + node.id_
+        kernel_name = "kernel_" + str(id(node))
         debug(primary_composite)
         debug(secondary_composites)
         kernel = usid.Kernel(

--- a/tests/eve_tests/unit_tests/test_concepts.py
+++ b/tests/eve_tests/unit_tests/test_concepts.py
@@ -18,38 +18,18 @@
 import pydantic
 import pytest
 
-from .. import definitions
-
 
 class TestNode:
     def test_validation(self, invalid_sample_node_maker):
         with pytest.raises(pydantic.ValidationError):
             invalid_sample_node_maker()
 
-    def test_mutability(self, sample_node):
-        sample_node.id_ = None
-
-    def test_inmutability(self, frozen_sample_node):
-        with pytest.raises(TypeError):
-            frozen_sample_node.id_ = None
-
     def test_unique_id(self, sample_node_maker):
         node_a = sample_node_maker()
         node_b = sample_node_maker()
         node_c = sample_node_maker()
 
-        assert node_a.id_ != node_b.id_ != node_c.id_
-
-    def test_custom_id(self, source_location, sample_node_maker):
-        custom_id = "my_custom_id"
-        my_node = definitions.LocationNode(id_=custom_id, loc=source_location)
-        other_node = sample_node_maker()
-
-        assert my_node.id_ == custom_id
-        assert my_node.id_ != other_node.id_
-
-        with pytest.raises(pydantic.ValidationError, match="id_"):
-            definitions.LocationNode(id_=32, loc=source_location)
+        assert id(node_a) != id(node_b) != id(node_c)
 
     def test_impl_fields(self, sample_node):
         impl_names = set(name for name, _ in sample_node.iter_impl_fields())

--- a/tests/gtc_unstructured_tests/test_nir_field_dependency_graph.py.disabled
+++ b/tests/gtc_unstructured_tests/test_nir_field_dependency_graph.py.disabled
@@ -46,8 +46,8 @@ class TestNIRFieldDependencyGraph:
         result = generate_dependency_graph(loops)
 
         assert len(result.nodes()) == 2
-        assert result.has_edge(write0.id_, write1.id_)
-        assert result[write0.id_][write1.id_]["extent"] is False
+        assert result.has_edge(id(write0), id(write1))
+        assert result[id(write0)][id(write1)]["extent"] is False
 
     def test_dependent_assignment_with_extent(self):
         loop0, write0 = make_horizontal_loop_with_init("write0")
@@ -57,5 +57,5 @@ class TestNIRFieldDependencyGraph:
         result = generate_dependency_graph(loops)
 
         assert len(result.nodes()) == 2
-        assert result.has_edge(write0.id_, write1.id_)
-        assert result[write0.id_][write1.id_]["extent"] is True
+        assert result.has_edge(id(write0), id(write1))
+        assert result[id(write0)][id(write1)]["extent"] is True


### PR DESCRIPTION
## Description

Removes the `id_` field from GTC nodes. This makes the nodes value-comparable.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


