### PR TITLE
Pin the GridTools C++ versions used

### DIFF
--- a/src/gt4py/gt_src_manager.py
+++ b/src/gt4py/gt_src_manager.py
@@ -19,23 +19,36 @@
 import argparse
 import os
 import subprocess
+from typing import Any
 
 import gt4py.config as gt_config
 
 
 _DEFAULT_GRIDTOOLS_VERSION = 1
 # TODO: GT2 release with CUDA SID adapter
-_GRIDTOOLS_GIT_BRANCHES = {1: "release_v1.1", 2: "master"}
-_GRIDTOOLS_INCLUDE_PATHS = {1: gt_config.GT_INCLUDE_PATH, 2: gt_config.GT2_INCLUDE_PATH}
+_GRIDTOOLS_GIT_REFS = {
+    # On the release_v1.1 branch
+    1: "eccd3e057d6deb1c97c7b6f8233ba6bf97a96622",
+    # On master
+    2: "15905e60ea52061847611b0baca08ba01fcab0c2",
+}
+_GRIDTOOLS_INCLUDE_PATHS = {
+    1: gt_config.build_settings["gt_include_path"],
+    2: gt_config.build_settings["gt2_include_path"],
+}
 _GRIDTOOLS_REPO_DIRNAMES = {1: gt_config.GT_REPO_DIRNAME, 2: gt_config.GT2_REPO_DIRNAME}
 
 
+def run_git_command(sub_command: str, **kwargs: Any) -> None:
+    subprocess.check_call(f"git {sub_command}".split(), stderr=subprocess.STDOUT, **kwargs)
+
+
 def install_gt_sources(major_version: int = _DEFAULT_GRIDTOOLS_VERSION) -> bool:
-    assert major_version in _GRIDTOOLS_GIT_BRANCHES
+    assert major_version in _GRIDTOOLS_GIT_REFS
 
     is_ok = has_gt_sources(major_version)
     if not is_ok:
-        GIT_BRANCH = _GRIDTOOLS_GIT_BRANCHES[major_version]
+        GIT_REF = _GRIDTOOLS_GIT_REFS[major_version]
         GIT_REPO = "https://github.com/GridTools/gridtools.git"
 
         install_path = os.path.dirname(__file__)
@@ -43,9 +56,10 @@ def install_gt_sources(major_version: int = _DEFAULT_GRIDTOOLS_VERSION) -> bool:
             os.path.join(install_path, "_external_src", _GRIDTOOLS_REPO_DIRNAMES[major_version])
         )
         if not os.path.exists(target_path):
-            git_cmd = f"git clone --depth 1 -b {GIT_BRANCH} {GIT_REPO} {target_path}"
-            print(f"Getting GridTools C++ sources...\n$ {git_cmd}")
-            subprocess.check_call(git_cmd.split(), stderr=subprocess.STDOUT)
+            run_git_command(f"init {target_path}")
+            run_git_command(f"remote add gt {GIT_REPO}", cwd=target_path)
+            run_git_command(f"fetch gt {GIT_REF}", cwd=target_path)
+            run_git_command("reset --hard FETCH_HEAD", cwd=target_path)
 
         is_ok = has_gt_sources(major_version)
         if is_ok:
@@ -54,7 +68,7 @@ def install_gt_sources(major_version: int = _DEFAULT_GRIDTOOLS_VERSION) -> bool:
             print(
                 f"\nOooops! GridTools sources have not been installed!\n"
                 f"Install them manually in '{install_path}/_external_src/'\n\n"
-                f"\tExample: git clone --depth 1 -b {GIT_BRANCH} {GIT_REPO} {target_path}\n"
+                f"src/gt4py/gt_src_manager.py specifies particular refs for each version.\n"
             )
 
     return is_ok
@@ -88,10 +102,21 @@ def remove_gt_sources(major_version: int = _DEFAULT_GRIDTOOLS_VERSION) -> bool:
 
 
 def has_gt_sources(major_version: int = _DEFAULT_GRIDTOOLS_VERSION) -> bool:
+    """Check if the gt sources present are compatible with gt4py."""
     assert major_version in _GRIDTOOLS_INCLUDE_PATHS
-    return os.path.isfile(
-        os.path.join(_GRIDTOOLS_INCLUDE_PATHS[major_version], "gridtools", "common", "defs.hpp")
-    )
+    include_path = _GRIDTOOLS_INCLUDE_PATHS[major_version]
+    has_source = os.path.isfile(os.path.join(include_path, "gridtools", "common", "defs.hpp"))
+
+    if has_source:
+        try:
+            run_git_command(
+                f"merge-base --is-ancestor {_GRIDTOOLS_GIT_REFS[major_version]} HEAD",
+                cwd=include_path,
+            )
+            return True
+        except subprocess.CalledProcessError:
+            pass
+    return False
 
 
 def _print_status(major_version: int = _DEFAULT_GRIDTOOLS_VERSION) -> None:
@@ -107,7 +132,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m",
         "--major-version",
-        choices=list(_GRIDTOOLS_GIT_BRANCHES.keys()),
+        choices=list(_GRIDTOOLS_GIT_REFS.keys()),
         type=int,
         default=_DEFAULT_GRIDTOOLS_VERSION,
         help=f"major GridTools version for the installation (default: {_DEFAULT_GRIDTOOLS_VERSION})",


### PR DESCRIPTION
## Description

Currently uses the latest versions of `release_v1.1` and does not check if the code is out of date. This new version pins the version. It allows commits that can descendants of the pinned commit, but it will flag installs when the pinned version is later than the one on disk.

Resolves #457.