### PR TITLE
Minor performance improvements in eve classes

### DIFF
--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -54,7 +54,6 @@ from .typingx import (
     Tuple,
     TypeVar,
     Union,
-    cast,
 )
 from .visitors import NodeVisitor
 
@@ -660,7 +659,7 @@ class TemplatedGenerator(NodeVisitor):
             String (or collection of strings) with the dumped version of the root IR node.
 
         """
-        return cast(Union[str, Collection[str]], cls().visit(root, **kwargs))
+        return cls().visit(root, **kwargs)  # 33type: ignore
 
     @classmethod
     def generic_dump(cls, node: TreeNode, **kwargs: Any) -> str:
@@ -671,12 +670,11 @@ class TemplatedGenerator(NodeVisitor):
         return str(node)
 
     def generic_visit(self, node: TreeNode, **kwargs: Any) -> Union[str, Collection[str]]:
-        result: Union[str, Collection[str]] = ""
         if isinstance(node, Node):
             template, key = self.get_template(node)
             if template:
                 try:
-                    result = self.render_template(
+                    return self.render_template(
                         template,
                         node,
                         self.transform_children(node, **kwargs),
@@ -692,16 +690,14 @@ class TemplatedGenerator(NodeVisitor):
                         node=node,
                     ) from e.__cause__
 
-        elif isinstance(
-            node, (collections.abc.Sequence, collections.abc.Set)
-        ) and utils.is_collection(node):
-            result = [self.visit(value, **kwargs) for value in node]
-        elif isinstance(node, collections.abc.Mapping):
-            result = {key: self.visit(value, **kwargs) for key, value in node.items()}
-        else:
-            result = self.generic_dump(node, **kwargs)
+        elif isinstance(node, (list, tuple, set, collections.abc.Set)) or (
+            isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes))
+        ):
+            return [self.visit(value, **kwargs) for value in node]
+        elif isinstance(node, (dict, collections.abc.Mapping)):
+            return {key: self.visit(value, **kwargs) for key, value in node.items()}
 
-        return result
+        return self.generic_dump(node, **kwargs)
 
     def get_template(self, node: TreeNode) -> Tuple[Optional[Template], Optional[str]]:
         """Get a template for a node instance (see class documentation)."""

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -690,7 +690,7 @@ class TemplatedGenerator(NodeVisitor):
                         node=node,
                     ) from e.__cause__
 
-        elif isinstance(node, (list, tuple, set, collections.abc.Set)) or (
+        elif isinstance(node, (list, tuple, collections.abc.Set)) or (
             isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes))
         ):
             return [self.visit(value, **kwargs) for value in node]

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -659,7 +659,7 @@ class TemplatedGenerator(NodeVisitor):
             String (or collection of strings) with the dumped version of the root IR node.
 
         """
-        return cls().visit(root, **kwargs)  # 33type: ignore
+        return cls().visit(root, **kwargs)
 
     @classmethod
     def generic_dump(cls, node: TreeNode, **kwargs: Any) -> str:

--- a/src/eve/iterators.py
+++ b/src/eve/iterators.py
@@ -55,7 +55,7 @@ def generic_iter_children(
         isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes))
     ):
         return enumerate(node) if with_keys else iter(node)
-    elif isinstance(node, (set, frozenset, collections.abc.Set)):
+    elif isinstance(node, (set, collections.abc.Set)):
         return zip(node, node) if with_keys else iter(node)  # type: ignore  # problems with iter(Set)
     elif isinstance(node, (dict, collections.abc.Mapping)):
         return node.items() if with_keys else node.values()

