### PR TITLE
Fix k-Cache Offset Calculation in CUIR

### DIFF
--- a/src/gtc/cuir/cuir.py
+++ b/src/gtc/cuir/cuir.py
@@ -176,7 +176,9 @@ class KExtent(LocNode):
     @classmethod
     def from_offset(cls, offset: Union[CartesianOffset, VariableKOffset]) -> "KExtent":
         MAX_OFFSET = 1000
-        return cls(k=(offset.k, offset.k)) if offset.k else cls(k=(-MAX_OFFSET, MAX_OFFSET))
+        if isinstance(offset, VariableKOffset):
+            return cls(k=(-MAX_OFFSET, MAX_OFFSET))
+        return cls(k=(offset.k, offset.k))
 
     def union(*extents: "KExtent") -> "KExtent":
         return KExtent(k=(min(e.k[0] for e in extents), max(e.k[1] for e in extents)))


### PR DESCRIPTION
## Description

Fixes incorrect k-cache offset calculation introduced with variable k-offsets. Fixes #580.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


