### PR TITLE
Raise template depth for GTC backends

### DIFF
--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -79,7 +79,7 @@ def get_gt_pyext_build_opts(
     extra_compile_args = dict(
         cxx=[
             "-std=c++14",
-            "-ftemplate-depth=800",
+            "-ftemplate-depth=1024",
             "-fvisibility=hidden",
             "-fPIC",
             "-isystem{}".format(gt_include_path),
@@ -90,6 +90,7 @@ def get_gt_pyext_build_opts(
         ],
         nvcc=[
             "-std=c++14",
+            "-ftemplate-depth=1024",
             "-arch=sm_{}".format(cuda_arch),
             "-isystem={}".format(gt_include_path),
             "-isystem={}".format(gt_config.build_settings["boost_include_path"]),

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -79,7 +79,7 @@ def get_gt_pyext_build_opts(
     extra_compile_args = dict(
         cxx=[
             "-std=c++14",
-            "-ftemplate-depth=1024",
+            "-ftemplate-depth={}".format(gt_config.build_settings["cpp_template_depth"]),
             "-fvisibility=hidden",
             "-fPIC",
             "-isystem{}".format(gt_include_path),
@@ -90,7 +90,7 @@ def get_gt_pyext_build_opts(
         ],
         nvcc=[
             "-std=c++14",
-            "-ftemplate-depth=1024",
+            "-ftemplate-depth={}".format(gt_config.build_settings["cpp_template_depth"]),
             "-arch=sm_{}".format(cuda_arch),
             "-isystem={}".format(gt_include_path),
             "-isystem={}".format(gt_config.build_settings["boost_include_path"]),

--- a/src/gt4py/config.py
+++ b/src/gt4py/config.py
@@ -42,6 +42,8 @@ GT2_INCLUDE_PATH: str = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "_external_src", GT2_REPO_DIRNAME, "include")
 )
 
+GT_CPP_TEMPLATE_DEPTH: int = 1024
+
 # Settings dict
 build_settings: Dict[str, Any] = {
     "boost_include_path": os.path.join(BOOST_ROOT, "include"),
@@ -63,6 +65,7 @@ build_settings: Dict[str, Any] = {
     },
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),
+    "cpp_template_depth": os.environ.get("GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH),
 }
 
 cache_settings: Dict[str, Any] = {


### PR DESCRIPTION
## Description

Augment template depth specialization for NVCC. fv3 model requires it for the newer GTC backends.

## Requirements

Before submitting this PR, please make sure:

- [x] The code builds cleanly without new errors or warnings
- [x] The code passes all the existing tests
- [x] If this PR adds a new feature, new tests have been added to test these
new features
- [x] All relevant documentation has been updated or added


