### PR TITLE
Fix managed storage synchronization issue

### DIFF
--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -261,7 +261,6 @@ class GPUStorage(Storage):
         )
         obj = field.view(_ViewableNdarray)
         obj = obj.view(GPUStorage)
-        print("construct", raw_buffer[-1:].data.ptr)
         obj._raw_buffer = raw_buffer
         obj.default_origin = default_origin
         return obj

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -303,7 +303,9 @@ class GPUStorage(Storage):
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):
             gpu_view = storage_utils.gpu_view(self)
-            self.device_to_host(True)
+            self.device_to_host()
+            if isinstance(value, GPUStorage):
+                value.device_to_host()
             gpu_view[key] = cp.asarray(value)
             return value
         else:

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -302,12 +302,13 @@ class GPUStorage(Storage):
     def __setitem__(self, key, value):
         if hasattr(value, "__cuda_array_interface__"):
             gpu_view = storage_utils.gpu_view(self)
+            gpu_view[key] = cp.asarray(value)
+            self._set_device_modified()
+            return value
+        else:
             self.device_to_host()
             if isinstance(value, GPUStorage):
                 value.device_to_host()
-            gpu_view[key] = cp.asarray(value)
-            return value
-        else:
             return super().__setitem__(key, value)
 
     @property

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -941,9 +941,7 @@ def test_auto_sync_storage():
         managed_memory=True,
     )
     q0_view = q0[3:, 3:, 3:]
-    print(id(q0))
-    print(id(q1))
-    print(id(q0_view))
+
     assert not gt_store.storage.GPUStorage.get_modified_storages()
 
     # call stencil and mark original storage clean

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -940,11 +940,33 @@ def test_auto_sync_storage():
         shape=shape,
         managed_memory=True,
     )
-
+    q0_view = q0[3:, 3:, 3:]
+    print(id(q0))
+    print(id(q1))
+    print(id(q0_view))
     assert not gt_store.storage.GPUStorage.get_modified_storages()
 
+    # call stencil and mark original storage clean
     swap_stencil(q0, q1)
     assert len(gt_store.storage.GPUStorage.get_modified_storages()) == 2
+    assert q0._is_device_modified
+    assert q0_view._is_device_modified
+    q0_view._set_clean()
+    assert len(gt_store.storage.GPUStorage.get_modified_storages()) == 1
+    assert not q0._is_device_modified
+    assert not q0_view._is_device_modified
 
+    # call stencil and mark original storage clean
+    swap_stencil(q0, q1)
+    assert len(gt_store.storage.GPUStorage.get_modified_storages()) == 2
+    assert q0._is_device_modified
+    assert q0_view._is_device_modified
+    q0_view._set_clean()
+    assert len(gt_store.storage.GPUStorage.get_modified_storages()) == 1
+    assert not q0._is_device_modified
+    assert not q0_view._is_device_modified
+
+    # call stencil and mark original storage clean
+    swap_stencil(q0, q1)
     q0.device_to_host()
     assert not gt_store.storage.GPUStorage.get_modified_storages()


### PR DESCRIPTION
* Fix performance issue where setitem in GPU storage always triggers host-to-device copy.
* Improve tracking of storages involved in a stencil, that might warrant a device synchronization.

@eddie-c-davis You originally introduced the change in `__setitem__` where `value.data` was used in `cp.asarray`. That actually always causes a host-to-device copy, can you please verify that this PR works for you?