### PR TITLE
Overlapping intervals check correction

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -862,7 +862,9 @@ class IRMaker(ast.NodeVisitor):
     def _are_intervals_nonoverlapping(self, compute_blocks: List[gt_ir.ComputationBlock]):
         for i, block in enumerate(compute_blocks[1:]):
             other = compute_blocks[i]
-            if not block.interval.disjoint_from(other.interval):
+            if not block.interval.equals(other.interval) and not block.interval.disjoint_from(
+                other.interval
+            ):
                 return False
         return True
 

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -862,7 +862,7 @@ class IRMaker(ast.NodeVisitor):
     def _are_intervals_nonoverlapping(self, compute_blocks: List[gt_ir.ComputationBlock]):
         for i, block in enumerate(compute_blocks[1:]):
             other = compute_blocks[i]
-            if not block.interval.equals(other.interval) and not block.interval.disjoint_from(
+            if block.interval != other.interval and not block.interval.disjoint_from(
                 other.interval
             ):
                 return False

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -862,7 +862,7 @@ class IRMaker(ast.NodeVisitor):
     def _are_intervals_nonoverlapping(self, compute_blocks: List[gt_ir.ComputationBlock]):
         for i, block in enumerate(compute_blocks[1:]):
             other = compute_blocks[i]
-            if block.interval != other.interval and not block.interval.disjoint_from(
+            if not block.interval.same_as(other.interval) and not block.interval.disjoint_from(
                 other.interval
             ):
                 return False

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -691,13 +691,16 @@ class AxisInterval(Node):
     end = attribute(of=AxisBound)
     loc = attribute(of=Location, optional=True)
 
-    def equals(self, other: "AxisInterval") -> bool:
+    def __eq__(self, other: "AxisInterval") -> bool:
         return (
             self.start.level.value == other.start.level.value
             and self.start.offset == other.start.offset
             and self.end.level.value == other.end.level.value
             and self.end.offset == other.end.offset
         )
+
+    def __ne__(self, other: "AxisInterval") -> bool:
+        return not (self == other)
 
     @classmethod
     def full_interval(cls, order=IterationOrder.PARALLEL):

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -691,6 +691,14 @@ class AxisInterval(Node):
     end = attribute(of=AxisBound)
     loc = attribute(of=Location, optional=True)
 
+    def equals(self, other: "AxisInterval") -> bool:
+        return (
+            self.start.level.value == other.start.level.value
+            and self.start.offset == other.start.offset
+            and self.end.level.value == other.end.level.value
+            and self.end.offset == other.end.offset
+        )
+
     @classmethod
     def full_interval(cls, order=IterationOrder.PARALLEL):
         if order != IterationOrder.BACKWARD:

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -691,14 +691,6 @@ class AxisInterval(Node):
     end = attribute(of=AxisBound)
     loc = attribute(of=Location, optional=True)
 
-    def __eq__(self, other: "AxisInterval") -> bool:
-        return (
-            self.start.level.value == other.start.level.value
-            and self.start.offset == other.start.offset
-            and self.end.level.value == other.end.level.value
-            and self.end.offset == other.end.offset
-        )
-
     def __ne__(self, other: "AxisInterval") -> bool:
         return not (self == other)
 
@@ -741,6 +733,14 @@ class AxisInterval(Node):
 
         return not (self_start <= other_start < self_end) and not (
             other_start <= self_start < other_end
+        )
+
+    def same_as(self, other: "AxisInterval") -> bool:
+        return (
+            self.start.level.value == other.start.level.value
+            and self.start.offset == other.start.offset
+            and self.end.level.value == other.end.level.value
+            and self.end.offset == other.end.offset
         )
 
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -24,7 +24,6 @@ import pytest
 
 import gt4py.definitions as gt_definitions
 import gt4py.ir as gt_ir
-import gt4py.utils as gt_utils
 from gt4py import gtscript
 from gt4py.frontend import gtscript_frontend as gt_frontend
 from gt4py.gtscript import (
@@ -477,6 +476,16 @@ class TestIntervalSyntax:
 
         parse_definition(
             definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
+        )
+
+    def test_overlapping_intervals_regions(self):
+        def definition_func(in_f: gtscript.Field[np.float_], out_f: gtscript.Field[np.float_]):
+            with computation(PARALLEL), interval(...):
+                with horizontal(region[: I[0] + 3, :], region[I[-1] - 3:, :]):
+                    out_f = 0.5 * (in_f + in_f[0, 1, 0])
+
+        parse_definition(
+            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__, rebuild=True
         )
 
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -485,7 +485,7 @@ class TestIntervalSyntax:
                     out_f = 0.5 * (in_f + in_f[0, 1, 0])
 
         parse_definition(
-            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__, rebuild=True
+            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
         )
 
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -481,7 +481,7 @@ class TestIntervalSyntax:
     def test_overlapping_intervals_regions(self):
         def definition_func(in_f: gtscript.Field[np.float_], out_f: gtscript.Field[np.float_]):
             with computation(PARALLEL), interval(...):
-                with horizontal(region[: I[0] + 3, :], region[I[-1] - 3:, :]):
+                with horizontal(region[: I[0] + 3, :], region[I[-1] - 3 :, :]):
                     out_f = 0.5 * (in_f + in_f[0, 1, 0])
 
         parse_definition(


### PR DESCRIPTION
## Description

This PR corrects an issue with horizontal regions where multiple computation blocks have the same vertical interval but different horizontal intervals that results in the overlapping intervals exception being thrown when parsing the frontend code. The correction is to check whether overlapping vertical intervals are NOT equal AND overlapping.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
