### PR TITLE
Fix forward loop, lower dimensional assignments in `gtc:numpy`

### DIFF
--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -111,7 +111,7 @@ class NpirGen(TemplatedGenerator):
     )
 
     AxisOffset_serial = JinjaTemplate(
-        "{{ axis_name | lower }}_{{ offset }}:{{ axis_name | lower }}_{{ offset }}+1"
+        "{{ lpar }}{{ axis_name | lower }}_{{ offset }}{{ rpar }}:({{ axis_name | lower }}_{{ offset}} + 1)"
     )
 
     AxisOffset = FormatTemplate("{parallel_or_serial_variant}")

--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -110,7 +110,9 @@ class NpirGen(TemplatedGenerator):
         "{{ lpar }}{{ axis_name | lower }}{{ offset }}{{ rpar }}:{{ lpar }}{{ axis_name | upper }}{{ offset }}{{ rpar }}"
     )
 
-    AxisOffset_serial = JinjaTemplate("{{ axis_name | lower }}_{{ offset }}")
+    AxisOffset_serial = JinjaTemplate(
+        "{{ axis_name | lower }}_{{ offset }}:{{ axis_name | lower }}_{{ offset }}+1"
+    )
 
     AxisOffset = FormatTemplate("{parallel_or_serial_variant}")
 

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -202,6 +202,25 @@ def test_lower_dimensional_inputs(backend):
     stencil(field_3d, field_2d, field_1d)
 
 
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_lower_dimensional_inputs_2d_to_3d_forward(backend):
+    @gtscript.stencil(backend=backend)
+    def copy_2to3(
+        inp: gtscript.Field[gtscript.IJ, np.float_], outp: gtscript.Field[gtscript.IJK, np.float_]
+    ):
+        with computation(FORWARD), interval(...):
+            outp[0, 0, 0] = inp
+
+    inp_f = gt_storage.from_array(np.random.randn(10, 10), default_origin=(0, 0), backend=backend)
+    outp_f = gt_storage.from_array(
+        np.random.randn(10, 10, 10), default_origin=(0, 0, 0), backend=backend
+    )
+    copy_2to3(inp_f, outp_f)
+    inp_f.device_to_host()
+    outp_f.device_to_host()
+    assert np.allclose(np.asarray(outp_f), np.asarray(inp_f)[:, :, np.newaxis])
+
+
 @pytest.mark.parametrize(
     "backend",
     [

--- a/tests/test_unittest/test_gtc/test_npir_gen.py
+++ b/tests/test_unittest/test_gtc/test_npir_gen.py
@@ -106,20 +106,20 @@ def test_parallel_offset_zero() -> None:
 def test_sequential_offset() -> None:
     result = npir_gen.NpirGen().visit(npir.AxisOffset.k(5))
     print(result)
-    assert result == "k_ + 5"
+    assert result == "(k_ + 5):(k_ + 5 + 1)"
 
 
 def test_sequential_offset_zero() -> None:
     result = npir_gen.NpirGen().visit(npir.AxisOffset.k(0))
     print(result)
-    assert result == "k_"
+    assert result == "k_:(k_ + 1)"
 
 
 def test_field_slice_sequential_k() -> None:
     result = npir_gen.NpirGen().visit(
         FieldSliceFactory(name="a_field", parallel_k=False, offsets=(-1, 0, 4))
     )
-    assert result == "a_field_[(i - 1):(I - 1), j:J, k_ + 4]"
+    assert result == "a_field_[(i - 1):(I - 1), j:J, (k_ + 4):(k_ + 4 + 1)]"
 
 
 def test_field_slice_parallel_k() -> None:
@@ -139,7 +139,7 @@ def test_native_function() -> None:
             ],
         )
     )
-    assert result == "np.minimum(a_[i:I, j:J, k_], b_[i:I, j:J, k_])"
+    assert result == "np.minimum(a_[i:I, j:J, k_:(k_ + 1)], b_[i:I, j:J, k_:(k_ + 1)])"
 
 
 def test_vector_assign() -> None:
@@ -149,7 +149,7 @@ def test_vector_assign() -> None:
             right__name="b",
         )
     )
-    assert result == "a_[i:I, j:J, k_] = b_[i:I, j:J, k_]"
+    assert result == "a_[i:I, j:J, k_:(k_ + 1)] = b_[i:I, j:J, k_:(k_ + 1)]"
 
 
 def test_temp_definition() -> None:
@@ -176,7 +176,7 @@ def test_vector_arithmetic() -> None:
             op=common.ArithmeticOperator.ADD,
         )
     )
-    assert result == "(a_[i:I, j:J, k_] + b_[i:I, j:J, k_])"
+    assert result == "(a_[i:I, j:J, k_:(k_ + 1)] + b_[i:I, j:J, k_:(k_ + 1)])"
 
 
 def test_vector_unary_op() -> None:
@@ -186,7 +186,7 @@ def test_vector_unary_op() -> None:
             op=common.UnaryOperator.NEG,
         )
     )
-    assert result == "(-(a_[i:I, j:J, k_]))"
+    assert result == "(-(a_[i:I, j:J, k_:(k_ + 1)]))"
 
 
 def test_vector_unary_not() -> None:
@@ -196,7 +196,7 @@ def test_vector_unary_not() -> None:
             op=common.UnaryOperator.NOT,
         )
     )
-    assert result == "(np.bitwise_not(a_[i:I, j:J, k_]))"
+    assert result == "(np.bitwise_not(a_[i:I, j:J, k_:(k_ + 1)]))"
 
 
 def test_numerical_offset_pos() -> None:


### PR DESCRIPTION
This PR fixes a bug where shapes could not be broadcast in the assignment if  IJ fields were assigned to IJK fields.