### PR TITLE
Functional: Implicit fencil

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -163,15 +163,12 @@ def is_none(arg):
 
 @builtins.domain.register(EMBEDDED)
 def domain(*args):
-    domain = {}
-    for arg in args:
-        domain.update(arg)
-    return domain
+    return dict(args)
 
 
 @builtins.named_range.register(EMBEDDED)
 def named_range(tag, start, end):
-    return {tag: range(start, end)}
+    return (tag, range(start, end))
 
 
 @builtins.minus.register(EMBEDDED)

--- a/src/functional/iterator/runtime.py
+++ b/src/functional/iterator/runtime.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
+from functional.iterator import builtins
 from functional.iterator.builtins import BackendNotSelectedError, builtin_dispatch
 
 
@@ -72,6 +73,32 @@ class FundefDispatcher:
     def __init__(self, fun) -> None:
         self.fun = fun
         self.__name__ = fun.__name__
+
+    def __getitem__(self, domain):
+        def implicit_fencil(*args, out, **kwargs):
+            @fendef
+            def impl(out, *inps):
+                dom = domain
+                if isinstance(dom, Callable):
+                    # if domain is expressed as calls to builtin `domain()` we need to pass it lazily
+                    # as dispatching needs to happen inside of the fencil
+                    dom = dom
+                if isinstance(dom, dict):
+                    # if passed as a dict, we need to convert back to builtins for interpretation by the backends
+                    dom = builtins.domain(
+                        *tuple(
+                            map(
+                                lambda x: builtins.named_range(x[0], x[1].start, x[1].stop),
+                                dom.items(),
+                            )
+                        )
+                    )
+                # TODO support for more than one inp in tracing
+                closure(dom, self, [out], [*inps])
+
+            impl(out, *args, **kwargs)
+
+        return implicit_fencil
 
     def __call__(self, *args):
         if type(self)._hook:

--- a/src/functional/iterator/runtime.py
+++ b/src/functional/iterator/runtime.py
@@ -82,7 +82,7 @@ class FundefDispatcher:
                 if isinstance(dom, Callable):
                     # if domain is expressed as calls to builtin `domain()` we need to pass it lazily
                     # as dispatching needs to happen inside of the fencil
-                    dom = dom
+                    dom = dom()
                 if isinstance(dom, dict):
                     # if passed as a dict, we need to convert back to builtins for interpretation by the backends
                     dom = builtins.domain(
@@ -93,7 +93,6 @@ class FundefDispatcher:
                             )
                         )
                     )
-                # TODO support for more than one inp in tracing
                 closure(dom, self, [out], [*inps])
 
             impl(out, *args, **kwargs)

--- a/src/functional/iterator/tracing.py
+++ b/src/functional/iterator/tracing.py
@@ -238,8 +238,10 @@ def make_node(o):
     raise NotImplementedError(f"Cannot handle {o}")
 
 
-def trace_function_call(fun):
-    body = fun(*list(_s(param) for param in inspect.signature(fun).parameters.keys()))
+def trace_function_call(fun, *, args=None):
+    if args is None:
+        args = (_s(param) for param in inspect.signature(fun).parameters.keys())
+    body = fun(*list(args))
     return make_node(body) if body is not None else None
 
 
@@ -310,20 +312,40 @@ def closure(domain, stencil, outputs, inputs):
     )
 
 
-def trace(fun):
+def _make_param_names(fun, args):
+    """Expand *args parameter with remaining args"""
+    args = [*args]
+    param_names = []
+    for p in inspect.signature(fun).parameters.values():
+        if (
+            p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+            or p.kind == inspect.Parameter.POSITIONAL_ONLY
+        ):
+            args.pop(0)
+            param_names.append(p.name)
+        elif p.kind == inspect.Parameter.VAR_POSITIONAL:
+            for i in range(len(args)):
+                param_names.append(f"_var{i}")
+        else:
+            raise RuntimeError("Illegal parameter kind")
+    return param_names
+
+
+def trace(fun, args):
     with Tracer() as _:
