### PR TITLE
Unregister legacy backends and disable tests

### DIFF
--- a/docs/gt4py/quickstart.rst
+++ b/docs/gt4py/quickstart.rst
@@ -88,7 +88,7 @@ over 3 dimensions:
 
     import gt4py.gtscript as gtscript
 
-    backend = "numpy"
+    backend = "gtc:numpy"
 
     @gtscript.stencil(backend=backend)
     def stencil_example(
@@ -128,11 +128,11 @@ function with the ``stencil`` decorator provided by GT4Py.
 The ``stencil`` decorator generates code in Python or C++ depending on the ``backend`` specified by name.
 Currently, the following backends are available:
 
-* ``"debug"``: a slow, yet human-readable python backend
-* ``"numpy"``: a vectorized python backend
-* ``"gtx86"``: a backend based on GridTools code performance-optimized for x86 architecture
-* ``"gtmc"``: a GridTools backend targeting many core architectures
-* ``"gtcuda"``: a GridTools backend targeting GPUs
+* ``"gtc:numpy"``: a vectorized python backend
+* ``"gtc:gt:cpu_kfirst"``: a backend based on GridTools code performance-optimized for x86 architecture
+* ``"gtc:gt:cpu_ifirst"``: a GridTools backend targeting many core architectures
+* ``"gtc:gt:gpu"``: a GridTools backend targeting GPUs
+* ``"gtc:gpu"``: a backend targeting NVIDIA GPUs using CUDA and some GridTools
 
 The decorator further replaces the stencil definition function (here ``stencil_example``) by a callable object that
 can be used as a function to call the generated code which modifies the passed data in place.

--- a/src/gt4py/backend/debug_backend.py
+++ b/src/gt4py/backend/debug_backend.py
@@ -281,7 +281,6 @@ def debug_is_compatible_type(field):
     return isinstance(field, np.ndarray)
 
 
-@gt_backend.register
 class DebugBackend(gt_backend.BaseBackend, gt_backend.PurePythonBackendCLIMixin):
     """Pure Python backend, unoptimized for debugging."""
 

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -717,11 +717,9 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
             pyext_file_path=pyext_file_path,
         )
 
-    def generate_computation(self, *, ir: Any = None) -> Dict[str, Union[str, Dict]]:
-        if not ir:
-            ir = self.builder.implementation_ir
+    def generate_computation(self) -> Dict[str, Union[str, Dict]]:
         dir_name = f"{self.builder.options.name}_src"
