### PR TITLE
Skip Offsets in gtc:gt:* Backends Where Possible

### DIFF
--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -76,6 +76,7 @@ class GTCppCodegen(codegen.TemplatedGenerator):
     def visit_AccessorRef(self, accessor_ref: gtcpp.AccessorRef, **kwargs):
         offset = accessor_ref.offset
         if offset.i == offset.j == offset.k == 0 and not accessor_ref.data_index:
+            # Skip offsets in the accessor if possible, improves generated code readability and reduces code size for point-wise computations significantly
             return f"eval({accessor_ref.name}())"
         return (
             f"eval({accessor_ref.name}({offset.i}, {offset.j}, {offset.k}"

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -73,11 +73,17 @@ class GTCppCodegen(codegen.TemplatedGenerator):
 
     AssignStmt = as_fmt("{left} = {right};")
 
-    AccessorRef = as_fmt("eval({name}({', '.join([offset, *data_index])}))")
+    def visit_AccessorRef(self, accessor_ref: gtcpp.AccessorRef, **kwargs):
+        offset = accessor_ref.offset
+        if offset.i == offset.j == offset.k == 0 and not accessor_ref.data_index:
+            return f"eval({accessor_ref.name}())"
+        return (
+            f"eval({accessor_ref.name}({offset.i}, {offset.j}, {offset.k}"
+            + "".join(", {d}" for d in accessor_ref.data_index)
+            + "))"
+        )
 
     LocalAccess = as_fmt("{name}")
-
-    CartesianOffset = as_fmt("{i}, {j}, {k}")
 
     BinaryOp = as_fmt("({left} {op} {right})")
 

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -79,7 +79,7 @@ class GTCppCodegen(codegen.TemplatedGenerator):
             return f"eval({accessor_ref.name}())"
         return (
             f"eval({accessor_ref.name}({offset.i}, {offset.j}, {offset.k}"
-            + "".join(", {d}" for d in accessor_ref.data_index)
+            + "".join(f", {d}" for d in accessor_ref.data_index)
             + "))"
         )
 


### PR DESCRIPTION
## Description

Skip accessor offsets in gtc:gt:* backends where possible. This decreases code size, increases readability of generated code (especially physics code with many point-wise operations) and might simplify the work for compilers.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


