### PR TITLE
Expose StencilObject

### DIFF
--- a/src/gt4py/__init__.py
+++ b/src/gt4py/__init__.py
@@ -35,3 +35,4 @@ __versioninfo__: Optional[Union[LegacyVersion, Version]] = parse(__version__)
 del DistributionNotFound, LegacyVersion, Version, get_distribution, parse
 
 from . import config, gtscript, storage
+from .stencil_object import StencilObject


### PR DESCRIPTION
## Description

Exposes StencilObject as `gt4py.StencilObject` for typing info.

Resolves #613.
