### PR TITLE
Frontend changes for horizontal regions

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -186,12 +186,8 @@ class AxisIntervalParser(gt_meta.ASTPass):
 
         if isinstance(node, ast.Slice):
             slice_node = node
-        elif isinstance(node, ast.Subscript):
-            slice_node = (
-                cls.slice_from_value(node)
-                if isinstance(node.slice, (ast.Index, ast.Constant))
-                else node.slice
-            )
+        elif isinstance(node.slice, ast.Slice):
+            slice_node = node.slice
         else:
             slice_node = cls.slice_from_value(node)
 
@@ -343,10 +339,12 @@ class AxisIntervalParser(gt_meta.ASTPass):
         if node.value.id != self.axis_name:
             raise self.interval_error
 
-        if not isinstance(node.slice, ast.Index):
-            raise self.interval_error
+        if isinstance(node.slice, ast.Index):
+            index = self.visit(node.slice.value)
+        else:
+            index = self.visit(node.slice)
 
-        return gtscript.AxisIndex(axis=self.axis_name, index=self.visit(node.slice.value), offset=0)
+        return gtscript.AxisIndex(axis=self.axis_name, index=index)
 
 
 parse_interval_node = AxisIntervalParser.apply

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -186,7 +186,7 @@ class AxisIntervalParser(gt_meta.ASTPass):
 
         if isinstance(node, ast.Slice):
             slice_node = node
-        elif isinstance(node.slice, ast.Slice):
+        elif isinstance(getattr(node, "slice", None), ast.Slice):
             slice_node = node.slice
         else:
             slice_node = cls.slice_from_value(node)

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -22,6 +22,7 @@ definitions for the keywords of the DSL.
 
 import collections
 import inspect
+import numbers
 import types
 
 import numpy as np
@@ -71,6 +72,8 @@ builtins = {
     "externals",
     "computation",
     "interval",
+    "horizontal",
+    "region",
     "__gtscript__",
     "__externals__",
     "__INLINED",
@@ -353,15 +356,36 @@ def lazy_stencil(
 
 
 class AxisIndex:
-    def __init__(self, axis: str, offset: int):
+    def __init__(self, axis: str, index: int, offset: int = 0):
         self.axis = axis
+        self.index = index
         self.offset = offset
 
     def __repr__(self):
-        return f"AxisIndex(axis={self.axis}, offset={self.offset})"
+        return f"AxisIndex(axis={self.axis}, index={self.index}, offset={self.offset})"
+
+    def __eq__(self, other):
+        return repr(self) == repr(other)
 
     def __str__(self):
-        return f"{self.axis}[{self.offset}]"
+        return f"{self.axis}[{self.index}] + {self.offset}"
+
+    def __add__(self, offset: int):
+        if not isinstance(offset, numbers.Integral):
+            raise TypeError("Offset should be an integer type")
+        if offset == 0:
+            return self
+        else:
+            return AxisIndex(self.axis, self.index, self.offset + offset)
+
+    def __radd__(self, offset: int):
+        return self.__add__(offset)
+
+    def __sub__(self, offset: int):
+        return self.__add__(-offset)
+
+    def __rsub__(self, offset: int):
+        return self.__radd__(-offset)
 
 
 class AxisInterval:
@@ -551,6 +575,21 @@ def computation(order):
 def interval(*args):
     """Define the interval of computation in the 'K' sequential axis."""
     pass
+
+
+def horizontal(*args):
+    """Define a block of code that is restricted to a set of regions in the parallel axes."""
+    pass
+
+
+class _Region:
+    def __getitem__(self, *args):
+        """Define a region in the parallel axes."""
+        pass
+
+
+# Horizontal regions
+region = _Region()
 
 
 def __INLINED(compile_if_expression):

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -709,6 +709,13 @@ class AxisInterval(Node):
 
         return interval
 
+    @property
+    def is_single_index(self) -> bool:
+        if not isinstance(self.start, AxisBound) or not isinstance(self.end, AxisBound):
+            return False
+
+        return self.start.level == self.end.level and self.start.offset == self.end.offset - 1
+
 
 # TODO Find a better place for this in the file.
 @attribclass

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -704,13 +704,6 @@ class AxisInterval(Node):
 
         return self.start.level == self.end.level and self.start.offset == self.end.offset - 1
 
-
-# TODO Find a better place for this in the file.
-@attribclass
-class HorizontalIf(Statement):
-    intervals = attribute(of=DictOf[str, AxisInterval])
-    body = attribute(of=BlockStmt)
-
     def disjoint_from(self, other: "AxisInterval") -> bool:
         # This made-up constant must be larger than any LevelMarker.offset used
         DOMAIN_SIZE: int = 1000
@@ -729,6 +722,13 @@ class HorizontalIf(Statement):
         return not (self_start <= other_start < self_end) and not (
             other_start <= self_start < other_end
         )
+
+
+# TODO Find a better place for this in the file.
+@attribclass
+class HorizontalIf(Statement):
+    intervals = attribute(of=DictOf[str, AxisInterval])
+    body = attribute(of=BlockStmt)
 
 
 @attribclass

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -94,7 +94,7 @@ storing a reference to the piece of source code which originated the node.
 
     NativeFuncCall(func: NativeFunction, args: List[Expr], data_type: DataType)
 
-    Cast(dtype: DataType, expr: Expr)
+    Cast(expr: Expr, data_type: DataType)
 
     Expr        = Literal | Ref | NativeFuncCall | Cast | CompositeExpr | InvalidBranch
 
@@ -112,6 +112,7 @@ storing a reference to the piece of source code which originated the node.
     Statement   = Decl
                 | Assign(target: Ref, value: Expr)
                 | If(condition: expr, main_body: BlockStmt, else_body: BlockStmt)
+                | HorizontalIf(intervals: Dict[str, Interval], body: BlockStmt)
                 | BlockStmt
 
     AxisBound(level: LevelMarker | VarRef, offset: int)
@@ -707,6 +708,13 @@ class AxisInterval(Node):
             )
 
         return interval
+
+
+# TODO Find a better place for this in the file.
+@attribclass
+class HorizontalIf(Statement):
+    intervals = attribute(of=DictOf[str, AxisInterval])
+    body = attribute(of=BlockStmt)
 
 
 @attribclass

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -562,8 +562,6 @@ class TestRegions:
             externals={"ie": I[-1]},
         )
 
