### PR TITLE
Fix bug where node was added to SDFG too late if no read acces was there

### DIFF
--- a/src/gtc/dace/oir_to_dace.py
+++ b/src/gtc/dace/oir_to_dace.py
@@ -371,6 +371,7 @@ class BaseOirSDFGBuilder(ABC):
     def build(cls, name, stencil: Stencil, nodes: List[dace.nodes.LibraryNode]):
         builder = cls(name, stencil, nodes)
         for n in nodes:
+            builder.add_node(n)
             builder.add_write_after_write_edges(n)
             builder.add_read_edges(n)
             builder.add_write_edges(n)

--- a/tests/test_unittest/test_gtc/test_dace.py
+++ b/tests/test_unittest/test_gtc/test_dace.py
@@ -21,18 +21,19 @@ import pytest
 from gt4py.backend.gtc_backend.defir_to_gtir import DefIRToGTIR
 from gt4py.definitions import BuildOptions
 from gt4py.frontend.gtscript_frontend import GTScriptFrontend
-from gtc.common import AxisBound
+from gtc.common import AxisBound, DataType
 from gtc.dace.dace_to_oir import convert
 from gtc.dace.oir_to_dace import OirSDFGBuilder
 from gtc.dace.utils import assert_sdfg_equal
 from gtc.gtir_to_oir import GTIRToOIR
-from gtc.oir import Interval
+from gtc.oir import Interval, Literal
 from gtc.passes.gtir_pipeline import GtirPipeline
 
 from ...test_integration.stencil_definitions import EXTERNALS_REGISTRY as externals_registry
 from ...test_integration.stencil_definitions import REGISTRY as stencil_registry
 from .oir_utils import (
     AssignStmtFactory,
+    HorizontalExecutionFactory,
     StencilFactory,
     VerticalLoopFactory,
     VerticalLoopSectionFactory,
@@ -89,4 +90,39 @@ def test_same_node_read_write_not_overlap():
         ]
     )
     sdfg = OirSDFGBuilder().visit(oir)
+    convert(sdfg)
+
+
+def test_two_vertical_loops_no_read():
+    oir_pre = StencilFactory(
+        vertical_loops=[
+            VerticalLoopFactory(
+                sections__0=VerticalLoopSectionFactory(
+                    horizontal_executions=[
+                        HorizontalExecutionFactory(
+                            body__0=AssignStmtFactory(
+                                left__name="field",
+                                right=Literal(value="42.0", dtype=DataType.FLOAT32),
+                            )
+                        )
+                    ],
+                    interval__end=AxisBound.from_start(3),
+                ),
+            ),
+            VerticalLoopFactory(
+                sections__0=VerticalLoopSectionFactory(
+                    horizontal_executions=[
+                        HorizontalExecutionFactory(
+                            body__0=AssignStmtFactory(
+                                left__name="field",
+                                right=Literal(value="43.0", dtype=DataType.FLOAT32),
+                            )
+                        )
+                    ],
+                    interval__start=AxisBound.from_start(3),
+                ),
+            ),
+        ]
+    )
+    sdfg = OirSDFGBuilder().visit(oir_pre)
     convert(sdfg)


### PR DESCRIPTION
Presumably a fix for #570 @fthaler can you verify that this fixes your original issue?

You wrote that it "fails on stencils that write to a different set of fields in different intervals" but this fix for your reproducer is not related to that reason.