### PR TITLE
Remove Unneeded Device Sync in gtc:cuda Backend

### DIFF
--- a/src/gtc/cuir/cuir_codegen.py
+++ b/src/gtc/cuir/cuir_codegen.py
@@ -499,8 +499,6 @@ class CUIRCodegen(codegen.TemplatedGenerator):
                             kernel_${id(kernel)},
                             0);
                     % endfor
-
-                    GT_CUDA_CHECK(cudaDeviceSynchronize());
                 };
             }
         }


### PR DESCRIPTION
## Description

A device sync is already present in the generated Python module file.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


