### PR TITLE
Use Numpy C struct to avoid copies & transform when indexing memory

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,7 @@ Authors
 * Cruz, Felipe. ETH Zurich - CSCS
 * Dahm, Johann. Vulcan Inc.
 * Davis, Eddie. Vulcan Inc.
+* Deconinck, Florian. Vulcan Inc.
 * Ehrengruber, Till. ETH Zurich - CSCS
 * George, Rhea. Vulcan Inc.
 * González Paredes, Enrique. ETH Zurich - CSCS

--- a/setup.cfg
+++ b/setup.cfg
@@ -183,7 +183,7 @@ lines_after_imports = 2
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = eve,gtc,gt4py,__externals__,__gtscript__
-known_third_party = attr,black,boltons,cached_property,click,dace,dawn4py,devtools,factory,hypothesis,jinja2,mako,networkx,numpy,packaging,pkg_resources,pybind11,pydantic,pytest,pytest_factoryboy,setuptools,tabulate,tests,typing_extensions,typing_inspect,xxhash
+known_third_party = attr,black,boltons,cached_property,click,dace,dawn4py,devtools,factory,hypothesis,jinja2,mako,networkx,numpy,packaging,pkg_resources,pybind11,pydantic,pytest,pytest_factoryboy,setuptools,tabulate,typing_extensions,typing_inspect,xxhash
 
 #-- mypy --
 [mypy]

--- a/src/gt4py/backend/module_generator.py
+++ b/src/gt4py/backend/module_generator.py
@@ -472,9 +472,11 @@ class PyExtModuleGenerator(BaseModuleGenerator):
         api_fields = set(field.name for field in definition_ir.api_fields)
         for arg in definition_ir.api_signature:
             if arg.name not in self.args_data.unreferenced:
-                args.append(arg.name)
                 if arg.name in api_fields:
+                    args.append(f"{arg.name}.__array_struct__")
                     args.append("list(_origin_['{}'])".format(arg.name))
+                else:
+                    args.append(f"{arg.name}")
 
         # only generate implementation if any multi_stages are present. e.g. if no statement in the
         # stencil has any effect on the API fields, this may not be the case since they could be

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 import pybind11
 import setuptools
 from setuptools.command.build_ext import build_ext
+import numpy as np
 
 from gt4py import config as gt_config
 
@@ -48,7 +49,7 @@ def get_gt_pyext_build_opts(
     gt_version: int = 1,
 ) -> Dict[str, Union[str, List[str], Dict[str, Any]]]:
 
-    include_dirs = [gt_config.build_settings["boost_include_path"]]
+    include_dirs = [gt_config.build_settings["boost_include_path"], np.get_include()]
     extra_compile_args_from_config = gt_config.build_settings["extra_compile_args"]
 
     if uses_cuda:
@@ -86,6 +87,7 @@ def get_gt_pyext_build_opts(
             "-isystem{}".format(gt_config.build_settings["boost_include_path"]),
             "-isystem{}".format(os.path.dirname(dace.__file__) + "/runtime/include/"),
             "-DBOOST_PP_VARIADICS",
+            "-DNPY_NO_DEPRECATED_API",
             *extra_compile_args_from_config["cxx"],
         ],
         nvcc=[
@@ -101,6 +103,7 @@ def get_gt_pyext_build_opts(
             "-fvisibility=hidden",
             "--compiler-options",
             "-fPIC",
+            "-DNPY_NO_DEPRECATED_API",
             *extra_compile_args_from_config["nvcc"],
         ],
     )

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -23,10 +23,10 @@ import os
 import shutil
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
+import numpy as np
 import pybind11
 import setuptools
 from setuptools.command.build_ext import build_ext
-import numpy as np
 
 from gt4py import config as gt_config
 

--- a/src/gt4py/backend/templates/bindings.cpp.in
+++ b/src/gt4py/backend/templates/bindings.cpp.in
@@ -32,25 +32,13 @@
 #include <vector>
 #include <chrono>
 
