### PR TITLE
Add mask_acc to NamedScalars and VectorTemps

### DIFF
--- a/src/gtc/numpy/npir_codegen.py
+++ b/src/gtc/numpy/npir_codegen.py
@@ -228,8 +228,8 @@ class NpirCodegen(TemplatedGenerator):
     def visit_FieldSlice(
         self,
         node: npir.FieldSlice,
-        mask_acc: str = "",
         *,
+        mask_acc: str = "",
         is_serial: bool = False,
         is_rhs: bool = False,
         **kwargs: Any,
@@ -267,9 +267,11 @@ class NpirCodegen(TemplatedGenerator):
 
     EmptyTemp = FormatTemplate("ShimmedView(np.zeros({shape}, dtype={dtype}), {origin})")
 
-    NamedScalar = FormatTemplate("{name}")
+    def visit_NamedScalar(self, node: npir.NamedScalar, *, mask_acc: str = "", **kwargs):
+        return f"{node.name}{mask_acc}"
 
-    VectorTemp = FormatTemplate("{name}_")
+    def visit_VectorTemp(self, node: npir.VectorTemp, *, mask_acc: str = "", **kwargs):
+        return f"{node.name}_{mask_acc}"
 
     def visit_MaskBlock(self, node: npir.MaskBlock, **kwargs) -> Union[str, Collection[str]]:
         if isinstance(node.mask, npir.FieldSlice):

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -247,8 +247,9 @@ def test_lower_dimensional_masked_2dcond(backend):
         outp: gtscript.Field[gtscript.IJK, np.float_],
     ):
         with computation(FORWARD), interval(...):
+            tmp = inp
             if cond > 0.0:
-                outp = inp
+                outp = tmp
 
     inp = np.random.randn(10, 10)
     outp = np.random.randn(10, 10, 10)


### PR DESCRIPTION
## Description

Adds mask accesses in the `gtc:numpy` backend to scalars referenced inside conditional blocks. Not sure why this has not triggered an error yet.

Without the change to the code generation, `gtc:numpy` backend raises an exception at run-time in the changed stencil. The problem is unrelated to lower dimensional storages, but that test was convenient to change.
```
            _mask_0_ = np.full((I - i, J - j, 1), mask_7638408784_gen_0_)
>           outp_[i:I, j:J, k_ : (k_ + 1)][_mask_0_] = tmp_gen_0_
E           TypeError: NumPy boolean array indexing assignment requires a 0 or 1-dimensional input, input has 3 dimensions
```
This happens because `[_mask_0_]` is not added on the RHS access.