### PR TITLE
Horizontal regions frontend fix

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -984,10 +984,10 @@ class IRMaker(ast.NodeVisitor):
                             gt_ir.HorizontalIf(
                                 intervals=intervals_dict, body=gt_ir.BlockStmt(stmts=stmts)
                             )
+                            for intervals_dict in intervals_dicts
                         ]
                     ),
                 )
-                for intervals_dict in intervals_dicts
             ]
         else:
             results = [


### PR DESCRIPTION
## Description

Instead of returning a `List[gt_ir.ComputationBlock]` (one for each region at the top level), return a `gt_ir.ComputeBlock` with multiple `gt_ir.HorizontalIf` `Stmt`s.

