### PR TITLE
Pin dace version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     black>=19.3b0
     cached-property>=1.5
     click>=7.1
-    dace@git+https://github.com/spcl/dace.git
+    dace@git+https://github.com/spcl/dace.git@7d0529f85ce8c7b9d9b55905def595725a690a03
     jinja2>=2.10
     numpy>=1.15
     packaging>=20.0


### PR DESCRIPTION
## Description

On my system when not pinning `dace`, using a git link like this makes setuptools continually clone and install `dace` every time I re-create my environment, even if it is in cache. This makes sure that does not happen and also makes sure new commits onto `master` do not break our usage of the package. We can and should then upgrade this with every release.

I hope this does not make development with the two packages together more difficult. @gronerl? The alternative would be to only specify `dace` instead of the git link, in which case the user would have to manually `pip` install whatever version they wish to before installing `gt4py`.