+#include "numpy/ndarraytypes.h"
+
 namespace py = ::pybind11;
 
 static constexpr int MAX_DIM = 3;
 
 namespace {
-
-// Per Numpy C struct
-// https://numpy.org/doc/stable/reference/c-api/types-and-structures.html#pyarray-type-and-pyarrayobject
-typedef struct {
-    int two;
-    int nd;
-    char typekind;
-    int itemsize;
-    int flags;
-    int64_t *shape;
-    int64_t *strides;
-    void *data;
-    PyObject *descr;
-} PyArrayInterface;
 
 BufferInfo make_buffer_info(const py::capsule& buffer_as_capsule) {
     PyArrayInterface* b = buffer_as_capsule.cast<py::capsule>();

--- a/src/gt4py/backend/templates/bindings.cpp.in
+++ b/src/gt4py/backend/templates/bindings.cpp.in
@@ -38,43 +38,23 @@ static constexpr int MAX_DIM = 3;
 
 namespace {
 
-BufferInfo make_buffer_info(py::object& b) {
-{%- if gt_backend == "cuda" %}
-    py_size_t ndim = static_cast<py_size_t>(b.attr("ndim").cast<int>());
-//    auto shape_tuple = b.attr("shape").cast<std::tuple<int, int, int>>();
-//    std::vector<py_size_t> shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple), std::get<2>(shape_tuple)};
-//    auto strides_tuple = b.attr("strides").cast<std::tuple<int, int, int>>();
-//    std::vector<py_size_t> strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple), std::get<2>(strides_tuple)};
-//    void* ptr =  reinterpret_cast<void*>(b.attr("data").attr("ptr").cast<std::size_t>());
-    py::dict __cuda_array_interface__ = b.attr("__cuda_array_interface__").cast<py::dict>();
-    std::vector<py_size_t> shape;
-    std::vector<py_size_t> strides;
-    if(ndim == 1) {
-        auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int>>();
-        shape = {std::get<0>(shape_tuple)};
-        auto strides_tuple = __cuda_array_interface__["strides"].cast<std::tuple<int>>();
-        strides = {std::get<0>(strides_tuple)};
-    } else if(ndim == 2) {
-        auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int, int>>();
-        shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple)};
-        auto strides_tuple = __cuda_array_interface__["strides"].cast<std::tuple<int, int>>();
-        strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple)};
-    } else {
-        auto shape_tuple =  __cuda_array_interface__["shape"].cast<std::tuple<int, int, int>>();
-        shape = {std::get<0>(shape_tuple), std::get<1>(shape_tuple), std::get<2>(shape_tuple)};
-        auto strides_tuple = __cuda_array_interface__["strides"].cast<std::tuple<int, int, int>>();
-        strides = {std::get<0>(strides_tuple), std::get<1>(strides_tuple), std::get<2>(strides_tuple)};
-    }
-    void* ptr =  reinterpret_cast<void*>(std::get<0>(__cuda_array_interface__["data"].cast<std::tuple<std::size_t, bool>>()));
-{%- else %}
-    auto buffer_info = static_cast<py::buffer&>(b).request();
-    py_size_t ndim = static_cast<py_size_t>(buffer_info.ndim);
-    std::vector<py_size_t>& shape = buffer_info.shape;
-    std::vector<py_size_t>& strides = buffer_info.strides;
-    void* ptr = static_cast<void*>(buffer_info.ptr);
-{%- endif %}
+// Per Numpy C struct
+// https://numpy.org/doc/stable/reference/c-api/types-and-structures.html#pyarray-type-and-pyarrayobject
+typedef struct {
+    int two;
+    int nd;
+    char typekind;
+    int itemsize;
+    int flags;
+    int64_t *shape;
+    int64_t *strides;
+    void *data;
+    PyObject *descr;
+} PyArrayInterface;
 
-    return BufferInfo{ndim, shape, strides, ptr};
+BufferInfo make_buffer_info(const py::capsule& buffer_as_capsule) {
+    PyArrayInterface* b = buffer_as_capsule.cast<py::capsule>();
+    return BufferInfo{b->nd, b->shape, b->strides, b->data};
 }
 
 void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
@@ -83,7 +63,7 @@ void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
 {%- for field in arg_fields -%}
 {%- if api_name == field.name -%}
                      {{- comma() }}
-                     py::object {{ field.name }}, const std::array<gt::uint_t, {{ field.naxes }}>& {{ field.name }}_origin
+                     const py::capsule& {{ field.name }}_capsule, const std::array<gt::uint_t, {{ field.naxes }}>& {{ field.name }}_origin
 {%- endif -%}
 {%- endfor -%}
 {%- for param in parameters -%}
@@ -101,7 +81,7 @@ void run_computation(const std::array<gt::uint_t, MAX_DIM>& domain,
     }
 
 {%- for field in arg_fields %}
-    auto bi_{{ field.name }} = make_buffer_info({{ field.name }});
+    auto bi_{{ field.name }} = make_buffer_info({{ field.name }}_capsule);
 {%- endfor %}
 
     {{ stencil_unique_name }}::run(domain,

--- a/src/gt4py/backend/templates/computation.hpp.in
+++ b/src/gt4py/backend/templates/computation.hpp.in
@@ -39,8 +39,8 @@ using py_size_t = std::intptr_t;
 
 struct BufferInfo {
     py_size_t ndim;
-    std::vector<py_size_t> shape;
-    std::vector<py_size_t> strides;
+    py_size_t* shape;
+    py_size_t* strides;
     void* ptr;
 };
 

--- a/tests/test_unittest/test_gtc_backend/test_defir_to_gtir.py
+++ b/tests/test_unittest/test_gtc_backend/test_defir_to_gtir.py
@@ -15,15 +15,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
-from tests.definition_setup import ijk_domain  # noqa: F401
-from tests.definition_setup import (
-    BlockStmt,
-    IterationOrder,
-    TAssign,
-    TComputationBlock,
-    TDefinition,
-    TFieldRef,
-)
 
 from gt4py.backend.gtc_backend.defir_to_gtir import DefIRToGTIR
 from gt4py.ir.nodes import (
@@ -37,6 +28,15 @@ from gt4py.ir.nodes import (
     ScalarLiteral,
 )
 from gtc import common, gtir
+from tests.definition_setup import ijk_domain  # noqa: F401
+from tests.definition_setup import (
+    BlockStmt,
+    IterationOrder,
+    TAssign,
+    TComputationBlock,
+    TDefinition,
+    TFieldRef,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Inquiries into python overhead for newer GPU lead to the discovery of an efficient way to collect memory information & ptr when doing the binding. Use `__array_interface__` on Numpy-like object is slower than passing down to C++ the `__array_struct__` which contains already all the information required. Because the computation has a lower lifetime than it's inputs, a ptr-copy only strategy can be used.

This PR addresses the legacy toolchain.

Changes:
* Change bindings.cpp.in
* Change module generation to pass down the __array_struct__ for fields.

Tested on `fv3core` `gtx86` and `gtcuda`

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added
