### PR TITLE
Use gridtools2 test headers

### DIFF
--- a/tests/reference_cpp_regression/build.py
+++ b/tests/reference_cpp_regression/build.py
@@ -34,7 +34,7 @@ assert gt_src_manager.has_gt_sources(2) or gt_src_manager.install_gt_sources(2)
 def compile_reference():
     current_dir = os.path.dirname(__file__)
     build_opts = pyext_builder.get_gt_pyext_build_opts()
-    build_opts["include_dirs"].extend([EXTERNAL_SRC_PATH, os.path.join(current_dir)])
+    build_opts["include_dirs"].extend([EXTERNAL_SRC_PATH, current_dir])
 
     build_opts.setdefault("extra_compile_args", [])
     build_opts["extra_compile_args"].append("-Wno-sign-compare")

--- a/tests/reference_cpp_regression/build.py
+++ b/tests/reference_cpp_regression/build.py
@@ -28,13 +28,13 @@ GT4PY_INSTALLATION_PATH = os.path.dirname(inspect.getabsfile(gt4py))
 EXTERNAL_SRC_PATH = os.path.join(GT4PY_INSTALLATION_PATH, "_external_src")
 
 
-assert gt_src_manager.has_gt_sources() or gt_src_manager.install_gt_sources()
+assert gt_src_manager.has_gt_sources(2) or gt_src_manager.install_gt_sources(2)
 
 
 def compile_reference():
     current_dir = os.path.dirname(__file__)
     build_opts = pyext_builder.get_gt_pyext_build_opts()
-    build_opts["include_dirs"].append(EXTERNAL_SRC_PATH)
+    build_opts["include_dirs"].extend([EXTERNAL_SRC_PATH, os.path.join(current_dir)])
 
     build_opts.setdefault("extra_compile_args", [])
     build_opts["extra_compile_args"].append("-Wno-sign-compare")

--- a/tests/reference_cpp_regression/horizontal_diffusion_repository.hpp
+++ b/tests/reference_cpp_regression/horizontal_diffusion_repository.hpp
@@ -1,0 +1,81 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <cmath>
+#include <functional>
+
+#include <gridtools/common/defs.hpp>
+
+namespace gridtools {
+    class horizontal_diffusion_repository {
+        using fun_t = std::function<double(int_t, int_t, int_t)>;
+        using j_fun_t = std::function<double(int_t)>;
+        uint_t m_d1, m_d2, m_d3;
+
+        double m_delta0 = (0.995156 - 0.994954) / (m_d2 - 1.);
+        double m_delta1 = (0.995143 - 0.994924) / (m_d2 - 1.);
+
+        j_fun_t m_crlat0 = [this](int_t j) { return 0.994954 + j * m_delta0; };
+        j_fun_t m_crlat1 = [this](int_t j) { return 0.994924 + j * m_delta1; };
+
+      public:
+        horizontal_diffusion_repository(uint_t d1, uint_t d2, uint_t d3) : m_d1(d1), m_d2(d2), m_d3(d3) {}
+
+        fun_t in = [this](int_t i, int_t j, int_t) {
+            const double PI = std::atan(1.) * 4.;
+            double dx = 1. / m_d1;
+            double dy = 1. / m_d2;
+            double x = dx * i;
+            double y = dy * j;
+            // in values between 5 and 9
+            return 5. + 8 * (2. + cos(PI * (x + 1.5 * y)) + sin(2 * PI * (x + 1.5 * y))) / 4.;
+        };
+
+        fun_t coeff = [](int_t, int_t, int_t) { return 0.025; };
+
+        fun_t crlato = [this](int_t, int_t j, int_t) { return m_crlat1(j) / m_crlat0(j); };
+
+        fun_t crlatu = [this](int_t, int_t j, int_t) { return j == 0 ? 0 : m_crlat1(j - 1) / m_crlat0(j); };
+
+        fun_t out = [this](int_t i, int_t j, int_t k) {
+            auto lap = [=](int_t ii, int_t jj) {
+                return 4 * in(ii, jj, k) -
+                       (in(ii + 1, jj, k) + in(ii, jj + 1, k) + in(ii - 1, jj, k) + in(ii, jj - 1, k));
+            };
+            auto flx = [=](int_t ii, int_t jj) {
+                double res = lap(ii + 1, jj) - lap(ii, jj);
+                if (res * (in(ii + 1, jj, k) - in(ii, jj, k)) > 0)
+                    res = 0.;
+                return res;
+            };
+            auto fly = [=](int_t ii, int_t jj) {
+                auto res = lap(ii, jj + 1) - lap(ii, jj);
+                if (res * (in(ii, jj + 1, k) - in(ii, jj, k)) > 0)
+                    res = 0.;
+                return res;
+            };
+            return in(i, j, k) - coeff(i, j, k) * (flx(i, j) - flx(i - 1, j) + fly(i, j) - fly(i, j - 1));
+        };
+
+        fun_t out_simple = [this](int_t i, int_t j, int_t k) {
+            auto lap = [=](int_t ii, int_t jj) {
+                return in(ii + 1, jj, k) + in(ii - 1, jj, k) - 2 * in(ii, jj, k) +
+                       crlato(ii, jj, k) * (in(ii, jj + 1, k) - in(ii, jj, k)) +
+                       crlatu(ii, jj, k) * (in(ii, jj - 1, k) - in(ii, jj, k));
+            };
+            auto fluxx = lap(i + 1, j) - lap(i, j);
+            auto fluxx_m = lap(i, j) - lap(i - 1, j);
+            auto fluxy = crlato(i, j, k) * (lap(i, j + 1) - lap(i, j));
+            auto fluxy_m = crlato(i, j, k) * (lap(i, j) - lap(i, j - 1));
+            return in(i, j, k) + ((fluxx_m - fluxx) + (fluxy_m - fluxy)) * coeff(i, j, k);
+        };
+    };
+} // namespace gridtools