-        trace_function_call(fun)
+        param_names = _make_param_names(fun, args)
+        trace_function_call(fun, args=(_s(p) for p in param_names))
 
         fencil = FencilDefinition(
             id=fun.__name__,
-            params=list(Sym(id=param) for param in inspect.signature(fun).parameters.keys()),
+            params=list(Sym(id=param) for param in param_names),
             closures=Tracer.closures,
         )
         return Program(function_definitions=Tracer.fundefs, fencil_definitions=[fencil], setqs=[])
 
 
 def fendef_tracing(fun, *args, **kwargs):
-    prog = trace(fun)
+    prog = trace(fun, args=args)
     execute_program(prog, *args, **kwargs)
 
 

--- a/src/functional/iterator/tracing.py
+++ b/src/functional/iterator/tracing.py
@@ -313,7 +313,7 @@ def closure(domain, stencil, outputs, inputs):
 
 
 def _make_param_names(fun, args):
-    """Expand *args parameter with remaining args"""
+    """Expand *args parameter with remaining args."""
     args = [*args]
     param_names = []
     for p in inspect.signature(fun).parameters.values():

--- a/tests/functional_tests/iterator_tests/test_implicit_fencil.py
+++ b/tests/functional_tests/iterator_tests/test_implicit_fencil.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pytest
+
+from functional.iterator.builtins import *
+from functional.iterator.embedded import np_as_located_field
+from functional.iterator.runtime import CartesianAxis, fundef
+
+
+I = CartesianAxis("I")
+
+_isize = 10
+
+
+@pytest.fixture
+def dom():
+    return {I: range(_isize)}
+
+
+def a_field():
+    return np_as_located_field(I)(np.asarray(range(_isize)))
+
+
+def out_field():
+    return np_as_located_field(I)(np.zeros(shape=(_isize,)))
+
+
+@fundef
+def copy_stencil(inp):
+    return deref(inp)
+
+
+def test_single_argument(backend, dom):
+    backend, validate = backend
+
+    inp = a_field()
+    out = out_field()
+
+    copy_stencil[dom](inp, out=out, offset_provider={}, backend=backend)
+    if validate:
+        assert np.allclose(inp, out)
+
+
+def test_2_arguments(backend, dom):
+    backend, validate = backend
+
+    @fundef
+    def fun(inp0, inp1):
+        return deref(inp0) + deref(inp1)
+
+    inp0 = a_field()
+    inp1 = a_field()
+    out = out_field()
+
+    fun[dom](inp0, inp1, out=out, offset_provider={}, backend=backend)
+
+    if validate:
+        assert np.allclose(inp0.array() + inp1.array(), out)
+
+
+def test_lambda_domain(backend):
+    backend, validate = backend
+    inp = a_field()
+    out = out_field()
+
+    dom = lambda: domain(named_range(I, 0, 10))
+    copy_stencil[dom](inp, out=out, offset_provider={}, backend=backend)
+
+    if validate:
+        assert np.allclose(inp, out)

--- a/tests/functional_tests/iterator_tests/test_toy_connectivity.py
+++ b/tests/functional_tests/iterator_tests/test_toy_connectivity.py
@@ -156,7 +156,7 @@ def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(backend):
     out = np_as_located_field(Cell)(np.zeros([9]))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
