### PR TITLE
Make gtc:cuda Extent Analysis Compatible with GT Extent Analysis

### DIFF
--- a/src/gtc/cuir/extent_analysis.py
+++ b/src/gtc/cuir/extent_analysis.py
@@ -25,8 +25,7 @@ from . import cuir
 
 class ComputeExtents(NodeTranslator):
     def visit_Program(self, node: cuir.Program) -> cuir.Program:
-        extents_map: Dict[str, cuir.IJExtent] = dict()
-        kernels = [self.visit(kernel, extents_map=extents_map) for kernel in reversed(node.kernels)]
+        kernels = [self.visit(kernel, extents_map=dict()) for kernel in reversed(node.kernels)]
         return cuir.Program(
             name=node.name,
             params=node.params,

--- a/tests/test_unittest/test_gtc/test_cuir_extent_analysis.py
+++ b/tests/test_unittest/test_gtc/test_cuir_extent_analysis.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gtc.cuir import extent_analysis
+from gtc.cuir import cuir, extent_analysis
 
 from .cuir_utils import (
     AssignStmtFactory,
@@ -22,6 +22,7 @@ from .cuir_utils import (
     IJCacheAccessFactory,
     IJCacheDeclFactory,
     IJExtentFactory,
+    KernelFactory,
     ProgramFactory,
     TemporaryFactory,
     VerticalLoopFactory,
@@ -48,6 +49,42 @@ def test_compute_extents():
     hexecs = transformed.kernels[0].vertical_loops[0].sections[0].horizontal_executions
     assert hexecs[0].extent.i == (0, 1)
     assert hexecs[0].extent.j == (-3, 0)
+    assert hexecs[1].extent.i == (0, 0)
+    assert hexecs[1].extent.j == (0, 0)
+
+
+def test_compute_extents_with_multiple_kernels():
+    testee = ProgramFactory(
+        kernels=[
+            KernelFactory(
+                vertical_loops__0__sections__0__horizontal_executions=[
+                    HorizontalExecutionFactory(
+                        body=[AssignStmtFactory(left__name="tmp")],
+                        extent=None,
+                    ),
+                ],
+            ),
+            KernelFactory(
+                vertical_loops__0__sections__0__horizontal_executions=[
+                    HorizontalExecutionFactory(
+                        body=[
+                            AssignStmtFactory(
+                                right__name="tmp",
+                                right__offset__i=1,
+                                right__offset__j=-3,
+                            )
+                        ],
+                        extent=None,
+                    ),
+                ]
+            ),
+        ],
+        params=[TemporaryFactory(name="tmp")],
+    )
+    transformed = extent_analysis.ComputeExtents().visit(testee)
+    hexecs = transformed.iter_tree().if_isinstance(cuir.HorizontalExecution).to_list()
+    assert hexecs[0].extent.i == (0, 0)
+    assert hexecs[0].extent.j == (0, 0)
     assert hexecs[1].extent.i == (0, 0)
     assert hexecs[1].extent.j == (0, 0)
 


### PR DESCRIPTION
## Description

Fixes an issue as reported by @huanglangwen where GT and gtc:cuda extent analysis differ.

## Requirements

Before submitting this PR, please make sure:

- [ ] The code builds cleanly without new errors or warnings
- [ ] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


