### PR TITLE
Fix NumPy patch failure for NumPy >= 1.21

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     click>=7.1
     dace@git+https://github.com/spcl/dace.git
     jinja2>=2.10
-    numpy>=1.15, <1.21 # test_numpy_patch fails for 1.21
+    numpy>=1.15
     packaging>=20.0
     pybind11>=2.5
     tabulate>=0.8

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -790,53 +790,95 @@ def test_view_gpu():
     run_test_view(backend="gtcuda")
 
 
-def test_numpy_patch():
-    storage = gt_store.from_array(
-        np.random.randn(5, 5, 5), default_origin=(1, 1, 1), backend="gtmc"
-    )
+class TestNumpyPatch:
+    def test_asarray(self):
+        storage = gt_store.from_array(
+            np.random.randn(5, 5, 5), default_origin=(1, 1, 1), backend="gtmc"
+        )
 
-    class npsub(np.ndarray):
-        pass
+        class npsub(np.ndarray):
+            pass
 
-    numpy_array = np.ones((3, 3, 3))
-    matrix = np.ones((3, 3)).view(npsub)
+        numpy_array = np.ones((3, 3, 3))
+        matrix = np.ones((3, 3)).view(npsub)
 
-    assert isinstance(np.asarray(storage), np.ndarray)
-    assert isinstance(np.asarray(numpy_array), np.ndarray)
-    assert isinstance(np.asarray(matrix), np.ndarray)
-    assert isinstance(np.asanyarray(storage), type(storage))
-    assert isinstance(np.asanyarray(numpy_array), np.ndarray)
-    assert isinstance(np.asanyarray(matrix), npsub)
-    assert isinstance(np.array(storage), np.ndarray)
-    assert isinstance(np.array(matrix), np.ndarray)
-    assert isinstance(np.array(numpy_array), np.ndarray)
+        assert isinstance(np.asarray(storage), np.ndarray)
+        assert isinstance(np.asarray(numpy_array), np.ndarray)
+        assert isinstance(np.asarray(matrix), np.ndarray)
+        assert isinstance(np.asanyarray(storage), type(storage))
+        assert isinstance(np.asanyarray(numpy_array), np.ndarray)
+        assert isinstance(np.asanyarray(matrix), npsub)
+        assert isinstance(np.array(storage), np.ndarray)
+        assert isinstance(np.array(matrix), np.ndarray)
+        assert isinstance(np.array(numpy_array), np.ndarray)
 
-    # apply numpy patch
-    gt_store.prepare_numpy()
+        # apply numpy patch
+        gt_store.prepare_numpy()
 
-    assert isinstance(np.asarray(storage), type(storage))
-    assert isinstance(np.asarray(numpy_array), np.ndarray)
-    assert isinstance(np.asarray(matrix), np.ndarray)
+        try:
+            assert isinstance(np.asarray(storage), type(storage))
+            assert isinstance(np.asarray(numpy_array), np.ndarray)
+            assert isinstance(np.asarray(matrix), np.ndarray)
 
-    assert isinstance(np.array(matrix), np.ndarray)
-    assert isinstance(np.array(numpy_array), np.ndarray)
-    try:
-        np.array(storage)
-    except RuntimeError:
-        pass
-    else:
-        assert False
+            assert isinstance(np.array(matrix), np.ndarray)
+            assert isinstance(np.array(numpy_array), np.ndarray)
+            with pytest.raises(RuntimeError):
+                np.array(storage)
+        finally:
+            # undo patch
+            gt_store.restore_numpy()
 
-    # undo patch
-    gt_store.restore_numpy()
+        assert isinstance(np.asarray(storage), np.ndarray)
+        assert isinstance(np.asarray(numpy_array), np.ndarray)
+        assert isinstance(np.asarray(matrix), np.ndarray)
 
-    assert isinstance(np.asarray(storage), np.ndarray)
-    assert isinstance(np.asarray(numpy_array), np.ndarray)
-    assert isinstance(np.asarray(matrix), np.ndarray)
+        assert isinstance(np.array(storage), np.ndarray)
+        assert isinstance(np.array(matrix), np.ndarray)
+        assert isinstance(np.array(numpy_array), np.ndarray)
 
