### PR TITLE
Make HorizontalExecution a SymbolTableTrait

### DIFF
--- a/src/eve/traits.py
+++ b/src/eve/traits.py
@@ -68,10 +68,6 @@ class SymbolTableTrait(concepts.Model):
         values["symtable_"] = cls._collect_symbols(values)
         return values
 
-    def collect_symbols(self) -> None:
-        self.symtable_ = dict()
-        self.symtable_ = self._collect_symbols(self)
-
     @staticmethod
     @contextlib.contextmanager
     def symtable_merger(

--- a/src/gtc/cuir/cuir.py
+++ b/src/gtc/cuir/cuir.py
@@ -190,7 +190,7 @@ class KCacheDecl(Decl):
     extent: Optional[KExtent]
 
 
-class HorizontalExecution(LocNode):
+class HorizontalExecution(LocNode, SymbolTableTrait):
     body: List[Stmt]
     declarations: List[LocalScalar]
     extent: Optional[IJExtent]

--- a/src/gtc/oir.py
+++ b/src/gtc/oir.py
@@ -159,7 +159,7 @@ class Interval(LocNode):
         return cls(start=AxisBound.start(), end=AxisBound.end())
 
 
-class HorizontalExecution(LocNode):
+class HorizontalExecution(LocNode, SymbolTableTrait):
     body: List[Stmt]
     declarations: List[LocalScalar]
 

--- a/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
+++ b/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
@@ -161,6 +161,7 @@ class OnTheFlyMerging(NodeTranslator):
             }
 
             # 4 contributions to the new declarations list
+            combined_symtable = {**symtable, **first.symtable_}
             decls_from_later = [
                 d for d in horizontal_execution.declarations if d.name not in duplicated_locals
             ]
@@ -170,15 +171,11 @@ class OnTheFlyMerging(NodeTranslator):
                 if d not in horizontal_execution.declarations or d.name in duplicated_locals
             ]
             decls_renamed_locals_in_later = [
-                oir.LocalScalar(
-                    name=new_name, dtype={**symtable, **first.symtable_}[old_name].dtype
-                )
+                oir.LocalScalar(name=new_name, dtype=combined_symtable[old_name].dtype)
                 for old_name, new_name in scalar_map.items()
             ]
             new_decls = [
-                oir.LocalScalar(
-                    name=new_name, dtype={**symtable, **first.symtable_}[old_name].dtype
-                )
+                oir.LocalScalar(name=new_name, dtype=combined_symtable[old_name].dtype)
                 for (old_name, _), new_name in offset_symbol_map.items()
             ]
 

--- a/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
+++ b/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
@@ -237,18 +237,19 @@ class OnTheFlyMerging(NodeTranslator):
         vertical_loops: List[oir.VerticalLoop] = []
         protected_fields = set(n.name for n in node.params)
         all_names = collect_symbol_names(node)
