### PR TITLE
Check k-axis size, add k boundary computation, fix horizontal boundary computation, allow negative origins

### DIFF
--- a/src/gt4py/analysis/infos.py
+++ b/src/gt4py/analysis/infos.py
@@ -246,8 +246,6 @@ class TransformData:
     implementation_ir = attribute(of=gt_ir.StencilImplementation)
     options = attribute(of=BuildOptions)
 
-    splitters_var = attribute(of=str, optional=True)
-    min_k_interval_sizes = attribute(of=ListOf[int], factory=list)
     symbols = attribute(of=DictOf[str, SymbolInfo], factory=dict)
     blocks = attribute(of=ListOf[DomainBlockInfo], factory=list)
 
@@ -258,10 +256,6 @@ class TransformData:
     @property
     def ndims(self):
         return self.definition_ir.domain.ndims
-
-    @property
-    def nk_intervals(self):
-        return len(self.min_k_interval_sizes)
 
     @property
     def axes_names(self):

--- a/src/gt4py/analysis/infos.py
+++ b/src/gt4py/analysis/infos.py
@@ -230,8 +230,6 @@ class TransformData:
         Implementation IR with the final implementation of the stencil.
     options : `gt4py.definitions.Options`
         Build options provided by the users.
-    splitters_var : `str`
-        Used in IntervalMaker when parsing variable splitters.
     min_k_interval_sizes : `list` [`int`]
         Used in IntervalMaker for storing the interval sizes.
     symbols : `dict` [`str`, `SymbolInfo`]
@@ -246,6 +244,7 @@ class TransformData:
     implementation_ir = attribute(of=gt_ir.StencilImplementation)
     options = attribute(of=BuildOptions)
 
+    min_k_interval_sizes = attribute(of=ListOf[int], factory=list)
     symbols = attribute(of=DictOf[str, SymbolInfo], factory=dict)
     blocks = attribute(of=ListOf[DomainBlockInfo], factory=list)
 

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -99,31 +99,6 @@ class InitInfoPass(TransformPass):
     def make_k_intervals(transform_data: TransformData) -> List[IntervalInfo]:
         """Determines intervals over which the computation runs."""
         node: gt_ir.StencilDefinition = transform_data.definition_ir
-        transform_data.splitters_var: Optional[str] = None
-        transform_data.min_k_interval_sizes: List[int] = [0]
-
-        # First, look for dynamic splitters variable
-        for computation in node.computations:
-            interval_def = computation.interval
-            for axis_bound in [interval_def.start, interval_def.end]:
-                if isinstance(axis_bound.level, gt_ir.VarRef):
-                    name = axis_bound.level.name
-                    for item in node.parameters:
-                        if item.name == name:
-                            decl = item
-                            break
-                    else:
-                        decl = None
-
-                    if decl is None or decl.length == 0:
-                        raise IntervalSpecificationError(
-                            interval_def,
-                            "Invalid variable reference in interval specification",
-                            loc=axis_bound.loc,
-                        )
-
-                    transform_data.splitters_var = decl.name
-                    transform_data.min_k_interval_sizes = [1] * (decl.length + 1)
 
         # Extract computation intervals
         computation_intervals = []
@@ -133,63 +108,26 @@ class InitInfoPass(TransformPass):
             bounds = [None, None]
 
             for i, axis_bound in enumerate([interval_def.start, interval_def.end]):
-                if isinstance(axis_bound.level, gt_ir.VarRef):
-                    # Dynamic splitters: check existing reference and extract size info
-                    if axis_bound.level.name != transform_data.splitters_var:
-                        raise IntervalSpecificationError(
-                            interval_def,
-                            "Non matching variable reference in interval specification",
-                            loc=axis_bound.loc,
-                        )
+                # Static splitter: extract size info
+                index = (
+                    1 if axis_bound.offset < 0 or axis_bound.level == gt_ir.LevelMarker.END else 0
+                )
+                offset = axis_bound.offset
 
-                    index = axis_bound.level.index + 1
-                    offset = axis_bound.offset
-                    if offset < 0:
-                        index = index - 1
-
-                else:
-                    # Static splitter: extract size info
-                    index = (
-                        transform_data.nk_intervals
-                        if axis_bound.offset < 0 or axis_bound.level == gt_ir.LevelMarker.END
-                        else 0
-                    )
-                    offset = axis_bound.offset
-
-                    if offset < 0 and axis_bound.level != gt_ir.LevelMarker.END:
-                        raise IntervalSpecificationError(
-                            interval_def,
-                            "Invalid offset in interval specification",
-                            loc=axis_bound.loc,
-                        )
-
-                    elif offset > 0 and axis_bound.level != gt_ir.LevelMarker.START:
-                        raise IntervalSpecificationError(
-                            interval_def,
-                            "Invalid offset in interval specification",
-                            loc=axis_bound.loc,
-                        )
-
-                # Update min sizes
-                if not 0 <= index <= transform_data.nk_intervals:
+                if offset < 0 and axis_bound.level != gt_ir.LevelMarker.END:
                     raise IntervalSpecificationError(
                         interval_def,
-                        "Invalid variable reference in interval specification",
+                        "Invalid offset in interval specification",
+                        loc=axis_bound.loc,
+                    )
+                elif offset > 0 and axis_bound.level != gt_ir.LevelMarker.START:
+                    raise IntervalSpecificationError(
+                        interval_def,
+                        "Invalid offset in interval specification",
                         loc=axis_bound.loc,
                     )
 
                 bounds[i] = (index, offset)
-                if index < transform_data.nk_intervals:
-                    transform_data.min_k_interval_sizes[index] = max(
-                        transform_data.min_k_interval_sizes[index], offset
-                    )
-
-            if bounds[0][0] == bounds[1][0] - 1:
-                index = bounds[0][0]
-                min_size = 1 + bounds[0][1] - bounds[1][1]
-                transform_data.min_k_interval_sizes[index] = max(
-                    transform_data.min_k_interval_sizes[index], min_size
-                )
 
             # Create computation intervals
             interval_info = IntervalInfo(*bounds)
@@ -1224,9 +1162,6 @@ class BuildIIRPass(TransformPass):
         self.data = transform_data
         self.iir = transform_data.implementation_ir
 
-        if self.data.splitters_var:
-            self.iir.axis_splitters_var = self.data.splitters_var
-
         # Signature
         self.iir.api_signature = self.data.definition_ir.api_signature
 
@@ -1337,15 +1272,10 @@ class BuildIIRPass(TransformPass):
         for bound in (interval.start, interval.end):
             if bound[0] == 0:
                 axis_bounds.append(gt_ir.AxisBound(level=gt_ir.LevelMarker.START, offset=bound[1]))