-    assert isinstance(np.array(storage), np.ndarray)
-    assert isinstance(np.array(matrix), np.ndarray)
-    assert isinstance(np.array(numpy_array), np.ndarray)
+    def test_array(self):
+        storage = gt_store.from_array(
+            np.random.randn(5, 5, 5), default_origin=(1, 1, 1), backend="gtmc"
+        )
+
+        class npsub(np.ndarray):
+            pass
+
+        numpy_array = np.ones((3, 3, 3))
+        matrix = np.ones((3, 3)).view(npsub)
+
+        assert isinstance(np.array(storage, copy=False), np.ndarray)
+        assert isinstance(np.array(numpy_array, copy=False), np.ndarray)
+        assert isinstance(np.array(matrix, copy=False), np.ndarray)
+        assert isinstance(np.asanyarray(storage), type(storage))
+        assert isinstance(np.asanyarray(numpy_array), np.ndarray)
+        assert isinstance(np.asanyarray(matrix), npsub)
+        assert isinstance(np.array(storage), np.ndarray)
+        assert isinstance(np.array(matrix), np.ndarray)
+        assert isinstance(np.array(numpy_array), np.ndarray)
+
+        # apply numpy patch
+        gt_store.prepare_numpy()
+        try:
+            assert isinstance(np.array(storage, copy=False), type(storage))
+            assert isinstance(np.array(numpy_array, copy=False), np.ndarray)
+            assert isinstance(np.array(matrix, copy=False), np.ndarray)
+
+            assert isinstance(np.array(matrix), np.ndarray)
+            assert isinstance(np.array(numpy_array), np.ndarray)
+            with pytest.raises(RuntimeError):
+                np.array(storage)
+        finally:
+            # undo patch
+            gt_store.restore_numpy()
+
+        assert isinstance(np.array(storage, copy=False), np.ndarray)
+        assert isinstance(np.array(numpy_array, copy=False), np.ndarray)
+        assert isinstance(np.array(matrix, copy=False), np.ndarray)
+
+        assert isinstance(np.array(storage), np.ndarray)
+        assert isinstance(np.array(matrix), np.ndarray)
+        assert isinstance(np.array(numpy_array), np.ndarray)
 
 
 @pytest.mark.requires_gpu

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -796,18 +796,18 @@ class TestNumpyPatch:
             np.random.randn(5, 5, 5), default_origin=(1, 1, 1), backend="gtmc"
         )
 
-        class npsub(np.ndarray):
+        class NDArraySub(np.ndarray):
             pass
 
         numpy_array = np.ones((3, 3, 3))
-        matrix = np.ones((3, 3)).view(npsub)
+        matrix = np.ones((3, 3)).view(NDArraySub)
 
         assert isinstance(np.asarray(storage), np.ndarray)
         assert isinstance(np.asarray(numpy_array), np.ndarray)
         assert isinstance(np.asarray(matrix), np.ndarray)
         assert isinstance(np.asanyarray(storage), type(storage))
         assert isinstance(np.asanyarray(numpy_array), np.ndarray)
-        assert isinstance(np.asanyarray(matrix), npsub)
+        assert isinstance(np.asanyarray(matrix), NDArraySub)
         assert isinstance(np.array(storage), np.ndarray)
         assert isinstance(np.array(matrix), np.ndarray)
         assert isinstance(np.array(numpy_array), np.ndarray)
@@ -841,18 +841,18 @@ class TestNumpyPatch:
             np.random.randn(5, 5, 5), default_origin=(1, 1, 1), backend="gtmc"
         )
 
-        class npsub(np.ndarray):
+        class NDArraySub(np.ndarray):
             pass
 
         numpy_array = np.ones((3, 3, 3))
-        matrix = np.ones((3, 3)).view(npsub)
+        matrix = np.ones((3, 3)).view(NDArraySub)
 
         assert isinstance(np.array(storage, copy=False), np.ndarray)
         assert isinstance(np.array(numpy_array, copy=False), np.ndarray)
         assert isinstance(np.array(matrix, copy=False), np.ndarray)
         assert isinstance(np.asanyarray(storage), type(storage))
         assert isinstance(np.asanyarray(numpy_array), np.ndarray)
-        assert isinstance(np.asanyarray(matrix), npsub)
+        assert isinstance(np.asanyarray(matrix), NDArraySub)
         assert isinstance(np.array(storage), np.ndarray)
         assert isinstance(np.array(matrix), np.ndarray)
         assert isinstance(np.array(numpy_array), np.ndarray)


### PR DESCRIPTION
Change patch to not rely on asarray forwarding to array with subok. New implementation overrides both `np.array` and `np.asarray`