### PR TITLE
Allow Any Integral dtype in Interval

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -261,8 +261,8 @@ class AxisIntervalParser(ast.NodeVisitor):
                 if node.value.axis != self.axis_name:
                     raise self.interval_error
                 offset = node.value.offset
-            elif isinstance(node.value, int):
-                offset = node.value
+            elif isinstance(node.value, numbers.Integral):
+                offset = int(node.value)
             else:
                 raise self.interval_error
             return self.make_axis_bound(offset, self.loc)


### PR DESCRIPTION
## Description

Allows more integral dtypes in gtscript interval definitions. Useful e.g. if numpy int dtypes are used in externals.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