-            elif bound[0] == self.data.nk_intervals:
+            elif bound[0] == 1:
                 axis_bounds.append(gt_ir.AxisBound(level=gt_ir.LevelMarker.END, offset=bound[1]))
             else:
-                axis_bounds.append(
-                    gt_ir.AxisBound(
-                        level=gt_ir.VarRef(name=self.data.splitters_var, index=bound[0] - 1),
-                        offset=bound[1],
-                    )
-                )
+                raise ValueError()
 
         result = gt_ir.AxisInterval(start=axis_bounds[0], end=axis_bounds[1])
 

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -100,8 +100,7 @@ class InitInfoPass(TransformPass):
         """Determines intervals over which the computation runs."""
         node: gt_ir.StencilDefinition = transform_data.definition_ir
 
-        min_k_interval_sizes = [0]
-        nk_intervals=1
+        min_k_interval_size = 0
 
         # Extract computation intervals
         computation_intervals = []
@@ -131,23 +130,23 @@ class InitInfoPass(TransformPass):
                     )
 
                 bounds[i] = (index, offset)
-                if index < nk_intervals:
-                    min_k_interval_sizes[index] = max(
-                        min_k_interval_sizes[index], offset
-                    )
+                if index == 0:
+                    min_k_interval_size = max(min_k_interval_size, offset)
 
             if bounds[0][0] == bounds[1][0] - 1:
                 index = bounds[0][0]
                 min_size = 1 + bounds[0][1] - bounds[1][1]
-                min_k_interval_sizes[index] = max(
-                    min_k_interval_sizes[index], min_size
-                )
+                min_k_interval_size = max(min_k_interval_size, min_size)
 
             # Create computation intervals
             interval_info = IntervalInfo(*bounds)
             computation_intervals.append(interval_info)
 
-        transform_data.min_k_interval_sizes = min_k_interval_sizes
+        # note(tehrengruber): initially min_k_interval_sizes was meant to store the minimal size of the respective
+        #  intervals inbetween axis splitters (for some reason excluding the last interval relative to LevelMarker.END).
+        #  Since dynamic splitters were removed only one interval remains, but we adhere to the old / initial format
+        #  in TransformData here.
+        transform_data.min_k_interval_sizes = [min_k_interval_size]
 
         return computation_intervals
 

--- a/src/gt4py/analysis/passes.py
+++ b/src/gt4py/analysis/passes.py
@@ -100,6 +100,9 @@ class InitInfoPass(TransformPass):
         """Determines intervals over which the computation runs."""
         node: gt_ir.StencilDefinition = transform_data.definition_ir
 
+        min_k_interval_sizes = [0]
+        nk_intervals=1
+
         # Extract computation intervals
         computation_intervals = []
         for computation in node.computations:
@@ -128,10 +131,23 @@ class InitInfoPass(TransformPass):
                     )
 
                 bounds[i] = (index, offset)
+                if index < nk_intervals:
+                    min_k_interval_sizes[index] = max(
+                        min_k_interval_sizes[index], offset
+                    )
+
+            if bounds[0][0] == bounds[1][0] - 1:
+                index = bounds[0][0]
+                min_size = 1 + bounds[0][1] - bounds[1][1]
+                min_k_interval_sizes[index] = max(
+                    min_k_interval_sizes[index], min_size
+                )
 
             # Create computation intervals
             interval_info = IntervalInfo(*bounds)
             computation_intervals.append(interval_info)
+
+        transform_data.min_k_interval_sizes = min_k_interval_sizes
 
         return computation_intervals
 

--- a/src/gt4py/backend/gtc_backend/cuda/backend.py
+++ b/src/gt4py/backend/gtc_backend/cuda/backend.py
@@ -86,7 +86,7 @@ class GTCCudaBindingsCodegen(codegen.TemplatedGenerator):
             data_ndim = len(node.data_dims)
             sid_ndim = domain_ndim + data_ndim
             if kwargs["external_arg"]:
-                return "py::buffer {name}, std::array<gt::uint_t,{sid_ndim}> {name}_origin".format(
+                return "py::buffer {name}, std::array<gt::int_t,{sid_ndim}> {name}_origin".format(
                     name=node.name,
                     sid_ndim=sid_ndim,
                 )

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type
 
 import dace
 
-from eve import NodeVisitor, codegen
+from eve import codegen
 from eve.codegen import MakoTemplate as as_mako
 from gt4py import backend as gt_backend
 from gt4py import gt_src_manager
@@ -28,7 +28,6 @@ from gt4py.backend.gtc_backend.common import bindings_main_template, pybuffer_to
 from gt4py.backend.gtc_backend.defir_to_gtir import DefIRToGTIR
 from gt4py.ir import StencilDefinition
 from gtc import gtir, gtir_to_oir
-from gtc.common import LevelMarker
 from gtc.dace.oir_to_dace import OirSDFGBuilder
 from gtc.dace.utils import array_dimensions
 from gtc.passes.gtir_k_boundary import compute_k_boundary
@@ -72,10 +71,6 @@ class GTCDaCeExtGenerator:
             "computation": {"computation.hpp": implementation},
             "bindings": {"bindings" + bindings_ext: bindings},
         }
-
-
-def compute_k_origins(node: gtir.Stencil) -> Dict[str, int]:
-    return {field_name: boundary[0] for field_name, boundary in compute_k_boundary(node).items()}
 
 
 class DaCeComputationCodegen:

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -91,7 +91,7 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
             data_ndim = len(node.data_dims)
             sid_ndim = domain_ndim + data_ndim
             if kwargs["external_arg"]:
