### PR TITLE
Print `pip list` for easier debugging of CI failures due to dependencies

### DIFF
--- a/.github/workflows/gt4py-precommit.yml
+++ b/.github/workflows/gt4py-precommit.yml
@@ -23,4 +23,5 @@ jobs:
         pre-commit install-hooks
     - name: Run checks
       run: |
+        python -m pip list
         pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,12 @@ extras =
 
 [testenv:py{38,39}-{internal,dawn}-cpu]
 commands =
+    pip list
     pytest --cache-clear --cov -v -m "not requires_gpu" {posargs}
     pytest --doctest-modules --cov --cov-append {envsitepackagesdir}/eve
 
 [testenv:py{38,39}-{internal,dawn}-{cuda,cuda90,cuda91,cuda92,cuda100,cuda101}]
 commands =
+    pip list
     pytest --cache-clear --cov -v -m "requires_gpu" {posargs}
     pytest --doctest-modules --cov --cov-append {envsitepackagesdir}/eve


### PR DESCRIPTION
This PR adds a `pip list` statement before the pytest runs in tox, s.t. upon failure of the CI, it is possible to retreive what dependency versions the error occured with. 