### PR TITLE
Fortran bindings prototype

### DIFF
--- a/src/gt4py/backend/base.py
+++ b/src/gt4py/backend/base.py
@@ -215,7 +215,7 @@ class CLIBackendMixin(Backend):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def generate_bindings(self, language_name: str) -> Dict[str, Union[str, Dict]]:
+    def generate_bindings(self, language_name: str, ir: Any) -> Dict[str, Union[str, Dict]]:
         """
         Generate bindings source code from ``language_name`` to the target language of the backend.
 

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -717,18 +717,12 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
             pyext_file_path=pyext_file_path,
         )
 
-    def generate_computation(self, *, ir: Any = None) -> Dict[str, Union[str, Dict]]:
-        if not ir:
-            ir = self.builder.implementation_ir
+    def generate_computation(self, ir: Any) -> Dict[str, Union[str, Dict]]:
         dir_name = f"{self.builder.options.name}_src"
         src_files = self.make_extension_sources(ir=ir)
         return {dir_name: src_files["computation"]}
 
-    def generate_bindings(
-        self, language_name: str, *, ir: Any = None
-    ) -> Dict[str, Union[str, Dict]]:
-        if not ir:
-            ir = self.builder.implementation_ir
+    def generate_bindings(self, language_name: str, ir: Any) -> Dict[str, Union[str, Dict]]:
         if language_name != "python":
             return super().generate_bindings(language_name)
         dir_name = f"{self.builder.options.name}_src"

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -164,7 +164,7 @@ class FortranBindingsCodegen(codegen.TemplatedGenerator):
                     name=node.name, sid_ndim=sid_ndim, dtype=dtype, stride_kind=stride_kind
                 )
             else:
-                return node.name
+                return f"gridtools::sid::shift_sid_origin({node.name}, gridtools::array<int, 3>{{offset_x, offset_y,offset_z}})"
 
     def visit_ScalarDecl(self, node: gtir.ScalarDecl, **kwargs):
         if "external_arg" in kwargs:
@@ -190,12 +190,12 @@ class FortranBindingsCodegen(codegen.TemplatedGenerator):
         #include <gridtools/storage/adapter/fortran_array_view.hpp>
 
         namespace {
-        void ${name}_impl(unsigned int nx, unsigned int ny, unsigned int nz,
+        void ${name}_impl(int offset_x, int offset_y, int offset_z, unsigned int nx, unsigned int ny, unsigned int nz,
                     ${','.join(entry_params)}) {
         auto computation = ${name}({nx, ny, nz});
         computation(${','.join(sid_params)});
         }
-        BINDGEN_EXPORT_BINDING_WRAPPED(${3+len(entry_params)}, ${name}, ${name}_impl);
+        BINDGEN_EXPORT_BINDING_WRAPPED(${6+len(entry_params)}, ${name}, ${name}_impl);
         } // namespace
         """
     )

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -203,8 +203,9 @@ class FortranBindingsCodegen(codegen.TemplatedGenerator):
     @classmethod
     def apply(cls, root, **kwargs) -> str:
         # This is hacky, probably we should keep the full list of parameters (even if unused) down to any backend
-        external_parameters = [cls().visit(p, external_arg=True) for p in root.params]
-        generated_code = cls().visit(
+        generator = cls()
+        external_parameters = [generator.visit(p, external_arg=True) for p in root.params]
+        generated_code = generator.visit(
             GtirPipeline(root).full(), external_parameters=external_parameters, **kwargs
         )
         if kwargs.get("format_source", True):

--- a/src/gt4py/backend/gtc_backend/gtcpp/backend.py
+++ b/src/gt4py/backend/gtc_backend/gtcpp/backend.py
@@ -134,13 +134,20 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
         return generated_code
 
 
-class GTCGTBaseBackend(BaseGTBackend, CLIBackendMixin):
+class GTCGTBaseBackend(BaseGTBackend):  # , CLIBackendMixin):
     options = BaseGTBackend.GT_BACKEND_OPTS
     PYEXT_GENERATOR_CLASS = GTCGTExtGenerator  # type: ignore
     USE_LEGACY_TOOLCHAIN = False
 
     def _generate_extension(self, uses_cuda: bool) -> Tuple[str, str]:
         return self.make_extension(gt_version=2, ir=self.builder.definition_ir, uses_cuda=uses_cuda)
+
+    def generate_bindings(self, language_name: str, ir):
+        if language_name != "fortran":
+            return super().generate_bindings(language_name, ir)
+        print("Generating Fortran bindings")
+        dir_name = f"{self.builder.options.name}_src"
+        return {dir_name: {"bla.f90": "bla"}}
 
     def generate(self) -> Type["StencilObject"]:
         self.check_options(self.builder.options)

--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -87,13 +87,13 @@ class StencilBuilder:
             stencil_class = self.backend.generate()
         return stencil_class
 
-    def generate_computation(self) -> Dict[str, Union[str, Dict]]:
+    def generate_computation(self, ir: Any) -> Dict[str, Union[str, Dict]]:
         """Generate the stencil source code, fail if backend does not support CLI."""
-        return self.cli_backend.generate_computation()
+        return self.cli_backend.generate_computation(ir)
 
-    def generate_bindings(self, targe_language: str) -> Dict[str, Union[str, Dict]]:
+    def generate_bindings(self, target_language: str, ir: Any) -> Dict[str, Union[str, Dict]]:
         """Generate ``target_language`` bindings source, fail if backend does not support CLI."""
-        return self.cli_backend.generate_bindings(targe_language)
+        return self.cli_backend.generate_bindings(target_language, ir)
 
     def with_caching(
         self: "StencilBuilder", caching_strategy_name: str, *args: Any, **kwargs: Any


### PR DESCRIPTION
This implements a very simple prototype for getting Fortran bindings via the command line interface (`gtpyc`). It uses cpp_bindgen to actually generate the Fortran (and C) files. Most likely this is not the best choice longer term (e.g. there is an extra codegen step involved by executing a binary; you don't get nice names for the Fortran functions; ...).

To test, do the following
1. `gtpyc gen --backend=gtc:gt:cpu_kfirst src/gscp_graupel.py --output-path=./generated_stencils --bindings fortran`  will generate a c++ file that instantiates the stencil, and a CMakeLists.txt for compilation.
2. Go to the generated code directory where the CMakeLists.txt is located and do, e.g. `mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/../install && make install`, which will generate the bindings and compile the C++ library.
3. Now compile the Fortran module that was generated and link it to your driver, e.g. something like `gfortran install/src/cpp_bindgen/handle.f90 install/src/cpp_bindgen/array_descriptor.f90 <the_generated_module.f90> <my_driver.f90> install/lib/libdemo_copy_module.a -fopenmp -lstdc++ install/lib/libcpp_bindgen_handle.a install/lib/libcpp_bindgen_generator.a`

TODO:
- the fix for the CLI for gtc is super hacky, most likely I broke the normal mode