--- a/src/eve/iterators.py
+++ b/src/eve/iterators.py
@@ -49,17 +49,17 @@ def generic_iter_children(
             Defaults to `False`.
 
     """
-    children_iterator: Iterable[Union[Any, Tuple[KeyValue, Any]]] = iter(())
-    if isinstance(node, concepts.Node):
-        children_iterator = node.iter_children() if with_keys else node.iter_children_values()
-    elif isinstance(node, collections.abc.Sequence) and utils.is_collection(node):
-        children_iterator = enumerate(node) if with_keys else iter(node)
-    elif isinstance(node, collections.abc.Set):
-        children_iterator = zip(node, node) if with_keys else iter(node)  # type: ignore  # problems with iter(Set)
-    elif isinstance(node, collections.abc.Mapping):
-        children_iterator = node.items() if with_keys else node.values()
 
-    return children_iterator
+    if isinstance(node, concepts.Node):
+        return node.iter_children() if with_keys else node.iter_children_values()
+    elif isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes)):
+        return enumerate(node) if with_keys else iter(node)
+    elif isinstance(node, collections.abc.Set):
+        return zip(node, node) if with_keys else iter(node)  # type: ignore  # problems with iter(Set)
+    elif isinstance(node, collections.abc.Mapping):
+        return node.items() if with_keys else node.values()
+
+    return iter(())
 
 
 class TraversalOrder(Enum):
@@ -68,8 +68,7 @@ class TraversalOrder(Enum):
     LEVELS_ORDER = "levels"
 
 
-@utils.as_xiter
-def iter_tree_pre(
+def _iter_tree_pre(
     node: concepts.TreeNode, *, with_keys: bool = False, __key__: Optional[Any] = None
 ) -> Generator[TreeIterationItem, None, None]:
     """Create a pre-order tree traversal iterator (Depth-First Search).
@@ -83,15 +82,14 @@ def iter_tree_pre(
     if with_keys:
         yield __key__, node
         for key, child in generic_iter_children(node, with_keys=True):
-            yield from iter_tree_pre(child, with_keys=True, __key__=key)
+            yield from _iter_tree_pre(child, with_keys=True, __key__=key)
     else:
         yield node
         for child in generic_iter_children(node, with_keys=False):
-            yield from iter_tree_pre(child, with_keys=False)
+            yield from _iter_tree_pre(child, with_keys=False)
 
 
-@utils.as_xiter
-def iter_tree_post(
+def _iter_tree_post(
     node: concepts.TreeNode, *, with_keys: bool = False, __key__: Optional[Any] = None
 ) -> Generator[TreeIterationItem, None, None]:
     """Create a post-order tree traversal iterator (Depth-First Search).
@@ -104,16 +102,15 @@ def iter_tree_post(
     """
     if with_keys:
         for key, child in generic_iter_children(node, with_keys=True):
-            yield from iter_tree_post(child, with_keys=True, __key__=key)
+            yield from _iter_tree_post(child, with_keys=True, __key__=key)
         yield __key__, node
     else:
         for child in generic_iter_children(node, with_keys=False):
-            yield from iter_tree_post(child, with_keys=False)
+            yield from _iter_tree_post(child, with_keys=False)
         yield node
 
 
-@utils.as_xiter
-def iter_tree_levels(
+def _iter_tree_levels(
     node: concepts.TreeNode,
     *,
     with_keys: bool = False,
@@ -134,13 +131,18 @@ def iter_tree_levels(
         __queue__.extend(generic_iter_children(node, with_keys=True))
         if __queue__:
             key, child = __queue__.pop(0)
-            yield from iter_tree_levels(child, with_keys=True, __key__=key, __queue__=__queue__)
+            yield from _iter_tree_levels(child, with_keys=True, __key__=key, __queue__=__queue__)
     else:
         yield node
         __queue__.extend(generic_iter_children(node, with_keys=False))
         if __queue__:
             child = __queue__.pop(0)
-            yield from iter_tree_levels(child, with_keys=False, __queue__=__queue__)
+            yield from _iter_tree_levels(child, with_keys=False, __queue__=__queue__)
+
+
+iter_tree_pre = utils.as_xiter(_iter_tree_pre)
+iter_tree_post = utils.as_xiter(_iter_tree_post)
+iter_tree_levels = utils.as_xiter(_iter_tree_levels)
 
 
 def iter_tree(
@@ -148,7 +150,7 @@ def iter_tree(
     traversal_order: TraversalOrder = TraversalOrder.PRE_ORDER,
     *,
     with_keys: bool = False,
-) -> utils.XIterator[TreeIterationItem]:
+) -> utils.XIterable[TreeIterationItem]:
     """Create a tree traversal iterator.
 
     Args:
@@ -159,8 +161,12 @@ def iter_tree(
             Defaults to `False`.
 
     """
-    assert isinstance(traversal_order, TraversalOrder)
-    iterator = globals()[f"iter_tree_{traversal_order.value}"](node=node, with_keys=with_keys)
-    assert isinstance(iterator, utils.XIterator)
 
-    return iterator
+    if traversal_order is traversal_order.PRE_ORDER:
+        return iter_tree_pre(node=node, with_keys=with_keys)
+    elif traversal_order is traversal_order.POST_ORDER:
+        return iter_tree_post(node=node, with_keys=with_keys)
+    elif traversal_order is traversal_order.LEVELS_ORDER:
+        return iter_tree_levels(node=node, with_keys=with_keys)
+    else:
+        raise ValueError(f"Invalid '{traversal_order}' traversal order.")

--- a/src/eve/iterators.py
+++ b/src/eve/iterators.py
@@ -52,11 +52,13 @@ def generic_iter_children(
 
     if isinstance(node, concepts.Node):
         return node.iter_children() if with_keys else node.iter_children_values()
-    elif isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes)):
+    elif isinstance(node, (list, tuple)) or (
+        isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes))
+    ):
         return enumerate(node) if with_keys else iter(node)
-    elif isinstance(node, collections.abc.Set):
+    elif isinstance(node, (set, frozenset, collections.abc.Set)):
         return zip(node, node) if with_keys else iter(node)  # type: ignore  # problems with iter(Set)
-    elif isinstance(node, collections.abc.Mapping):
+    elif isinstance(node, (dict, collections.abc.Mapping)):
         return node.items() if with_keys else node.values()
 
     return iter(())

--- a/src/eve/iterators.py
+++ b/src/eve/iterators.py
@@ -49,7 +49,6 @@ def generic_iter_children(
             Defaults to `False`.
 
     """
-
     if isinstance(node, concepts.Node):
         return node.iter_children() if with_keys else node.iter_children_values()
     elif isinstance(node, (list, tuple)) or (
@@ -163,7 +162,6 @@ def iter_tree(
             Defaults to `False`.
 
     """
-
     if traversal_order is traversal_order.PRE_ORDER:
         return iter_tree_pre(node=node, with_keys=with_keys)
     elif traversal_order is traversal_order.POST_ORDER:

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -27,7 +27,6 @@ import itertools
 import operator
 import pickle
 import re
-import sys
 import types
 import typing
 import uuid
@@ -76,12 +75,6 @@ except ModuleNotFoundError:
 
 
 T = TypeVar("T")
-
-
-if sys.version_info[:3] <= (3, 9, 0):
-    GenericIterable = typing.Iterable[T]
-else:
-    GenericIterable = collections.abc.Iterable  # type: ignore[misc]
 
 
 def isinstancechecker(type_info: Union[Type, Iterable[Type]]) -> Callable[[Any], bool]:
@@ -528,7 +521,7 @@ def as_xiter(iterator_func: Callable[..., Iterator[T]]) -> Callable[..., XIterab
 xenumerate = as_xiter(enumerate)
 
 
-class XIterable(GenericIterable[T]):
+class XIterable(Iterable[T]):
     """Iterable wrapper supporting method chaining for extra functionality."""
 
     iterator: Iterator[T]

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -27,6 +27,7 @@ import itertools
 import operator
 import pickle
 import re
+import sys
 import types
 import typing
 import uuid
@@ -74,6 +75,16 @@ except ModuleNotFoundError:
     import toolz  # noqa: F401  # imported but unused
 
 T = TypeVar("T")
+
+
+if sys.version_info[:3] <= (3, 9, 0):
+
+    class GenericIterable(collections.abc.Iterable, Iterable[T]):  # type: ignore
+        ...
+
+
+else:
+    GenericIterable = collections.abc.Iterable  # type: ignore
 
 
 def isinstancechecker(type_info: Union[Type, Iterable[Type]]) -> Callable[[Any], bool]:
@@ -520,7 +531,7 @@ def as_xiter(iterator_func: Callable[..., Iterator[T]]) -> Callable[..., XIterab
 xenumerate = as_xiter(enumerate)
 
 
-class XIterable(collections.abc.Iterable, Iterable[T]):
+class XIterable(GenericIterable[T]):
     """Iterable wrapper supporting method chaining for extra functionality."""
 
     iterator: Iterator[T]

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -74,17 +74,14 @@ except ModuleNotFoundError:
     # Fall back to pure Python toolz
     import toolz  # noqa: F401  # imported but unused
 
+
 T = TypeVar("T")
 
 
 if sys.version_info[:3] <= (3, 9, 0):
-
-    class GenericIterable(collections.abc.Iterable, Iterable[T]):  # type: ignore
-        ...
-
-
+    GenericIterable = typing.Iterable[T]
 else:
-    GenericIterable = collections.abc.Iterable  # type: ignore
+    GenericIterable = collections.abc.Iterable  # type: ignore[misc]
 
 
 def isinstancechecker(type_info: Union[Type, Iterable[Type]]) -> Callable[[Any], bool]:

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -507,40 +507,26 @@ S = TypeVar("S")
 K = TypeVar("K")
 
 
-def as_xiter(iterator_func: Callable[..., Iterator[T]]) -> Callable[..., XIterator[T]]:
-    """Wrap the provided callable to convert its output in a :class:`XIterator`."""
+def as_xiter(iterator_func: Callable[..., Iterator[T]]) -> Callable[..., XIterable[T]]:
+    """Wrap the provided callable to convert its output in a :class:`XIterable`."""
 
     @functools.wraps(iterator_func)
-    def _xiterator(*args: Any, **keywords: Any) -> XIterator[T]:
+    def _xiterator(*args: Any, **keywords: Any) -> XIterable[T]:
         return xiter(iterator_func(*args, **keywords))
 
     return _xiterator
 
 
-def xiter(iterable: Iterable[T]) -> XIterator[T]:
-    """Create an XIterator from any iterable (like ``iter()``)."""
-    if isinstance(iterable, collections.abc.Iterator):
-        it = iterable
-    elif isinstance(iterable, collections.abc.Iterable):
-        it = iter(iterable)
-    else:
-        raise TypeError(f"Invalid iterable instance: '{iterable}'.")
-
-    return XIterator(it)
-
-
 xenumerate = as_xiter(enumerate)
 
 
-class XIterator(collections.abc.Iterator, Iterable[T]):
-    """Iterator wrapper supporting method chaining for extra functionality."""
+class XIterable(collections.abc.Iterable, Iterable[T]):
+    """Iterable wrapper supporting method chaining for extra functionality."""
 
     iterator: Iterator[T]
 
     def __init__(self, it: Union[Iterable[T], Iterator[T]]) -> None:
-        if not isinstance(it, collections.abc.Iterator):
-            raise TypeError(f"Invalid iterator instance: '{it}'.")
-        object.__setattr__(self, "iterator", it.iterator if isinstance(it, XIterator) else it)
+        object.__setattr__(self, "iterator", iter(it))
 
     def __getattr__(self, name: str) -> Any:
         # Forward special methods to wrapped iterator
@@ -551,10 +537,10 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
     def __setattr__(self, name: str, value: Any) -> None:
         raise TypeError(f"{type(self).__name__} is immutable.")
 
-    def __next__(self) -> T:
-        return next(self.iterator)
+    def __iter__(self) -> Iterator[T]:
+        return self.iterator
 
-    def map(self, func: AnyCallable) -> XIterator[Any]:  # noqa  # A003: shadowing a python builtin
+    def map(self, func: AnyCallable) -> XIterable[Any]:  # noqa  # A003: shadowing a python builtin
         """Apply a callable to every iterator element.
 
         Equivalent to ``map(func, self)``.
@@ -592,11 +578,11 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         """
         if not callable(func):
             raise ValueError(f"Invalid function or callable: '{func}'.")
-        return XIterator(map(func, self.iterator))
+        return XIterable(map(func, self.iterator))
 
     def filter(  # noqa  # A003: shadowing a python builtin
         self, func: Callable[..., bool]
-    ) -> XIterator[T]:
+    ) -> XIterable[T]:
         """Filter elements with callables.
 
         Equivalent to ``filter(func, self)``.
@@ -619,9 +605,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         """
         if not callable(func):
             raise TypeError(f"Invalid function or callable: '{func}'.")
-        return XIterator(filter(func, self.iterator))
+        return XIterable(filter(func, self.iterator))
 
-    def if_isinstance(self, *types: Type) -> XIterator[T]:
+    def if_isinstance(self, *types: Type) -> XIterable[T]:
         """Filter elements using :func:`isinstance` checks.
 
         Equivalent to ``xiter(item for item in self if isinstance(item, types))``.
@@ -632,9 +618,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [1, 3.3]
 
         """
-        return XIterator(filter(isinstancechecker([*types]), self.iterator))
+        return XIterable(filter(isinstancechecker([*types]), self.iterator))
 
-    def if_not_isinstance(self, *types: Type) -> XIterator[T]:
+    def if_not_isinstance(self, *types: Type) -> XIterable[T]:
         """Filter elements using negated :func:`isinstance` checks.
 
         Equivalent to ``xiter(item for item in self if not isinstance(item, types))``.
@@ -645,11 +631,11 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             ['2', [4, 5], {6, 7}]
 
         """
-        return XIterator(
+        return XIterable(
             filter(toolz.functoolz.complement(isinstancechecker([*types])), self.iterator)
         )
 
-    def if_is(self, obj: Any) -> XIterator[T]:
+    def if_is(self, obj: Any) -> XIterable[T]:
         """Filter elements using :func:`operator.is_` checks.
 
         Equivalent to ``xiter(item for item in self if item is obj)``.
@@ -668,9 +654,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             []
 
         """
-        return XIterator(filter(lambda x: operator.is_(x, obj), self.iterator))
+        return XIterable(filter(lambda x: operator.is_(x, obj), self.iterator))
 
-    def if_is_not(self, obj: Any) -> XIterator[T]:
+    def if_is_not(self, obj: Any) -> XIterable[T]:
         """Filter elements using negated  :func:`operator.is_` checks.
 
         Equivalent to ``xiter(item for item in self if item is not obj)``.
@@ -689,9 +675,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [1, None, 1, 123456789, None, 123456789]
 
         """
-        return XIterator(filter(lambda x: not operator.is_(x, obj), self.iterator))
+        return XIterable(filter(lambda x: not operator.is_(x, obj), self.iterator))
 
-    def if_in(self, collection: Collection[T]) -> XIterator[T]:
+    def if_in(self, collection: Collection[T]) -> XIterable[T]:
         """Filter elements using :func:`operator.contains` checks.
 
         Equivalent to ``xiter(item for item in self if item in collection)``.
@@ -702,9 +688,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [0, 2, 4, 6]
 
         """
-        return XIterator(filter(lambda x: operator.contains(collection, x), self.iterator))
+        return XIterable(filter(lambda x: operator.contains(collection, x), self.iterator))
 
-    def if_not_in(self, collection: Collection[T]) -> XIterator[T]:
+    def if_not_in(self, collection: Collection[T]) -> XIterable[T]:
         """Filter elements using negated :func:`operator.contains` checks.
 
         Equivalent to ``xiter(item for item in self if item not in collection)``.
@@ -715,9 +701,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [1, 3, 5, 7]
 
         """
-        return XIterator(filter(lambda x: not operator.contains(collection, x), self.iterator))
+        return XIterable(filter(lambda x: not operator.contains(collection, x), self.iterator))
 
-    def if_contains(self, *values: Any) -> XIterator[T]:
+    def if_contains(self, *values: Any) -> XIterable[T]:
         """Filter elements using :func:`operator.contains` checks.
 
         Equivalent to ``xiter(item for item in self if all(v in item for v in values))``.
@@ -739,9 +725,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             except Exception:
                 return False
 
-        return XIterator(filter((lambda x: _contains(x, values)), self.iterator))
+        return XIterable(filter((lambda x: _contains(x, values)), self.iterator))
 
-    def if_hasattr(self, *names: str) -> XIterator[T]:
+    def if_hasattr(self, *names: str) -> XIterable[T]:
         """Filter elements using :func:`hasattr` checks.
 
         Equivalent to ``filter(attrchecker(names), self)``.
@@ -756,11 +742,11 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             ['2', [4, 5]]
 
         """
-        return XIterator(filter(attrchecker(*names), self.iterator))
+        return XIterable(filter(attrchecker(*names), self.iterator))
 
     def getattr(  # noqa  # A003: shadowing a python builtin
         self, *names: str, default: Any = NOTHING
-    ) -> XIterator[Any]:
+    ) -> XIterable[Any]:
         """Get provided attributes from each item in a sequence.
 
         Equivalent to ``map(attrgetter_(*names, default=default), self)``.
@@ -783,9 +769,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [(1.0, None), (2.0, None), (3.0, None)]
 
         """
-        return XIterator(map(attrgetter_(*names, default=default), self.iterator))
+        return XIterable(map(attrgetter_(*names, default=default), self.iterator))
 
-    def getitem(self, *indices: Union[int, str], default: Any = NOTHING) -> XIterator[Any]:
+    def getitem(self, *indices: Union[int, str], default: Any = NOTHING) -> XIterable[Any]:
         """Get provided indices data from each item in a sequence.
 
         Equivalent to ``toolz.itertoolz.pluck(indices, self)``.
@@ -816,11 +802,11 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         else:
             ind = [*indices]
         if default is NOTHING:
-            return XIterator(toolz.itertoolz.pluck(ind, self.iterator))
+            return XIterable(toolz.itertoolz.pluck(ind, self.iterator))
         else:
-            return XIterator(toolz.itertoolz.pluck(ind, self.iterator, default))
+            return XIterable(toolz.itertoolz.pluck(ind, self.iterator, default))
 
-    def chain(self, *others: Iterable) -> XIterator[Union[T, S]]:
+    def chain(self, *others: Iterable) -> XIterable[Union[T, S]]:
         """Chain iterators.
 
         Equivalent to ``itertools.chain(self, *others)``.
@@ -837,15 +823,15 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [0, 1, 'a', 'b', 'A', 'B']
 
         """
-        iterators = [it.iterator if isinstance(it, XIterator) else it for it in others]
-        return XIterator(itertools.chain(self.iterator, *iterators))
+        iterators = [it.iterator if isinstance(it, XIterable) else it for it in others]
+        return XIterable(itertools.chain(self.iterator, *iterators))
 
     def diff(
         self,
         *others: Iterable,
         default: Any = NOTHING,
         key: Union[NOTHING, Callable] = NOTHING,
-    ) -> XIterator[Tuple[T, S]]:
+    ) -> XIterable[Tuple[T, S]]:
         """Diff iterators.
 
         Equivalent to ``toolz.itertoolz.diff(self, *others)``.
@@ -884,12 +870,12 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         if key is not NOTHING:
             kwargs["key"] = key
 
-        iterators = [it.iterator if isinstance(it, XIterator) else it for it in others]
-        return XIterator(toolz.itertoolz.diff(self.iterator, *iterators, **kwargs))
+        iterators = [it.iterator if isinstance(it, XIterable) else it for it in others]
+        return XIterable(toolz.itertoolz.diff(self.iterator, *iterators, **kwargs))
 
     def product(
         self, other: Union[Iterable[S], int]
-    ) -> Union[XIterator[Tuple[T, S]], XIterator[Tuple[T, T]]]:
+    ) -> Union[XIterable[Tuple[T, S]], XIterable[Tuple[T, T]]]:
         """Product of iterators.
 
         Equivalent to ``itertools.product(it_a, it_b)``.
@@ -913,15 +899,15 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
                 raise ValueError(
                     f"Only non-negative integer numbers are accepted (provided: {other})."
                 )
-            return XIterator(map(lambda item: tuple([item] * other), self.iterator))  # type: ignore  # mypy gets confused with `other`
+            return XIterable(map(lambda item: tuple([item] * other), self.iterator))  # type: ignore  # mypy gets confused with `other`
         else:
-            if not isinstance(other, XIterator):
+            if not isinstance(other, XIterable):
                 other = xiter(other)
-        return XIterator(itertools.product(self.iterator, other.iterator))
+        return XIterable(itertools.product(self.iterator, other.iterator))
 
     def partition(
         self, n: int, *, exact: bool = False, fill: Any = NOTHING
-    ) -> XIterator[Tuple[T, ...]]:
+    ) -> XIterable[Tuple[T, ...]]:
         """Partition iterator into tuples of length `n` (``exact=True``) or at most `n` (``exact=False``).
 
         Equivalent to ``toolz.itertoolz.partition(n, self)`` or
@@ -961,9 +947,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         else:
             iterator = toolz.itertoolz.partition_all(n, self.iterator)
 
-        return XIterator(iterator)
+        return XIterable(iterator)
 
-    def take_nth(self, n: int) -> XIterator[T]:
+    def take_nth(self, n: int) -> XIterable[T]:
         """Take every nth item in sequence.
 
         Equivalent to ``toolz.itertoolz.take_nth(n, self)``.
@@ -978,11 +964,11 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         """
         if not isinstance(n, int) or n < 1:
             raise ValueError(f"Only positive integer numbers are accepted (provided: {n}).")
-        return XIterator(toolz.itertoolz.take_nth(n, self.iterator))
+        return XIterable(toolz.itertoolz.take_nth(n, self.iterator))
 
     def zip(  # noqa  # A003: shadowing a python builtin
         self, *others: Iterable, fill: Any = NOTHING
-    ) -> XIterator[Tuple[T, S]]:
+    ) -> XIterable[Tuple[T, S]]:
         """Zip iterators.
 
         Equivalent to ``zip(self, *others)`` or ``itertools.zip_longest(self, *others, fillvalue=fill)``.
@@ -1007,13 +993,13 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [(0, 'a', 'A'), (1, 'b', 'B'), (2, 'c', 'C'), (3, None, None), (4, None, None)]
 
         """
-        iterators = [it.iterator if isinstance(it, XIterator) else it for it in others]
+        iterators = [it.iterator if isinstance(it, XIterable) else it for it in others]
         if fill is NOTHING:
-            return XIterator(zip(self.iterator, *iterators))
+            return XIterable(zip(self.iterator, *iterators))
         else:
-            return XIterator(itertools.zip_longest(self.iterator, *iterators, fillvalue=fill))
+            return XIterable(itertools.zip_longest(self.iterator, *iterators, fillvalue=fill))
 
-    def unzip(self) -> XIterator[Tuple[Any, ...]]:
+    def unzip(self) -> XIterable[Tuple[Any, ...]]:
         """Unzip iterator.
 
         Equivalent to ``zip(*self)``.
@@ -1026,19 +1012,19 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [('a', 'b', 'c'), (1, 2, 3)]
 
         """
-        return XIterator(zip(*self.iterator))  # type: ignore  # mypy gets confused with *args
+        return XIterable(zip(*self.iterator))  # type: ignore  # mypy gets confused with *args
 
     @typing.overload
-    def islice(self, __stop: int) -> XIterator[T]:
+    def islice(self, __stop: int) -> XIterable[T]:
         ...
 
     @typing.overload
-    def islice(self, __start: int, __stop: int, __step: int = 1) -> XIterator[T]:
+    def islice(self, __start: int, __stop: int, __step: int = 1) -> XIterable[T]:
         ...
 
     def islice(
         self, __start_or_stop: int, __stop_or_nothing: Union[int, NOTHING] = NOTHING, step: int = 1
-    ) -> XIterator[T]:
+    ) -> XIterable[T]:
         """Select elements from an iterable.
 
         Equivalent to ``itertools.islice(iterator, start, stop, step)``.
@@ -1065,9 +1051,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         else:
             start = __start_or_stop
             stop = __stop_or_nothing
-        return XIterator(itertools.islice(self.iterator, start, stop, step))
+        return XIterable(itertools.islice(self.iterator, start, stop, step))
 
-    def select(self, selectors: Iterable[bool]) -> XIterator[T]:
+    def select(self, selectors: Iterable[bool]) -> XIterable[T]:
         """Return only the elements which have a corresponding element in selectors that evaluates to True.
 
         Equivalent to ``itertools.compress(self, selectors)``.
@@ -1082,9 +1068,9 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         """
         if not isinstance(selectors, collections.abc.Iterable):
             raise TypeError(f"Non-iterable 'selectors' value: '{selectors}'.")
-        return XIterator(itertools.compress(self.iterator, selectors))
+        return XIterable(itertools.compress(self.iterator, selectors))
 
-    def unique(self, *, key: Union[NOTHING, Callable] = NOTHING) -> XIterator[T]:
+    def unique(self, *, key: Union[NOTHING, Callable] = NOTHING) -> XIterable[T]:
         """Return only unique elements of a sequence.
 
         Equivalent to ``toolz.itertoolz.unique(self)``.
@@ -1105,24 +1091,24 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
 
         """
         if key is NOTHING:
-            return XIterator(toolz.itertoolz.unique(self.iterator))
+            return XIterable(toolz.itertoolz.unique(self.iterator))
         else:
-            return XIterator(toolz.itertoolz.unique(self.iterator, key=key))
+            return XIterable(toolz.itertoolz.unique(self.iterator, key=key))
 
     @typing.overload
     def groupby(
         self, key: str, *other_keys: str, as_dict: bool = False
-    ) -> XIterator[Tuple[Any, List[T]]]:
+    ) -> XIterable[Tuple[Any, List[T]]]:
         ...
 
     @typing.overload
-    def groupby(self, key: List[Any], *, as_dict: bool = False) -> XIterator[Tuple[Any, List[T]]]:
+    def groupby(self, key: List[Any], *, as_dict: bool = False) -> XIterable[Tuple[Any, List[T]]]:
         ...
 
     @typing.overload
     def groupby(
         self, key: Callable[[T], Any], *, as_dict: bool = False
-    ) -> XIterator[Tuple[Any, List[T]]]:
+    ) -> XIterable[Tuple[Any, List[T]]]:
         ...
 
     def groupby(
@@ -1130,7 +1116,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         key: Union[str, List[Any], Callable[[T], Any]],
         *attr_keys: str,
         as_dict: bool = False,
-    ) -> Union[XIterator[Tuple[Any, List[T]]], Dict]:
+    ) -> Union[XIterable[Tuple[Any, List[T]]], Dict]:
         """Group a sequence by a given key.
 
         More or less equivalent to ``toolz.itertoolz.groupby(key, self)`` with some caveats.
@@ -1145,7 +1131,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
               for :func:`operator.itemgetter`.
 
         Keyword Arguments:
-            as_dict: if `True`, it will return the groups ``dict`` instead of a :class:`XIterator`
+            as_dict: if `True`, it will return the groups ``dict`` instead of a :class:`XIterable`
                 instance over `groups.items()`.
 
         For detailed information check :func:`toolz.itertoolz.groupby` reference.
@@ -1195,7 +1181,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
 
     def accumulate(
         self, func: Callable[[Any, T], Any] = operator.add, *, init: Any = None
-    ) -> XIterator:
+    ) -> XIterable:
         """Reduce an iterator using a callable.
 
         Equivalent to ``itertools.accumulate(self, func, init)``.
@@ -1219,7 +1205,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
             [-1, -1, -2, -6, -24]
 
         """
-        return XIterator(itertools.accumulate(self.iterator, func, initial=init))
+        return XIterable(itertools.accumulate(self.iterator, func, initial=init))
 
     def reduce(self, bin_op_func: Callable[[Any, T], Any], *, init: Any = None) -> Any:
         """Reduce an iterator using a callable.
@@ -1251,7 +1237,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         *,
         init: Union[S, NOTHING],
         as_dict: Literal[False],
-    ) -> XIterator[Tuple[str, S]]:
+    ) -> XIterable[Tuple[str, S]]:
         ...
 
     @typing.overload