--- a/tests/reference_cpp_regression/reference.cpp
+++ b/tests/reference_cpp_regression/reference.cpp
@@ -14,8 +14,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include "gridtools/regression/horizontal_diffusion_repository.hpp"
-#include "gridtools/regression/vertical_advection_repository.hpp"
+#include "horizontal_diffusion_repository.hpp"
+#include "vertical_advection_repository.hpp"
 #include <iostream>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -43,7 +43,7 @@ py::array_t<DType> apply_function(gt::uint_t d1,
     size_t j_stride = result.strides()[1]/8;
     size_t k_stride = result.strides()[2]/8;
     DType* ptr = static_cast<DType*>(result.request().ptr);
-    
+
     for (gt::uint_t i = 0; i < d1_loc; i++) {
         for (gt::uint_t j = 0; j < d2_loc; j++) {
             for (gt::uint_t k = 0; k < d3_loc; k++) {

--- a/tests/reference_cpp_regression/vertical_advection_repository.hpp
+++ b/tests/reference_cpp_regression/vertical_advection_repository.hpp
@@ -1,0 +1,158 @@
+/*
+ * GridTools
+ *
+ * Copyright (c) 2014-2021, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <functional>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include <gridtools/common/defs.hpp>
+
+// define some physical constants
+constexpr double BETA_V = 0;
+constexpr double BET_M = (1 - BETA_V) / 2;
+constexpr double BET_P = (1 + BETA_V) / 2;
+
+namespace gridtools {
+    class vertical_advection_repository {
+
+        using column_t = std::vector<double>;
+
+        template <class Fun>
+        struct cached_f {
+            Fun m_fun;
+            mutable std::map<std::array<int_t, 2>, column_t> m_cache;
+
+            column_t const *lookup(int_t i, int_t j) const {
+                column_t const *res = nullptr;
+#pragma omp critical
+                {
+                    auto it = m_cache.find({i, j});
+                    if (it != m_cache.end())
+                        res = &it->second;
+                }
+                return res;
+            }
+
+            double operator()(int_t i, int_t j, int_t k) const {
+                if (auto *cached = lookup(i, j))
+                    return (*cached)[k];
+                auto column = m_fun(i, j);
+                double res = column[k];
+#pragma omp critical
+                { m_cache.insert({{i, j}, std::move(column)}); }
+                return res;
+            }
+        };
+        template <class Fun>
+        static cached_f<Fun> cache(Fun &&fun) {
+            return {std::forward<Fun>(fun)};
+        }
+
+        const double PI = std::atan(1) * 4;
+        size_t m_d1, m_d2, m_d3;
+
+        double x(int_t i) const { return 1. * i / m_d1; }
+        double y(int_t j) const { return 1. * j / m_d2; }
+        double z(int_t k) const { return 1. * k / m_d3; }
+
+      public:
+        using fun_t = std::function<double(int_t, int_t, int_t)>;
+
+        double dtr_stage = 3. / 20.;
+
+        const fun_t u_stage = [this](int_t i, int_t j, int_t) {
+            double t = x(i) + y(j);
+            // u values between 5 and 9
+            return 7 + std::cos(PI * t) + std::sin(2 * PI * t);
+        };
+
+        const fun_t wcon = [this](int_t i, int_t j, int_t k) {
+            // wcon values between -2e-4 and 2e-4 (with zero at k=0)
+            return 2e-4 * (-1.07 + (2 + cos(PI * (x(i) + z(k))) + cos(PI * y(j))) / 2);
+        };
+
+        const fun_t utens = [this](int_t i, int_t j, int_t k) {
+            // utens values between -3e-6 and 3e-6 (with zero at k=0)
+            return 3e-6 * (-1.0235 + (2. + cos(PI * (x(i) + y(j))) + cos(PI * y(j) * z(k))) / 2);
+        };
+
+        const fun_t u_pos = u_stage;
+
+        const fun_t utens_stage_in = [this](int_t i, int_t j, int_t k) {
+            double t = x(i) + y(j);
+            return 7 + 1.25 * (2. + cos(PI * t) + sin(2 * PI * t)) + .1 * k;
+        };
+
+        const fun_t utens_stage_out = cache([this](int_t i, int_t j) {
+            constexpr int_t IShift = 1;
+            constexpr int_t JShift = 0;
+            column_t c(m_d3), d(m_d3), res(m_d3);
+            // forward
+            // k minimum
+            int k = 0;
+            {
+                double gcv = .25 * (wcon(i + IShift, j + JShift, k + 1) + wcon(i, j, k + 1));
+                double cs = gcv * BET_M;
+                c[k] = gcv * BET_P;
+                double b = dtr_stage - c[k];
+                // update the d column
+                double correctionTerm = -cs * (u_stage(i, j, k + 1) - u_stage(i, j, k));
+                d[k] = dtr_stage * u_pos(i, j, k) + utens(i, j, k) + utens_stage_in(i, j, k) + correctionTerm;
+                c[k] /= b;
+                d[k] /= b;
+            }
+            // kbody
+            for (++k; k < m_d3 - 1; ++k) {
+                double gav = -.25 * (wcon(i + IShift, j + JShift, k) + wcon(i, j, k));
+                double gcv = .25 * (wcon(i + IShift, j + JShift, k + 1) + wcon(i, j, k + 1));
+                double as = gav * BET_M;
+                double cs = gcv * BET_M;
+                double a = gav * BET_P;
+                c[k] = gcv * BET_P;
+                double bcol = dtr_stage - a - c[k];
+                double correctionTerm =
+                    -as * (u_stage(i, j, k - 1) - u_stage(i, j, k)) - cs * (u_stage(i, j, k + 1) - u_stage(i, j, k));
+                d[k] = dtr_stage * u_pos(i, j, k) + utens(i, j, k) + utens_stage_in(i, j, k) + correctionTerm;
+                double divided = 1 / (bcol - (c[k - 1] * a));
+                c[k] *= divided;
+                d[k] = (d[k] - d[k - 1] * a) * divided;
+            }
+            // k maximum
+            {
+                double gav = -.25 * (wcon(i + IShift, j + JShift, k) + wcon(i, j, k));
+                double as = gav * BET_M;
+                double a = gav * BET_P;
+                double b = dtr_stage - a;
+                // update the d column
+                double correctionTerm = -as * (u_stage(i, j, k - 1) - u_stage(i, j, k));
+                d[k] = dtr_stage * u_pos(i, j, k) + utens(i, j, k) + utens_stage_in(i, j, k) + correctionTerm;
+                d[k] = (d[k] - d[k - 1] * a) / (b - (c[k - 1] * a));
+            }
+            // backward
+            double data = d[k];
+            c[k] = data;
+            res[k] = dtr_stage * (data - u_pos(i, j, k));
+            // kbody
+            for (--k; k >= 0; --k) {
+                data = d[k] - c[k] * data;
+                c[k] = data;
+                res[k] = dtr_stage * (data - u_pos(i, j, k));
+            }
+            return res;
+        });
+
+        vertical_advection_repository(size_t d1, size_t d2, size_t d3) : m_d1(d1), m_d2(d2), m_d3(d3) {}
+    };
+} // namespace gridtools


### PR DESCRIPTION
## Description

Adds `horizontal_diffusion_repository.hpp` and `vertical_advection_repository.hpp` from GridTools to remove dependency on non-installed headers.

Resolves https://github.com/GridTools/gt4py/issues/497, and is a pre-requisite to removing the legacy backends.