### PR TITLE
Compile-Time Unit-Stride Dimensions for GTC Backends

### DIFF
--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -214,11 +214,10 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
         gt_ir.Builtin.TRUE: "true",
     }
 
-    def __init__(self, class_name, module_name, gt_backend_t, options):
+    def __init__(self, class_name, module_name, backend):
         self.class_name = class_name
         self.module_name = module_name
-        self.gt_backend_t = gt_backend_t
-        self.options = options
+        self.backend = backend
 
         self.templates = {}
         for key, file_name in self.TEMPLATE_FILES.items():
@@ -335,7 +334,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
 
     def visit_NativeFuncCall(self, node: gt_ir.NativeFuncCall) -> str:
         call = self.NATIVE_FUNC_TO_CPP[node.func]
-        if self.gt_backend_t != "cuda":
+        if self.backend.GT_BACKEND_T != "cuda":
             call = "std::" + call
         args = ",".join(self.visit(arg) for arg in node.args)
         return f"{call}({args})"
@@ -514,7 +513,7 @@ class GTPyExtGenerator(gt_ir.IRNodeVisitor):
             api_names=api_names,
             arg_fields=arg_fields,
             constants=constants,
-            gt_backend=self.gt_backend_t,
+            gt_backend=self.backend.GT_BACKEND_T,
             halo_sizes=halo_sizes,
             k_axis=k_axis,
             module_name=self.module_name,
@@ -643,9 +642,7 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
             if self.builder.stencil_id
             else f"{self.builder.options.name}_pyext"
         )
-        gt_pyext_generator = self.PYEXT_GENERATOR_CLASS(
-            class_name, module_name, self.GT_BACKEND_T, self.builder.options
-        )
+        gt_pyext_generator = self.PYEXT_GENERATOR_CLASS(class_name, module_name, self)
         gt_pyext_sources = gt_pyext_generator(ir)
         final_ext = ".cu" if self.languages and self.languages["computation"] == "cuda" else ".cpp"
         comp_src = gt_pyext_sources["computation"]

--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -117,12 +117,19 @@ class GTCCudaBindingsCodegen(codegen.TemplatedGenerator):
                     sid_ndim=sid_ndim,
                 )
             else:
+                layout_map = [
+                    x
+                    for x in make_cuda_layout_map(node.dimensions + (True,) * data_ndim)
+                    if x is not None
+                ]
                 sid_def = """gt::as_cuda_sid<{dtype}, {sid_ndim},
-                    gt::integral_constant<int, {unique_index}>>({name})""".format(
+                    gt::integral_constant<int, {unique_index}>,
+                    {unit_stride_dim}>({name})""".format(
                     name=node.name,
                     dtype=self.visit(node.dtype),
                     unique_index=self.unique_index(),
                     sid_ndim=sid_ndim,
+                    unit_stride_dim=layout_map.index(max(layout_map)),
                 )
                 if domain_ndim != 3:
                     gt_dims = [

--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -57,10 +57,9 @@ if TYPE_CHECKING:
 
 
 class GTCCudaExtGenerator:
-    def __init__(self, class_name, module_name, gt_backend_t, options):
+    def __init__(self, class_name, module_name, backend):
         self.class_name = class_name
         self.module_name = module_name
-        self.options = options
 
     def __call__(self, definition_ir) -> Dict[str, Dict[str, str]]:
         gtir = DefIRToGTIR.apply(definition_ir)

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -54,11 +54,10 @@ if TYPE_CHECKING:
 
 
 class GTCDaCeExtGenerator:
-    def __init__(self, class_name, module_name, gt_backend_t, options):
+    def __init__(self, class_name, module_name, backend):
         self.class_name = class_name
         self.module_name = module_name
-        self.gt_backend_t = gt_backend_t
-        self.options = options
+        self.backend = backend
 
     def __call__(self, definition_ir: StencilDefinition) -> Dict[str, Dict[str, str]]:
         gtir = DefIRToGTIR.apply(definition_ir)
@@ -75,7 +74,7 @@ class GTCDaCeExtGenerator:
         implementation = DaCeComputationCodegen.apply(gtir, sdfg)
         bindings = DaCeBindingsCodegen.apply(gtir, sdfg, module_name=self.module_name)
 
-        bindings_ext = ".cu" if self.gt_backend_t == "gpu" else ".cpp"
+        bindings_ext = ".cu" if self.backend.GT_BACKEND_T == "gpu" else ".cpp"
         return {
             "computation": {"computation.hpp": implementation},
             "bindings": {"bindings" + bindings_ext: bindings},

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -110,12 +110,6 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
 
     def visit_FieldDecl(self, node: gtcpp.FieldDecl, **kwargs):
         assert "gt_backend_t" in kwargs
-        backend_cls = globals()[
-            "GTCGT"
-            + re.sub(r"(^|_)[a-z]", lambda m: m[0][-1].upper(), kwargs["gt_backend_t"])
-            + "Backend"
-        ]
-        make_layout_map = backend_cls.storage_info["layout_map"]
         if "external_arg" in kwargs:
             domain_ndim = node.dimensions.count(True)
             data_ndim = len(node.data_dims)
@@ -126,6 +120,12 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
                     sid_ndim=sid_ndim,
                 )
             else:
+                backend_cls = globals()[
+                    "GTCGT"
+                    + re.sub(r"(^|_)[a-z]", lambda m: m[0][-1].upper(), kwargs["gt_backend_t"])
+                    + "Backend"
+                ]
+                make_layout_map = backend_cls.storage_info["layout_map"]
                 layout_map = [
                     x
                     for x in make_layout_map(node.dimensions + (True,) * data_ndim)


### PR DESCRIPTION
## Description

Uses compile-time unit strides for the contiguous dimension. This enables faster index calculations and specifically vectorization on CPU backends.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