@@ -1263,7 +1249,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         *attr_keys: str,
         init: Union[S, NOTHING],
         as_dict: Literal[False],
-    ) -> XIterator[Tuple[Tuple[str, ...], S]]:
+    ) -> XIterable[Tuple[Tuple[str, ...], S]]:
         ...
 
     @typing.overload
@@ -1297,7 +1283,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         *,
         init: Union[S, NOTHING],
         as_dict: Literal[False],
-    ) -> XIterator[Tuple[K, S]]:
+    ) -> XIterable[Tuple[K, S]]:
         ...
 
     @typing.overload
@@ -1319,7 +1305,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         *,
         init: Union[S, NOTHING],
         as_dict: Literal[False],
-    ) -> XIterator[Tuple[K, S]]:
+    ) -> XIterable[Tuple[K, S]]:
         ...
 
     @typing.overload
@@ -1341,11 +1327,11 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
         init: Union[S, NOTHING] = NOTHING,
         as_dict: bool = False,
     ) -> Union[
-        XIterator[Tuple[str, S]],
+        XIterable[Tuple[str, S]],
         Dict[str, S],
-        XIterator[Tuple[Tuple[str, ...], S]],
+        XIterable[Tuple[Tuple[str, ...], S]],
         Dict[Tuple[str, ...], S],
-        XIterator[Tuple[K, S]],
+        XIterable[Tuple[K, S]],
         Dict[K, S],
     ]:
         """Group a sequence by a given key and simultaneously perform a reduction inside the groups.
@@ -1364,7 +1350,7 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
 
         Keyword Arguments:
             init: initial value for the reduction.
-            as_dict: if `True`, it will return the groups ``dict`` instead of a :class:`XIterator`
+            as_dict: if `True`, it will return the groups ``dict`` instead of a :class:`XIterable`
                 instance over `groups.items()`.
 
         For detailed information check :func:`toolz.itertoolz.reduceby` reference.
@@ -1440,3 +1426,6 @@ class XIterator(collections.abc.Iterator, Iterable[T]):
 
         """
         return set(self.iterator)