-        src_files = self.make_extension_sources(ir=ir)
+        src_files = self.make_extension_sources(ir=self.builder.definition_ir)
         return {dir_name: src_files["computation"]}
 
     def generate_bindings(

--- a/src/gt4py/backend/gt_backends.py
+++ b/src/gt4py/backend/gt_backends.py
@@ -808,7 +808,6 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
         return gt_pyext_sources
 
 
-@gt_backend.register
 class GTX86Backend(BaseGTBackend):
 
     GT_BACKEND_T = "x86"
@@ -829,7 +828,6 @@ class GTX86Backend(BaseGTBackend):
         return self.make_extension(uses_cuda=False)
 
 
-@gt_backend.register
 class GTMCBackend(BaseGTBackend):
 
     GT_BACKEND_T = "mc"
@@ -868,7 +866,6 @@ class GTCUDAPyModuleGenerator(CUDAPyExtModuleGenerator):
         return "\n".join([f + "._set_device_modified()" for f in output_field_names])
 
 
-@gt_backend.register
 class GTCUDABackend(BaseGTBackend):
 
     MODULE_GENERATOR_CLASS = GTCUDAPyModuleGenerator

--- a/src/gt4py/backend/gtc_backend/numpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/numpy/backend.py
@@ -88,6 +88,8 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
     name = "gtc:numpy"
     options: ClassVar[Dict[str, Any]] = {
         "oir_pipeline": {"versioning": True, "type": OirPipeline},
+        # TODO: Implement this option in source code
+        "ignore_np_errstate": {"versioning": True, "type": bool},
     }
     storage_info = {
         "alignment": 1,

--- a/src/gt4py/backend/gtc_backend/numpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/numpy/backend.py
@@ -111,7 +111,8 @@ class GTCNumpyBackend(BaseBackend, CLIBackendMixin):
             + ".py"
         )
 
-        source = NpirCodegen.apply(self.npir)
+        ignore_np_errstate = self.builder.options.backend_opts.get("ignore_np_errstate", True)
+        source = NpirCodegen.apply(self.npir, ignore_np_errstate=ignore_np_errstate)
         if self.builder.options.format_source:
             source = format_source("python", source)
 

--- a/src/gt4py/backend/numpy_backend.py
+++ b/src/gt4py/backend/numpy_backend.py
@@ -565,7 +565,6 @@ def numpy_is_compatible_type(field: Any) -> bool:
     return isinstance(field, np.ndarray)
 
 
-@gt_backend.register
 class NumPyBackend(gt_backend.BaseBackend, gt_backend.PurePythonBackendCLIMixin):
     """Pure Python backend using NumPy for faster computations than the debug backend.
 

--- a/src/gt4py/cli.py
+++ b/src/gt4py/cli.py
@@ -41,9 +41,9 @@ class BackendChoice(click.Choice):
     -------
     .. code-block: bash
 
-        $ cmd --backend="debug"
+        $ cmd --backend="gtc:numpy"
 
-    gets converted to :py:class:`gt4py.backend.debug_backend.DebugBackend`.
+    gets converted to :py:class:`gt4py.backend.GTCNumpyBackend`.
     """
 
     name = "backend"

--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -71,7 +71,7 @@ class StencilBuilder:
         self.options = options or BuildOptions(  # type: ignore
             **self.default_options_dict(definition_func)
         )
-        backend = backend or "debug"
+        backend = backend or "gtc:numpy"
         backend = gt4py.backend.from_name(backend) if isinstance(backend, str) else backend
         self.backend: "BackendType" = backend(self)
         self.frontend: "FrontendType" = frontend or gt4py.frontend.from_name("gtscript")

--- a/src/gt4py/storage/utils.py
+++ b/src/gt4py/storage/utils.py
@@ -48,7 +48,7 @@ def normalize_storage_spec(default_origin, shape, dtype, mask):
             - default_origin: tuple of ints with default origin values for the non-masked dimensions
             - shape: tuple of ints with shape values for the non-masked dimensions
             - dtype: scalar numpy.dtype (non-structured and without subarrays)
-            - backend: backend identifier string (debug, numpy, gtx86, gtmc, gtcuda, ...)
+            - backend: backend identifier string (gtc:numpy, gtc:gt:cpu_kfirst, gtc:gpu, ...)
             - mask: a tuple of bools (at least 3d)
     """
 

--- a/src/gtc/cuir/kernel_fusion.py
+++ b/src/gtc/cuir/kernel_fusion.py
@@ -50,7 +50,8 @@ class FuseKernels(NodeTranslator):
                 kernel.iter_tree()
                 .if_isinstance(cuir.FieldAccess)
                 .filter(
-                    lambda x: x.offset.i != 0 or x.offset.j != 0 or (x.offset.k != 0 and parallel)
+                    lambda x: any(off != 0 for off in x.offset.to_dict().values())
+                    or (x.offset.to_dict()["k"] != 0 and parallel)
                 )
                 .getattr("name")
                 .to_set()

--- a/src/gtc/numpy/npir_codegen.py
+++ b/src/gtc/numpy/npir_codegen.py
@@ -426,9 +426,13 @@ class NpirCodegen(TemplatedGenerator):
                 with np.errstate():
                 {% endif %}
 
+                {% if vertical_passes %}
                 {% for pass in vertical_passes %}
                 {{ pass | indent(8) }}
                 {% endfor %}
+                {% else %}
+                    pass
+                {% endif %}
 
             {{ var_offset_func }}
             """

--- a/src/gtc/numpy/npir_codegen.py
+++ b/src/gtc/numpy/npir_codegen.py
@@ -442,13 +442,11 @@ class NpirCodegen(TemplatedGenerator):
                 with np.errstate():
                 {% endif %}
 
-                {% if vertical_passes %}
                 {% for pass in vertical_passes %}
                 {{ pass | indent(8) }}
-                {% endfor %}
                 {% else %}
                     pass
-                {% endif %}
+                {% endfor %}
 
             {{ var_offset_func }}
             """

--- a/src/gtc/numpy/npir_codegen.py
+++ b/src/gtc/numpy/npir_codegen.py
@@ -420,8 +420,14 @@ class NpirCodegen(TemplatedGenerator):
                 {% for name in field_params %}{{ name }}_ = ShimmedView({{ name }}, _origin_["{{ name }}"])
                 {% endfor %}# -- end data views --
 
+                {% if ignore_np_errstate %}
+                with np.errstate(divide='ignore', over='ignore', under='ignore', invalid='ignore'):
+                {% else %}
+                with np.errstate():
+                {% endif %}
+
                 {% for pass in vertical_passes %}
-                {{ pass | indent(4) }}
+                {{ pass | indent(8) }}
                 {% endfor %}
 
             {{ var_offset_func }}

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -69,13 +69,6 @@ INTERNAL_GPU_BACKENDS = [
 
 INTERNAL_BACKENDS = INTERNAL_CPU_BACKENDS + INTERNAL_GPU_BACKENDS
 
-OLD_BACKENDS = [
-    _backend_name_as_param(name) for name in _ALL_BACKEND_NAMES if not name.startswith("gtc:")
-]
-OLD_INTERNAL_BACKENDS = [
-    _backend_name_as_param(name) for name in _INTERNAL_BACKEND_NAMES if not name.startswith("gtc:")
-]
-
 
 @pytest.fixture()
 def id_version():

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -41,9 +41,7 @@ def make_backend_params(*names):
 
 
 _ALL_BACKEND_NAMES = list(gt_backend.REGISTRY.keys())
-_INTERNAL_BACKEND_NAMES = ["debug", "numpy"] + [
-    name for name in _ALL_BACKEND_NAMES if name.startswith("gt")
-]
+_INTERNAL_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name.startswith("gt")]
 
 
 CPU_BACKENDS = [
@@ -77,8 +75,6 @@ OLD_BACKENDS = [
 OLD_INTERNAL_BACKENDS = [
     _backend_name_as_param(name) for name in _INTERNAL_BACKEND_NAMES if not name.startswith("gtc:")
 ]
-
-LEGACY_GRIDTOOLS_BACKENDS = [_backend_name_as_param(name) for name in ("gtx86", "gtmc", "gtcuda")]
 
 
 @pytest.fixture()

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -19,7 +19,7 @@ import pytest
 
 from gt4py import gtscript
 from gt4py import storage as gt_storage
-from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
+from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, Field, computation, interval
 
 from ..definitions import ALL_BACKENDS, CPU_BACKENDS, INTERNAL_BACKENDS
 from .stencil_definitions import EXTERNALS_REGISTRY as externals_registry
@@ -352,7 +352,10 @@ def test_input_order(backend):
             out_field = in_field * parameter
 
 
-@pytest.mark.parametrize("backend", ALL_BACKENDS)
+# TODO: Enable variable offsets on gtc:dace backend
+@pytest.mark.parametrize(
+    "backend", [backend for backend in ALL_BACKENDS if "dace" not in backend.values[0]]
+)
 def test_variable_offsets(backend):
     @gtscript.stencil(backend=backend)
     def stencil_ij(

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -21,7 +21,7 @@ from gt4py import gtscript
 from gt4py import storage as gt_storage
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
-from ..definitions import ALL_BACKENDS, CPU_BACKENDS, OLD_BACKENDS
+from ..definitions import ALL_BACKENDS, CPU_BACKENDS, INTERNAL_BACKENDS, OLD_BACKENDS
 from .stencil_definitions import EXTERNALS_REGISTRY as externals_registry
 from .stencil_definitions import REGISTRY as stencil_definitions
 
@@ -92,14 +92,10 @@ def test_ignore_np_errstate():
         divide_by_zero(field_a)
 
     # Usual behavior: with the numpy backend there is no error
-    setup_and_run(backend="numpy")
-
-    # Expect warning with debug or numpy + ignore_np_errstate=False
-    with pytest.warns(RuntimeWarning, match="divide by zero encountered"):
-        setup_and_run(backend="debug")
+    setup_and_run(backend="gtc:numpy")
 
     with pytest.warns(RuntimeWarning, match="divide by zero encountered"):
-        setup_and_run(backend="numpy", ignore_np_errstate=False)
+        setup_and_run(backend="gtc:numpy", ignore_np_errstate=False)
 
 
 @pytest.mark.parametrize("backend", CPU_BACKENDS)
@@ -291,11 +287,6 @@ def test_lower_dimensional_inputs_2d_to_3d_forward(backend):
 @pytest.mark.parametrize(
     "backend",
     [
-        "debug",
-        "numpy",
-        pytest.param("gtx86", marks=[pytest.mark.xfail]),
-        pytest.param("gtmc", marks=[pytest.mark.xfail]),
-        pytest.param("gtcuda", marks=[pytest.mark.requires_gpu, pytest.mark.xfail]),
         "gtc:numpy",
         "gtc:gt:cpu_ifirst",
         "gtc:gt:cpu_kfirst",
@@ -361,7 +352,7 @@ def test_input_order(backend):
             out_field = in_field * parameter
 
 
-@pytest.mark.parametrize("backend", OLD_BACKENDS)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_variable_offsets(backend):
     @gtscript.stencil(backend=backend)
     def stencil_ij(
@@ -383,7 +374,7 @@ def test_variable_offsets(backend):
             out_field = in_field[0, 0, 1] + in_field[0, 0, index_field + 1]
 
 
-@pytest.mark.parametrize("backend", OLD_BACKENDS)
+@pytest.mark.skip("While loop not yet supported")
 def test_variable_offsets_and_while_loop(backend):
     @gtscript.stencil(backend=backend)
     def stencil(
@@ -473,11 +464,6 @@ def test_read_data_dim_indirect_addressing(backend):
 @pytest.mark.parametrize(
     "backend",
     [
-        pytest.param("debug", marks=[pytest.mark.xfail]),
-        pytest.param("numpy", marks=[pytest.mark.xfail]),
-        pytest.param("gtx86", marks=[pytest.mark.xfail]),
-        pytest.param("gtmc", marks=[pytest.mark.xfail]),
-        pytest.param("gtcuda", marks=[pytest.mark.requires_gpu, pytest.mark.xfail]),
         "gtc:numpy",
         "gtc:gt:cpu_ifirst",
         "gtc:gt:cpu_kfirst",
@@ -509,3 +495,38 @@ def test_negative_origin(backend):
             input_field, output_field, origin={"input_field": origin}
         )
         assert output_field[0, 0, 0] == 1
+
+
+@pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+def test_origin_k_fields(backend):
+    @gtscript.stencil(backend=backend, rebuild=True)
+    def k_to_ijk(outp: Field[np.float64], inp: Field[gtscript.K, np.float64]):
+        with computation(PARALLEL), interval(...):
+            outp = inp
+
+    origin = {"outp": (0, 0, 1), "inp": (2,)}
+    domain = (2, 2, 8)
+
+    data = np.arange(10, dtype=np.float64)
+    inp = gt_storage.from_array(
+        data=data,
+        shape=(10,),
+        default_origin=(0,),
+        dtype=np.float64,
+        mask=[False, False, True],
+        backend=backend,
+    )
+    outp = gt_storage.zeros(
+        shape=(2, 2, 10), default_origin=(0, 0, 0), dtype=np.float64, backend=backend
+    )
+
+    k_to_ijk(outp, inp, origin=origin, domain=domain)
+
+    inp.device_to_host()
+    outp.device_to_host()
+    np.testing.assert_allclose(data, np.asarray(inp))
+    np.testing.assert_allclose(
+        np.broadcast_to(data[2:], shape=(2, 2, 8)), np.asarray(outp)[:, :, 1:-1]
+    )
+    np.testing.assert_allclose(0.0, np.asarray(outp)[:, :, 0])
+    np.testing.assert_allclose(0.0, np.asarray(outp)[:, :, -1])

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -21,7 +21,7 @@ from gt4py import gtscript
 from gt4py import storage as gt_storage
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
-from ..definitions import ALL_BACKENDS, CPU_BACKENDS, LEGACY_GRIDTOOLS_BACKENDS, OLD_BACKENDS
+from ..definitions import ALL_BACKENDS, CPU_BACKENDS, OLD_BACKENDS
 from .stencil_definitions import EXTERNALS_REGISTRY as externals_registry
 from .stencil_definitions import REGISTRY as stencil_definitions
 
@@ -445,12 +445,8 @@ def test_write_data_dim_indirect_addressing(backend):
     input_field = gt_storage.ones(backend, default_origin, full_shape, dtype=np.int32)
     output_field = gt_storage.zeros(backend, default_origin, full_shape, dtype=INT32_VEC2)
 
-    if backend in (backend.values[0] for backend in LEGACY_GRIDTOOLS_BACKENDS):
-        with pytest.raises(ValueError):
-            gtscript.stencil(definition=stencil, backend=backend)
-    else:
-        gtscript.stencil(definition=stencil, backend=backend)(input_field, output_field, index := 1)
-        assert output_field[0, 0, 0, index] == 1
+    gtscript.stencil(definition=stencil, backend=backend)(input_field, output_field, index := 1)
+    assert output_field[0, 0, 0, index] == 1
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
@@ -470,12 +466,8 @@ def test_read_data_dim_indirect_addressing(backend):
     input_field = gt_storage.ones(backend, default_origin, full_shape, dtype=INT32_VEC2)
     output_field = gt_storage.zeros(backend, default_origin, full_shape, dtype=np.int32)
 
-    if backend in (backend.values[0] for backend in LEGACY_GRIDTOOLS_BACKENDS):
-        with pytest.raises(ValueError):
-            gtscript.stencil(definition=stencil, backend=backend)
-    else:
-        gtscript.stencil(definition=stencil, backend=backend)(input_field, output_field, 1)
-        assert output_field[0, 0, 0] == 1
+    gtscript.stencil(definition=stencil, backend=backend)(input_field, output_field, 1)
+    assert output_field[0, 0, 0] == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -21,7 +21,7 @@ from gt4py import gtscript
 from gt4py import storage as gt_storage
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, computation, interval
 
-from ..definitions import ALL_BACKENDS, CPU_BACKENDS, INTERNAL_BACKENDS, OLD_BACKENDS
+from ..definitions import ALL_BACKENDS, CPU_BACKENDS, INTERNAL_BACKENDS
 from .stencil_definitions import EXTERNALS_REGISTRY as externals_registry
 from .stencil_definitions import REGISTRY as stencil_definitions
 

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -16,7 +16,6 @@
 
 
 import numpy as np
-import pytest
 
 from gt4py import gtscript
 from gt4py import testing as gt_testing
@@ -624,17 +623,7 @@ class TestNon3DFields(gt_testing.StencilTestSuite):
         "field_out": np.float64,
     }
     domain_range = [(4, 10), (4, 10), (4, 10)]
-    backends = [
-        "debug",
-        "numpy",
-        pytest.param("gtx86", marks=[pytest.mark.xfail]),
-        pytest.param("gtmc", marks=[pytest.mark.xfail]),
-        pytest.param("gtcuda", marks=[pytest.mark.xfail]),
-        "gtc:gt:cpu_ifirst",
-        "gtc:gt:cpu_kfirst",
-        "gtc:gt:gpu",
-        "gtc:dace",
-    ]
+    backends = ["gtc:gt:cpu_ifirst", "gtc:gt:cpu_kfirst", "gtc:gt:gpu", "gtc:dace"]
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="K", boundary=[(0, 0), (0, 0), (0, 0)]

--- a/tests/test_unittest/test_backend_api.py
+++ b/tests/test_unittest/test_backend_api.py
@@ -43,10 +43,7 @@ def test_generate_computation(backend, tmp_path):
     builder = StencilBuilder(init_1, backend=backend).with_caching(
         "nocaching", output_path=tmp_path / __name__ / "generate_computation"
     )
-    if backend.name.startswith("gtc:") and (backend.name != "gtc:numpy"):
-        result = builder.backend.generate_computation(ir=builder.definition_ir)
-    else:
-        result = builder.backend.generate_computation()
+    result = builder.backend.generate_computation()
 
     # python backends only need to generate one module, either the stencil module...
     py_result = backend.languages["computation"] == "python" and "init_1.py" in result

--- a/tests/test_unittest/test_caching.py
+++ b/tests/test_unittest/test_caching.py
@@ -45,7 +45,7 @@ def simple_stencil_with_doc(field: Field[float]):  # type: ignore
 def builder():
     """Preconfigure builder so everything but definition has defaults."""
 
-    def make_builder(definition, backend_name="debug", module=None):
+    def make_builder(definition, backend_name="gtc:numpy", module=None):
         """Make a builder instance a definition and default params."""
         return StencilBuilder(
             definition,
@@ -87,10 +87,10 @@ def test_jit_version(builder):
     simple_stencil_same.__name__ = "simple_stencil"
 
     # create builders with jit caching strategy
-    original = builder(simple_stencil, "gtx86").with_caching("jit")
-    duplicate = builder(simple_stencil, "gtx86").with_caching("jit")
-    samebody = builder(simple_stencil_same, "gtx86").with_caching("jit")
-    withdoc = builder(simple_stencil_with_doc, "gtx86").with_caching("jit")
+    original = builder(simple_stencil, "gtc:gt:cpu_kfirst").with_caching("jit")
+    duplicate = builder(simple_stencil, "gtc:gt:cpu_kfirst").with_caching("jit")
+    samebody = builder(simple_stencil_same, "gtc:gt:cpu_kfirst").with_caching("jit")
+    withdoc = builder(simple_stencil_with_doc, "gtc:gt:cpu_kfirst").with_caching("jit")
 
     assert stencil_fingerprints_are_equal(original, duplicate)
     assert not stencil_fingerprints_are_equal(original, samebody)
@@ -117,7 +117,7 @@ def test_jit_version(builder):
 
 
 def test_jit_extrainfo(builder):
-    builder = builder(simple_stencil, "gtx86").with_caching("jit")
+    builder = builder(simple_stencil, "gtc:gt:cpu_kfirst").with_caching("jit")
     builder.backend.generate()
 
     assert "pyext_file_path" in builder.caching.cache_info
@@ -139,28 +139,26 @@ def assert_nocaching_gtcpp_source_file_tree_conforms_to_expectations(root_path, 
     build_path = stencil_path / f"{stencil_name}_pyext_BUILD"
 
     module_path = stencil_path / f"{stencil_name}.py"
-    comp_cpp_path = build_path / "computation.cpp"
     comp_hpp_path = build_path / "computation.hpp"
     comp_bindings_path = build_path / "bindings.cpp"
 
     assert module_path.exists()
-    assert comp_cpp_path.exists()
     assert comp_hpp_path.exists()
     assert comp_bindings_path.exists()
 
 
 def test_nocaching_generate(builder, tmp_path):
     # generate pure python stencil and ensure the module is in the right place
-    builder_d = builder(simple_stencil, backend_name="debug", module="foo_d").with_caching(
+    builder_d = builder(simple_stencil, backend_name="gtc:numpy", module="foo_d").with_caching(
         "nocaching", output_path=tmp_path
     )
     builder_d.backend.generate()
     assert tmp_path.joinpath("foo_d", "foo", "foo.py").exists()
 
     # generate a GT C++ extension stencil and check the locations of the source files
-    builder_g = builder(simple_stencil, backend_name="gtx86", module="foo_g").with_caching(
-        "nocaching", output_path=tmp_path
-    )
+    builder_g = builder(
+        simple_stencil, backend_name="gtc:gt:cpu_kfirst", module="foo_g"
+    ).with_caching("nocaching", output_path=tmp_path)
     builder_g.backend.generate()
 
     assert_nocaching_gtcpp_source_file_tree_conforms_to_expectations(tmp_path / "foo_g", "foo")

--- a/tests/test_unittest/test_call_interface.py
+++ b/tests/test_unittest/test_call_interface.py
@@ -39,14 +39,16 @@ def base_stencil(
 
 
 def test_origin_selection():
-    stencil = gtscript.stencil(definition=base_stencil, backend="numpy")
+    stencil = gtscript.stencil(definition=base_stencil, backend="gtc:numpy")
 
-    A = gt_storage.ones(backend="gtmc", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0))
+    A = gt_storage.ones(
+        backend="gtc:gt:cpu_ifirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0)
+    )
     B = gt_storage.ones(
-        backend="gtx86", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
+        backend="gtc:gt:cpu_kfirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
     )
     C = gt_storage.ones(
-        backend="numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
+        backend="gtc:numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
     )
 
     stencil(A, B, C, param=3.0, origin=(1, 1, 1), domain=(1, 1, 1))
@@ -58,12 +60,14 @@ def test_origin_selection():
     assert np.sum(np.asarray(B)) == 33
     assert np.sum(np.asarray(C)) == 47
 
-    A = gt_storage.ones(backend="gtmc", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0))
+    A = gt_storage.ones(
+        backend="gtc:gt:cpu_ifirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0)
+    )
     B = gt_storage.ones(
-        backend="gtx86", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
+        backend="gtc:gt:cpu_kfirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
     )
     C = gt_storage.ones(
-        backend="numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
+        backend="gtc:numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
     )
     stencil(A, B, C, param=3.0, origin={"_all_": (1, 1, 1), "field1": (2, 2, 2)}, domain=(1, 1, 1))
 
@@ -74,12 +78,14 @@ def test_origin_selection():
     assert np.sum(np.asarray(B)) == 33
     assert np.sum(np.asarray(C)) == 47
 
-    A = gt_storage.ones(backend="gtmc", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0))
+    A = gt_storage.ones(
+        backend="gtc:gt:cpu_ifirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0)
+    )
     B = gt_storage.ones(
-        backend="gtx86", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
+        backend="gtc:gt:cpu_kfirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
     )
     C = gt_storage.ones(
-        backend="numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
+        backend="gtc:numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
     )
     stencil(A, B, C, param=3.0, origin={"field1": (2, 2, 2)}, domain=(1, 1, 1))
 
@@ -91,50 +97,17 @@ def test_origin_selection():
     assert np.sum(np.asarray(C)) == 47
 
 
-@pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
-def test_origin_k_fields(backend):
-    @gtscript.stencil(backend=backend, rebuild=True)
-    def k_to_ijk(outp: Field[np.float64], inp: Field[gtscript.K, np.float64]):
-        with computation(PARALLEL), interval(...):
-            outp = inp
-
-    origin = {"outp": (0, 0, 1), "inp": (2,)}
-    domain = (2, 2, 8)
-
-    data = np.arange(10, dtype=np.float64)
-    inp = gt_storage.from_array(
-        data=data,
-        shape=(10,),
-        default_origin=(0,),
-        dtype=np.float64,
-        mask=[False, False, True],
-        backend=backend,
-    )
-    outp = gt_storage.zeros(
-        shape=(2, 2, 10), default_origin=(0, 0, 0), dtype=np.float64, backend=backend
-    )
-
-    k_to_ijk(outp, inp, origin=origin, domain=domain)
-
-    inp.device_to_host()
-    outp.device_to_host()
-    np.testing.assert_allclose(data, np.asarray(inp))
-    np.testing.assert_allclose(
-        np.broadcast_to(data[2:], shape=(2, 2, 8)), np.asarray(outp)[:, :, 1:-1]
-    )
-    np.testing.assert_allclose(0.0, np.asarray(outp)[:, :, 0])
-    np.testing.assert_allclose(0.0, np.asarray(outp)[:, :, -1])
-
-
 def test_domain_selection():
-    stencil = gtscript.stencil(definition=base_stencil, backend="numpy")
+    stencil = gtscript.stencil(definition=base_stencil, backend="gtc:numpy")
 
-    A = gt_storage.ones(backend="gtmc", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0))
+    A = gt_storage.ones(
+        backend="gtc:gt:cpu_ifirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0)
+    )
     B = gt_storage.ones(
-        backend="gtx86", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
+        backend="gtc:gt:cpu_kfirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
     )
     C = gt_storage.ones(
-        backend="numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
+        backend="gtc:numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
     )
 
     stencil(A, B, C, param=3.0, origin=(1, 1, 1), domain=(1, 1, 1))
@@ -146,12 +119,14 @@ def test_domain_selection():
     assert np.sum(np.asarray(B)) == 33
     assert np.sum(np.asarray(C)) == 47
 
-    A = gt_storage.ones(backend="gtmc", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0))
+    A = gt_storage.ones(
+        backend="gtc:gt:cpu_ifirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(0, 0, 0)
+    )
     B = gt_storage.ones(
-        backend="gtx86", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
+        backend="gtc:gt:cpu_kfirst", dtype=np.float64, shape=(3, 3, 3), default_origin=(2, 2, 2)
     )
     C = gt_storage.ones(
-        backend="numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
+        backend="gtc:numpy", dtype=np.float32, shape=(3, 3, 3), default_origin=(0, 1, 0)
     )
     stencil(A, B, C, param=3.0, origin=(0, 0, 0))
 
@@ -286,7 +261,7 @@ def test_halo_checks(backend):
 
 
 def test_np_int_types():
-    backend = "numpy"
+    backend = "gtc:numpy"
     stencil = gtscript.stencil(definition=avg_stencil, backend=backend)
 
     # test numpy int types are accepted
@@ -311,7 +286,7 @@ def test_np_int_types():
 
 
 def test_np_array_int_types():
-    backend = "numpy"
+    backend = "gtc:numpy"
     stencil = gtscript.stencil(definition=avg_stencil, backend=backend)
 
     # test numpy int types are accepted
@@ -337,7 +312,7 @@ def test_np_array_int_types():
 
 def test_ndarray_warning():
     """test that proper warnings are raised depending on field type."""
-    backend = "numpy"
+    backend = "gtc:numpy"
     stencil = gtscript.stencil(definition=avg_stencil, backend=backend)
 
     # test numpy int types are accepted
@@ -371,7 +346,7 @@ def test_ndarray_warning():
     assert len(record) == 0
 
 
-@pytest.mark.parametrize("backend", ["debug", "numpy", "gtx86"])
+@pytest.mark.parametrize("backend", ["gtc:numpy", "gtc:gt:cpu_kfirst"])
 def test_exec_info(backend):
     """test that proper warnings are raised depending on field type."""
     stencil = gtscript.stencil(definition=avg_stencil, backend=backend)
@@ -398,7 +373,7 @@ def test_exec_info(backend):
     assert all([k + "_start_time" in exec_info for k in timings])
     assert all([k + "_end_time" in exec_info for k in timings])
     assert all([exec_info[k + "_end_time"] > exec_info[k + "_start_time"] for k in timings])
-    if backend.startswith("gt"):
+    if backend.startswith("gtc:gt"):
         assert "run_cpp_start_time" in exec_info
         assert "run_cpp_end_time" in exec_info
         assert exec_info["run_cpp_end_time"] > exec_info["run_cpp_start_time"]
@@ -407,7 +382,7 @@ def test_exec_info(backend):
 class TestAxesMismatch:
     @pytest.fixture
     def sample_stencil(self):
-        @gtscript.stencil(backend="debug")
+        @gtscript.stencil(backend="gtc:numpy")
         def _stencil(
             field_out: gtscript.Field[gtscript.IJ, np.float64],
         ):
@@ -432,14 +407,14 @@ class TestAxesMismatch:
                     shape=(3, 3),
                     mask=[True, False, True],
                     dtype=np.float64,
-                    backend="debug",
+                    backend="gtc:numpy",
                     default_origin=(0, 0),
                 )
             )
 
 
 class TestDataDimensions:
-    backend = "debug"
+    backend = "gtc:numpy"
 
     @pytest.fixture
     def sample_stencil(self):

--- a/tests/test_unittest/test_cli.py
+++ b/tests/test_unittest/test_cli.py
@@ -25,7 +25,7 @@ from click.testing import CliRunner
 from gt4py import backend, cli
 from gt4py.backend.base import CLIBackendMixin
 
-from ..definitions import OLD_INTERNAL_BACKENDS
+from ..definitions import INTERNAL_BACKENDS
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def clirunner():
 
 @pytest.fixture(
     params=[
-        *OLD_INTERNAL_BACKENDS,  # gtc backends require definition ir as input, for now we skip the tests
+        *INTERNAL_BACKENDS,  # gtc backends require definition ir as input, for now we skip the tests
         pytest.param(
             "nocli",
         ),
@@ -93,15 +93,11 @@ def nocli_backend(scope="module"):
 
 
 BACKEND_ROW_PATTERN_BY_NAME = {
-    "debug": r"^\s*debug\s*python\s*Yes",
-    "numpy": r"^\s*numpy\s*python\s*Yes",
-    "gtx86": r"^\s*gtx86\s*c\+\+\s*python\s*Yes",
-    "gtmc": r"^\s*gtmc\s*c\+\+\s*python\s*Yes",
-    "gtcuda": r"^\s*gtcuda\s*cuda\s*python\s*Yes",
     "gtc:gt:cpu_ifirst": r"^\s*gtc:gt:cpu_ifirst\s*c\+\+\s*python\s*Yes",
     "gtc:gt:cpu_kfirst": r"^\s*gtc:gt:cpu_kfirst\s*c\+\+\s*python\s*Yes",
     "gtc:gt:gpu": r"^\s*gtc:gt:gpu\s*c\+\+\s*python\s*Yes",
     "gtc:numpy": r"^\s*gtc:numpy\s*python\s*python\s*Yes",
+    "gtc:dace": r"^\s*gtc:dace\s*c\+\+\s*python\s*Yes",
     "nocli": r"^\s*nocli\s*\?\s*\?\s*No",
 }
 
@@ -131,7 +127,7 @@ def test_gen_silent(clirunner, simple_stencil, tmp_path):
         cli.gtpyc,
         [
             "gen",
-            "--backend=debug",
+            "--backend=gtc:numpy",
             "--output-path",
             str(tmp_path / "test_gen_silent"),
             "--silent",
@@ -146,7 +142,7 @@ def test_gen_silent(clirunner, simple_stencil, tmp_path):
 
 def test_gen_missing_arg(clirunner):
     """Test for error if no input path argument is passed to gen."""
-    result = clirunner.invoke(cli.gtpyc, ["gen", "--backend=debug"])
+    result = clirunner.invoke(cli.gtpyc, ["gen", "--backend=gtc:numpy"])
 
     assert result.exit_code == 2
     assert "Missing argument 'INPUT_PATH'." in result.output
@@ -195,31 +191,46 @@ def test_gen_enabled_backend_choice(
         assert result.exit_code == 0
 
 
-def test_gen_gtx86(clirunner, simple_stencil, tmp_path):
+def test_gen_gtc_cpu(clirunner, simple_stencil, tmp_path):
     """Only generate the c++ files."""
-    output_path = tmp_path / "test_gen_gtx86"
+    output_path = tmp_path / "test_gen_gtc_cpu"
     result = clirunner.invoke(
         cli.gtpyc,
-        ["gen", f"--output-path={output_path}", "--backend=gtx86", str(simple_stencil)],
+        ["gen", f"--output-path={output_path}", "--backend=gtc:gt:cpu_kfirst", str(simple_stencil)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
     src_path = output_path / "init_1_src"
     src_files = [path.name for path in src_path.iterdir()]
-    assert set(["computation.hpp", "computation.cpp"]) == set(src_files), result.output
+    print(src_files)
+    assert ["computation.hpp"] == src_files, result.output
 
 
 def test_backend_option_order(clirunner, simple_stencil, tmp_path):
     """Make sure the order in which --backend and --option are passed does not matter."""
     output_path1 = tmp_path / "backend_first"
     # putting the option after the backend should definitely check against the chosen backend
+    print(
+        clirunner.invoke(
+            cli.gtpyc,
+            [
+                "gen",
+                f"--output-path={output_path1}",
+                "--backend=gtc:numpy",
+                "-O",
+                "ignore_np_errstate=True",
+                str(simple_stencil),
+            ],
+            catch_exceptions=False,
+        ).stdout_bytes
+    )
     assert (
         clirunner.invoke(
             cli.gtpyc,
             [
                 "gen",
                 f"--output-path={output_path1}",
-                "--backend=numpy",
+                "--backend=gtc:numpy",
                 "-O",
                 "ignore_np_errstate=True",
                 str(simple_stencil),
@@ -237,7 +248,7 @@ def test_backend_option_order(clirunner, simple_stencil, tmp_path):
                 f"--output-path={output_path1}",
                 "-O",
                 "ignore_np_errstate=True",
-                "--backend=numpy",
+                "--backend=gtc:numpy",
                 str(simple_stencil),
             ],
             catch_exceptions=False,
@@ -248,7 +259,7 @@ def test_backend_option_order(clirunner, simple_stencil, tmp_path):
 
 def test_write_computation_src(tmp_path, simple_stencil):
     builder = cli.GTScriptBuilder(
-        simple_stencil, output_path=tmp_path, backend=backend.from_name("debug")
+        simple_stencil, output_path=tmp_path, backend=backend.from_name("gtc:numpy")
     )
     toplevel = "test_write_computation_src"
     test_src = {

--- a/tests/test_unittest/test_cli.py
+++ b/tests/test_unittest/test_cli.py
@@ -93,11 +93,12 @@ def nocli_backend(scope="module"):
 
 
 BACKEND_ROW_PATTERN_BY_NAME = {
+    "gtc:cuda": r"^\s*gtc:cuda\s*cuda\s*python\s*Yes",
+    "gtc:dace": r"^\s*gtc:dace\s*c\+\+\s*python\s*Yes",
     "gtc:gt:cpu_ifirst": r"^\s*gtc:gt:cpu_ifirst\s*c\+\+\s*python\s*Yes",
     "gtc:gt:cpu_kfirst": r"^\s*gtc:gt:cpu_kfirst\s*c\+\+\s*python\s*Yes",
-    "gtc:gt:gpu": r"^\s*gtc:gt:gpu\s*c\+\+\s*python\s*Yes",
+    "gtc:gt:gpu": r"^\s*gtc:gt:gpu\s*cuda\s*python\s*Yes",
     "gtc:numpy": r"^\s*gtc:numpy\s*python\s*python\s*Yes",
-    "gtc:dace": r"^\s*gtc:dace\s*c\+\+\s*python\s*Yes",
     "nocli": r"^\s*nocli\s*\?\s*\?\s*No",
 }
 

--- a/tests/test_unittest/test_cli.py
+++ b/tests/test_unittest/test_cli.py
@@ -210,20 +210,6 @@ def test_backend_option_order(clirunner, simple_stencil, tmp_path):
     """Make sure the order in which --backend and --option are passed does not matter."""
     output_path1 = tmp_path / "backend_first"
     # putting the option after the backend should definitely check against the chosen backend
-    print(
-        clirunner.invoke(
-            cli.gtpyc,
-            [
-                "gen",
-                f"--output-path={output_path1}",
-                "--backend=gtc:numpy",
-                "-O",
-                "ignore_np_errstate=True",
-                str(simple_stencil),
-            ],
-            catch_exceptions=False,
-        ).stdout_bytes
-    )
     assert (
         clirunner.invoke(
             cli.gtpyc,

--- a/tests/test_unittest/test_exec_info.py
+++ b/tests/test_unittest/test_exec_info.py
@@ -29,9 +29,6 @@ from gt4py import storage as gt_storage
 from ..definitions import INTERNAL_BACKENDS
 
 
-backend_list = [backend for backend in INTERNAL_BACKENDS if backend.values[0] != "debug"]
-
-
 class TestExecInfo:
     @staticmethod
     def advection_def(
@@ -192,7 +189,7 @@ class TestExecInfo:
                 assert stencil_info["total_run_cpp_time"] > stencil_info["run_cpp_time"]
 
     @given(data=hyp_st.data())
-    @pytest.mark.parametrize("backend", backend_list)
+    @pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
     def test_backcompatibility(self, data, backend):
         # set backend as instance attribute
         self.backend = backend
@@ -235,7 +232,7 @@ class TestExecInfo:
         assert type(self.diffusion).__name__ not in exec_info
 
     @given(data=hyp_st.data())
-    @pytest.mark.parametrize("backend", backend_list)
+    @pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
     def test_aggregate(self, data, backend):
         # set backend as instance attribute
         self.backend = backend

--- a/tests/test_unittest/test_gtc/test_passes/test_legacy_extents.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_legacy_extents.py
@@ -16,7 +16,7 @@ def test_noextents():
         with computation(PARALLEL), interval(...):
             field_a = field_b[0, 0, 0]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -29,7 +29,7 @@ def test_single_pos_offset():
         with computation(PARALLEL), interval(...):
             field_a = field_b[1, 0, 0]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -42,7 +42,7 @@ def test_single_neg_offset():
         with computation(PARALLEL), interval(...):
             field_a = field_b[0, -1, 0]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -55,7 +55,7 @@ def test_single_k_offset():
         with computation(PARALLEL), interval(...):
             field_a = field_b[0, 0, 1]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -73,7 +73,7 @@ def test_offset_chain():
             tmp = field_b[0, -1, 0] + field_b[0, 1, 0]
             field_a = tmp[0, 0, 0] + tmp[0, 0, -1]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -86,7 +86,7 @@ def test_ij():
         with computation(PARALLEL), interval(...):
             field_a = field_b[0, 1]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -99,7 +99,7 @@ def test_j():
         with computation(PARALLEL), interval(...):
             field_a = field_b[1] + field_b[-2]
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -112,7 +112,7 @@ def test_unreferenced():
         with computation(PARALLEL), interval(...):
             field_a = 1.0
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 
@@ -132,7 +132,7 @@ def test_field_if():
                 tmp = -field_b[0, 1, 0]
                 field_a = tmp
 
-    builder = StencilBuilder(stencil, backend=from_name("debug"))
+    builder = StencilBuilder(stencil, backend=from_name("gtc:numpy"))
     old_ext = builder.implementation_ir.fields_extents
     legacy_ext = compute_legacy_extents(prepare_gtir(builder), mask_inwards=True)
 

--- a/tests/test_unittest/test_gtc/test_passes/test_min_k_interval.py
+++ b/tests/test_unittest/test_gtc/test_passes/test_min_k_interval.py
@@ -129,7 +129,7 @@ def stencil_with_extent_6(field_a: gs.Field[float], field_b: gs.Field[float]):
 
 @pytest.mark.parametrize("definition,expected_k_bounds", [(s, d["k_bounds"]) for s, d in test_data])
 def test_k_bounds(definition, expected_k_bounds):
-    builder = StencilBuilder(definition, backend=from_name("debug"))
+    builder = StencilBuilder(definition, backend=from_name("gtc:numpy"))
     k_boundary = compute_k_boundary(builder.gtir_pipeline.full(skip=[prune_unused_parameters]))[
         "field_b"
     ]
@@ -141,7 +141,7 @@ def test_k_bounds(definition, expected_k_bounds):
     "definition,expected_min_k_size", [(s, d["min_k_size"]) for s, d in test_data]
 )
 def test_min_k_size(definition, expected_min_k_size):
-    builder = StencilBuilder(definition, backend=from_name("debug"))
+    builder = StencilBuilder(definition, backend=from_name("gtc:numpy"))
     min_k_size = compute_min_k_size(builder.gtir_pipeline.full(skip=[prune_unused_parameters]))
 
     assert expected_min_k_size == min_k_size
@@ -213,6 +213,6 @@ def stencil_with_invalid_temporary_access_end(field_a: gs.Field[float], field_b:
     [stencil_with_invalid_temporary_access_start, stencil_with_invalid_temporary_access_end],
 )
 def test_invalid_temporary_access(definition):
-    builder = StencilBuilder(definition, backend=from_name("debug"))
+    builder = StencilBuilder(definition, backend=from_name("gtc:numpy"))
     with pytest.raises(TypeError, match="Invalid access with offset in k to temporary field tmp."):
         k_boundary = compute_k_boundary(builder.gtir_pipeline.full(skip=[prune_unused_parameters]))

--- a/tests/test_unittest/test_lazy_stencil.py
+++ b/tests/test_unittest/test_lazy_stencil.py
@@ -63,7 +63,7 @@ def test_lazy_stencil():
     )
     lazy_s = LazyStencil(builder)
 
-    assert lazy_s.backend.name == "debug"
+    assert lazy_s.backend.name == "gtc:numpy"
 
 
 def test_lazy_syntax_check(frontend, backend):

--- a/tests/test_unittest/test_stencil_builder.py
+++ b/tests/test_unittest/test_stencil_builder.py
@@ -46,7 +46,7 @@ def test_setters():
     assert version
 
     # should reset build data, stencil_id particularly should be recomputed
-    builder.with_backend("numpy")
+    builder.with_backend("gtc:numpy")
     assert builder.is_build_data_empty
     assert builder.externals == {"a": 1.0}
     assert builder.backend_data == {}
@@ -72,7 +72,7 @@ def test_setters():
 def test_usage_numpy_caching():
     builder = (
         StencilBuilder(simple_stencil)
-        .with_backend("numpy")
+        .with_backend("gtc:numpy")
         .with_externals({"a": 1.0})
         .with_options(name=simple_stencil.__name__, module=simple_stencil.__module__, rebuild=False)
     )
@@ -96,25 +96,23 @@ def test_usage_numpy_caching():
 def test_usage_numpy_nocaching(tmp_path):
     builder = (
         StencilBuilder(simple_stencil)
-        .with_backend("numpy")
+        .with_backend("gtc:numpy")
         .with_externals({"a": 1.0})
         .with_caching("nocaching", output_path=tmp_path)
         .with_options(name="simple_stencil", module="")
     )
 
     computation_src = builder.generate_computation()
-    assert "simple_stencil.py" in computation_src
+    assert "computation.py" in computation_src
 
     builder.build()
-    assert tmp_path.joinpath("simple_stencil", "simple_stencil.py").exists(), list(
-        tmp_path.iterdir()
-    )
+    assert tmp_path.joinpath("simple_stencil", "computation.py").exists(), list(tmp_path.iterdir())
 
 
 def test_regression_run_analysis_twice(tmp_path):
     builder = (
         StencilBuilder(assign_bool_float)
-        .with_backend("numpy")
+        .with_backend("gtc:numpy")
         .with_externals({"a": 1.0})
         .with_caching("nocaching", output_path=tmp_path)
         .with_options(name="simple_stencil", module="", rebuild=True)

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -476,7 +476,11 @@ def test_masked_storage_gpu(param_dict):
 
     # no assert when all is defined in descriptor, no grid_group
     store = gt_store.empty(
-        dtype=np.float64, default_origin=default_origin, shape=shape, mask=mask, backend="gtcuda"
+        dtype=np.float64,
+        default_origin=default_origin,
+        shape=shape,
+        mask=mask,
+        backend="gtc:gt:gpu",
     )
     assert sum(store.mask) == store.ndim
     assert sum(store.mask) == len(store.data.shape)
@@ -523,7 +527,7 @@ def test_slices_gpu():
     shape = (10, 10, 10)
     array = cp.random.randn(*shape)
     stor = gt_store.from_array(
-        array, backend="gtcuda", dtype=np.float64, default_origin=default_origin, shape=shape
+        array, backend="gtc:gt:gpu", dtype=np.float64, default_origin=default_origin, shape=shape
     )
     sliced = stor[::2, ::2, ::2]
     # assert (sliced == array[::2, ::2, ::2]).all()
@@ -535,10 +539,10 @@ def test_slices_gpu():
     shape = (10, 10, 10)
     array = cp.random.randn(*shape)
     stor = gt_store.from_array(
-        array, backend="gtcuda", dtype=np.float64, default_origin=default_origin, shape=shape
+        array, backend="gtc:gt:gpu", dtype=np.float64, default_origin=default_origin, shape=shape
     )
     ref = gt_store.from_array(
-        array, backend="gtcuda", dtype=np.float64, default_origin=default_origin, shape=shape
+        array, backend="gtc:gt:gpu", dtype=np.float64, default_origin=default_origin, shape=shape
     )
     # assert (sliced == array[::2, ::2, ::2]).all()
     stor[::2, ::2, ::2] = ref[::2, ::2, ::2]
@@ -550,7 +554,7 @@ def test_slices_gpu():
     shape = (10, 10, 10)
     array = cp.random.randn(*shape)
     stor = gt_store.from_array(
-        array, backend="gtcuda", dtype=np.float64, default_origin=default_origin, shape=shape
+        array, backend="gtc:gt:gpu", dtype=np.float64, default_origin=default_origin, shape=shape
     )
     ref = copy.deepcopy(stor)
     # assert (sliced == array[::2, ::2, ::2]).all()
@@ -563,7 +567,7 @@ def test_slices_gpu():
     array = cp.random.randn(*shape)
     stor = gt_store.from_array(
         array,
-        backend="gtcuda",
+        backend="gtc:gt:gpu",
         dtype=np.float64,
         default_origin=default_origin,
         shape=shape,
@@ -571,7 +575,7 @@ def test_slices_gpu():
     )
     ref = gt_store.from_array(
         array,
-        backend="gtcuda",
+        backend="gtc:gt:gpu",
         dtype=np.float64,
         default_origin=default_origin,
         shape=shape,
@@ -588,7 +592,7 @@ def test_slices_gpu():
     array = cp.random.randn(*shape)
     stor = gt_store.from_array(
         array,
-        backend="gtcuda",
+        backend="gtc:gt:gpu",
         dtype=np.float64,
         default_origin=default_origin,
         shape=shape,
@@ -605,7 +609,7 @@ def test_slices_gpu():
     array = cp.random.randn(*shape)
     stor = gt_store.from_array(
         array,
-        backend="gtcuda",
+        backend="gtc:gt:gpu",
         dtype=np.float64,
         default_origin=default_origin,
         shape=shape,
@@ -613,7 +617,7 @@ def test_slices_gpu():
     )
     ref = gt_store.from_array(
         array,
-        backend="gtcuda",
+        backend="gtc:gt:gpu",
         dtype=np.float64,
         default_origin=default_origin,
         shape=shape,


### PR DESCRIPTION
## Description

Removes the legacy backends from the backend registery and thereby also disables running tests with these.

Resolves #622.