### PR TITLE
Fix issue uncovered with new pydantic version, and update pre-commit and hook versions

### DIFF
--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
 #   - id: check-useless-excludes
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.1.0
   hooks:
   - id: check-case-conflict
 #  - id: check-json
@@ -20,7 +20,7 @@ repos:
 #  - id: pretty-format-json
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.0.0
+  rev: v2.2.0
   hooks:
   - id: pretty-format-ini
     args: [--autofix]
@@ -75,17 +75,17 @@ repos:
 #     - pygments
 
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 21.12b0
   hooks:
   - id: black
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.7.0
+  rev: v5.10.1
   hooks:
   - id: isort
 
 - repo: https://gitlab.com/PyCQA/flake8
-  rev: 3.8.4
+  rev: 4.0.1
   hooks:
   - id: flake8
     additional_dependencies:
@@ -150,7 +150,7 @@ repos:
       )$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.800
+  rev: v0.812
   hooks:
   - id: mypy
     exclude: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 check-manifest>=0.40
 coverage>=5.0
 darglint>=1.6
-factory-boy>=3.1 
+factory-boy>=3.1
 flake8>=3.8
 flake8-bugbear>=20.11.1
 flake8-builtins>=1.5.3
@@ -14,7 +14,7 @@ flakehell>=0.9
 hypothesis>=4.14
 isort~=5.1
 mypy>=0.800
-pre-commit~=1.18
+pre-commit~=2.15
 psutil>=5.0
 pygments>=2.7
 pytest~=6.1

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -655,10 +655,12 @@ class _LvalueDimsValidator(NodeVisitor):
         symtable: Dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        if decl := symtable.get(node.left.name, None) is None:
+        decl = symtable.get(node.left.name, None)
+        if decl is None:
             raise ValueError("Symbol {} not found.".format(node.left.name))
         if not isinstance(decl, self.decl_type):
             return None
+
         allowed_flags = self._allowed_flags(loop_order)
         flags = decl.dimensions
         if flags not in allowed_flags:

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -655,10 +655,12 @@ class _LvalueDimsValidator(NodeVisitor):
         symtable: Dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        if not isinstance(symtable[node.left.name], self.decl_type):
+        if decl := symtable.get(node.left.name, None) is None:
+            raise ValueError("Symbol {} not found.".format(node.left.name))
+        if not isinstance(decl, self.decl_type):
             return None
         allowed_flags = self._allowed_flags(loop_order)
-        flags = symtable[node.left.name].dimensions
+        flags = decl.dimensions
         if flags not in allowed_flags:
             dims = dimension_flags_to_names(flags)
             raise ValueError(

--- a/tests/test_unittest/test_gtc/test_gtir.py
+++ b/tests/test_unittest/test_gtc/test_gtir.py
@@ -135,7 +135,7 @@ def test_no_horizontal_offset_allowed(assign_stmt_with_offset):
 
 
 def test_symbolref_without_decl():
-    with pytest.raises(ValidationError, match=r"Symbols.*not found"):
+    with pytest.raises(ValidationError, match=r"Symbol.*not found"):
         StencilFactory(
             params=[],
             vertical_loops__0__body__0=ParAssignStmtFactory(


### PR DESCRIPTION
## Description

Updates pydantic and a few pre-commit hook libraries, but does not unpin python 3.9 because that triggers another issue.