### PR TITLE
Pin tox CI to use Python 3.9.7

### DIFF
--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -27,7 +27,7 @@ jobs:
         mv boost_1_76_0/boost boost/include/
         echo "BOOST_ROOT=${PWD}/boost" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies

--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -35,7 +35,8 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
     - name: Test with tox
       run: |
-        pyversion_no_dot="${{ matrix.python-version }}"
-        pyversion_no_dot="${${pyversion_no_dot//./}:0:2}"
+        pyversion_no_dot=${{ matrix.python-version }}
+        pyversion_no_dot=${pyversion_no_dot//./}
+        pyversion_no_dot=${pyversion_no_dot:0:2}
         pip install tox clang-format
         tox -r -e py${pyversion_no_dot}-internal-cpu

--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -36,6 +36,6 @@ jobs:
     - name: Test with tox
       run: |
         pyversion_no_dot="${{ matrix.python-version }}"
-        pyversion_no_dot="${pyversion_no_dot/./}"
+        pyversion_no_dot="${${pyversion_no_dot//./}:0:2}"
         pip install tox clang-format
         tox -r -e py${pyversion_no_dot}-internal-cpu


### PR DESCRIPTION
## Description

Downgrades the Python 3.9 version used in CI as described in https://github.com/GridTools/gt4py/issues/551 to avoid a Pydantic issue.