### PR TITLE
Add SourceLocationGroup utility to eve

### DIFF
--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -194,8 +194,9 @@ class SourceLocationGroup(pydantic.BaseModel):
         super().__init__(locations=locations, context=context)
 
     def __str__(self) -> str:
-        output = f"[{', '.join(str(loc) for loc in self.locations)}]"
-        return f"{output}#<{self.context}>" if self.context is not None else output
+        locs = ", ".join(str(loc) for loc in self.locations)
+        context = f"#{self.context}" if self.context else ""
+        return f"<{context}[{locs}]>"
 
     @validator("locations")
     def non_empty_tuple(cls, v):

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -27,12 +27,12 @@ import boltons.typeutils
 import pydantic
 import xxhash
 from boltons.typeutils import classproperty  # noqa: F401
-from pydantic import validator
 from pydantic import NegativeFloat, NegativeInt, PositiveFloat, PositiveInt  # noqa
 from pydantic import StrictBool as Bool  # noqa: F401
 from pydantic import StrictFloat as Float  # noqa: F401
 from pydantic import StrictInt as Int  # noqa: F401
 from pydantic import StrictStr as Str
+from pydantic import validator  # noqa
 from pydantic.types import ConstrainedStr
 
 from .typingx import Any, Callable, Generator, Optional, Tuple, Type, Union

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import ast
 import enum
 import functools
 import re
@@ -169,13 +170,53 @@ class SourceLocation(pydantic.BaseModel):
     line: PositiveInt
     column: PositiveInt
     source: Str
+    end_line: Optional[PositiveInt]
+    end_column: Optional[PositiveInt]
 
-    def __init__(self, line: int, column: int, source: str) -> None:
-        super().__init__(line=line, column=column, source=source)
+    @classmethod
+    def from_AST(cls, ast_node: ast.AST, source: Optional[str] = None) -> SourceLocation:
+        if (
+            not isinstance(ast_node, ast.AST)
+            or getattr(ast_node, "lineno", None) is None
+            or getattr(ast_node, "col_offset", None) is None
+        ):
+            raise ValueError(
+                f"Passed AST node '{ast_node}' does not contain a valid source location."
+            )
+        if source is None:
+            source = f"<ast.{type(ast_node).__name__} at 0x{id(ast_node):x}>"
+        return cls(
+            ast_node.lineno,
+            ast_node.col_offset + 1,
+            source,
+            end_line=ast_node.end_lineno,
+            end_column=ast_node.end_col_offset + 1 if ast_node.end_col_offset is not None else None,
+        )
+
+    def __init__(
+        self,
+        line: int,
+        column: int,
+        source: str,
+        *,
+        end_line: Optional[int] = None,
+        end_column: Optional[int] = None,
+    ) -> None:
+        assert end_column is None or end_line is not None
+        super().__init__(
+            line=line, column=column, source=source, end_line=end_line, end_column=end_column
+        )
 
     def __str__(self) -> str:
         src = self.source or ""
-        return f"<{src}: Line {self.line}, Col {self.column}>"
+
+        end_part = ""
+        if self.end_line is not None:
+            end_part += f" to Line {self.end_line}"
+        if self.end_column is not None:
+            end_part += f", Col {self.end_column}"
+
+        return f"<'{src}': Line {self.line}, Col {self.column}{end_part}>"
 
     class Config:
         extra = "forbid"
@@ -195,7 +236,7 @@ class SourceLocationGroup(pydantic.BaseModel):
 
     def __str__(self) -> str:
         locs = ", ".join(str(loc) for loc in self.locations)
-        context = f"#{self.context}" if self.context else ""
+        context = f"#{self.context}#" if self.context else ""
         return f"<{context}[{locs}]>"
 
     @validator("locations")

--- a/src/eve/typingx.py
+++ b/src/eve/typingx.py
@@ -37,6 +37,9 @@ V = TypeVar("V")
 T_contra = TypeVar("T_contra", contravariant=True)
 V_co = TypeVar("V_co", covariant=True)
 
+ZeroOrMore = Union[None, T, Tuple[T, ...]]
+OneOrMore = Union[T, Tuple[T, ...]]
+
 
 class NonDataDescriptor(Protocol[T_contra, V_co]):
     @overload

--- a/tests/eve_tests/unit_tests/test_type_definitions.py
+++ b/tests/eve_tests/unit_tests/test_type_definitions.py
@@ -54,21 +54,49 @@ def test_symbol_types():
 
 class TestSourceLocation:
     def test_valid_position(self):
-        eve.type_definitions.SourceLocation(line=1, column=1, source="source")
+        eve.type_definitions.SourceLocation(line=1, column=1, source="source.py")
 
     def test_invalid_position(self):
         with pytest.raises(pydantic.ValidationError):
-            eve.type_definitions.SourceLocation(line=1, column=-1, source="source")
+            eve.type_definitions.SourceLocation(line=1, column=-1, source="source.py")
 
     def test_str(self):
