### PR TITLE
Add tests to known_first_party isort config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,12 +79,6 @@ repos:
   hooks:
   - id: black
 
-- repo: https://github.com/asottile/seed-isort-config
-  rev: v2.2.0
-  hooks:
-  - id: seed-isort-config
-    args: ['--application-directories=src:tests']
-
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v5.7.0
   hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -182,8 +182,8 @@ use_parentheses = true
 lines_after_imports = 2
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_first_party = eve,gtc,gt4py,__externals__,__gtscript__
-known_third_party = attr,black,boltons,cached_property,click,dace,dawn4py,devtools,factory,hypothesis,jinja2,mako,networkx,numpy,packaging,pkg_resources,pybind11,pydantic,pytest,pytest_factoryboy,setuptools,tabulate,tests,typing_extensions,xxhash
+known_first_party = eve,gtc,gt4py,tests,__externals__,__gtscript__
+known_third_party = attr,black,boltons,cached_property,click,dace,dawn4py,devtools,factory,hypothesis,jinja2,mako,networkx,numpy,packaging,pkg_resources,pybind11,pydantic,pytest,pytest_factoryboy,setuptools,tabulate,typing_extensions,xxhash
 
 #-- mypy --
 [mypy]

--- a/tests/test_unittest/test_gtc_backend/test_defir_to_gtir.py
+++ b/tests/test_unittest/test_gtc_backend/test_defir_to_gtir.py
@@ -15,15 +15,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
-from tests.definition_setup import ijk_domain  # noqa: F401
-from tests.definition_setup import (
-    BlockStmt,
-    IterationOrder,
-    TAssign,
-    TComputationBlock,
-    TDefinition,
-    TFieldRef,
-)
 
 from gt4py.backend.gtc_backend.defir_to_gtir import DefIRToGTIR
 from gt4py.ir.nodes import (
@@ -37,6 +28,15 @@ from gt4py.ir.nodes import (
     ScalarLiteral,
 )
 from gtc import common, gtir
+from tests.definition_setup import ijk_domain  # noqa: F401
+from tests.definition_setup import (
+    BlockStmt,
+    IterationOrder,
+    TAssign,
+    TComputationBlock,
+    TDefinition,
+    TFieldRef,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

- Make tests `known_first_party` since they are included in the repo.
- Remove `seed-isort-config` as it is deprecated since isort v5 (see https://github.com/asottile-archive/seed-isort-config).