### PR TITLE
Fix lower dimensional masked assignments for `gtc:numpy` (serial)

### DIFF
--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -137,7 +137,7 @@ class NpirGen(TemplatedGenerator):
     )
 
     def visit_FieldSlice(
-        self, node: npir.FieldSlice, mask_acc="", mask_shape=None, **kwargs: Any
+        self, node: npir.FieldSlice, mask_acc="", *, is_serial=False, **kwargs: Any
     ) -> Union[str, Collection[str]]:
 
         offset = [node.i_offset, node.j_offset, node.k_offset]
@@ -145,7 +145,8 @@ class NpirGen(TemplatedGenerator):
         offset_str = ", ".join(self.visit(off, **kwargs) if off else ":" for off in offset)
 
         if mask_acc and any(off is None for off in offset):
-            arr_expr = f"np.broadcast_to({node.name}_[{offset_str}], (I-i, J-j, K-k))"
+            k_size = 1 if is_serial else "K - k"
+            arr_expr = f"np.broadcast_to({node.name}_[{offset_str}], (I - i, J - j, {k_size}))"
         else:
             arr_expr = f"{node.name}_[{offset_str}]"
 
@@ -238,6 +239,11 @@ class NpirGen(TemplatedGenerator):
         elif node is common.LoopOrder.BACKWARD:
             return "for k_ in range(K-1, k-1, -1):"
         return ""
+
+    def visit_VerticalPass(self, node: npir.VerticalPass, **kwargs):
+        return self.generic_visit(
+            node, is_serial=(node.direction != common.LoopOrder.PARALLEL), **kwargs
+        )
 
     VerticalPass = JinjaTemplate(
         textwrap.dedent(

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -234,6 +234,37 @@ def test_lower_dimensional_masked(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_lower_dimensional_masked_2dcond(backend):
+    @gtscript.stencil(backend=backend)
+    def copy_2to3(
+        cond: gtscript.Field[gtscript.IJK, np.float_],
+        inp: gtscript.Field[gtscript.IJ, np.float_],
+        outp: gtscript.Field[gtscript.IJK, np.float_],
+    ):
+        with computation(FORWARD), interval(...):
+            if cond > 0.0:
+                outp = inp
+
+    inp = np.random.randn(10, 10)
+    outp = np.random.randn(10, 10, 10)
+    cond = np.random.randn(10, 10, 10)
+
+    inp_f = gt_storage.from_array(inp, default_origin=(0, 0), backend=backend)
+    outp_f = gt_storage.from_array(outp, default_origin=(0, 0, 0), backend=backend)
+    cond_f = gt_storage.from_array(cond, default_origin=(0, 0, 0), backend=backend)
+
+    copy_2to3(cond_f, inp_f, outp_f)
+
+    inp3d = np.empty_like(outp)
+    inp3d[...] = inp[:, :, np.newaxis]
+
+    outp = np.choose(cond > 0.0, [outp, inp3d])
+
+    outp_f.device_to_host()
+    assert np.allclose(outp, np.asarray(outp_f))
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_lower_dimensional_inputs_2d_to_3d_forward(backend):
     @gtscript.stencil(backend=backend)
     def copy_2to3(


### PR DESCRIPTION
This PR fixes masked assignments involving lower dimensional masked fields within a VerticalPass with serial loop order. 

Basically a not previously handled case of #472 namely the special treatment of serial vertical loops where slices are not fully 3d, but only a slice in k. 