-        loc = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
-        assert str(loc) == "<source: Line 1, Col 1>"
+        loc = eve.type_definitions.SourceLocation(line=1, column=1, source="dir/source.py")
+        assert str(loc) == "<'dir/source.py': Line 1, Col 1>"
+
+        loc = eve.type_definitions.SourceLocation(
+            line=1, column=1, source="dir/source.py", end_line=2
+        )
+        assert str(loc) == "<'dir/source.py': Line 1, Col 1 to Line 2>"
+
+        loc = eve.type_definitions.SourceLocation(
+            line=1, column=1, source="dir/source.py", end_line=2, end_column=2
+        )
+        assert str(loc) == "<'dir/source.py': Line 1, Col 1 to Line 2, Col 2>"
+
+    def test_construction_from_ast(self):
+        import ast
+
+        ast_node = ast.parse("a = b + 1").body[0]
+        loc = eve.type_definitions.SourceLocation.from_AST(ast_node, "source.py")
+        print("\n", ast_node.end_lineno)
+        print(loc)
+
+        assert loc.line == ast_node.lineno
+        assert loc.column == ast_node.col_offset + 1
+        assert loc.source == "source.py"
+
+        loc = eve.type_definitions.SourceLocation.from_AST(ast_node)
+
+        assert loc.line == ast_node.lineno
+        assert loc.column == ast_node.col_offset + 1
+        assert loc.source == f"<ast.Assign at 0x{id(ast_node):x}>"
 
 
 class TestSourceLocationGroup:
     def test_valid_locations(self):
-        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
-        loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source_2")
+        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source1.py")
+        loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source2.py")
         eve.type_definitions.SourceLocationGroup(loc1)
         eve.type_definitions.SourceLocationGroup(loc1, loc2)
         eve.type_definitions.SourceLocationGroup(loc1, loc1, loc2, loc2, context="test context")
@@ -76,12 +104,15 @@ class TestSourceLocationGroup:
     def test_invalid_locations(self):
         with pytest.raises(pydantic.ValidationError):
             eve.type_definitions.SourceLocationGroup()
-        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
+        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source.py")
         with pytest.raises(pydantic.ValidationError):
             eve.type_definitions.SourceLocationGroup(loc1, "loc2")
 
     def test_str(self):
-        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
-        loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source_2")
-        loc = eve.type_definitions.SourceLocationGroup(loc1, loc2, context="test context")
-        assert str(loc) == "<#test context[<source: Line 1, Col 1>, <source_2: Line 2, Col 2>]>"
+        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source1.py")
+        loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source2.py")
+        loc = eve.type_definitions.SourceLocationGroup(loc1, loc2, context="some context")
+        assert (
+            str(loc)
+            == "<#some context#[<'source1.py': Line 1, Col 1>, <'source2.py': Line 2, Col 2>]>"
+        )

--- a/tests/eve_tests/unit_tests/test_type_definitions.py
+++ b/tests/eve_tests/unit_tests/test_type_definitions.py
@@ -63,3 +63,25 @@ class TestSourceLocation:
     def test_str(self):
         loc = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
         assert str(loc) == "<source: Line 1, Col 1>"
+
+
+class TestSourceLocationGroup:
+    def test_valid_locations(self):
+        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
+        loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source_2")
+        eve.type_definitions.SourceLocationGroup(loc1)
+        eve.type_definitions.SourceLocationGroup(loc1, loc2)
+        eve.type_definitions.SourceLocationGroup(loc1, loc1, loc2, loc2, context="test context")
+
+    def test_invalid_locations(self):
+        with pytest.raises(pydantic.ValidationError):
+            eve.type_definitions.SourceLocationGroup()
+        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
+        with pytest.raises(pydantic.ValidationError):
+            eve.type_definitions.SourceLocationGroup(loc1, "loc2")
+
+    def test_str(self):
+        loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
+        loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source_2")
+        loc = eve.type_definitions.SourceLocationGroup(loc1, loc2, context="test context")
+        assert str(loc) == "[<source: Line 1, Col 1>, <source_2: Line 2, Col 2>]#<test context>"

--- a/tests/eve_tests/unit_tests/test_type_definitions.py
+++ b/tests/eve_tests/unit_tests/test_type_definitions.py
@@ -79,18 +79,20 @@ class TestSourceLocation:
 
         ast_node = ast.parse("a = b + 1").body[0]
         loc = eve.type_definitions.SourceLocation.from_AST(ast_node, "source.py")
-        print("\n", ast_node.end_lineno)
-        print(loc)
 
         assert loc.line == ast_node.lineno
         assert loc.column == ast_node.col_offset + 1
         assert loc.source == "source.py"
+        assert loc.end_line == ast_node.end_lineno
+        assert loc.end_column == ast_node.end_col_offset + 1
 
         loc = eve.type_definitions.SourceLocation.from_AST(ast_node)
 
         assert loc.line == ast_node.lineno
         assert loc.column == ast_node.col_offset + 1
         assert loc.source == f"<ast.Assign at 0x{id(ast_node):x}>"
+        assert loc.end_line == ast_node.end_lineno
+        assert loc.end_column == ast_node.end_col_offset + 1
 
 
 class TestSourceLocationGroup:

--- a/tests/eve_tests/unit_tests/test_type_definitions.py
+++ b/tests/eve_tests/unit_tests/test_type_definitions.py
@@ -84,4 +84,4 @@ class TestSourceLocationGroup:
         loc1 = eve.type_definitions.SourceLocation(line=1, column=1, source="source")
         loc2 = eve.type_definitions.SourceLocation(line=2, column=2, source="source_2")
         loc = eve.type_definitions.SourceLocationGroup(loc1, loc2, context="test context")
-        assert str(loc) == "[<source: Line 1, Col 1>, <source_2: Line 2, Col 2>]#<test context>"
+        assert str(loc) == "<#test context[<source: Line 1, Col 1>, <source_2: Line 2, Col 2>]>"


### PR DESCRIPTION
## Description

Add another utility class to eve representing a source location originated from a fusing several canonical source locations.