-        # TODO: Does this need to assert anything?
-
     def test_error_undefined(self):
         def stencil(in_f: gtscript.Field[np.float_]):
             from gt4py.__externals__ import i0  # forget to add 'ia'

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -28,12 +28,10 @@ import gt4py.utils as gt_utils
 from gt4py import gtscript
 from gt4py.frontend import gtscript_frontend as gt_frontend
 from gt4py.gtscript import (
-    __INLINED,
     PARALLEL,
     I,
     J,
     K,
-    __externals__,
     abs,
     asin,
     compile_assert,
@@ -443,7 +441,7 @@ class TestIntervalSyntax:
 
     def test_overlapping_intervals_none(self):
         def definition_func(field: gtscript.Field[float]):
-            with computation(FORWARD):
+            with computation(PARALLEL):
                 with interval(0, None):
                     field = 0
                 with interval(-1, None):
@@ -456,7 +454,7 @@ class TestIntervalSyntax:
 
     def test_overlapping_intervals(self):
         def definition_func(field: gtscript.Field[float]):
-            with computation(FORWARD):
+            with computation(PARALLEL):
                 with interval(0, 3):
                     field = 0
                 with interval(2, None):
@@ -469,7 +467,7 @@ class TestIntervalSyntax:
 
     def test_nonoverlapping_intervals(self):
         def definition_func(field: gtscript.Field[float]):
-            with computation(FORWARD):
+            with computation(PARALLEL):
                 with interval(0, 2):
                     field = 0
                 with interval(3, -1):
@@ -509,7 +507,7 @@ class TestRegions:
 
     def test_from_external(self):
         def stencil(in_f: gtscript.Field[np.float_]):
-            from __externals__ import i1
+            from gt4py.__externals__ import i1
 
             with computation(PARALLEL), interval(...), horizontal(region[i1, :]):
                 in_f = 1.0
@@ -545,7 +543,7 @@ class TestRegions:
     def test_inside_function(self):
         @gtscript.function
         def region_func():
-            from __externals__ import ie
+            from gt4py.__externals__ import ie
 
             field = 0.0
             with horizontal(region[ie, :]):
@@ -568,7 +566,7 @@ class TestRegions:
 
     def test_error_undefined(self):
         def stencil(in_f: gtscript.Field[np.float_]):
-            from __externals__ import i0  # forget to add 'ia'
+            from gt4py.__externals__ import i0  # forget to add 'ia'
 
             with computation(PARALLEL), interval(...):
                 in_f = in_f + 1.0


### PR DESCRIPTION
## Description

Frontend changes to parse `with horizontal(region[...])` and build `gt_ir.HorizontalRegion` nodes into definition IR.

The `AxisIntervalParser` had to be rewritten to be able to handle important corner cases where the axis endpoint flips. Specifically, the case of `-2 + 3` never came up when parsing vertical intervals, since it was outside the bounds. For horizontal intervals however, the original code would have said this is equivalent to `I[-1] + 1`, but in reality since it flips direction and should be `I[2]`. The extensive changes to the `AxisIntervalParser` make this work correctly.

To do:
- [x] Add tests for feature
- [x] Ensure frontend changes are compatible with Python 3.9 `ast`
- [x] Clean up `AxisIntervalParser`
- [x] Improve tests
- [ ] Address TODOs