-                return "py::buffer {name}, std::array<gt::uint_t,{sid_ndim}> {name}_origin".format(
+                return "py::buffer {name}, std::array<gt::int_t,{sid_ndim}> {name}_origin".format(
                     name=node.name,
                     sid_ndim=sid_ndim,
                 )

--- a/src/gt4py/backend/module_generator.py
+++ b/src/gt4py/backend/module_generator.py
@@ -121,7 +121,7 @@ def make_args_data_from_gtir(pipeline: GtirPipeline, legacy=False) -> ModuleData
     """
     Compute module data containing information about stencil arguments from gtir.
 
-    Use `legacy` parameter to ensure equality with values from make_args_data_from_iir.
+    Use `legacy` parameter to ensure equality with values from :func:`make_args_data_from_iir`.
     """
     data = ModuleData()
     node = pipeline.full()

--- a/src/gt4py/backend/module_generator.py
+++ b/src/gt4py/backend/module_generator.py
@@ -125,8 +125,6 @@ def make_args_data_from_gtir(pipeline: GtirPipeline, legacy=False) -> ModuleData
     """
     data = ModuleData()
     node = pipeline.full()
-    field_extents = compute_legacy_extents(node, mask_inwards=legacy)
-    k_boundary = compute_k_boundary(node) if not legacy else (0, 0)
 
     write_fields = (
         node.iter_tree()
@@ -144,6 +142,10 @@ def make_args_data_from_gtir(pipeline: GtirPipeline, legacy=False) -> ModuleData
     referenced_field_params = [
         param.name for param in node.params if isinstance(param, gtir.FieldDecl)
     ]
+    field_extents = compute_legacy_extents(node, mask_inwards=legacy)
+    k_boundary = (
+        compute_k_boundary(node) if not legacy else {v: (0, 0) for v in referenced_field_params}
+    )
     for name in sorted(referenced_field_params):
         access = AccessKind.NONE
         if name in read_fields:

--- a/src/gt4py/backend/module_generator.py
+++ b/src/gt4py/backend/module_generator.py
@@ -119,7 +119,7 @@ def get_unused_params_from_gtir(
 
 def make_args_data_from_gtir(pipeline: GtirPipeline, legacy=False) -> ModuleData:
     """
-    Compute module data containing information about stencil arguments from gtir
+    Compute module data containing information about stencil arguments from gtir.
 
     Use `legacy` parameter to ensure equality with values from make_args_data_from_iir.
     """

--- a/src/gt4py/backend/module_generator.py
+++ b/src/gt4py/backend/module_generator.py
@@ -117,11 +117,16 @@ def get_unused_params_from_gtir(
     ]
 
 
-def make_args_data_from_gtir(pipeline: GtirPipeline) -> ModuleData:
+def make_args_data_from_gtir(pipeline: GtirPipeline, legacy=False) -> ModuleData:
+    """
+    Compute module data containing information about stencil arguments from gtir
+
+    Use `legacy` parameter to ensure equality with values from make_args_data_from_iir.
+    """
     data = ModuleData()
     node = pipeline.full()
-    field_extents = compute_legacy_extents(node)
-    k_boundary = compute_k_boundary(node)
+    field_extents = compute_legacy_extents(node, mask_inwards=legacy)
+    k_boundary = compute_k_boundary(node) if not legacy else (0, 0)
 
     write_fields = (
         node.iter_tree()

--- a/src/gt4py/definitions.py
+++ b/src/gt4py/definitions.py
@@ -660,6 +660,7 @@ class AccessKind(enum.IntFlag):
 class DomainInfo:
     parallel_axes: Tuple[str, ...]
     sequential_axis: str
+    min_sequential_axis_size: int
     ndim: int
 
 

--- a/src/gt4py/ir/nodes.py
+++ b/src/gt4py/ir/nodes.py
@@ -715,7 +715,7 @@ class IterationOrder(enum.Enum):
 
 @attribclass
 class AxisBound(Node):
-    level = attribute(of=UnionOf[LevelMarker, VarRef])
+    level = attribute(of=LevelMarker)
     offset = attribute(of=int, default=0)
     loc = attribute(of=Location, optional=True)
 

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -263,7 +263,6 @@ class StencilObject(abc.ABC):
                 field = field_args[name]
                 api_domain_mask = field_info.domain_mask
                 api_domain_ndim = field_info.domain_ndim
-                lower_indices = field_info.boundary.lower_indices.filter_mask(api_domain_mask)
                 upper_indices = field_info.boundary.upper_indices.filter_mask(api_domain_mask)
                 field_origin = Index.from_value(origin[name])
                 field_domain = tuple(

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -263,10 +263,11 @@ class StencilObject(abc.ABC):
                 field = field_args[name]
                 api_domain_mask = field_info.domain_mask
                 api_domain_ndim = field_info.domain_ndim
+                lower_indices = field_info.boundary.lower_indices.filter_mask(api_domain_mask)
                 upper_indices = field_info.boundary.upper_indices.filter_mask(api_domain_mask)
                 field_origin = Index.from_value(origin[name])
                 field_domain = tuple(
-                    field.shape[i] - (field_origin[i] + upper_indices[i])
+                    max(0, field.shape[i] - (lower_indices[i] + upper_indices[i]))
                     for i in range(api_domain_ndim)
                 )
                 max_domain &= Shape.from_mask(field_domain, api_domain_mask, default=max_size)
@@ -312,6 +313,11 @@ class StencilObject(abc.ABC):
         if not domain <= (max_domain := self._get_max_domain(field_args, origin, squeeze=False)):
             raise ValueError(
                 f"Compute domain too large (provided: {domain}, maximum: {max_domain})"
+            )
+
+        if domain[2] < self.domain_info.min_sequential_axis_size:
+            raise ValueError(
+                f"Compute domain too small. Sequential axis is {domain[2]}, but must be at least {self.domain_info.min_sequential_axis_size}."
             )
 
         # assert compatibility of fields with stencil
@@ -387,9 +393,10 @@ class StencilObject(abc.ABC):
                     )
 
                 spatial_domain = typing.cast(Shape, domain).filter_mask(field_domain_mask)
+                lower_indices = field_info.boundary.lower_indices.filter_mask(field_domain_mask)
                 upper_indices = field_info.boundary.upper_indices.filter_mask(field_domain_mask)
                 min_shape = tuple(
-                    o + d + h for o, d, h in zip(field_domain_origin, spatial_domain, upper_indices)
+                    l + d + h for d, l, h in zip(spatial_domain, lower_indices, upper_indices)
                 )
                 if min_shape > field.shape:
                     raise ValueError(

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -395,7 +395,7 @@ class StencilObject(abc.ABC):
                 lower_indices = field_info.boundary.lower_indices.filter_mask(field_domain_mask)
                 upper_indices = field_info.boundary.upper_indices.filter_mask(field_domain_mask)
                 min_shape = tuple(
-                    l + d + h for d, l, h in zip(spatial_domain, lower_indices, upper_indices)
+                    l + d + h for l, d, h in zip(lower_indices, spatial_domain, upper_indices)
                 )
                 if min_shape > field.shape:
                     raise ValueError(

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -267,7 +267,7 @@ class StencilObject(abc.ABC):
                 upper_indices = field_info.boundary.upper_indices.filter_mask(api_domain_mask)
                 field_origin = Index.from_value(origin[name])
                 field_domain = tuple(
-                    max(0, field.shape[i] - (lower_indices[i] + upper_indices[i]))
+                    field.shape[i] - (field_origin[i] + upper_indices[i])
                     for i in range(api_domain_ndim)
                 )
                 max_domain &= Shape.from_mask(field_domain, api_domain_mask, default=max_size)

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -395,7 +395,7 @@ class StencilObject(abc.ABC):
                 lower_indices = field_info.boundary.lower_indices.filter_mask(field_domain_mask)
                 upper_indices = field_info.boundary.upper_indices.filter_mask(field_domain_mask)
                 min_shape = tuple(
-                    l + d + h for l, d, h in zip(lower_indices, spatial_domain, upper_indices)
+                    lb + d + ub for lb, d, ub in zip(lower_indices, spatial_domain, upper_indices)
                 )
                 if min_shape > field.shape:
                     raise ValueError(

--- a/src/gtc/dace/oir_to_dace.py
+++ b/src/gtc/dace/oir_to_dace.py
@@ -40,7 +40,7 @@ from gtc.passes.oir_optimizations.utils import AccessCollector
 
 
 def _offset_origin(interval: oir.Interval, origin: oir.AxisBound) -> oir.Interval:
-    if origin >= oir.AxisBound.start():
+    if origin.level != LevelMarker.START:
         return interval
     return interval.shifted(-origin.offset)
 
@@ -503,7 +503,7 @@ class StencilOirSDFGBuilder(BaseOirSDFGBuilder):
                     subset = edge.data.subset
                 subset = dace.subsets.union(subset, edge.data.subset)
         subset: dace.subsets.Range
-        k_size = subset.bounding_box_size()[axis_idx]
+        k_size = subset.bounding_box_size()[axis_idx] + subset.ranges[axis_idx][0]
 
         k_sym = dace.symbol("__K")
         k_size_symbolic = dace.symbolic.pystr_to_symbolic(k_size)

--- a/src/gtc/passes/gtir_k_boundary.py
+++ b/src/gtc/passes/gtir_k_boundary.py
@@ -1,5 +1,6 @@
 import math
-from typing import Any, Dict, Tuple, Union, cast
+import typing
+from typing import Any, Dict, Tuple, Union
 
 from eve import NodeVisitor
 from eve.utils import XIterable
@@ -24,7 +25,7 @@ class KBoundaryVisitor(NodeVisitor):
                 b[0] if b[0] != -math.inf else 0,
                 b[1] if b[1] != -math.inf else 0,
             )
-        return cast(Dict[str, Tuple[int, int]], field_boundaries)
+        return typing.cast(Dict[str, Tuple[int, int]], field_boundaries)
 
     def visit_FieldAccess(
         self,

--- a/src/gtc/passes/gtir_k_boundary.py
+++ b/src/gtc/passes/gtir_k_boundary.py
@@ -12,11 +12,7 @@ def _iter_field_names(node: Union[gtir.Stencil, gtir.ParAssignStmt]) -> XIterabl
 
 
 class KBoundaryVisitor(NodeVisitor):
-    """
-    For every field compute the boundary in k, e.g. (2, -1) if [k_origin-2, k_origin+k_domain-1] is accessed
-    """
-
-    contexts = (SymbolTableTrait.symtable_merger,)
+    "For every field compute the boundary in k, e.g. (2, -1) if [k_origin-2, k_origin+k_domain-1] is accessed."
 
     def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> Dict[str, Tuple[int, int]]:
         field_boundaries = {name: (-math.inf, -math.inf) for name in _iter_field_names(node)}
@@ -34,7 +30,7 @@ class KBoundaryVisitor(NodeVisitor):
         self,
         node: gtir.FieldAccess,
         vloop: gtir.VerticalLoop,
-        field_boundaries: Dict[str, Tuple[int, int]],
+        field_boundaries: Dict[str, Tuple[Union[float, int], Union[float, int]]],
         include_center_interval: bool,
         **kwargs: Any,
     ):
@@ -63,9 +59,7 @@ def compute_k_boundary(
 
 
 def compute_min_k_size(node: gtir.Stencil, include_center_interval=True) -> int:
-    """
-    Compute the required number of k levels to run a stencil
-    """
+    "Compute the required number of k levels to run a stencil."
     min_size_start = 0
     min_size_end = 0
     for vloop in node.vertical_loops:

--- a/src/gtc/passes/gtir_k_boundary.py
+++ b/src/gtc/passes/gtir_k_boundary.py
@@ -40,14 +40,13 @@ class KBoundaryVisitor(NodeVisitor):
     ):
         boundary = field_boundaries[node.name]
         interval = vloop.interval
-        if interval.start.level == LevelMarker.START and (
-            include_center_interval or interval.end.level == LevelMarker.START
-        ):
-            boundary = (max(-interval.start.offset - node.offset.k, boundary[0]), boundary[1])
-        if (
-            include_center_interval or interval.start.level == LevelMarker.END
-        ) and interval.end.level == LevelMarker.END:
-            boundary = (boundary[0], max(interval.end.offset + node.offset.k, boundary[1]))
+        if not isinstance(node.offset, gtir.VariableKOffset):
+            if interval.start.level == LevelMarker.START and (
+                    include_center_interval or interval.end.level == LevelMarker.START):
+                boundary = (max(-interval.start.offset - node.offset.k, boundary[0]), boundary[1])
+            if (include_center_interval or interval.start.level == LevelMarker.END) and \
+                    interval.end.level == LevelMarker.END:
+                boundary = (boundary[0], max(interval.end.offset + node.offset.k, boundary[1]))
         if node.name in [decl.name for decl in vloop.temporaries] and (
             boundary[0] > 0 or boundary[1] > 0
         ):

--- a/src/gtc/passes/gtir_k_boundary.py
+++ b/src/gtc/passes/gtir_k_boundary.py
@@ -1,0 +1,81 @@
+import math
+from typing import Any, Dict, Tuple, Union
+
+from eve import NodeVisitor, SymbolTableTrait
+from eve.utils import XIterable
+from gtc import gtir
+from gtc.common import LevelMarker
+
+
+def _iter_field_names(node: Union[gtir.Stencil, gtir.ParAssignStmt]) -> XIterable[gtir.FieldAccess]:
+    return node.iter_tree().if_isinstance(gtir.FieldDecl).getattr("name").unique()
+
+
+class KBoundaryVisitor(NodeVisitor):
+    """
+    For every field compute the boundary in k, e.g. (2, -1) if [k_origin-2, k_origin+k_domain-1] is accessed
+    """
+
+    contexts = (SymbolTableTrait.symtable_merger,)
+
+    def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> Dict[str, Tuple[int, int]]:
+        field_boundaries = {name: (-math.inf, -math.inf) for name in _iter_field_names(node)}
+        for vloop in node.vertical_loops:
+            self.generic_visit(vloop.body, vloop=vloop, field_boundaries=field_boundaries, **kwargs)
+        # if there is no left or right boundary set to zero
+        for name, b in field_boundaries.items():
+            field_boundaries[name] = (
+                b[0] if b[0] != -math.inf else 0,
+                b[1] if b[1] != -math.inf else 0,
+            )
+        return field_boundaries
+
+    def visit_FieldAccess(
+        self,
+        node: gtir.FieldAccess,
+        vloop: gtir.VerticalLoop,
+        field_boundaries: Dict[str, Tuple[int, int]],
+        include_center_interval: bool,
+        **kwargs: Any,
+    ):
+        boundary = field_boundaries[node.name]
+        interval = vloop.interval
+        if interval.start.level == LevelMarker.START and (
+            include_center_interval or interval.end.level == LevelMarker.START
+        ):
+            boundary = (max(-interval.start.offset - node.offset.k, boundary[0]), boundary[1])
+        if (
+            include_center_interval or interval.start.level == LevelMarker.END
+        ) and interval.end.level == LevelMarker.END:
+            boundary = (boundary[0], max(interval.end.offset + node.offset.k, boundary[1]))
+        if node.name in [decl.name for decl in vloop.temporaries] and (
+            boundary[0] > 0 or boundary[1] > 0
+        ):
+            raise TypeError(f"Invalid access with offset in k to temporary field {node.name}.")
+        assert node.name in field_boundaries
+        field_boundaries[node.name] = boundary
+
+
+def compute_k_boundary(
+    node: gtir.Stencil, include_center_interval=True
+) -> Dict[str, Tuple[int, int]]:
+    # loop from START to END is not considered as it might be empty. additional check possible in the future
+    return KBoundaryVisitor().visit(node, include_center_interval=include_center_interval)
+
+
+def compute_min_k_size(node: gtir.Stencil, include_center_interval=True) -> int:
+    """
+    Compute the required number of k levels to run a stencil
+    """
+    min_size_start = 0
+    min_size_end = 0
+    for vloop in node.vertical_loops:
+        if vloop.interval.start.level == LevelMarker.START and (
+            include_center_interval or vloop.interval.end.level == LevelMarker.START
+        ):
+            min_size_start = max(min_size_start, vloop.interval.end.offset)
+        elif (
+            include_center_interval or vloop.interval.start.level == LevelMarker.END
+        ) and vloop.interval.end.level == LevelMarker.END:
+            min_size_end = max(min_size_end, -vloop.interval.start.offset)
+    return min_size_start + min_size_end

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -97,5 +97,5 @@ class LegacyExtentsVisitor(NodeVisitor):
             pa_ctx.assign_extents[node.name] |= extent
 
 
-def compute_legacy_extents(node: gtir.Stencil, mask_inwards=True) -> FIELD_EXT_T:
+def compute_legacy_extents(node: gtir.Stencil, mask_inwards=False) -> FIELD_EXT_T:
     return LegacyExtentsVisitor().visit(node, mask_inwards=mask_inwards)

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -50,8 +50,8 @@ class LegacyExtentsVisitor(NodeVisitor):
                 field_extents[name] = Extent.zeros()
             if mask_inwards:
                 # set inward pointing extents to zero
-                field_extents[name] = tuple(
-                    (min(0, e[0]), max(0, e[1])) for e in field_extents[name]
+                field_extents[name] = Extent(
+                    *((min(0, e[0]), max(0, e[1])) for e in field_extents[name])
                 )
         return field_extents
 

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -16,14 +16,7 @@ def _iter_assigns(node: gtir.Stencil) -> XIterable[gtir.ParAssignStmt]:
 
 
 def _ext_from_off(offset: Union[gtir.CartesianOffset, gtir.VariableKOffset]) -> Extent:
-    all_offsets = offset.to_dict()
-    return Extent(
-        (
-            (min(all_offsets["i"], 0), max(all_offsets["i"], 0)),
-            (min(all_offsets["j"], 0), max(all_offsets["j"], 0)),
-            (0, 0),
-        )
-    )
+    return Extent(((offset.i, offset.i), (offset.j, offset.j), (0, 0)))
 
 
 FIELD_EXT_T = Dict[str, Extent]
@@ -40,7 +33,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
     def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> FIELD_EXT_T:
-        field_extents = {name: Extent.zeros() for name in _iter_field_names(node)}
+        field_extents = {}
         ctx = self.StencilContext()
         for field_if in node.iter_tree().if_isinstance(gtir.FieldIfStmt):
             self.visit(field_if, ctx=ctx)
@@ -66,7 +59,10 @@ class LegacyExtentsVisitor(NodeVisitor):
         )
         self.visit(node.right, field_extents=field_extents, pa_ctx=pa_ctx, **kwargs)
         for key, value in pa_ctx.assign_extents.items():
-            field_extents[key] |= value
+            if key not in field_extents:
+                field_extents[key] = value
+            else:
+                field_extents[key] |= value
 
     def visit_FieldIfStmt(
         self, node: gtir.FieldIfStmt, *, ctx: StencilContext, **kwargs: Any
@@ -84,10 +80,11 @@ class LegacyExtentsVisitor(NodeVisitor):
         pa_ctx: AssignContext,
         **kwargs: Any,
     ) -> None:
-        pa_ctx.assign_extents.setdefault(
-            node.name, field_extents.setdefault(node.name, Extent.zeros())
-        )
-        pa_ctx.assign_extents[node.name] |= pa_ctx.left_extent + _ext_from_off(node.offset)
+        extent = pa_ctx.left_extent + _ext_from_off(node.offset)
+        if node.name not in pa_ctx.assign_extents:
+            pa_ctx.assign_extents[node.name] = extent
+        else:
+            pa_ctx.assign_extents[node.name] |= extent
 
 
 def compute_legacy_extents(node: gtir.Stencil) -> FIELD_EXT_T:

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -34,7 +34,9 @@ class LegacyExtentsVisitor(NodeVisitor):
     class StencilContext:
         assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
-    def visit_Stencil(self, node: gtir.Stencil, *, mask_inwards: bool, **kwargs: Any) -> FIELD_EXT_T:
+    def visit_Stencil(
+        self, node: gtir.Stencil, *, mask_inwards: bool, **kwargs: Any
+    ) -> FIELD_EXT_T:
         field_extents: FIELD_EXT_T = {}
         ctx = self.StencilContext()
         for field_if in node.iter_tree().if_isinstance(gtir.FieldIfStmt):
@@ -48,7 +50,9 @@ class LegacyExtentsVisitor(NodeVisitor):
                 field_extents[name] = Extent.zeros()
             if mask_inwards:
                 # set inward pointing extents to zero
-                field_extents[name] = tuple((min(0, e[0]), max(0, e[1])) for e in field_extents[name])
+                field_extents[name] = tuple(
+                    (min(0, e[0]), max(0, e[1])) for e in field_extents[name]
+                )
         return field_extents
 
     def visit_ParAssignStmt(

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -46,8 +46,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         for name in _iter_field_names(node):
             # ensure we have an extent for all fields. note that we do not initialize to zero in the beginning as this
             #  breaks inward pointing extends (i.e. negative boundaries).
-            if name not in field_extents:
-                field_extents[name] = Extent.zeros()
+            field_extents.setdefault(name, Extent.zeros())
             if mask_inwards:
                 # set inward pointing extents to zero
                 field_extents[name] = Extent(

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -35,7 +35,7 @@ class LegacyExtentsVisitor(NodeVisitor):
         assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
     def visit_Stencil(self, node: gtir.Stencil, *, mask_inwards: bool, **kwargs: Any) -> FIELD_EXT_T:
-        field_extents = {}
+        field_extents: FIELD_EXT_T = {}
         ctx = self.StencilContext()
         for field_if in node.iter_tree().if_isinstance(gtir.FieldIfStmt):
             self.visit(field_if, ctx=ctx)

--- a/src/gtc/passes/gtir_legacy_extents.py
+++ b/src/gtc/passes/gtir_legacy_extents.py
@@ -16,6 +16,8 @@ def _iter_assigns(node: gtir.Stencil) -> XIterable[gtir.ParAssignStmt]:
 
 
 def _ext_from_off(offset: Union[gtir.CartesianOffset, gtir.VariableKOffset]) -> Extent:
+    if isinstance(offset, gtir.VariableKOffset):
+        return Extent(((0, 0), (0, 0), (0, 0)))
     return Extent(((offset.i, offset.i), (offset.j, offset.j), (0, 0)))
 
 
@@ -32,13 +34,21 @@ class LegacyExtentsVisitor(NodeVisitor):
     class StencilContext:
         assign_conditions: Dict[int, List[gtir.FieldAccess]] = field(default_factory=dict)
 
-    def visit_Stencil(self, node: gtir.Stencil, **kwargs: Any) -> FIELD_EXT_T:
+    def visit_Stencil(self, node: gtir.Stencil, *, mask_inwards: bool, **kwargs: Any) -> FIELD_EXT_T:
         field_extents = {}
         ctx = self.StencilContext()
         for field_if in node.iter_tree().if_isinstance(gtir.FieldIfStmt):
             self.visit(field_if, ctx=ctx)
         for assign in reversed(_iter_assigns(node).to_list()):
             self.visit(assign, ctx=ctx, field_extents=field_extents)
+        for name in _iter_field_names(node):
+            # ensure we have an extent for all fields. note that we do not initialize to zero in the beginning as this
+            #  breaks inward pointing extends (i.e. negative boundaries).
+            if name not in field_extents:
+                field_extents[name] = Extent.zeros()
+            if mask_inwards:
+                # set inward pointing extents to zero
+                field_extents[name] = tuple((min(0, e[0]), max(0, e[1])) for e in field_extents[name])
         return field_extents
 
     def visit_ParAssignStmt(
@@ -87,5 +97,5 @@ class LegacyExtentsVisitor(NodeVisitor):
             pa_ctx.assign_extents[node.name] |= extent
 
 
-def compute_legacy_extents(node: gtir.Stencil) -> FIELD_EXT_T:
-    return LegacyExtentsVisitor().visit(node)
+def compute_legacy_extents(node: gtir.Stencil, mask_inwards=True) -> FIELD_EXT_T:
+    return LegacyExtentsVisitor().visit(node, mask_inwards=mask_inwards)

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -489,8 +489,8 @@ def test_read_data_dim_indirect_addressing(backend):
         "gtc:numpy",
         "gtc:gt:cpu_ifirst",
         "gtc:gt:cpu_kfirst",
-        pytest.param("gtc:gt:gpu", marks=[pytest.mark.requires_gpu, pytest.mark.xfail]),
-        pytest.param("gtc:cuda", marks=[pytest.mark.requires_gpu, pytest.mark.xfail]),
+        pytest.param("gtc:gt:gpu", marks=[pytest.mark.requires_gpu]),
+        pytest.param("gtc:cuda", marks=[pytest.mark.requires_gpu]),
         "gtc:dace",
     ],
 )

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -717,7 +717,7 @@ class TestNon3DFields(gt_testing.StencilTestSuite):
         )
 
 
-class TestReadOutsideKInterval(gt_testing.StencilTestSuite):
+class TestReadOutsideKInterval1(gt_testing.StencilTestSuite):
     dtypes = {
         "field_in": np.float64,
         "field_out": np.float64,
@@ -741,6 +741,54 @@ class TestReadOutsideKInterval(gt_testing.StencilTestSuite):
 
     def validation(field_in, field_out, *, domain, origin):
         field_out[:, :, :] = field_in[:, :, 0:-2] + field_in[:, :, 2:]
+
+
+class TestReadOutsideKInterval2(gt_testing.StencilTestSuite):
+    dtypes = {
+        "field_in": np.float64,
+        "field_out": np.float64,
+    }
+    domain_range = [(4, 4), (4, 4), (4, 4)]
+    backends = INTERNAL_BACKENDS
+    symbols = {
+        "field_in": gt_testing.field(
+            in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 1)]
+        ),
+        "field_out": gt_testing.field(
+            in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]
+        ),
+    }
+
+    def definition(field_in, field_out):
+        with computation(PARALLEL), interval(-1, None):
+            field_out = field_in[0, 0, 1]  # noqa: F841  # Local name is assigned to but never used
+
+    def validation(field_in, field_out, *, domain, origin):
+        field_out[:, :, -1] = field_in[:, :, domain[2]]
+
+
+class TestReadOutsideKInterval3(gt_testing.StencilTestSuite):
+    dtypes = {
+        "field_in": np.float64,
+        "field_out": np.float64,
+    }
+    domain_range = [(4, 4), (4, 4), (4, 4)]
+    backends = INTERNAL_BACKENDS
+    symbols = {
+        "field_in": gt_testing.field(
+            in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (1, 0)]
+        ),
+        "field_out": gt_testing.field(
+            in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]
+        ),
+    }
+
+    def definition(field_in, field_out):
+        with computation(PARALLEL), interval(0, 1):
+            field_out = field_in[0, 0, -1]  # noqa: F841  # Local name is assigned to but never used
+
+    def validation(field_in, field_out, *, domain, origin):
+        field_out[:, :, 0] = field_in[:, :, 0]
 
 
 class TestVariableKRead(gt_testing.StencilTestSuite):

--- a/tests/test_unittest/test_gtc/test_passes/test_legacy_extents.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_legacy_extents.py
@@ -18,7 +18,7 @@ def test_noextents():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -31,7 +31,7 @@ def test_single_pos_offset():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -44,7 +44,7 @@ def test_single_neg_offset():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -57,7 +57,7 @@ def test_single_k_offset():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -75,7 +75,7 @@ def test_offset_chain():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -88,7 +88,7 @@ def test_ij():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -101,7 +101,7 @@ def test_j():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -114,7 +114,7 @@ def test_unreferenced():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext
@@ -134,7 +134,7 @@ def test_field_if():
 
     builder = StencilBuilder(stencil, backend=from_name("debug"))
     old_ext = builder.implementation_ir.fields_extents
-    legacy_ext = compute_legacy_extents(prepare_gtir(builder))
+    legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
     for name, ext in old_ext.items():
         assert legacy_ext[name] == ext

--- a/tests/test_unittest/test_gtc/test_passes/test_min_k_interval.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_min_k_interval.py
@@ -1,0 +1,214 @@
+# flake8: noqa: F841
+from typing import Any, Callable, List, Tuple
+
+import numpy as np
+import pytest
+
+import gt4py.storage
+from gt4py import gtscript as gs
+from gt4py.backend import from_name
+from gt4py.gtscript import PARALLEL, computation, interval, stencil
+from gt4py.stencil_builder import StencilBuilder
+from gtc.passes.gtir_k_boundary import compute_k_boundary, compute_min_k_size
+from gtc.passes.gtir_pipeline import prune_unused_parameters
+
+
+# populated by test_case decorator
+test_data: List[Tuple[Callable, Any]] = []
+test_data_k_bounds: List[Tuple[Callable, Any]] = []
+test_data_min_k_size: List[Tuple[Callable, Any]] = []
+
+
+def register_test_case(**kwargs):
+    def _wrapper(definition):
+        globals()["test_data"].append((definition, kwargs))
+        for k, v in kwargs.items():
+            globals()["test_data_" + k].append((definition, v))
+        return definition
+
+    return _wrapper
+
+
+# stencils with no extent
+@register_test_case(k_bounds=(0, 0), min_k_size=0)
+def stencil_no_extent_0(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(...):
+        field_a = field_b[0, 0, 0]
+
+
+@register_test_case(k_bounds=(max(0, -2), 0), min_k_size=2)
+def stencil_no_extent_1(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, 2):
+        field_a = field_b[0, 0, 0]
+
+
+@register_test_case(k_bounds=(max(-1, -2), 0), min_k_size=2)
+def stencil_no_extent_2(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(1, 2):
+        field_a = field_b[0, 0, 0]
+
+
+@register_test_case(k_bounds=(max(max(0, -2), max(-2, -2)), 0), min_k_size=3)
+def stencil_no_extent_3(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, 2):
+        field_a = field_b[0, 0, 0]
+    with computation(PARALLEL), interval(2, 3):
+        field_a = field_b[0, 0, 0]
+    with computation(PARALLEL), interval(3, None):
+        field_a = field_b[0, 0, 0]
+
+
+@register_test_case(k_bounds=(0, max(-1, 0)), min_k_size=1)
+def stencil_no_extent_4(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(-1, None):
+        field_a = field_b[0, 0, 0]
+
+
+@register_test_case(k_bounds=(max(0, -1), max(-2, 0)), min_k_size=3)
+def stencil_no_extent_5(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, 1):
+        field_a = field_b[0, 0, 0]
+    with computation(PARALLEL), interval(-2, None):
+        field_a = field_b[0, 0, 0]
+
+
+# stencils with extent
+@register_test_case(k_bounds=(5, -5), min_k_size=0)
+def stencil_with_extent_0(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(...):
+        field_a = field_b[0, 0, -5]
+
+
+@register_test_case(k_bounds=(4, 0), min_k_size=2)
+def stencil_with_extent_1(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(1, 2):
+        field_a = field_b[0, 0, -5]
+
+
+@register_test_case(k_bounds=(-6, 0), min_k_size=2)
+def stencil_with_extent_2(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(1, 2):
+        field_a = field_b[0, 0, 5]
+
+
+@register_test_case(k_bounds=(3, -3), min_k_size=3)
+def stencil_with_extent_3(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, 2):
+        field_a = field_b[0, 0, -1]
+    with computation(PARALLEL), interval(2, 3):
+        field_a = field_b[0, 0, -5]
+    with computation(PARALLEL), interval(3, None):
+        field_a = field_b[0, 0, -3]
+
+
+@register_test_case(k_bounds=(-5, 5), min_k_size=1)
+def stencil_with_extent_4(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, -1):
+        field_a = field_b[0, 0, 5]
+    with computation(PARALLEL), interval(-1, None):
+        field_a = field_b[0, 0, 5]
+
+
+@register_test_case(k_bounds=(5, -5), min_k_size=3)
+def stencil_with_extent_5(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, 1):
+        field_a = field_b[0, 0, -5]
+    with computation(PARALLEL), interval(-2, None):
+        field_a = field_b[0, 0, -5]
+
+
+@register_test_case(k_bounds=(5, 3), min_k_size=2)
+def stencil_with_extent_6(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(0, 1):
+        field_a = field_b[0, 0, -5] + field_b[0, 0, 3]
+    with computation(PARALLEL), interval(-1, None):
+        field_a = field_b[0, 0, -5] + field_b[0, 0, 3]
+
+
+@pytest.mark.parametrize("definition,expected_k_bounds", test_data_k_bounds)
+def test_k_bounds(definition, expected_k_bounds):
+    builder = StencilBuilder(definition, backend=from_name("debug"))
+    k_boundary = compute_k_boundary(builder.gtir_pipeline.full(skip=[prune_unused_parameters]))[
+        "field_b"
+    ]
+
+    assert expected_k_bounds == k_boundary
+
+
+@pytest.mark.parametrize("definition,expected_min_k_size", test_data_min_k_size)
+def test_min_k_size(definition, expected_min_k_size):
+    builder = StencilBuilder(definition, backend=from_name("debug"))
+    min_k_size = compute_min_k_size(builder.gtir_pipeline.full(skip=[prune_unused_parameters]))
+
+    assert expected_min_k_size == min_k_size
+
+
+@pytest.mark.parametrize("definition,expected", test_data)
+def test_k_bounds_exec(definition, expected):
+    expected_k_bounds, expected_min_k_size = expected["k_bounds"], expected["min_k_size"]
+
+    required_field_size = expected_min_k_size + expected_k_bounds[0] + expected_k_bounds[1]
+
+    if required_field_size > 0:
+        backend = "gtc:gt:cpu_ifirst"
+        compiled_stencil = stencil(backend, definition)
+        field_a = gt4py.storage.zeros(
+            backend=backend,
+            default_origin=(0, 0, 0),
+            shape=(1, 1, required_field_size),
+            dtype=np.float64,
+        )
+        field_b = gt4py.storage.ones(
+            backend=backend,
+            default_origin=(0, 0, 0),
+            shape=(1, 1, required_field_size),
+            dtype=np.float64,
+        )
+
+        # test with correct domain, origin to low
+        with pytest.raises(ValueError, match="Origin for field field_b too small"):
+            compiled_stencil(
+                field_a,
+                field_b,
+                domain=(1, 1, expected_min_k_size),
+                origin={"field_b": (0, 0, expected_k_bounds[0] - 1)},
+            )
+
+        # test with correct domain, correct origin
+        compiled_stencil(
+            field_a,
+            field_b,
+            domain=(1, 1, expected_min_k_size),
+            origin={"field_b": (0, 0, expected_k_bounds[0])},
+        )
+
+        # test with wrong domain, correct origin
+        with pytest.raises(ValueError, match="Compute domain too small. Sequential axis"):
+            compiled_stencil(
+                field_a,
+                field_b,
+                domain=(1, 1, expected_min_k_size - 1),
+                origin={"field_b": (0, 0, expected_k_bounds[0])},
+            )
+
+
+def stencil_with_invalid_temporary_access_start(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(...):
+        tmp = field_b[0, 0, 0]
+        field_a = tmp[0, 0, -1]
+
+
+def stencil_with_invalid_temporary_access_end(field_a: gs.Field[float], field_b: gs.Field[float]):
+    with computation(PARALLEL), interval(...):
+        tmp = field_b[0, 0, 0]
+        field_a = tmp[0, 0, 1]
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [stencil_with_invalid_temporary_access_start, stencil_with_invalid_temporary_access_end],
+)
+def test_invalid_temporary_access(definition):
+    builder = StencilBuilder(definition, backend=from_name("debug"))
+    with pytest.raises(TypeError, match="Invalid access with offset in k to temporary field tmp."):
+        k_boundary = compute_k_boundary(builder.gtir_pipeline.full(skip=[prune_unused_parameters]))

--- a/tests/test_unittest/test_gtc/test_passes/test_min_k_interval.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_min_k_interval.py
@@ -155,7 +155,7 @@ def test_k_bounds_exec(definition, expected):
         field_a = gt4py.storage.zeros(
             backend=backend,
             default_origin=(0, 0, 0),
-            shape=(1, 1, required_field_size),
+            shape=(1, 1, expected_min_k_size),
             dtype=np.float64,
         )
         field_b = gt4py.storage.ones(

--- a/tests/test_unittest/test_module_generator.py
+++ b/tests/test_unittest/test_module_generator.py
@@ -82,6 +82,6 @@ def test_module_data_equivalence():
     builder = StencilBuilder(sample_stencil_with_args)
 
     legacy_module_data = make_args_data_from_iir(builder.implementation_ir)
-    gtc_module_data = make_args_data_from_gtir(builder.gtir_pipeline)
+    gtc_module_data = make_args_data_from_gtir(builder.gtir_pipeline, legacy=True)
 
     assert legacy_module_data == gtc_module_data


### PR DESCRIPTION
## Description

__1. Runtime check for sequential axis size (fixes #177, gtc backends only)__
The following stencil requires a domain of at least 2, which is checked now:
```python
def stencil(in_field: Field3D, out_field: Field3D):
    with computation(PARALLEL):
        with interval(0, 2):
            out_field = in_field
```

__2. Fix field boundary computation and extend to include k-dimension (gtc backends only)__
Before this PR field boundaries were always positive and the boundary in the `k` dimension was unconditionally zero. Now boundaries can be negative indicating values not being read (this is in line with the docstrings describing the boundary semantics already existing). This only applies to the gtc backends while all legacy backends relying on IIR to compute extends (in ComputeExtentsPass) return the old values. As the set of all valid stencil calls given the old boundary values is a subset of the valid stencils given the new boundary values the discrepancy between legacy backends and gtc backends should not pose a problem.

| Expression                             | Boundary old             | Boundary new              |
|----------------------------------------|--------------------------|---------------------------|
| `in_field[1, 0, 0]`                    | ((0, 1), (0, 0), (0, 0)) | ((-1, 1), (0, 0), (0, 0)) |
| `in_field[-1, 0, 0]+in_field[1, 0, 0]` | ((1, 1), (0, 0), (0, 0)) | ((1, 1), (0, 0), (0, 0))  |
| `in_field[0, 0, 1]+in_field[0, 0, 2]`                    | ((0, 0), (0, 0), (0, 0)) | ((0, 0), (0, 0), (-1, 2)) |

Note that the boundary computation in `k` usually also depends on the specified interval bounds.

__3. Allow negative origin (all backends)__
In the majority of cases origins are positive and it is always possible to reformulate a stencil or add padding to a field such that origins are strictly positive. In FVM however reformulating stencils breaks the index conventions  that we try to strictly adhere (such that finite differences formulated on paper agree with the respective stencil code) and padding is more a workaround than a real fix. This PR enables usage of negative origins to avoid this.

Consider the following stencil called for the domain (1, J, K) then using an origin of `-1, 0, 0` for `in_field` being a field of shape (1, J, K) works correctly now.
```python
def stencil(in_field: Field3D, out_field: Field3D):
    with computation(PARALLEL):
        with interval(...):
            out_field = in_field[1, 0, 0]
```

### Miscellaneous Details

- The dace backend already contained a visitor computing "k origins". The visitor was removed and replaced by the new `compute_k_boundary` pass.
- Additional tests for read outside k interval + fix for the dace backend (#582)
- Removed dead code for dynamic splitters

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


