### PR TITLE
add cython as a build dependency fixes cytoolz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=40.8.0", "wheel", "setuptools_scm", "cython"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
On python 3.10 it seems that cytoolz only works if cython was available during it's installation.
This PR fixes that by adding cython to build dependencies in the pyproject.toml file
 


