### PR TITLE
Support 'format_source' option in GTCpp and CUDA backends

### DIFF
--- a/src/gtc/cuir/cuir_codegen.py
+++ b/src/gtc/cuir/cuir_codegen.py
@@ -513,5 +513,7 @@ class CUIRCodegen(codegen.TemplatedGenerator):
         if not isinstance(root, cuir.Program):
             raise ValueError("apply() requires gtcpp.Progam root node")
         generated_code = super().apply(root, **kwargs)
-        formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
-        return formatted_code
+        if kwargs.get("format_source", True):
+            formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
+            generated_code = formatted_code
+        return generated_code

--- a/src/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gtc/gtcpp/gtcpp_codegen.py
@@ -249,5 +249,7 @@ class GTCppCodegen(codegen.TemplatedGenerator):
         if "gt_backend_t" not in kwargs:
             raise TypeError("apply() missing 1 required keyword-only argument: 'gt_backend_t'")
         generated_code = super().apply(root, offset_limit=_offset_limit(root), **kwargs)
-        formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
-        return formatted_code
+        if kwargs.get("format_source", True):
+            formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
+            generated_code = formatted_code
+        return generated_code


### PR DESCRIPTION
## Description

This PR modifies the `GTCpp` and `CUDA` backends to check whether the `format_source` backend option is `True` before applying `clang-format` to the generated code.

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
 