-    first_vertex_neigh_of_first_edge_neigh_of_cells[{Cell, range(0, 9)}](
+    first_vertex_neigh_of_first_edge_neigh_of_cells[{Cell: range(0, 9)}](
         inp,
         out=out,
         backend=backend,

--- a/tests/functional_tests/iterator_tests/test_toy_connectivity.py
+++ b/tests/functional_tests/iterator_tests/test_toy_connectivity.py
@@ -135,7 +135,7 @@ def test_sum_edges_to_vertices_reduce(backend):
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
-    sum_edges_to_vertices_reduce[domain(named_range(Vertex, 0, 9))](
+    sum_edges_to_vertices_reduce[{Vertex: range(0, 9)}](
         inp,
         out=out,
         backend=backend,
@@ -156,7 +156,7 @@ def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(backend):
     out = np_as_located_field(Cell)(np.zeros([9]))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
-    first_vertex_neigh_of_first_edge_neigh_of_cells[domain(named_range(Cell, 0, 9))](
+    first_vertex_neigh_of_first_edge_neigh_of_cells[{Cell, range(0, 9)}](
         inp,
         out=out,
         backend=backend,

--- a/tests/functional_tests/iterator_tests/test_toy_connectivity.py
+++ b/tests/functional_tests/iterator_tests/test_toy_connectivity.py
@@ -108,23 +108,18 @@ def sum_edges_to_vertices(in_edges):
     )
 
 
-@fendef(offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)})
-def e2v_sum_fencil(in_edges, out_vertices):
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        sum_edges_to_vertices,
-        [out_vertices],
-        [in_edges],
-    )
-
-
 def test_sum_edges_to_vertices(backend):
     backend, validate = backend
     inp = index_field(Edge)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
-    e2v_sum_fencil(inp, out, backend=backend)
+    sum_edges_to_vertices[{Vertex: range(0, 9)}](
+        inp,
+        out=out,
+        backend=backend,
+        offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
+    )
     if validate:
         assert allclose(out, ref)
 
@@ -134,23 +129,18 @@ def sum_edges_to_vertices_reduce(in_edges):
     return reduce(lambda a, b: a + b, 0)(shift(V2E)(in_edges))
 
 
-@fendef(offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)})
-def e2v_sum_fencil_reduce(in_edges, out_vertices):
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        sum_edges_to_vertices_reduce,
-        [out_vertices],
-        [in_edges],
-    )
-
-
 def test_sum_edges_to_vertices_reduce(backend):
     backend, validate = backend
     inp = index_field(Edge)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
-    e2v_sum_fencil_reduce(inp, out, backend=backend)
+    sum_edges_to_vertices_reduce[domain(named_range(Vertex, 0, 9))](
+        inp,
+        out=out,
+        backend=backend,
+        offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
+    )
     if validate:
         assert allclose(out, ref)
 
@@ -160,43 +150,28 @@ def first_vertex_neigh_of_first_edge_neigh_of_cells(in_vertices):
     return deref(shift(E2V, 0)(shift(C2E, 0)(in_vertices)))
 
 
-@fendef(
-    offset_provider={
-        "E2V": NeighborTableOffsetProvider(e2v_arr, Edge, Vertex, 2),
-        "C2E": NeighborTableOffsetProvider(c2e_arr, Cell, Edge, 4),
-    }
-)
-def first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(in_vertices, out_cells):
-    closure(
-        domain(named_range(Cell, 0, 9)),
-        first_vertex_neigh_of_first_edge_neigh_of_cells,
-        [out_cells],
-        [in_vertices],
-    )
-
-
-def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil():
+def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(backend):
+    backend, validate = backend
     inp = index_field(Vertex)
     out = np_as_located_field(Cell)(np.zeros([9]))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
-    first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(inp, out, backend="double_roundtrip")
-    assert allclose(out, ref)
+    first_vertex_neigh_of_first_edge_neigh_of_cells[domain(named_range(Cell, 0, 9))](
+        inp,
+        out=out,
+        backend=backend,
+        offset_provider={
+            "E2V": NeighborTableOffsetProvider(e2v_arr, Edge, Vertex, 2),
+            "C2E": NeighborTableOffsetProvider(c2e_arr, Cell, Edge, 4),
+        },
+    )
+    if validate:
+        assert allclose(out, ref)
 
 
 @fundef
 def sparse_stencil(inp):
     return reduce(lambda a, b: a + b, 0)(inp)
-
-
-@fendef
-def sparse_fencil(inp, out):
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        sparse_stencil,
-        [out],
-        [inp],
-    )
 
 
 def test_sparse_input_field(backend):
@@ -206,9 +181,9 @@ def test_sparse_input_field(backend):
 
     ref = np.ones([9]) * 10
 
