### PR TITLE
Replace eve.concepts.AnyNode by eve.concepts.BaseNode

### DIFF
--- a/src/eve/concepts.py
+++ b/src/eve/concepts.py
@@ -37,6 +37,7 @@ from .typingx import (
     Set,
     Tuple,
     TypedDict,
+    TypeVar,
     Union,
     no_type_check,
 )
@@ -115,6 +116,7 @@ class FrozenModel(pydantic.BaseModel):
 _EVE_NODE_INTERNAL_SUFFIX = "__"
 _EVE_NODE_IMPL_SUFFIX = "_"
 
+NodeT = TypeVar("NodeT", bound="BaseNode")
 ValueNode = Union[bool, bytes, int, float, str, IntEnum, StrEnum]
 LeafNode = Union["BaseNode", ValueNode]
 CollectionNode = Union[List[LeafNode], Dict[Any, LeafNode], Set[LeafNode]]

--- a/src/eve/concepts.py
+++ b/src/eve/concepts.py
@@ -37,7 +37,6 @@ from .typingx import (
     Set,
     Tuple,
     TypedDict,
-    TypeVar,
     Union,
     no_type_check,
 )
@@ -116,11 +115,10 @@ class FrozenModel(pydantic.BaseModel):
 _EVE_NODE_INTERNAL_SUFFIX = "__"
 _EVE_NODE_IMPL_SUFFIX = "_"
 
-AnyNode = TypeVar("AnyNode", bound="BaseNode")
 ValueNode = Union[bool, bytes, int, float, str, IntEnum, StrEnum]
-LeafNode = Union[AnyNode, ValueNode]
+LeafNode = Union["BaseNode", ValueNode]
 CollectionNode = Union[List[LeafNode], Dict[Any, LeafNode], Set[LeafNode]]
-TreeNode = Union[AnyNode, CollectionNode]
+TreeNode = Union["BaseNode", CollectionNode]
 
 
 class NodeMetaclass(pydantic.main.ModelMetaclass):


### PR DESCRIPTION
## Description

This removes the TypeVar from concepts, which means these can be used in `ClassVar` instances.

Resolves #565.