+
+
+xiter = XIterable

--- a/src/eve/visitors.py
+++ b/src/eve/visitors.py
@@ -25,7 +25,7 @@ import copy
 import operator
 
 from . import concepts, iterators, utils
-from .concepts import NOTHING
+from .concepts import NOTHING, Node
 from .typingx import (
     Any,
     Callable,
@@ -114,30 +114,29 @@ class NodeVisitor:
 
     contexts: ClassVar[Optional[Tuple[ContextCallable, ...]]] = None
 
-    def _managed_visit(self, visitor: Callable, node: concepts.TreeNode, **kwargs: Any) -> Any:
-        with contextlib.ExitStack() as stack:
-            for ctx in self.contexts or []:
-                stack.enter_context(ctx(self, node, kwargs))
-
-            return visitor(node, **kwargs)
-
     def visit(self, node: concepts.TreeNode, **kwargs: Any) -> Any:
         visitor = self.generic_visit
 
         method_name = "visit_" + node.__class__.__name__
         if hasattr(self, method_name):
             visitor = getattr(self, method_name)
-        elif isinstance(node, concepts.Node):
+        elif isinstance(node, Node):
             for node_class in node.__class__.__mro__[1:]:
                 method_name = "visit_" + node_class.__name__
                 if hasattr(self, method_name):
                     visitor = getattr(self, method_name)
                     break
 
-                if node_class is concepts.Node:
+                if node_class is Node:
                     break
 
-        return self._managed_visit(visitor, node, **kwargs)
+        if ctxs := type(self).contexts:
+            with contextlib.ExitStack() as stack:
+                for ctx in ctxs:
+                    stack.enter_context(ctx(self, node, kwargs))
+                return visitor(node, **kwargs)
+        else:
+            return visitor(node, **kwargs)
 
     def generic_visit(self, node: concepts.TreeNode, **kwargs: Any) -> Any:
         for child in iterators.generic_iter_children(node):
@@ -171,33 +170,35 @@ class NodeTranslator(NodeVisitor):
     _memo_dict_: Dict[int, Any]
 
     def generic_visit(self, node: concepts.TreeNode, **kwargs: Any) -> Any:
-        result: Any = None
-        if isinstance(node, (concepts.Node, collections.abc.Collection)) and utils.is_collection(
-            node
+        if isinstance(node, Node):
+            return node.__class__(  # type: ignore
+                **{key: value for key, value in node.iter_impl_fields()},
+                **{
+                    key: processed_value
+                    for key, value in node.iter_children()
+                    if (processed_value := self.visit(value, **kwargs)) is not NOTHING
+                },
+            )
+
+        elif isinstance(node, (list, tuple, set, collections.abc.Set)) or (
+            isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes))
         ):
