### PR TITLE
Fix assignment involving both masks and lower dimensional fields in `gtc:numpy` backend

### DIFF
--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -202,6 +202,37 @@ def test_lower_dimensional_inputs(backend):
     stencil(field_3d, field_2d, field_1d)
 
 
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_lower_dimensional_masked(backend):
+    @gtscript.stencil(backend=backend)
+    def copy_2to3(
+        cond: gtscript.Field[gtscript.IJK, np.float_],
+        inp: gtscript.Field[gtscript.IJ, np.float_],
+        outp: gtscript.Field[gtscript.IJK, np.float_],
+    ):
+        with computation(PARALLEL), interval(...):
+            if cond > 0.0:
+                outp = inp
+
+    inp = np.random.randn(10, 10)
+    outp = np.random.randn(10, 10, 10)
+    cond = np.random.randn(10, 10, 10)
+
+    inp_f = gt_storage.from_array(inp, default_origin=(0, 0), backend=backend)
+    outp_f = gt_storage.from_array(outp, default_origin=(0, 0, 0), backend=backend)
+    cond_f = gt_storage.from_array(cond, default_origin=(0, 0, 0), backend=backend)
+
+    copy_2to3(cond_f, inp_f, outp_f)
+
+    inp3d = np.empty_like(outp)
+    inp3d[...] = inp[:, :, np.newaxis]
+
+    outp = np.choose(cond > 0.0, [outp, inp3d])
+
+    outp_f.device_to_host()
+    assert np.allclose(outp, np.asarray(outp_f))
+
+
 @pytest.mark.parametrize(
     "backend",
     [


### PR DESCRIPTION
This PR fixes a bug that occurs if a lower dimensional field is accessed within an if condition, since the bool field representing the mask can be 3d, which is not compatible as a key for getitem for <3d fields.
We work around this by reproducing the lower dimensional fields accordingly by means of `np.broadcast_to`. 