### PR TITLE
Constrain NumPy to < 1.21: numpy_patch fails

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     click>=7.1
     dace@git+https://github.com/spcl/dace.git
     jinja2>=2.10
-    numpy>=1.15
+    numpy>=1.15, <1.21 # test_numpy_patch fails for 1.21
     packaging>=20.0
     pybind11>=2.5
     tabulate>=0.8


### PR DESCRIPTION
Constrain NumPy version until the "numpy_patch" is fixed (or removed). With 1.21 `test_numpy_patch`fails.