### PR TITLE
Fix bug when slicing a ExplicitlyManagedGPUStorage

### DIFF
--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -529,7 +529,7 @@ class ExplicitlySyncedGPUStorage(Storage):
     def _finalize_view(self, base):
 
         if self.shape != base.shape or self.strides != base.strides:
-            offset = (base.ctypes.data - self.ctypes.data) + (
+            offset = (self.ctypes.data - base.ctypes.data) + (
                 self._device_field.data.ptr - self._device_raw_buffer.data.ptr
             )
             assert not offset % self.dtype.itemsize

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -973,4 +973,3 @@ def test_slice_gpu():
 
     assert view_start > storage_start
     assert view_end < storage_end
-    # np.testing.assert_equal(cpu_view, gpu_view.as_numpy())


### PR DESCRIPTION
Fix bug where slicing a ExplicitlyManagedGPUStorage would cause the resulting GPU view be offset with the wrong sign.