### PR TITLE
Fix bug where gtc:numpy would modify the `origin` argument.

### DIFF
--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -124,7 +124,7 @@ class StencilObject(abc.ABC):
     def _make_origin_dict(origin: Any) -> Dict[str, Index]:
         try:
             if isinstance(origin, dict):
-                return origin
+                return dict(origin)
             if origin is None:
                 return {}
             if isinstance(origin, collections.abc.Iterable):

--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -296,7 +296,6 @@ class NpirGen(TemplatedGenerator):
                 _dI_, _dJ_, _dK_ = _domain_
                 # -- end domain padding --
 
-                _origin_ = dict(_origin_)
                 {% for decl in field_decls %}{{ decl | indent(4) }}
                 {% endfor %}
                 # -- begin data views --

--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -296,6 +296,7 @@ class NpirGen(TemplatedGenerator):
                 _dI_, _dJ_, _dK_ = _domain_
                 # -- end domain padding --
 
+                _origin_ = dict(_origin_)
                 {% for decl in field_decls %}{{ decl | indent(4) }}
                 {% endfor %}
                 # -- begin data views --

--- a/tests/test_unittest/test_call_interface.py
+++ b/tests/test_unittest/test_call_interface.py
@@ -467,4 +467,4 @@ def test_origin_unchanged(backend):
 
     assert all(k in origin_ref for k in origin.keys())
     assert all(k in origin for k in origin_ref.keys())
-    assert all(v is origin_ref[k] for k, v in origin)
+    assert all(v is origin_ref[k] for k, v in origin.items())

--- a/tests/test_unittest/test_call_interface.py
+++ b/tests/test_unittest/test_call_interface.py
@@ -20,7 +20,7 @@ import pytest
 import gt4py.backend as gt_backend
 import gt4py.gtscript as gtscript
 import gt4py.storage as gt_storage
-from gt4py.gtscript import Field
+from gt4py.gtscript import Field, K
 
 from ..definitions import INTERNAL_BACKENDS, INTERNAL_CPU_BACKENDS
 
@@ -436,3 +436,35 @@ class TestAxesMismatch:
                     default_origin=(0, 0),
                 )
             )
+
+
+@pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+def test_origin_unchanged(backend):
+    @gtscript.stencil(backend=backend)
+    def calc_damp(outp: Field[float], inp: Field[K, float]):
+        with computation(FORWARD), interval(...):
+            outp = inp
+
+    outp = gt_storage.ones(
+        backend=backend,
+        default_origin=(1, 1, 1),
+        shape=(4, 4, 4),
+        dtype=float,
+        mask=[True, True, True],
+    )
+    inp = gt_storage.ones(
+        backend=backend,
+        default_origin=(1,),
+        shape=(4, 4, 4),
+        dtype=float,
+        mask=[False, False, True],
+    )
+
+    origin = {"_all_": (1, 1, 1), "inp": (1,)}
+    origin_ref = dict(origin)
+
+    calc_damp(outp, inp, origin=origin, domain=(3, 3, 3))
+
+    assert all(k in origin_ref for k in origin.keys())
+    assert all(k in origin for k in origin_ref.keys())
+    assert all(v is origin_ref[k] for k, v in origin)


### PR DESCRIPTION
This PR fixes a bug where the gtc:numpy backend modies the origin dictionary by expanding the dimension of lower dimensional fields, which prevents the use of said dictionary in subsequent calls to the same stencil. 