### PR TITLE
Add concurrency to GitHub Actions

### DIFF
--- a/.github/workflows/gt4py-gitlab-ci.yml
+++ b/.github/workflows/gt4py-gitlab-ci.yml
@@ -8,7 +8,7 @@ on:
     - staging
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gt4py-gitlab-ci.yml
+++ b/.github/workflows/gt4py-gitlab-ci.yml
@@ -1,10 +1,16 @@
-name: CI
+name: Daint CI
+
 on:
   push:
     branches:
     - master
     - trying
     - staging
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gt4py-gitlab-ci.yml
+++ b/.github/workflows/gt4py-gitlab-ci.yml
@@ -6,11 +6,6 @@ on:
     - master
     - trying
     - staging
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gt4py-sphinx.yml
+++ b/.github/workflows/gt4py-sphinx.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sphinx-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gt4py-sphinx.yml
+++ b/.github/workflows/gt4py-sphinx.yml
@@ -9,7 +9,7 @@ on:
     - master
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -10,6 +10,10 @@ on:
     branches:
     - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gt4py-tox.yml
+++ b/.github/workflows/gt4py-tox.yml
@@ -11,7 +11,7 @@ on:
     - master
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/README.rst
+++ b/README.rst
@@ -173,8 +173,6 @@ Development roadmap
 A short overview of the new features and changes planned for the coming
 weeks & months.
 
--  Integration with `Dawn <https://github.com/MeteoSwiss-APN/dawn>`__
-   compiler
 -  Update documentation (API reference, tutorial, notebooks and
    examples)
 -  Missing features:


### PR DESCRIPTION
## Description

This should cancel expensive continuous integration when new commits are added to PRs. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow