### PR TITLE
Fix K-Cache Fill Pruning for Accesses Outside of Full Loop Interval

### DIFF
--- a/src/gtc/passes/oir_optimizations/caches.py
+++ b/src/gtc/passes/oir_optimizations/caches.py
@@ -190,6 +190,16 @@ class PruneKCacheFills(NodeTranslator):
         # Consider accesses outside of loop interval
         # Note: those accesses would not require a fill in the whole loop interval in in theory
         # but restriction to the GridTools k-cache types makes this necessary
+        # E.g. consider the following loop with k = 1, 2:
+        # k | no fill required | initial fill required |
+        # - | ---------------- | --------------------- |
+        # 1 | a[k] = init      | a[k] = a[k - 1]       |
+        # 2 | a[k] = a[k - 1]  | a[k] = a[k - 1]       |
+        # In the first case, no fill is required. In the second case, a[0] has to be filled on
+        # level k = 1. On level k = 2, no fill would be necessary, but GridTools C++ does not
+        # support a k-cache type that only fills on the initial level, so fills are inserted on all
+        # levels here.
+
         first_section_offsets = AccessCollector.apply(node.sections[0]).offsets()
         last_section_offsets = AccessCollector.apply(node.sections[-1]).offsets()
         for field in list(pruneable):


### PR DESCRIPTION
## Description

The PruneKCacheFills optimization pass wrongly assumed that no accesses to fill fields happen outside of the loop interval. Fixes #438.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


