### PR TITLE
Fix gtc:cuda Extent Analysis of Kernels with Multiple Vertical Loops

### DIFF
--- a/src/gtc/cuir/extent_analysis.py
+++ b/src/gtc/cuir/extent_analysis.py
@@ -34,6 +34,18 @@ class ComputeExtents(NodeTranslator):
             kernels=list(reversed(kernels)),
         )
 
+    def visit_Kernel(self, node: cuir.Kernel, extents_map: Dict[str, cuir.IJExtent]) -> cuir.Kernel:
+        return cuir.Kernel(
+            vertical_loops=list(
+                reversed(
+                    [
+                        self.visit(vertical_loop, extents_map=extents_map)
+                        for vertical_loop in reversed(node.vertical_loops)
+                    ]
+                )
+            )
+        )
+
     def visit_VerticalLoop(
         self, node: cuir.VerticalLoop, extents_map: Dict[str, cuir.IJExtent]
     ) -> cuir.VerticalLoop:


### PR DESCRIPTION
## Description

Extent analysis of kernels with multiple loops was broken in gtc:cuda backend due to wrong order of loop traversal in the analysis. Issue reported by @huanglangwen.  

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


