### PR TITLE
Fix Disappearing Horizontal Executions in OnTheFlyMerging

### DIFF
--- a/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
+++ b/src/gtc/passes/oir_optimizations/horizontal_execution_merging.py
@@ -363,22 +363,17 @@ class OnTheFlyMerging(NodeTranslator):
         )
 
     def visit_Stencil(self, node: oir.Stencil, **kwargs: Any) -> oir.Stencil:
-        vertical_loops: List[oir.VerticalLoop] = []
         protected_fields = set(n.name for n in node.params)
-        all_names = collect_symbol_names(node)
-        vertical_loops = [
-            *reversed(
-                [
-                    self.visit(
-                        vl,
-                        new_symbol_name=symbol_name_creator(all_names),
-                        protected_fields=protected_fields,
-                        **kwargs,
-                    )
-                    for vl in reversed(node.vertical_loops)
-                ]
+        new_symbol_name = symbol_name_creator(collect_symbol_names(node))
+        vertical_loops = []
+        for vl in reversed(node.vertical_loops):
+            vl = self.visit(
+                vl, new_symbol_name=new_symbol_name, protected_fields=protected_fields, **kwargs
             )
-        ]
+            vertical_loops.append(vl)
+            protected_fields |= AccessCollector.apply(vl).read_fields()
+        vertical_loops = list(reversed(vertical_loops))
+
         accessed = AccessCollector.apply(vertical_loops).fields()
         return oir.Stencil(
             name=node.name,

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -126,6 +126,31 @@ def test_on_the_fly_merging_basic():
     assert not transformed.declarations
 
 
+def test_on_the_fly_merging_without_tmps():
+    testee = StencilFactory(
+        vertical_loops=[
+            VerticalLoopFactory(
+                sections__0__horizontal_executions=[
+                    HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="tmp0")]),
+                    HorizontalExecutionFactory(body=[AssignStmtFactory(left__name="tmp1")]),
+                ]
+            ),
+            VerticalLoopFactory(
+                sections__0__horizontal_executions=[
+                    HorizontalExecutionFactory(body=[AssignStmtFactory(right__name="tmp0")]),
+                    HorizontalExecutionFactory(body=[AssignStmtFactory(right__name="tmp1")]),
+                ]
+            ),
+        ],
+        declarations=[TemporaryFactory(name="tmp0"), TemporaryFactory(name="tmp1")],
+    )
+    transformed = OnTheFlyMerging().visit(testee)
+    hexecs0 = transformed.vertical_loops[0].sections[0].horizontal_executions
+    assert len(hexecs0) == 2
+    hexecs1 = transformed.vertical_loops[1].sections[0].horizontal_executions
+    assert len(hexecs1) == 2
+
+
 def test_on_the_fly_merging_with_offsets():
     testee = StencilFactory(
         vertical_loops__0__sections__0__horizontal_executions=[

--- a/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_oir_optimizations/test_horizontal_execution_merging.py
@@ -126,7 +126,7 @@ def test_on_the_fly_merging_basic():
     assert not transformed.declarations
 
 
-def test_on_the_fly_merging_without_tmps():
+def test_on_the_fly_merging_with_inter_loop_dependency():
     testee = StencilFactory(
         vertical_loops=[
             VerticalLoopFactory(


### PR DESCRIPTION
## Description

OnTheFlyMerging ignored dependencies (reads after writes) between vertical loops. This could cause disappearing horizontal executions and assertion failures in subsequent optimization passes. Found while analyzing #450.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