-    sparse_fencil(
+    sparse_stencil[{Vertex: range(0, 9)}](
         inp,
-        out,
+        out=out,
         backend=backend,
         offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
     )
@@ -227,9 +202,9 @@ def test_sparse_input_field_v2v(backend):
 
     ref = np.asarray(list(sum(row) for row in v2v_arr))
 
-    sparse_fencil(
+    sparse_stencil[{Vertex: range(0, 9)}](
         inp,
-        out,
+        out=out,
         backend=backend,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
     )
@@ -248,21 +223,15 @@ def lift_stencil(inp):
     return deref(shift(V2V, 2)(lift(deref_stencil)(inp)))
 
 
-@fendef
-def lift_fencil(inp, out):
-    closure(domain(named_range(Vertex, 0, 9)), lift_stencil, [out], [inp])
-
-
 def test_lift(backend):
     backend, validate = backend
     inp = index_field(Vertex)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 
-    lift_fencil(None, None, backend="cpptoy")
-    lift_fencil(
+    lift_stencil[{Vertex: range(0, 9)}](
         inp,
-        out,
+        out=out,
         backend=backend,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
     )
@@ -275,25 +244,15 @@ def sparse_shifted_stencil(inp):
     return deref(shift(0, 2)(shift(V2V)(inp)))
 
 
-@fendef
-def sparse_shifted_fencil(inp, out):
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        sparse_shifted_stencil,
-        [out],
-        [inp],
-    )
-
-
 def test_shift_sparse_input_field(backend):
     backend, validate = backend
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 
-    sparse_shifted_fencil(
+    sparse_shifted_stencil[{Vertex: range(0, 9)}](
         inp,
-        out,
+        out=out,
         backend=backend,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
     )
@@ -312,22 +271,6 @@ def shift_sparse_stencil2(inp):
     return deref(shift(1, 3)(shift(V2E)(inp)))
 
 
-@fendef
-def sparse_shifted_fencil2(inp_sparse, inp, out1, out2):
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        shift_shift_stencil2,
-        [out1],
-        [inp],
-    )
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        shift_sparse_stencil2,
-        [out2],
-        [inp_sparse],
-    )
-
-
 def test_shift_sparse_input_field2(backend):
     backend, validate = backend
     inp = index_field(Vertex)
@@ -335,16 +278,15 @@ def test_shift_sparse_input_field2(backend):
     out1 = np_as_located_field(Vertex)(np.zeros([9]))
     out2 = np_as_located_field(Vertex)(np.zeros([9]))
 
-    sparse_shifted_fencil2(
-        inp_sparse,
-        inp,
-        out1,
-        out2,
-        backend=backend,
-        offset_provider={
-            "E2V": NeighborTableOffsetProvider(e2v_arr, Edge, Vertex, 2),
-            "V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4),
-        },
+    offset_provider = {
+        "E2V": NeighborTableOffsetProvider(e2v_arr, Edge, Vertex, 2),
+        "V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4),
+    }
+
+    domain = {Vertex: range(0, 9)}
+    shift_shift_stencil2[domain](inp, out=out1, offset_provider=offset_provider, backend=backend)
+    shift_sparse_stencil2[domain](
+        inp_sparse, out=out2, offset_provider=offset_provider, backend=backend
     )
 
     if validate:
@@ -358,16 +300,6 @@ def sparse_shifted_stencil_reduce(inp):
 
     # return deref(shift(V2V, 0)(lift(deref)(shift(0)(inp))))
     return reduce(sum_, 0)(shift(V2V)(lift(reduce(sum_, 0))(inp)))
-
-
-@fendef
-def sparse_shifted_fencil_reduce(inp, out):
-    closure(
-        domain(named_range(Vertex, 0, 9)),
-        sparse_shifted_stencil_reduce,
-        [out],
-        [inp],
-    )
 
 
 def test_shift_sparse_input_field(backend):
@@ -384,9 +316,10 @@ def test_shift_sparse_input_field(backend):
 
     ref = np.asarray(ref)
 
-    sparse_shifted_fencil_reduce(
+    domain = {Vertex: range(0, 9)}
+    sparse_shifted_stencil_reduce[domain](
         inp,
-        out,
+        out=out,
         backend=backend,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
     )


### PR DESCRIPTION
Adds `stencil[domain](..., out=out, backend=backend, offset_provider=offset_provider)` syntax for directly calling a stencil. Useful for testing to avoid the boiler-plate of adding a fencil for a single stencil test.

`domain` should be either
- a dict `{Axis: range(start, stop), ...}` or
- a lambda for delaying a function call to the `domain()` builtin (otherwise the default builtin will be executed), e.g. `lambda: domain(named_range(Axis, start, stop), ...)`