-            tmp_items: Collection[concepts.TreeNode] = []
-            if isinstance(node, concepts.Node):
-                tmp_items = {
-                    key: self.visit(value, **kwargs) for key, value in node.iter_children()
+            # Sequence or set: create a new container instance with the new values
+            return node.__class__(  # type: ignore
+                processed_value
+                for value in node
+                if (processed_value := self.visit(value, **kwargs)) is not NOTHING  # type: ignore[no-redef]
+            )
+
+        elif isinstance(node, (dict, collections.abc.Mapping)):
+            # Mapping: create a new mapping instance with the new values
+            return node.__class__(  # type: ignore[call-arg]
+                {
+                    key: processed_value
+                    for key, value in node.items()
+                    if (processed_value := self.visit(value, **kwargs)) is not NOTHING  # type: ignore[no-redef]
                 }
-                result = node.__class__(  # type: ignore
-                    **{key: value for key, value in node.iter_impl_fields()},
-                    **{key: value for key, value in tmp_items.items() if value is not NOTHING},
-                )
-
-            elif isinstance(node, (collections.abc.Sequence, collections.abc.Set)):
-                # Sequence or set: create a new container instance with the new values
-                tmp_items = [self.visit(value, **kwargs) for value in node]
-                result = node.__class__(  # type: ignore
-                    value for value in tmp_items if value is not NOTHING
-                )
-
-            elif isinstance(node, collections.abc.Mapping):
-                # Mapping: create a new mapping instance with the new values
-                tmp_items = {key: self.visit(value, **kwargs) for key, value in node.items()}
-                result = node.__class__(  # type: ignore
-                    {key: value for key, value in tmp_items.items() if value is not NOTHING}
-                )
+            )
 
         else:
             if not hasattr(self, "_memo_dict_"):

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -101,10 +101,11 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
             + ".py"
         )
         return {
-            computation_name: format_source(
-                "python",
-                NpirGen.apply(self.npir, field_extents=compute_legacy_extents(self.builder.gtir)),
-            ),
+            computation_name: NpirGen.apply(self.npir, field_extents=compute_legacy_extents(self.builder.gtir))
+            # computation_name: format_source(
+            #     "python",
+            #     NpirGen.apply(self.npir, field_extents=compute_legacy_extents(self.builder.gtir)),
+            # ),
         }
 
     def generate_bindings(self, language_name: str) -> Dict[str, Union[str, Dict]]:

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -101,11 +101,10 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
             + ".py"
         )
         return {
-            computation_name: NpirGen.apply(self.npir, field_extents=compute_legacy_extents(self.builder.gtir))
-            # computation_name: format_source(
-            #     "python",
-            #     NpirGen.apply(self.npir, field_extents=compute_legacy_extents(self.builder.gtir)),
-            # ),
+            computation_name: format_source(
+                "python",
+                NpirGen.apply(self.npir, field_extents=compute_legacy_extents(self.builder.gtir)),
+            ),
         }
 
     def generate_bindings(self, language_name: str) -> Dict[str, Union[str, Dict]]:

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -2,16 +2,16 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Union
 
 from eve import NodeVisitor
