### PR TITLE
Fix flake8 Pre-Commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,8 @@ repos:
     - flake8-docstrings
     - flake8-eradicate
     - flake8-mutable
-    - flake8-rst-docstrings
+  # Disabled for now due to random false positives
+  # - flake8-rst-docstrings
     - pygments
     exclude: |
       (?x)^(


### PR DESCRIPTION
## Description

Just disables flake8-rst-docstrings for now which fails due to random false positives.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


