### PR TITLE
Minor refactor of gtir legacy extents

### DIFF
--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -296,6 +296,34 @@ class CartesianOffset(Node):
         return {"i": self.i, "j": self.j, "k": self.k}
 
 
+class IJExtent(LocNode):
+    i: Tuple[int, int]
+    j: Tuple[int, int]
+
+    @classmethod
+    def zero(cls) -> "IJExtent":
+        return cls(i=(0, 0), j=(0, 0))
+
+    @classmethod
+    def from_offset(cls, offset: CartesianOffset) -> "IJExtent":
+        return cls(i=(offset.i, offset.i), j=(offset.j, offset.j))
+
+    def union(*extents: "IJExtent") -> "IJExtent":
+        return IJExtent(
+            i=(min(e.i[0] for e in extents), max(e.i[1] for e in extents)),
+            j=(min(e.j[0] for e in extents), max(e.j[1] for e in extents)),
+        )
+
+    def __or__(self, other: "IJExtent") -> "IJExtent":
+        return self.union(other)
+
+    def __add__(self, other: "IJExtent") -> "IJExtent":
+        return IJExtent(
+            i=(self.i[0] + other.i[0], self.i[1] + other.i[1]),
+            j=(self.j[0] + other.j[0], self.j[1] + other.j[1]),
+        )
+
+
 class ScalarAccess(LocNode):
     name: SymbolRef
     kind = ExprKind.SCALAR

--- a/src/gtc/cuir/cuir.py
+++ b/src/gtc/cuir/cuir.py
@@ -135,29 +135,8 @@ class Temporary(Decl):
     pass
 
 
-class IJExtent(LocNode):
-    i: Tuple[int, int]
-    j: Tuple[int, int]
-
-    @classmethod
-    def zero(cls) -> "IJExtent":
-        return cls(i=(0, 0), j=(0, 0))
-
-    @classmethod
-    def from_offset(cls, offset: CartesianOffset) -> "IJExtent":
-        return cls(i=(offset.i, offset.i), j=(offset.j, offset.j))
-
-    def union(*extents: "IJExtent") -> "IJExtent":
-        return IJExtent(
-            i=(min(e.i[0] for e in extents), max(e.i[1] for e in extents)),
-            j=(min(e.j[0] for e in extents), max(e.j[1] for e in extents)),
-        )
-
-    def __add__(self, other: "IJExtent") -> "IJExtent":
-        return IJExtent(
-            i=(self.i[0] + other.i[0], self.i[1] + other.i[1]),
-            j=(self.j[0] + other.j[0], self.j[1] + other.j[1]),
-        )
+class IJExtent(common.IJExtent):
+    pass
 
 
 class KExtent(LocNode):

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -16,7 +16,7 @@ def _iter_assigns(node: gtir.Stencil) -> XIterator[gtir.ParAssignStmt]:
 
 
 def _ext_from_off(offset: gtir.CartesianOffset) -> common.IJExtent:
-    return common.IExtent(
+    return common.IJExtent(
         i=(min(offset.i, 0), max(offset.i, 0)), j=(min(offset.j, 0), max(offset.j, 0))
     )
 
@@ -36,7 +36,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
     def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> Dict[str, common.IJExtent]:
-        field_extents = {name: common.IJExtent.zeros() for name in _iter_field_names(node)}
+        field_extents = {name: common.IJExtent.zero() for name in _iter_field_names(node)}
         ctx = self.StencilContext()
         for field_if in node.iter_tree().if_isinstance(gtir.FieldIfStmt):
             self.visit(field_if, ctx=ctx)
@@ -52,7 +52,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         field_extents: Dict[str, common.IJExtent],
         **kwargs: Any,
     ) -> None:
-        left_extent = field_extents.setdefault(node.left.name, common.IJExtent.zeros())
+        left_extent = field_extents.setdefault(node.left.name, common.IJExtent.zero())
         pa_ctx = self.AssignContext(left_extent=left_extent)
         self.visit(
             ctx.assign_conditions.get(id(node), []),
@@ -81,7 +81,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         **kwargs: Any,
     ) -> None:
         pa_ctx.assign_extents.setdefault(
-            node.name, field_extents.setdefault(node.name, common.IJExtent.zeros())
+            node.name, field_extents.setdefault(node.name, common.IJExtent.zero())
         )
         pa_ctx.assign_extents[node.name] |= pa_ctx.left_extent + _ext_from_off(node.offset)
 

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Union
 from eve import NodeVisitor
 from eve.utils import XIterator
 from gt4py.definitions import Extent
-from gtc import gtir
+from gtc import common, gtir
 
 
 def _iter_field_names(node: Union[gtir.Stencil, gtir.ParAssignStmt]) -> XIterator[gtir.FieldAccess]:
