### PR TITLE
Fix origin offseting if i or j is not present in field for gtc backends

### DIFF
--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -124,6 +124,10 @@ class GTCCudaBindingsCodegen(codegen.TemplatedGenerator):
                     unique_index=self.unique_index(),
                     sid_ndim=sid_ndim,
                 )
+                sid_def = "gt::sid::shift_sid_origin({sid_def}, {name}_origin)".format(
+                    sid_def=sid_def,
+                    name=node.name,
+                )
                 if domain_ndim != 3:
                     gt_dims = [
                         f"gt::stencil::dim::{dim}"
@@ -137,10 +141,7 @@ class GTCCudaBindingsCodegen(codegen.TemplatedGenerator):
                         gt_dims=", ".join(gt_dims), sid_def=sid_def
                     )
 
-                return "gt::sid::shift_sid_origin({sid_def}, {name}_origin)".format(
-                    sid_def=sid_def,
-                    name=node.name,
-                )
+                return sid_def
 
     def visit_ScalarDecl(self, node: cuir.ScalarDecl, **kwargs):
         if "external_arg" in kwargs:

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -177,7 +177,7 @@ class DaCeComputationCodegen:
                 symbols.update(
                     {
                         f"__{name}_d{dim}_stride": fmt.format(
-                            dim=f"gt::integral_constant<int, {3 + dim}>", name=name
+                            dim=f"gt::integral_constant<int, {len(dims) + dim}>", name=name
                         )
                         for dim in range(data_ndim)
                     }

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -164,20 +164,20 @@ class DaCeComputationCodegen:
                 data_ndim = len(array.shape) - len(dims)
 
                 # api field strides
-                fmt = "gt::sid::get_stride<{dim}>(gt::sid::sid_get_strides(__{name}_sid))"
+                fmt = "gt::sid::get_stride<{dim}>(gt::sid::get_strides(__{name}_sid))"
 
                 symbols.update(
                     {
                         f"__{name}_{dim}_stride": fmt.format(
-                            dim=f"gt::integral_constant<int, {idx}>", name=name
+                            dim=f"gt::stencil::dim::{dim.lower()}", name=name
                         )
-                        for idx, dim in enumerate(dims)
+                        for dim in dims
                     }
                 )
                 symbols.update(
                     {
                         f"__{name}_d{dim}_stride": fmt.format(
-                            dim=f"gt::integral_constant<int, {len(dims) + dim}>", name=name
+                            dim=f"gt::integral_constant<int, {3 + dim}>", name=name
                         )
                         for dim in range(data_ndim)
                     }

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -127,6 +127,10 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
                     unique_index=self.unique_index(),
                     sid_ndim=sid_ndim,
                 )
+                sid_def = "gt::sid::shift_sid_origin({sid_def}, {name}_origin)".format(
+                    sid_def=sid_def,
+                    name=node.name,
+                )
                 if domain_ndim != 3:
                     gt_dims = [
                         f"gt::stencil::dim::{dim}"
@@ -140,10 +144,7 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
                         gt_dims=", ".join(gt_dims), sid_def=sid_def
                     )
 
-                return "gt::sid::shift_sid_origin({sid_def}, {name}_origin)".format(
-                    sid_def=sid_def,
-                    name=node.name,
-                )
+                return sid_def
 
     def visit_GlobalParamDecl(self, node: gtcpp.GlobalParamDecl, **kwargs):
         if "external_arg" in kwargs:


### PR DESCRIPTION
- `sid::shift_sid_origin` with "unnamed" indices needs to go before renaming
- fix use of `sid::get_strides` (`sid::sid_get_strides` is not part of the public API, note the extra `sid_`)