### PR TITLE
Iterator: Cleanup fendef dispatch, rename embedded backend

### DIFF
--- a/src/iterator/ARCHITECTURE.md
+++ b/src/iterator/ARCHITECTURE.md
@@ -9,13 +9,13 @@ A program for the iterator view consists of Python functions decorated with `@fu
 Legal functions much not have side-effects, however, e.g., for debugging purposes, side-effects can be used in embedded execution.
 
 There are 2 modes of execution: *embedded* (direct execution in Python) and *tracing* (trace function calls -> Eve IR representation -> code generation).
-The implementations of *embedded* and *tracing* are decoupled by registering themselves (dependency inversion) in the functions defined in `builtins.py` (contains dispatch functions for all builtins of the model) and `runtime.py` (contains dispatch mechanism for the `fendef` and `fundef` decorators and the `closure(...)` function).
+The implementations of *embedded* and *tracing* are decoupled by registering themselves (dependency inversion) in `builtins.py` (contains dispatch functions for all builtins of the model) and `runtime.py` (contains dispatch mechanism for the `fendef` and `fundef` decorators and the `closure(...)` function).
 
 The builtins dispatcher is implemented in `dispatcher.py`. Implementations are registered with a key (`str`) (currently `tracing` and `embedded`). The active implementation is selected by pushing a key to the dispatcher stack.
 
 `fundef` returns a wrapper around the function, which dispatches `__call__` to a hook if a predicate is met (used for *tracing*). By default the original function is called (used in *embedded* mode).
 
-`fendef` return a wrapper that dispatches to a registered function. Should be simplified. *Embedded* registers itself as default, *tracing* registers itself such that it's used if the fencil is called with `backend` keyword argument.
+`fendef` return a wrapper that dispatches to a registered function. If `backend` is in the keyword arguments and not `None` `fendef_codegen` will be called, otherwise `fundef_embedded` will be called.
 
 ## Embedded execution
 
@@ -43,19 +43,19 @@ Sketch:
 
 See directory `backends/`.
 
-### Cpptoy
+### `cpptoy`
 
 Generates C++ code in the spirit of https://github.com/GridTools/gridtools/pull/1643. Incomplete, will be adapted to the full C++ prototype. (only code generation)
 
-### Lisp
+### `lisp`
 
 Incomplete. Example for the grammar used in the model design document. (not executable)
 
-### Embedded
+### `roundtrip`
 
-Generates from the IR an aquivalent Python iterator view program which is then executed in embedded mode (round trip).
+Generates from the IR an aquivalent Python iterator view program which is then executed in embedded mode.
 
-### Double roundtrip
+### `double_roundtrip`
 
 Generates the Python iterator view program, traces it again, generates again and executes. Ensures that the generated Python code can still be traced. While the original program might be different from the generated program (e.g. `+` will be converted to `plus()` builtin). The programs from the embedded and double roundtrip backends should be identical.
 

--- a/src/iterator/backends/__init__.py
+++ b/src/iterator/backends/__init__.py
@@ -1,1 +1,1 @@
-from . import cpptoy, double_roundtrip, embedded, lisp
+from . import cpptoy, double_roundtrip, roundtrip, lisp

--- a/src/iterator/backends/double_roundtrip.py
+++ b/src/iterator/backends/double_roundtrip.py
@@ -1,9 +1,9 @@
 from eve.concepts import Node
-from iterator.backends import backend, embedded
+from iterator.backends import backend, roundtrip
 
 
 def executor(ir: Node, *args, **kwargs):
-    embedded.executor(ir, *args, dispatch_backend=embedded._BACKEND_NAME, **kwargs)
+    roundtrip.executor(ir, *args, dispatch_backend=roundtrip._BACKEND_NAME, **kwargs)
 
 
 backend.register_backend("double_roundtrip", executor)

--- a/src/iterator/backends/roundtrip.py
+++ b/src/iterator/backends/roundtrip.py
@@ -80,7 +80,7 @@ class WrapperGenerator(EmbeddedDSL):
         return f"\ndef {node.id}_wrapper({','.join(non_tmp_params)}, **kwargs):\n    {body}\n"
 
 
-_BACKEND_NAME = "embedded"
+_BACKEND_NAME = "roundtrip"
 
 
 def executor(ir: Node, *args, **kwargs):

--- a/src/iterator/embedded.py
+++ b/src/iterator/embedded.py
@@ -588,4 +588,4 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
     fun(*args)
 
 
-iterator.runtime.fendef_registry[None] = fendef_embedded
+iterator.runtime.fendef_embedded = fendef_embedded

--- a/src/iterator/tracing.py
+++ b/src/iterator/tracing.py
@@ -314,4 +314,4 @@ def fendef_tracing(fun, *args, **kwargs):
     execute_program(prog, *args, **kwargs)
 
 
-iterator.runtime.fendef_registry[lambda kwargs: "backend" in kwargs] = fendef_tracing
+iterator.runtime.fendef_codegen = fendef_tracing

--- a/tests/iterator_tests/conftest.py
+++ b/tests/iterator_tests/conftest.py
@@ -9,9 +9,10 @@ def use_tmps(request):
 @pytest.fixture(
     params=[
         # (backend, do_validate)
+        (None, True),
         ("lisp", False),
         ("cpptoy", False),
-        ("embedded", True),
+        ("roundtrip", True),
         ("double_roundtrip", True),
     ],
     ids=lambda p: f"backend={p[0]}",

--- a/tests/iterator_tests/test_cartesian_offset_provider.py
+++ b/tests/iterator_tests/test_cartesian_offset_provider.py
@@ -46,7 +46,7 @@ def test_cartesian_offset_provider():
     fencil_swapped(out, inp)
     assert out[0][0] == 1
 
-    fencil(out, inp, backend="embedded")
+    fencil(out, inp, backend="roundtrip")
     assert out[0][0] == 42
 
     fencil(out, inp, backend="double_roundtrip")
@@ -76,5 +76,5 @@ def test_delay_complete_shift():
     assert out[0, 0] == 43
 
     out = np_as_located_field(I_loc, J_loc)(np.asarray([[-1]]))
-    delay_complete_shift_fencil(out, inp, backend="embedded", debug=True)
+    delay_complete_shift_fencil(out, inp, backend="roundtrip", debug=True)
     assert out[0, 0] == 43


### PR DESCRIPTION
- instead of more generic registry for fendef dispatch,
just dispatch either to embedded or codegen
- rename `embedded` backend to `roundtrip`
to avoid confusion with embedded execution without codegen
- backend=None or no backend kwarg is embedded execution

