### PR TITLE
Custom oir_pipeline backend option

### DIFF
--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -30,6 +30,7 @@ from gt4py import gt_src_manager
 from gt4py import ir as gt_ir
 from gt4py import utils as gt_utils
 from gt4py.utils import text as gt_text
+from gtc.passes.oir_pipeline import OirPipeline
 
 from . import pyext_builder
 from .module_generator import CUDAPyExtModuleGenerator, PyExtModuleGenerator
@@ -671,6 +672,7 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
         "clean": {"versioning": False, "type": bool},
         "debug_mode": {"versioning": True, "type": bool},
         "verbose": {"versioning": False, "type": bool},
+        "oir_pipeline": {"versioning": True, "type": OirPipeline},
     }
 
     GT_BACKEND_T: str

--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -50,8 +50,8 @@ class GTCCudaExtGenerator:
         def default_pipeline(oir):
             return OirPipeline(oir).full(skip=[NoFieldAccessPruning])
 
-        oir_pipeline = (
-            self.backend.builder.options.backend_opts.get("oir_pipeline") or default_pipeline
+        oir_pipeline = self.backend.builder.options.backend_opts.get(
+            "oir_pipeline", default_pipeline
         )
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
         oir = oir_pipeline(gtir_to_oir.GTIRToOIR().visit(gtir))

--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -33,7 +33,7 @@ from gtc.common import DataType
 from gtc.cuir import cuir, cuir_codegen, extent_analysis, kernel_fusion, oir_to_cuir
 from gtc.passes.gtir_pipeline import GtirPipeline
 from gtc.passes.oir_optimizations.pruning import NoFieldAccessPruning
-from gtc.passes.oir_pipeline import DefaultOirPipeline
+from gtc.passes.oir_pipeline import DefaultPipeline
 
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ class GTCCudaExtGenerator:
         self.backend = backend
 
     def __call__(self, definition_ir) -> Dict[str, Dict[str, str]]:
-        default_pipeline = DefaultOirPipeline(skip=[NoFieldAccessPruning])
+        default_pipeline = DefaultPipeline(skip=[NoFieldAccessPruning])
 
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
         base_oir = gtir_to_oir.GTIRToOIR().visit(gtir)

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -50,15 +50,13 @@ class GTCDaCeExtGenerator:
         self.backend = backend
 
     def __call__(self, definition_ir: StencilDefinition) -> Dict[str, Dict[str, str]]:
-        default_pipeline = DefaultPipeline(
-            skip=[MaskStmtMerging, MaskInlining, FillFlushToLocalKCaches]
-        )
-
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
         base_oir = gtir_to_oir.GTIRToOIR().visit(gtir)
-        oir = self.backend.builder.options.backend_opts.get("oir_pipeline", default_pipeline).run(
-            base_oir
+        oir_pipeline = self.backend.builder.options.backend_opts.get(
+            "oir_pipeline",
+            DefaultPipeline(skip=[MaskStmtMerging, MaskInlining, FillFlushToLocalKCaches]),
         )
+        oir = oir_pipeline.run(base_oir)
         sdfg = OirSDFGBuilder().visit(oir)
         sdfg.expand_library_nodes(recursive=True)
         sdfg.apply_strict_transformations(validate=True)

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -59,8 +59,8 @@ class GTCDaCeExtGenerator:
                 ]
             )
 
