### PR TITLE
Fix masks which involve fields read with an offset in `gtc:numpy`

### DIFF
--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -18,6 +18,7 @@ import textwrap
 from typing import Any, Collection, Tuple, Union
 
 from eve.codegen import FormatTemplate, JinjaTemplate, TemplatedGenerator
+from gt4py.definitions import Extent
 from gtc import common
 from gtc.passes.gtir_legacy_extents import FIELD_EXT_T
 from gtc.python import npir
@@ -258,9 +259,10 @@ class NpirGen(TemplatedGenerator):
         lower, upper = [0, 0], [0, 0]
 
         if extents := kwargs.get("field_extents"):
-            fields = set(node.iter_tree().if_isinstance(npir.FieldSlice).getattr("name")) & set(
-                extents
-            )
+            fields = set(node.iter_tree().if_isinstance(npir.FieldSlice).getattr("name"))
+            for field in fields:
+                # The extent of masks hsa not yet been collected but is always zero.
+                extents.setdefault(field, Extent.zeros())
             lower[0] = min(extents[field].to_boundary()[0][0] for field in fields)
             lower[1] = min(extents[field].to_boundary()[1][0] for field in fields)
             upper[0] = min(extents[field].to_boundary()[0][1] for field in fields)

--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -261,7 +261,7 @@ class NpirGen(TemplatedGenerator):
         if extents := kwargs.get("field_extents"):
             fields = set(node.iter_tree().if_isinstance(npir.FieldSlice).getattr("name"))
             for field in fields:
-                # The extent of masks hsa not yet been collected but is always zero.
+                # The extent of masks has not yet been collected but is always zero.
                 extents.setdefault(field, Extent.zeros())
             lower[0] = min(extents[field].to_boundary()[0][0] for field in fields)
             lower[1] = min(extents[field].to_boundary()[1][0] for field in fields)

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -373,7 +373,6 @@ def test_mask_with_offset_written_in_conditional(backend):
 
         with computation(PARALLEL), interval(...):
             cond = True
-            # outp = 1.0 if cond[0, -1, 0] or cond[0, 0, 0] else 0.0 # this works
             if cond[0, -1, 0] or cond[0, 0, 0]:
                 outp = 1.0
             else:

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -73,10 +73,7 @@ def test_stage_without_effect(backend):
 def test_ignore_np_errstate():
     def setup_and_run(backend, **kwargs):
         field_a = gt_storage.zeros(
-            dtype=np.float_,
-            backend=backend,
-            shape=(3, 3, 1),
-            default_origin=(0, 0, 0),
+            dtype=np.float_, backend=backend, shape=(3, 3, 1), default_origin=(0, 0, 0)
         )
 
         @gtscript.stencil(backend=backend, **kwargs)
@@ -318,9 +315,7 @@ def test_higher_dimensional_fields(backend):
 def test_input_order(backend):
     @gtscript.stencil(backend=backend)
     def stencil(
-        in_field: gtscript.Field[np.float],
-        parameter: np.float,
-        out_field: gtscript.Field[np.float],
+        in_field: gtscript.Field[np.float], parameter: np.float, out_field: gtscript.Field[np.float]
     ):
         with computation(PARALLEL), interval(...):
             out_field = in_field * parameter
@@ -367,3 +362,28 @@ def test_variable_offsets_and_while_loop(backend):
                     qsum += qin[0, 0, lev] / (pe2[0, 0, 1] - pe1[0, 0, lev])
                     lev = lev + 1
                 qout = qsum / (pe2[0, 0, 1] - pe2)
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_mask_with_offset_written_in_conditional(backend):
+    @gtscript.stencil(backend, externals={"mord": 5})
+    def stencil(
+        outp: gtscript.Field[np.float_],
+    ):
+
+        with computation(PARALLEL), interval(...):
+            cond = True
+            # outp = 1.0 if cond[0, -1, 0] or cond[0, 0, 0] else 0.0 # this works
+            if cond[0, -1, 0] or cond[0, 0, 0]:
+                outp = 1.0
+            else:
+                outp = 0.0
+
+    outp = gt_storage.zeros(
+        shape=(10, 10, 10), backend=backend, default_origin=(0, 0, 0), dtype=float
+    )
+
+    stencil(outp)
+
+    outp.device_to_host()
+    assert np.allclose(1.0, np.asarray(outp))


### PR DESCRIPTION
The extents are collected based on gtir, where masks are not explicitly instantiated as fields, and are not considered for some analysis in the codegen. Fortunately, they are never read with offset and we can just assume this extent is `(0, 0, 0)`.

Fixes #471