-from eve.utils import XIterator
+from eve.utils import XIterable
 from gt4py.definitions import Extent
 from gtc import gtir
 
 
-def _iter_field_names(node: Union[gtir.Stencil, gtir.ParAssignStmt]) -> XIterator[gtir.FieldAccess]:
+def _iter_field_names(node: Union[gtir.Stencil, gtir.ParAssignStmt]) -> XIterable[gtir.FieldAccess]:
     return node.iter_tree().if_isinstance(gtir.FieldDecl).getattr("name").unique()
 
 
-def _iter_assigns(node: gtir.Stencil) -> XIterator[gtir.ParAssignStmt]:
+def _iter_assigns(node: gtir.Stencil) -> XIterable[gtir.ParAssignStmt]:
     return node.iter_tree().if_isinstance(gtir.ParAssignStmt)
 
 

--- a/src/gtc/passes/oir_optimizations/pruning.py
+++ b/src/gtc/passes/oir_optimizations/pruning.py
@@ -23,7 +23,7 @@ from gtc import oir
 class NoFieldAccessPruning(NodeTranslator):
     def visit_HorizontalExecution(self, node: oir.HorizontalExecution) -> Any:
         try:
-            next(node.iter_tree().if_isinstance(oir.FieldAccess))
+            next(iter(node.iter_tree().if_isinstance(oir.FieldAccess)))
         except StopIteration:
             return NOTHING
         return node

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, List, Set, Tuple
 
 from eve import NodeVisitor
 from eve.concepts import TreeNode