@@ -15,27 +15,28 @@ def _iter_assigns(node: gtir.Stencil) -> XIterator[gtir.ParAssignStmt]:
     return node.iter_tree().if_isinstance(gtir.ParAssignStmt)
 
 
-def _ext_from_off(offset: gtir.CartesianOffset) -> Extent:
-    return Extent(
-        ((min(offset.i, 0), max(offset.i, 0)), (min(offset.j, 0), max(offset.j, 0)), (0, 0))
+def _ext_from_off(offset: gtir.CartesianOffset) -> common.IJExtent:
+    return common.IExtent(
+        i=(min(offset.i, 0), max(offset.i, 0)), j=(min(offset.j, 0), max(offset.j, 0))
     )
 
 
-FIELD_EXT_T = Dict[str, Extent]
+def _to_gt4py_extent(extent: common.IJExtent) -> Extent:
+    return Extent(extent.i, extent.j, (0, 0))
 
 
 class LegacyExtentsVisitor(NodeVisitor):
     @dataclass
     class AssignContext:
-        left_extent: Extent
-        assign_extents: FIELD_EXT_T = field(default_factory=dict)
+        left_extent: common.IJExtent
+        assign_extents: Dict[str, common.IJExtent] = field(default_factory=dict)
 
     @dataclass
     class StencilContext:
         assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
-    def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> FIELD_EXT_T:
-        field_extents = {name: Extent.zeros() for name in _iter_field_names(node)}
+    def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> Dict[str, common.IJExtent]:
+        field_extents = {name: common.IJExtent.zeros() for name in _iter_field_names(node)}
         ctx = self.StencilContext()
         for field_if in node.iter_tree().if_isinstance(gtir.FieldIfStmt):
             self.visit(field_if, ctx=ctx)
@@ -48,10 +49,10 @@ class LegacyExtentsVisitor(NodeVisitor):
         node: gtir.ParAssignStmt,
         *,
         ctx: StencilContext,
-        field_extents: FIELD_EXT_T,
+        field_extents: Dict[str, common.IJExtent],
         **kwargs: Any,
     ) -> None:
-        left_extent = field_extents.setdefault(node.left.name, Extent.zeros())
+        left_extent = field_extents.setdefault(node.left.name, common.IJExtent.zeros())
         pa_ctx = self.AssignContext(left_extent=left_extent)
         self.visit(
             ctx.assign_conditions.get(id(node), []),
@@ -75,15 +76,18 @@ class LegacyExtentsVisitor(NodeVisitor):
         self,
         node: gtir.FieldAccess,
         *,
-        field_extents: FIELD_EXT_T,
+        field_extents: Dict[str, common.IJExtent],
         pa_ctx: AssignContext,
         **kwargs: Any,
     ) -> None:
         pa_ctx.assign_extents.setdefault(
-            node.name, field_extents.setdefault(node.name, Extent.zeros())
+            node.name, field_extents.setdefault(node.name, common.IJExtent.zeros())
         )
         pa_ctx.assign_extents[node.name] |= pa_ctx.left_extent + _ext_from_off(node.offset)
 
 
-def compute_legacy_extents(node: gtir.Stencil) -> FIELD_EXT_T:
-    return LegacyExtentsVisitor().visit(node)
+def compute_legacy_extents(node: gtir.Stencil) -> Dict[str, Extent]:
+    return {
+        name: _to_gt4py_extent(extent)
+        for name, extent in LegacyExtentsVisitor().visit(node).items()
+    }

--- a/src/gtc/python/npir_gen.py
+++ b/src/gtc/python/npir_gen.py
@@ -15,12 +15,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import textwrap
-from typing import Any, Collection, Tuple, Union
+from typing import Any, Collection, Dict, Tuple, Union
 
 from eve.codegen import FormatTemplate, JinjaTemplate, TemplatedGenerator
 from gt4py.definitions import Extent
 from gtc import common
-from gtc.passes.gtir_legacy_extents import FIELD_EXT_T
 from gtc.python import npir
 
 
@@ -289,7 +288,7 @@ class NpirGen(TemplatedGenerator):
     )
 
     def visit_Computation(
-        self, node: npir.Computation, *, field_extents: FIELD_EXT_T, **kwargs: Any
+        self, node: npir.Computation, *, field_extents: Dict[str, Extent], **kwargs: Any
     ) -> Union[str, Collection[str]]:
         signature = ["*", *node.params, "_domain_", "_origin_"]
         kwargs["field_extents"] = field_extents


### PR DESCRIPTION
## Description

Move `IJExtent` into `common` and use in `gtir_legacy_extents`.

This is a precursor to some of the changes for horizontal regions.