-        for vl in reversed(node.vertical_loops):
-            vertical_loops.insert(
-                0,
-                self.visit(
-                    vl,
-                    new_symbol_name=symbol_name_creator(all_names),
-                    protected_fields=protected_fields,
-                    **kwargs,
-                ),
+        vertical_loops = [
+            *reversed(
+                [
+                    self.visit(
+                        vl,
+                        new_symbol_name=symbol_name_creator(all_names),
+                        protected_fields=protected_fields,
+                        **kwargs,
+                    )
+                    for vl in reversed(node.vertical_loops)
+                ]
             )
-            access_collection = AccessCollector.apply(vl)
-            protected_fields |= access_collection.fields()
+        ]
         accessed = AccessCollector.apply(vertical_loops).fields()
         return oir.Stencil(
             name=node.name,

--- a/src/gtc/passes/oir_optimizations/temporaries.py
+++ b/src/gtc/passes/oir_optimizations/temporaries.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Dict, Set, Union
 from eve import NodeTranslator, SymbolTableTrait
 from gtc import oir
 
-from .utils import AccessCollector, symbol_name_creator
+from .utils import AccessCollector, collect_symbol_names, symbol_name_creator
 
 
 class TemporariesToScalarsBase(NodeTranslator):
@@ -78,12 +78,13 @@ class TemporariesToScalarsBase(NodeTranslator):
 
     def visit_Stencil(self, node: oir.Stencil, **kwargs: Any) -> oir.Stencil:
         tmps_to_replace = kwargs["tmps_to_replace"]
+        all_names = collect_symbol_names(node)
         return oir.Stencil(
             name=node.name,
             params=node.params,
             vertical_loops=self.visit(
                 node.vertical_loops,
-                new_symbol_name=symbol_name_creator(set(kwargs["symtable"])),
+                new_symbol_name=symbol_name_creator(all_names),
                 **kwargs,
             ),
             declarations=[d for d in node.declarations if d.name not in tmps_to_replace],

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Set, Tuple, Typ
 
 from eve import NodeVisitor
 from eve.concepts import TreeNode
+from eve.traits import SymbolTableTrait
 from eve.utils import XIterable, xiter
 from gtc import oir
 
@@ -161,7 +162,7 @@ def symbol_name_creator(used_names: Set[str]) -> Callable[[str], str]:
 
     def increment_string_suffix(s: str) -> str:
         if not s[-1].isnumeric():
-            return s + "0"
+            return s + "_tmp_0"
         return re.sub(r"[0-9]+$", lambda n: str(int(n.group()) + 1), s)
 
     def new_symbol_name(name: str) -> str:
@@ -171,3 +172,12 @@ def symbol_name_creator(used_names: Set[str]) -> Callable[[str], str]:
         return name
 
     return new_symbol_name
+
+
+def collect_symbol_names(node: TreeNode) -> Set[str]:
+    return (
+        node.iter_tree()
+        .if_isinstance(SymbolTableTrait)
+        .getattr("symtable_")
+        .reduce(lambda names, symtable: names.union(symtable.keys()), init=set())
+    )

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -162,7 +162,7 @@ def symbol_name_creator(used_names: Set[str]) -> Callable[[str], str]:
 
     def increment_string_suffix(s: str) -> str:
         if not s[-1].isnumeric():
-            return s + "_tmp_0"
+            return s + "_gen_0"
         return re.sub(r"[0-9]+$", lambda n: str(int(n.group()) + 1), s)
 
     def new_symbol_name(name: str) -> str:

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -30,6 +30,10 @@ OffsetT = TypeVar("OffsetT")
 GeneralOffsetTuple = Tuple[int, int, Optional[int]]
 
 
+digits_at_end_pattern = re.compile(r"[0-9]+$")
+generated_name_pattern = re.compile(r".+_gen_[0-9]+")
+
+
 @dataclass(frozen=True)
 class GenericAccess(Generic[OffsetT]):
     field: str
@@ -161,9 +165,9 @@ def symbol_name_creator(used_names: Set[str]) -> Callable[[str], str]:
     """
 
     def increment_string_suffix(s: str) -> str:
-        if not re.match(r".+_gen_[0-9]+", s):
+        if not generated_name_pattern.match(s):
             return s + "_gen_0"
-        return re.sub(r"[0-9]+$", lambda n: str(int(n.group()) + 1), s)
+        return digits_at_end_pattern.sub(lambda n: str(int(n.group()) + 1), s)
 
     def new_symbol_name(name: str) -> str:
         while name in used_names:

--- a/src/gtc/passes/oir_optimizations/utils.py
+++ b/src/gtc/passes/oir_optimizations/utils.py
@@ -161,7 +161,7 @@ def symbol_name_creator(used_names: Set[str]) -> Callable[[str], str]:
     """
 
     def increment_string_suffix(s: str) -> str:
-        if not s[-1].isnumeric():
+        if not re.match(r".+_gen_[0-9]+", s):
             return s + "_gen_0"
         return re.sub(r"[0-9]+$", lambda n: str(int(n.group()) + 1), s)
 

--- a/tests/test_unittest/test_gtc/common_utils.py
+++ b/tests/test_unittest/test_gtc/common_utils.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Set
 
 import factory
 
-from eve import concepts, traits, type_definitions, visitors
+from eve import concepts, type_definitions, visitors
 from gtc import common
 
 
@@ -35,8 +35,7 @@ def undefined_symbol_list(
                     elif issubclass(type_, type_definitions.SymbolRef):
                         refs.add(getattr(node, name))
 
-            if not isinstance(node, traits.SymbolTableTrait):
-                self.generic_visit(node, symbols=symbols, refs=refs)
+            self.generic_visit(node, symbols=symbols, refs=refs)
 
     def func(obj):
         symbols: Set[str] = set()

--- a/tests/test_unittest/test_gtc/oir_utils.py
+++ b/tests/test_unittest/test_gtc/oir_utils.py
@@ -40,6 +40,15 @@ class ScalarAccessFactory(factory.Factory):
     dtype = common.DataType.FLOAT32
 
 
+class BinaryOpFactory(factory.Factory):
+    class Meta:
+        model = oir.BinaryOp
+
+    op = common.ArithmeticOperator.ADD
+    left = factory.SubFactory(FieldAccessFactory, dtype=common.DataType.FLOAT32)
+    right = factory.SubFactory(FieldAccessFactory, dtype=common.DataType.FLOAT32)
+
+
 class VariableKOffsetFactory(factory.Factory):
     class Meta:
         model = oir.VariableKOffset

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -239,3 +239,4 @@ def test_on_the_fly_merging_localscalars():
     transformed = OnTheFlyMerging().visit(testee)
     hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
     assert len(hexecs) == 1
+    assert len(hexecs[0].declarations) == 3

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -222,6 +222,7 @@ def test_on_the_fly_merging_localscalars():
                     AssignStmtFactory(
                         left=ScalarAccessFactory(name="scalar_tmp"),
                         right__name="in",
+                        right__offset__i=1,
                     ),
                     AssignStmtFactory(
                         left__name="out",

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -177,31 +177,6 @@ def test_on_the_fly_merging_repeated():
     assert len(hexecs) == 2
 
 
-def test_on_the_fly_merging_nested():
-    testee = StencilFactory(
-        vertical_loops__0__sections__0__horizontal_executions=[
-            HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="tmp")]),
-            HorizontalExecutionFactory(
-                body=[
-                    AssignStmtFactory(
-                        left__name="tmp_offset", right__name="tmp", right__offset__i=1
-                    )
-                ]
-            ),
-            HorizontalExecutionFactory(
-                body=[AssignStmtFactory(left__name="out", right__name="tmp_offset")]
-            ),
-            HorizontalExecutionFactory(
-                body=[AssignStmtFactory(left__name="out2", right__name="tmp_offset")]
-            ),
-        ],
-        declarations=[TemporaryFactory(name="tmp"), TemporaryFactory(name="tmp_offset")],
-    )
-    transformed = OnTheFlyMerging().visit(testee)
-    hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
-    assert len(hexecs) == 2
-
-
 def test_on_the_fly_merging_localscalars():
     testee = StencilFactory(
         vertical_loops__0__sections__0__horizontal_executions=[

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -172,3 +172,28 @@ def test_on_the_fly_merging_repeated():
     transformed = OnTheFlyMerging().visit(testee)
     hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
     assert len(hexecs) == 2
+
+
+def test_on_the_fly_merging_nested():
+    testee = StencilFactory(
+        vertical_loops__0__sections__0__horizontal_executions=[
+            HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="tmp")]),
+            HorizontalExecutionFactory(
+                body=[
+                    AssignStmtFactory(
+                        left__name="tmp_offset", right__name="tmp", right__offset__i=1
+                    )
+                ]
+            ),
+            HorizontalExecutionFactory(
+                body=[AssignStmtFactory(left__name="out", right__name="tmp_offset")]
+            ),
+            HorizontalExecutionFactory(
+                body=[AssignStmtFactory(left__name="out2", right__name="tmp_offset")]
+            ),
+        ],
+        declarations=[TemporaryFactory(name="tmp"), TemporaryFactory(name="tmp_offset")],
+    )
+    transformed = OnTheFlyMerging().visit(testee)
+    hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
+    assert len(hexecs) == 2

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -19,8 +19,11 @@ from gtc.passes.oir_optimizations.horizontal_execution_merging import OnTheFlyMe
 
 from ...oir_utils import (
     AssignStmtFactory,
+    BinaryOpFactory,
     HorizontalExecutionFactory,
+    LocalScalarFactory,
     NativeFuncCallFactory,
+    ScalarAccessFactory,
     StencilFactory,
     TemporaryFactory,
     VerticalLoopFactory,
@@ -197,3 +200,41 @@ def test_on_the_fly_merging_nested():
     transformed = OnTheFlyMerging().visit(testee)
     hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
     assert len(hexecs) == 2
+
+
+def test_on_the_fly_merging_localscalars():
+    testee = StencilFactory(
+        vertical_loops__0__sections__0__horizontal_executions=[
+            HorizontalExecutionFactory(
+                body=[
+                    AssignStmtFactory(
+                        left=ScalarAccessFactory(name="scalar_tmp"),
+                        right__name="in",
+                    ),
+                    AssignStmtFactory(
+                        left__name="tmp", right=ScalarAccessFactory(name="scalar_tmp")
+                    ),
+                ],
+                declarations=[LocalScalarFactory(name="scalar_tmp")],
+            ),
+            HorizontalExecutionFactory(
+                body=[
+                    AssignStmtFactory(
+                        left=ScalarAccessFactory(name="scalar_tmp"),
+                        right__name="in",
+                    ),
+                    AssignStmtFactory(
+                        left__name="out",
+                        right=BinaryOpFactory(
+                            left=ScalarAccessFactory(name="scalar_tmp"), right__name="tmp"
+                        ),
+                    ),
+                ],
+                declarations=[LocalScalarFactory(name="scalar_tmp")],
+            ),
+        ],
+        declarations=[TemporaryFactory(name="tmp")],
+    )
+    transformed = OnTheFlyMerging().visit(testee)
+    hexecs = transformed.vertical_loops[0].sections[0].horizontal_executions
+    assert len(hexecs) == 1


### PR DESCRIPTION
## Description

Makes the `oir.HorizontalExecution` a `SymbolTableTrait`, which allows multiple `oir.HorizontalExecution` to define and use `declarations` `Decl`s with the same name. Follow-ons from this change:
- Makes a change to the horizontal execution merging pass to handle merging executions that have local scalars with the same name: in this case one needs to be re-named.
- Adds existing scalars to the symbol name mapper in order to ensure that all new temporaries have unique names.
- Adds a test for this new behavior.

Fixes #559. Alternative to #562; might be cleaner.