-from eve.utils import XIterator, xiter
+from eve.utils import XIterable, xiter
 from gtc import oir
 
 
@@ -71,7 +71,7 @@ class AccessCollector(NodeVisitor):
         _ordered_accesses: List["Access"]
 
         @staticmethod
-        def _offset_dict(accesses: XIterator) -> Dict[str, Set[Tuple[int, int, int]]]:
+        def _offset_dict(accesses: XIterable) -> Dict[str, Set[Tuple[int, int, int]]]:
             return accesses.reduceby(
                 lambda acc, x: acc | {x.offset}, "field", init=set(), as_dict=True
             )

--- a/tests/eve_tests/unit_tests/test_utils.py
+++ b/tests/eve_tests/unit_tests/test_utils.py
@@ -24,7 +24,7 @@ import pydantic
 import pytest
 
 import eve.utils
-from eve.utils import XIterator
+from eve.utils import XIterable
 
 
 def test_getitem_():
@@ -259,11 +259,11 @@ def test_xiter():
     from eve.utils import xiter
 
     it = xiter(range(6))
-    assert isinstance(it, XIterator)
+    assert isinstance(it, XIterable)
     assert list(it) == [0, 1, 2, 3, 4, 5]
 
     it = xiter([0, 1, 2, 3, 4, 5])
-    assert isinstance(it, XIterator)
+    assert isinstance(it, XIterable)
     assert list(it) == [0, 1, 2, 3, 4, 5]
 
 


### PR DESCRIPTION
Minor improvements of eve infrastructure performance.

Main changes:

- Improve performance of eve several components by using concrete `isinstance()` checks for the most common cases.
- Rename `XIterator` to `XIterable` (in eve.utils) and improve performance by removing unnecessary checks and reducing the number of Python function calls.
- Improve performance of iterating fields and children of eve Nodes by reusing information computed at class creation time.
- Improve eve visitors performance by using assignment expressions to reduce the number of dict/list comprehensions.