-        oir_pipeline = (
-            self.backend.builder.options.backend_opts.get("oir_pipeline") or default_pipeline
+        oir_pipeline = self.backend.builder.options.backend_opts.get(
+            "oir_pipeline", default_pipeline
         )
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
         oir = oir_pipeline(gtir_to_oir.GTIRToOIR().visit(gtir))

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -36,7 +36,7 @@ from gtc.passes.gtir_pipeline import GtirPipeline
 from gtc.passes.oir_optimizations.caches import FillFlushToLocalKCaches
 from gtc.passes.oir_optimizations.inlining import MaskInlining
 from gtc.passes.oir_optimizations.mask_stmt_merging import MaskStmtMerging
-from gtc.passes.oir_pipeline import DefaultOirPipeline
+from gtc.passes.oir_pipeline import DefaultPipeline
 
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ class GTCDaCeExtGenerator:
         self.backend = backend
 
     def __call__(self, definition_ir: StencilDefinition) -> Dict[str, Dict[str, str]]:
-        default_pipeline = DefaultOirPipeline(
+        default_pipeline = DefaultPipeline(
             skip=[MaskStmtMerging, MaskInlining, FillFlushToLocalKCaches]
         )
 

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -25,7 +25,14 @@ from gt4py.backend.debug_backend import (
     debug_layout,
 )
 from gtc.gtir_to_oir import GTIRToOIR
-from gtc.passes.oir_pipeline import OirPipeline
+from gtc.passes.oir_optimizations.caches import (
+    FillFlushToLocalKCaches,
+    IJCacheDetection,
+    KCacheDetection,
+    PruneKCacheFills,
+    PruneKCacheFlushes,
+)
+from gtc.passes.oir_pipeline import DefaultOirPipeline, OirPipeline
 from gtc.python import npir
 from gtc.python.npir_gen import NpirGen
 from gtc.python.oir_to_npir import OirToNpir
@@ -79,7 +86,9 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
     """NumPy backend using gtc."""
 
     name = "gtc:numpy"
-    options: ClassVar[Dict[str, Any]] = {}
+    options: ClassVar[Dict[str, Any]] = {
+        "oir_pipeline": {"versioning": True, "type": OirPipeline},
+    }
     storage_info = {
         "alignment": 1,
         "device": "cpu",
@@ -119,11 +128,21 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
         return self.make_module()
 
     def _make_npir(self) -> npir.Computation:
-        def default_pipeline(oir):
-            return OirPipeline(oir).full()
-
-        oir_pipeline = self.builder.options.backend_opts.get("oir_pipeline", default_pipeline)
-        return OirToNpir().visit(oir_pipeline(GTIRToOIR().visit(self.builder.gtir)))
+        default_pipeline = DefaultOirPipeline(
+            skip=[
+                IJCacheDetection,
+                KCacheDetection,
+                PruneKCacheFills,
+                PruneKCacheFlushes,
+                FillFlushToLocalKCaches,
+            ]
+        )
+        base_oir = GTIRToOIR().visit(self.builder.gtir)
+        oir = self.builder.options.backend_opts.get(
+            "oir_pipeline",
+            default_pipeline,
+        ).run(base_oir)
+        return OirToNpir().visit(oir)
 
     @property
     def npir(self) -> npir.Computation:

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -32,7 +32,7 @@ from gtc.passes.oir_optimizations.caches import (
     PruneKCacheFills,
     PruneKCacheFlushes,
 )
-from gtc.passes.oir_pipeline import DefaultOirPipeline, OirPipeline
+from gtc.passes.oir_pipeline import DefaultPipeline, OirPipeline
 from gtc.python import npir
 from gtc.python.npir_gen import NpirGen
 from gtc.python.oir_to_npir import OirToNpir
@@ -128,7 +128,7 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
         return self.make_module()
 
     def _make_npir(self) -> npir.Computation:
-        default_pipeline = DefaultOirPipeline(
+        default_pipeline = DefaultPipeline(
             skip=[
                 IJCacheDetection,
                 KCacheDetection,

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -119,7 +119,11 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
         return self.make_module()
 
     def _make_npir(self) -> npir.Computation:
-        return OirToNpir().visit(OirPipeline(GTIRToOIR().visit(self.builder.gtir)).full())
+        def default_pipeline(oir):
+            return OirPipeline(oir).full()
+
+        oir_pipeline = self.builder.options.backend_opts.get("oir_pipeline") or default_pipeline
+        return OirToNpir().visit(oir_pipeline(GTIRToOIR().visit(self.builder.gtir)))
 
     @property
     def npir(self) -> npir.Computation:

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -122,7 +122,7 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
         def default_pipeline(oir):
             return OirPipeline(oir).full()
 
-        oir_pipeline = self.builder.options.backend_opts.get("oir_pipeline") or default_pipeline
+        oir_pipeline = self.builder.options.backend_opts.get("oir_pipeline", default_pipeline)
         return OirToNpir().visit(oir_pipeline(GTIRToOIR().visit(self.builder.gtir)))
 
     @property

--- a/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcnumpy/backend.py
@@ -128,20 +128,20 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
         return self.make_module()
 
     def _make_npir(self) -> npir.Computation:
-        default_pipeline = DefaultPipeline(
-            skip=[
-                IJCacheDetection,
-                KCacheDetection,
-                PruneKCacheFills,
-                PruneKCacheFlushes,
-                FillFlushToLocalKCaches,
-            ]
-        )
         base_oir = GTIRToOIR().visit(self.builder.gtir)
-        oir = self.builder.options.backend_opts.get(
+        oir_pipeline = self.builder.options.backend_opts.get(
             "oir_pipeline",
-            default_pipeline,
-        ).run(base_oir)
+            DefaultPipeline(
+                skip=[
+                    IJCacheDetection,
+                    KCacheDetection,
+                    PruneKCacheFills,
+                    PruneKCacheFlushes,
+                    FillFlushToLocalKCaches,
+                ]
+            ),
+        )
+        oir = oir_pipeline.run(base_oir)
         return OirToNpir().visit(oir)
 
     @property

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -55,8 +55,8 @@ class GTCGTExtGenerator:
         def default_pipeline(oir):
             return OirPipeline(oir).full(skip=[FillFlushToLocalKCaches])
 
-        oir_pipeline = (
-            self.backend.builder.options.backend_opts.get("oir_pipeline") or default_pipeline
+        oir_pipeline = self.backend.builder.options.backend_opts.get(
+            "oir_pipeline", default_pipeline
         )
 
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -52,13 +52,12 @@ class GTCGTExtGenerator:
         self.backend = backend
 
     def __call__(self, definition_ir) -> Dict[str, Dict[str, str]]:
-        default_pipeline = DefaultPipeline(skip=[FillFlushToLocalKCaches])
-
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
         base_oir = gtir_to_oir.GTIRToOIR().visit(gtir)
-        oir = self.backend.builder.options.backend_opts.get("oir_pipeline", default_pipeline).run(
-            base_oir
+        oir_pipeline = self.backend.builder.options.backend_opts.get(
+            "oir_pipeline", DefaultPipeline(skip=[FillFlushToLocalKCaches])
         )
+        oir = oir_pipeline.run(base_oir)
         gtcpp = oir_to_gtcpp.OIRToGTCpp().visit(oir)
         format_source = self.backend.builder.options.format_source
         implementation = gtcpp_codegen.GTCppCodegen.apply(

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -38,7 +38,7 @@ from gtc.common import DataType
 from gtc.gtcpp import gtcpp, gtcpp_codegen, oir_to_gtcpp
 from gtc.passes.gtir_pipeline import GtirPipeline
 from gtc.passes.oir_optimizations.caches import FillFlushToLocalKCaches
-from gtc.passes.oir_pipeline import DefaultOirPipeline
+from gtc.passes.oir_pipeline import DefaultPipeline
 
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ class GTCGTExtGenerator:
         self.backend = backend
 
     def __call__(self, definition_ir) -> Dict[str, Dict[str, str]]:
-        default_pipeline = DefaultOirPipeline(skip=[FillFlushToLocalKCaches])
+        default_pipeline = DefaultPipeline(skip=[FillFlushToLocalKCaches])
 
         gtir = GtirPipeline(DefIRToGTIR.apply(definition_ir)).full()
         base_oir = gtir_to_oir.GTIRToOIR().visit(gtir)

--- a/src/gtc/passes/oir_pipeline.py
+++ b/src/gtc/passes/oir_pipeline.py
@@ -65,7 +65,7 @@ class OirPipeline(ABC):
         pass
 
 
-class DefaultOirPipeline(OirPipeline):
+class DefaultPipeline(OirPipeline):
     """
     OIR passes pipeline runs passes in order and allows skipping.
 

--- a/tests/test_unittest/test_gtc/test_oir_pipeline.py
+++ b/tests/test_unittest/test_gtc/test_oir_pipeline.py
@@ -1,12 +1,12 @@
 from gtc.passes.oir_optimizations.horizontal_execution_merging import OnTheFlyMerging
 from gtc.passes.oir_optimizations.vertical_loop_merging import AdjacentLoopMerging
-from gtc.passes.oir_pipeline import DefaultOirPipeline, hash_step
+from gtc.passes.oir_pipeline import DefaultPipeline, hash_step
 
 from .oir_utils import StencilFactory
 
 
 def test_no_skipping():
-    pipeline = DefaultOirPipeline()
+    pipeline = DefaultPipeline()
     pipeline.run(StencilFactory())
 
     steps = tuple(hash_step(i) for i in pipeline.steps())
@@ -15,7 +15,7 @@ def test_no_skipping():
 
 
 def test_skip_one():
-    pipeline = DefaultOirPipeline(skip=[AdjacentLoopMerging])
+    pipeline = DefaultPipeline(skip=[AdjacentLoopMerging])
     pipeline.run(StencilFactory())
 
     steps = tuple(hash_step(i) for i in pipeline.steps())

--- a/tests/test_unittest/test_gtc/test_oir_pipeline.py
+++ b/tests/test_unittest/test_gtc/test_oir_pipeline.py
@@ -1,13 +1,13 @@
 from gtc.passes.oir_optimizations.horizontal_execution_merging import OnTheFlyMerging
 from gtc.passes.oir_optimizations.vertical_loop_merging import AdjacentLoopMerging
-from gtc.passes.oir_pipeline import OirPipeline, hash_step
+from gtc.passes.oir_pipeline import DefaultOirPipeline, hash_step
 
 from .oir_utils import StencilFactory
 
 
 def test_no_skipping():
-    pipeline = OirPipeline(StencilFactory())
-    pipeline.full()
+    pipeline = DefaultOirPipeline()
+    pipeline.run(StencilFactory())
 
     steps = tuple(hash_step(i) for i in pipeline.steps())
 
@@ -15,8 +15,8 @@ def test_no_skipping():
 
 
 def test_skip_one():
-    pipeline = OirPipeline(StencilFactory())
-    pipeline.full(skip=[AdjacentLoopMerging])
+    pipeline = DefaultOirPipeline(skip=[AdjacentLoopMerging])
+    pipeline.run(StencilFactory())
 
     steps = tuple(hash_step(i) for i in pipeline.steps())
     skipped = tuple(i for i in steps if i != hash_step(AdjacentLoopMerging))

--- a/tests/test_unittest/test_gtc/test_oir_pipeline.py
+++ b/tests/test_unittest/test_gtc/test_oir_pipeline.py
@@ -1,6 +1,21 @@
-from gtc.passes.oir_optimizations.horizontal_execution_merging import OnTheFlyMerging
+# -*- coding: utf-8 -*-
+#
+# GTC Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2014-2021, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gtc.passes.oir_optimizations.vertical_loop_merging import AdjacentLoopMerging
-from gtc.passes.oir_pipeline import DefaultPipeline, hash_step
+from gtc.passes.oir_pipeline import DefaultPipeline
 
 from .oir_utils import StencilFactory
 
@@ -8,20 +23,11 @@ from .oir_utils import StencilFactory
 def test_no_skipping():
     pipeline = DefaultPipeline()
     pipeline.run(StencilFactory())
-
-    steps = tuple(hash_step(i) for i in pipeline.steps())
-
-    assert steps in pipeline._cache
+    assert pipeline.steps == DefaultPipeline.all_steps()
 
 
-def test_skip_one():
-    pipeline = DefaultPipeline(skip=[AdjacentLoopMerging])
+def test_skip():
+    skip = [AdjacentLoopMerging]
+    pipeline = DefaultPipeline(skip=skip)
     pipeline.run(StencilFactory())
-
-    steps = tuple(hash_step(i) for i in pipeline.steps())
-    skipped = tuple(i for i in steps if i != hash_step(AdjacentLoopMerging))
-    wrong_skipped = tuple(i for i in steps if i != hash_step(OnTheFlyMerging))
-
-    assert steps not in pipeline._cache
-    assert skipped in pipeline._cache
-    assert wrong_skipped not in pipeline._cache
+    assert all(s not in pipeline.steps for s in skip)


### PR DESCRIPTION
## Description

Implement a backend option to customize the OIR optimization passes run. Users may derive custom OirPipeline instances, or use their own. A common use case to skip a specific pass would be:

```python
from gtc.passes.oir_dace_optimizations.horizontal_execution_merging import (
    graph_merge_horizontal_executions,
)
from gtc.passes.oir_pipeline import DefaultPipeline

...

gtscript.stencil(
    definition=stencil,
    backend=some_backend,
    oir_pipeline=DefaultPipeline(skip=[graph_merge_horizontal_executions])
)
```

but users can pass any class instance following the `gtc.passes.oir_pipeline.OirPipeline` interface.
