### PR TITLE
Fixes #220: Add definitive assignment analysis

### DIFF
--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -30,7 +30,6 @@ import numpy as np
 
 from gt4py import definitions as gt_definitions
 from gt4py.lazy_stencil import LazyStencil
-from gt4py.stencil_builder import StencilBuilder
 
 
 # GTScript builtins
@@ -349,7 +348,7 @@ def lazy_stencil(
             Defers the generation step until the last moment and allows syntax checking independently.
             Also gives access to a more fine grained generate / build process.
     """
-    from gt4py import frontend
+    from gt4py.stencil_builder import StencilBuilder
 
     def _decorator(func):
         _set_arg_dtypes(func, dtypes or {})

--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -18,6 +18,7 @@ import pathlib
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 import gt4py.caching
+import gt4py.frontend
 from gt4py.backend.gtc_backend.defir_to_gtir import DefIRToGTIR
 from gt4py.definitions import BuildOptions, StencilID
 from gt4py.type_hints import AnnotatedStencilFunc, StencilFunc

--- a/src/gtc/passes/gtir_definitive_assignment_analysis.py
+++ b/src/gtc/passes/gtir_definitive_assignment_analysis.py
@@ -42,9 +42,9 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
             invalid_accesses.append(node)
 
     @classmethod
-    def apply(cls, gtir_stencil_expr: gtir.Stencil) -> Set[gtir.FieldAccess]:
+    def apply(cls, gtir_stencil_expr: gtir.Stencil) -> List[gtir.FieldAccess]:
         """Execute analysis and return all accesses to undefined symbols."""
-        invalid_accesses: Set[gtir.FieldAccess] = set()
+        invalid_accesses: List[gtir.FieldAccess] = []
         DefinitiveAssignmentAnalysis().visit(
             gtir_stencil_expr,
             alive_vars=set(gtir_stencil_expr.param_names),

--- a/src/gtc/passes/gtir_definitive_assignment_analysis.py
+++ b/src/gtc/passes/gtir_definitive_assignment_analysis.py
@@ -24,7 +24,9 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
         self.visit(node.false_branch, alive_vars=false_branch_vars, **kwargs)
         alive_vars.update(true_branch_vars & false_branch_vars)
 
-    def visit_ParAssignStmt(self, node: gtir.ParAssignStmt, *, alive_vars: Set[str], **kwargs) -> None:
+    def visit_ParAssignStmt(
+        self, node: gtir.ParAssignStmt, *, alive_vars: Set[str], **kwargs
+    ) -> None:
         self.visit(node.right, alive_vars=alive_vars, **kwargs)
         alive_vars.add(node.left.name)
 

--- a/src/gtc/passes/gtir_definitive_assignment_analysis.py
+++ b/src/gtc/passes/gtir_definitive_assignment_analysis.py
@@ -17,14 +17,14 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
     result of the condition.
     """
 
-    def visit_IfStmt(self, node: gtir.FieldIfStmt, *, alive_vars: Set[str], **kwargs):
+    def visit_IfStmt(self, node: gtir.FieldIfStmt, *, alive_vars: Set[str], **kwargs) -> None:
         true_branch_vars = {*alive_vars}
         false_branch_vars = {*alive_vars}
         self.visit(node.true_branch, alive_vars=true_branch_vars, **kwargs)
         self.visit(node.false_branch, alive_vars=false_branch_vars, **kwargs)
         alive_vars.update(true_branch_vars & false_branch_vars)
 
-    def visit_ParAssignStmt(self, node: gtir.ParAssignStmt, *, alive_vars: Set[str], **kwargs):
+    def visit_ParAssignStmt(self, node: gtir.ParAssignStmt, *, alive_vars: Set[str], **kwargs) -> None:
         self.visit(node.right, alive_vars=alive_vars, **kwargs)
         alive_vars.add(node.left.name)
 
@@ -35,14 +35,14 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
         alive_vars: Set[str],
         invalid_accesses: List[gtir.FieldAccess],
         **kwargs,
-    ):
+    ) -> None:
         if node.name not in alive_vars:
             invalid_accesses.append(node)
 
     @classmethod
-    def apply(cls, gtir_stencil_expr: gtir.Stencil):
+    def apply(cls, gtir_stencil_expr: gtir.Stencil) -> Set[gtir.FieldAccess]:
         """Execute analysis and return all accesses to undefined symbols."""
-        invalid_accesses: List[gtir.FieldAccess] = []
+        invalid_accesses: Set[gtir.FieldAccess] = set()
         DefinitiveAssignmentAnalysis().visit(
             gtir_stencil_expr,
             alive_vars=set(gtir_stencil_expr.param_names),
@@ -54,7 +54,7 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
 analyze = DefinitiveAssignmentAnalysis.apply
 
 
-def check(gtir_stencil_expr: gtir.Stencil):
+def check(gtir_stencil_expr: gtir.Stencil) -> gtir.Stencil:
     """Execute definitive assignment analysis and warn on errors."""
     invalid_accesses = analyze(gtir_stencil_expr)
     for invalid_access in invalid_accesses:

--- a/src/gtc/passes/gtir_definitive_assignment_analysis.py
+++ b/src/gtc/passes/gtir_definitive_assignment_analysis.py
@@ -16,6 +16,7 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
     previous value again). Note that whether a symbols is defined is independent of the actual
     result of the condition.
     """
+
     def visit_IfStmt(self, node: gtir.FieldIfStmt, *, alive_vars: Set[str], **kwargs):
         true_branch_vars = {*alive_vars}
         false_branch_vars = {*alive_vars}
@@ -31,7 +32,7 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
         self,
         node: gtir.FieldAccess,
         *,
-        alive_vars: [str],
+        alive_vars: Set[str],
         invalid_accesses: List[gtir.FieldAccess],
         **kwargs,
     ):
@@ -54,9 +55,7 @@ analyze = DefinitiveAssignmentAnalysis.apply
 
 
 def check(gtir_stencil_expr: gtir.Stencil):
-    """
-    Execute definitive assignment analysis and warn on errors.
-    """
+    """Execute definitive assignment analysis and warn on errors."""
     invalid_accesses = analyze(gtir_stencil_expr)
     for invalid_access in invalid_accesses:
         warnings.warn(f"`{invalid_access.name}` may be uninitialized.")

--- a/src/gtc/passes/gtir_definitive_assignment_analysis.py
+++ b/src/gtc/passes/gtir_definitive_assignment_analysis.py
@@ -1,0 +1,63 @@
+import copy
+import warnings
+from typing import List, Set
+
+from eve import NodeVisitor
+from gtc import gtir
+
+
+class DefinitiveAssignmentAnalysis(NodeVisitor):
+    def visit_IfStmt(self, node: gtir.FieldIfStmt, *, alive_vars: Set[str], **kwargs):
+        true_branch_vars = copy.copy(alive_vars)
+        false_branch_vars = copy.copy(alive_vars)
+        self.visit(node.true_branch, alive_vars=true_branch_vars, **kwargs)
+        self.visit(node.false_branch, alive_vars=false_branch_vars, **kwargs)
+        alive_vars.update(true_branch_vars & false_branch_vars)
+
+    def visit_ParAssignStmt(self, node: gtir.ParAssignStmt, *, alive_vars: Set[str], **kwargs):
+        self.visit(node.right, alive_vars=alive_vars, **kwargs)
+        alive_vars.add(node.left.name)
+
+    def visit_FieldAccess(
+        self,
+        node: gtir.FieldAccess,
+        *,
+        alive_vars: Set,
+        invalid_accesses: List[gtir.FieldAccess],
+        **kwargs,
+    ):
+        if node.name not in alive_vars:
+            invalid_accesses.append(node)
+
+
+def analyse(gtir_stencil_expr: gtir.Stencil):
+    """
+    Analyse gtir stencil expression for access to undefined symbols.
+
+    A symbol is said to be defined if it was assigned to in the code-path of its usage. In other words: If a symbol is
+    defined in both branches of an if-statement it may be used outside. If a symbol is only defined in a single branch
+    it may only be used inside that branch unless it was already defined previously (as this is equal to assigning to
+    the previous value again). Note that whether a symbols is defined is independent of the actual result of the
+    condition.
+    """
+    invalid_accesses: List[gtir.FieldAccess] = []
+    DefinitiveAssignmentAnalysis().visit(
+        gtir_stencil_expr,
+        alive_vars=set(gtir_stencil_expr.param_names),
+        invalid_accesses=invalid_accesses,
+    )
+    return invalid_accesses
+
+
+def check(gtir_stencil_expr: gtir.Stencil):
+    """
+    Execute definitive assignment analysis and warn on errors.
+
+    :param gtir_stencil_expr:
+    :return:
+    """
+    invalid_accesses = analyse(gtir_stencil_expr)
+    for invalid_access in invalid_accesses:
+        warnings.warn(f"`{invalid_access.name}` may be uninitialized.")
+
+    return gtir_stencil_expr

--- a/src/gtc/passes/gtir_definitive_assignment_analysis.py
+++ b/src/gtc/passes/gtir_definitive_assignment_analysis.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 from typing import List, Set
 
@@ -7,9 +6,19 @@ from gtc import gtir
 
 
 class DefinitiveAssignmentAnalysis(NodeVisitor):
+    """
+    Analyse gtir stencil expression for access to undefined symbols.
+
+    A symbol is said to be defined if it was assigned to in the code-path of its usage. In
+    other words: If a symbol is defined in both branches of an if-statement it may be used
+    outside. If a symbol is only defined in a single branch it may only be used inside that
+    branch unless it was already defined previously (as this is equal to assigning to the
+    previous value again). Note that whether a symbols is defined is independent of the actual
+    result of the condition.
+    """
     def visit_IfStmt(self, node: gtir.FieldIfStmt, *, alive_vars: Set[str], **kwargs):
-        true_branch_vars = copy.copy(alive_vars)
-        false_branch_vars = copy.copy(alive_vars)
+        true_branch_vars = {*alive_vars}
+        false_branch_vars = {*alive_vars}
         self.visit(node.true_branch, alive_vars=true_branch_vars, **kwargs)
         self.visit(node.false_branch, alive_vars=false_branch_vars, **kwargs)
         alive_vars.update(true_branch_vars & false_branch_vars)
@@ -22,41 +31,33 @@ class DefinitiveAssignmentAnalysis(NodeVisitor):
         self,
         node: gtir.FieldAccess,
         *,
-        alive_vars: Set,
+        alive_vars: [str],
         invalid_accesses: List[gtir.FieldAccess],
         **kwargs,
     ):
         if node.name not in alive_vars:
             invalid_accesses.append(node)
 
+    @classmethod
+    def apply(cls, gtir_stencil_expr: gtir.Stencil):
+        """Execute analysis and return all accesses to undefined symbols."""
+        invalid_accesses: List[gtir.FieldAccess] = []
+        DefinitiveAssignmentAnalysis().visit(
+            gtir_stencil_expr,
+            alive_vars=set(gtir_stencil_expr.param_names),
+            invalid_accesses=invalid_accesses,
+        )
+        return invalid_accesses
 
-def analyse(gtir_stencil_expr: gtir.Stencil):
-    """
-    Analyse gtir stencil expression for access to undefined symbols.
 
-    A symbol is said to be defined if it was assigned to in the code-path of its usage. In other words: If a symbol is
-    defined in both branches of an if-statement it may be used outside. If a symbol is only defined in a single branch
-    it may only be used inside that branch unless it was already defined previously (as this is equal to assigning to
-    the previous value again). Note that whether a symbols is defined is independent of the actual result of the
-    condition.
-    """
-    invalid_accesses: List[gtir.FieldAccess] = []
-    DefinitiveAssignmentAnalysis().visit(
-        gtir_stencil_expr,
-        alive_vars=set(gtir_stencil_expr.param_names),
-        invalid_accesses=invalid_accesses,
-    )
-    return invalid_accesses
+analyze = DefinitiveAssignmentAnalysis.apply
 
 
 def check(gtir_stencil_expr: gtir.Stencil):
     """
     Execute definitive assignment analysis and warn on errors.
-
-    :param gtir_stencil_expr:
-    :return:
     """
-    invalid_accesses = analyse(gtir_stencil_expr)
+    invalid_accesses = analyze(gtir_stencil_expr)
     for invalid_access in invalid_accesses:
         warnings.warn(f"`{invalid_access.name}` may be uninitialized.")
 

--- a/src/gtc/passes/gtir_pipeline.py
+++ b/src/gtc/passes/gtir_pipeline.py
@@ -17,6 +17,7 @@
 from typing import Callable, Dict, Optional, Sequence, Tuple
 
 from gtc import gtir
+from gtc.passes.gtir_definitive_assignment_analysis import check as check_assignments
 from gtc.passes.gtir_dtype_resolver import resolve_dtype
 from gtc.passes.gtir_prune_unused_parameters import prune_unused_parameters
 from gtc.passes.gtir_upcaster import upcast
@@ -37,7 +38,7 @@ class GtirPipeline:
         self._cache: Dict[Tuple[PASS_T, ...], gtir.Stencil] = {}
 
     def steps(self) -> Sequence[PASS_T]:
-        return [prune_unused_parameters, resolve_dtype, upcast]
+        return [check_assignments, prune_unused_parameters, resolve_dtype, upcast]
 
     def apply(self, steps: Sequence[PASS_T]) -> gtir.Stencil:
         result = self.gtir

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -597,25 +597,6 @@ class TestNotSpecifiedTwoOptionalFields(TestTwoOptionalFields):
     symbols["phys_tend_a"] = gt_testing.none()
 
 
-class TestConstantFolding(gt_testing.StencilTestSuite):
-    dtypes = {("outfield",): np.float64, ("cond",): np.float64}
-    domain_range = [(15, 15), (15, 15), (15, 15)]
-    backends = INTERNAL_BACKENDS
-    symbols = dict(
-        outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
-        cond=gt_testing.field(in_range=(1, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
-    )
-
-    def definition(outfield, cond):
-        with computation(PARALLEL), interval(...):
-            if cond != 0:
-                tmp = 1
-            outfield = tmp  # noqa: F841  # local variable assigned to but never used
-
-    def validation(outfield, cond, *, domain, origin, **kwargs):
-        outfield[np.array(cond, dtype=np.bool_)] = 1
-
-
 class TestNon3DFields(gt_testing.StencilTestSuite):
     dtypes = {
         "field_in": np.float64,

--- a/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
@@ -127,7 +127,7 @@ def daa_8(in_field: Field[float], out_field: Field[float]):
             out_field = tmp
 
 @register_test_case(valid=True)
-def daa_8(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
+def daa_9(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
     """Valid stencil with `tmp` defined in all branches of a nested if-elif-else statement"""
     with computation(PARALLEL):
         with interval(...):
@@ -143,7 +143,7 @@ def daa_8(in_field: Field[float], cond_field: Field[float], mask: bool, out_fiel
             out_field = tmp
 
 @register_test_case(valid=False)
-def daa_8(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
+def daa_10(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
     """Invalid stencil with `tmp` defined in all, but one branches of a nested if-elif-else statement"""
     with computation(PARALLEL):
         with interval(...):

--- a/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
@@ -8,6 +8,7 @@ from gt4py.gtscript import PARALLEL, Field, computation, interval, stencil
 from gt4py.stencil_builder import StencilBuilder
 from gtc.passes import gtir_definitive_assignment_analysis as daa
 
+
 # A list of dictionaries containing a stencil definition and the expected test case outputs
 test_data: List[Tuple[Callable, bool]] = []
 
@@ -113,6 +114,7 @@ def daa_7(in_field: Field[float], out_field: Field[float]):
                 tmp = in_field + 1
             out_field = tmp
 
+
 @register_test_case(valid=True)
 def daa_8(in_field: Field[float], out_field: Field[float]):
     """Valid stencil with `tmp` defined in all three branches of if-elif-else statement"""
@@ -126,6 +128,7 @@ def daa_8(in_field: Field[float], out_field: Field[float]):
                 tmp = in_field + 2
             out_field = tmp
 
+
 @register_test_case(valid=True)
 def daa_9(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
     """Valid stencil with `tmp` defined in all branches of a nested if-elif-else statement"""
@@ -134,13 +137,14 @@ def daa_9(in_field: Field[float], cond_field: Field[float], mask: bool, out_fiel
             if in_field > 0:
                 tmp = in_field
             elif in_field == 0:
-                if in_field+1 == 0:
+                if in_field + 1 == 0:
                     tmp = in_field + 1
                 else:
                     tmp = in_field + 2
             else:
                 tmp = in_field + 3
             out_field = tmp
+
 
 @register_test_case(valid=False)
 def daa_10(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
@@ -150,11 +154,12 @@ def daa_10(in_field: Field[float], cond_field: Field[float], mask: bool, out_fie
             if in_field > 0:
                 tmp = in_field
             elif in_field == 0:
-                if in_field+1 == 0:
+                if in_field + 1 == 0:
                     tmp = in_field + 1
             else:
                 tmp = in_field + 3
             out_field = tmp
+
 
 @pytest.mark.parametrize("definition,valid", [(stencil, valid) for stencil, valid in test_data])
 def test_daa(definition, valid):

--- a/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
@@ -8,19 +8,14 @@ from gt4py.gtscript import PARALLEL, Field, computation, interval, stencil
 from gt4py.stencil_builder import StencilBuilder
 from gtc.passes import gtir_definitive_assignment_analysis as daa
 
-
-class TestData(TypedDict):
-    valid: bool
-
-
 # A list of dictionaries containing a stencil definition and the expected test case outputs
-test_data: List[Tuple[Callable, TestData]] = []
+test_data: List[Tuple[Callable, bool]] = []
 
 
 def register_test_case(*, valid):
     def _wrapper(definition):
         global test_data
-        test_data.append((definition, {"valid": valid}))
+        test_data.append((definition, valid))
         return definition
 
     return _wrapper
@@ -29,6 +24,7 @@ def register_test_case(*, valid):
 # test cases
 @register_test_case(valid=False)
 def daa_0(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    """Invalid stencil with `tmp` undefined in one branch if a conditional on a boolean mask field"""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -38,6 +34,7 @@ def daa_0(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
 
 @register_test_case(valid=False)
 def daa_1(in_field: Field[float], mask: bool, out_field: Field[float]):
+    """Invalid stencil with `tmp` undefined in one branch if a conditional on a boolean mask parameter"""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -47,6 +44,7 @@ def daa_1(in_field: Field[float], mask: bool, out_field: Field[float]):
 
 @register_test_case(valid=True)
 def daa_2(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    """Valid stencil with `tmp` defined in one branch and only used inside of that branch."""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -56,6 +54,7 @@ def daa_2(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
 
 @register_test_case(valid=True)
 def daa_3(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    """Valid stencil with `tmp` defined in both branches of a conditional on a boolean field and used outside."""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -67,6 +66,7 @@ def daa_3(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
 
 @register_test_case(valid=False)
 def daa_4(in_field: Field[float], mask: bool, out_field: Field[float]):
+    """Valid stencil with `tmp` defined in both branches of a conditional on a boolean parameter and used outside."""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -78,6 +78,7 @@ def daa_4(in_field: Field[float], mask: bool, out_field: Field[float]):
 
 @register_test_case(valid=True)
 def daa_5(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    """Valid stencil with `tmp` defined in every branch of a nested if-statement and used outside."""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -92,6 +93,7 @@ def daa_5(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
 
 @register_test_case(valid=True)
 def daa_6(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    """Valid stencil with `tmp` defined in one branch only, but unconditionally overwritten outside before use."""
     with computation(PARALLEL):
         with interval(...):
             if mask:
@@ -101,7 +103,8 @@ def daa_6(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
 
 
 @register_test_case(valid=True)
-def daa_7(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+def daa_7(in_field: Field[float], out_field: Field[float]):
+    """Valid stencil with `tmp` defined in both branches with a condition on a float field"""
     with computation(PARALLEL):
         with interval(...):
             if in_field > 0:
@@ -110,19 +113,61 @@ def daa_7(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
                 tmp = in_field + 1
             out_field = tmp
 
+@register_test_case(valid=True)
+def daa_8(in_field: Field[float], out_field: Field[float]):
+    """Valid stencil with `tmp` defined in all three branches of if-elif-else statement"""
+    with computation(PARALLEL):
+        with interval(...):
+            if in_field > 0:
+                tmp = in_field
+            elif in_field == 0:
+                tmp = in_field + 1
+            else:
+                tmp = in_field + 2
+            out_field = tmp
 
-@pytest.mark.parametrize("definition,valid", [(s, d["valid"]) for s, d in test_data])
+@register_test_case(valid=True)
+def daa_8(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
+    """Valid stencil with `tmp` defined in all branches of a nested if-elif-else statement"""
+    with computation(PARALLEL):
+        with interval(...):
+            if in_field > 0:
+                tmp = in_field
+            elif in_field == 0:
+                if in_field+1 == 0:
+                    tmp = in_field + 1
+                else:
+                    tmp = in_field + 2
+            else:
+                tmp = in_field + 3
+            out_field = tmp
+
+@register_test_case(valid=False)
+def daa_8(in_field: Field[float], cond_field: Field[float], mask: bool, out_field: Field[float]):
+    """Invalid stencil with `tmp` defined in all, but one branches of a nested if-elif-else statement"""
+    with computation(PARALLEL):
+        with interval(...):
+            if in_field > 0:
+                tmp = in_field
+            elif in_field == 0:
+                if in_field+1 == 0:
+                    tmp = in_field + 1
+            else:
+                tmp = in_field + 3
+            out_field = tmp
+
+@pytest.mark.parametrize("definition,valid", [(stencil, valid) for stencil, valid in test_data])
 def test_daa(definition, valid):
     builder = StencilBuilder(definition, backend=from_name("debug"))
     gtir_stencil_expr = builder.gtir_pipeline.full()
-    invalid_accesses = daa.analyse(gtir_stencil_expr)
+    invalid_accesses = daa.analyze(gtir_stencil_expr)
     if valid:
         assert len(invalid_accesses) == 0
     else:
         assert len(invalid_accesses) == 1 and invalid_accesses[0].name == "tmp"
 
 
-@pytest.mark.parametrize("definition", [s for s, d in test_data if not d["valid"]])
+@pytest.mark.parametrize("definition", [stencil for stencil, valid in test_data if not valid])
 def test_daa_warn(definition):
     backend = "gtc:gt:cpu_ifirst"
     with pytest.warns(UserWarning, match="`tmp` may be uninitialized."):

--- a/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/test_unittest/test_gtc/test_definitive_assignment_analysis.py
@@ -1,0 +1,129 @@
+# flake8: noqa: F841
+from typing import Callable, List, Tuple, TypedDict
+
+import pytest
+
+from gt4py.backend import from_name
+from gt4py.gtscript import PARALLEL, Field, computation, interval, stencil
+from gt4py.stencil_builder import StencilBuilder
+from gtc.passes import gtir_definitive_assignment_analysis as daa
+
+
+class TestData(TypedDict):
+    valid: bool
+
+
+# A list of dictionaries containing a stencil definition and the expected test case outputs
+test_data: List[Tuple[Callable, TestData]] = []
+
+
+def register_test_case(*, valid):
+    def _wrapper(definition):
+        global test_data
+        test_data.append((definition, {"valid": valid}))
+        return definition
+
+    return _wrapper
+
+
+# test cases
+@register_test_case(valid=False)
+def daa_0(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                tmp = in_field
+            out_field = tmp
+
+
+@register_test_case(valid=False)
+def daa_1(in_field: Field[float], mask: bool, out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                tmp = in_field
+            out_field = tmp
+
+
+@register_test_case(valid=True)
+def daa_2(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                tmp = in_field
+                out_field = tmp
+
+
+@register_test_case(valid=True)
+def daa_3(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                tmp = in_field
+            else:
+                tmp = in_field + 1
+            out_field = tmp
+
+
+@register_test_case(valid=False)
+def daa_4(in_field: Field[float], mask: bool, out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                tmp = in_field
+            if not mask:
+                tmp = in_field + 1
+            out_field = tmp
+
+
+@register_test_case(valid=True)
+def daa_5(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                if not mask:
+                    tmp = in_field
+                else:
+                    tmp = in_field + 1
+            else:
+                tmp = in_field + 2
+            out_field = tmp
+
+
+@register_test_case(valid=True)
+def daa_6(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if mask:
+                tmp = in_field
+            tmp = in_field + 1
+            out_field = tmp
+
+
+@register_test_case(valid=True)
+def daa_7(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
+    with computation(PARALLEL):
+        with interval(...):
+            if in_field > 0:
+                tmp = in_field
+            else:
+                tmp = in_field + 1
+            out_field = tmp
+
+
+@pytest.mark.parametrize("definition,valid", [(s, d["valid"]) for s, d in test_data])
+def test_daa(definition, valid):
+    builder = StencilBuilder(definition, backend=from_name("debug"))
+    gtir_stencil_expr = builder.gtir_pipeline.full()
+    invalid_accesses = daa.analyse(gtir_stencil_expr)
+    if valid:
+        assert len(invalid_accesses) == 0
+    else:
+        assert len(invalid_accesses) == 1 and invalid_accesses[0].name == "tmp"
+
+
+@pytest.mark.parametrize("definition", [s for s, d in test_data if not d["valid"]])
+def test_daa_warn(definition):
+    backend = "gtc:gt:cpu_ifirst"
+    with pytest.warns(UserWarning, match="`tmp` may be uninitialized."):
+        stencil(backend, definition)


### PR DESCRIPTION
## Description

If a variable is assigned to before it is used is currently not checked. This PR adds a simple static pass to validate this and warns the user if not (see [#220](https://github.com/GridTools/gt4py/issues/220#issuecomment-988887788) for examples).

__Excerpt from the documentation__
> A symbol is said to be defined if it was assigned to in the code-path of its usage. In other words: If a symbol is defined in both branches of an if-statement it may be used outside. If a symbol is only defined in a single branch it may only be used inside that branch unless it was already defined previously (as this is equal to assigning to the previous value again). Note that whether a symbols is defined is independent of the actual result of the condition.

__Notes on condition evaluation__
In my first implementation I started symbolically evaluating the conditions for all possible values of the mask to also cover cases like these:
```python
def daa_4(in_field: Field[float], mask: bool, out_field: Field[float]):
    with computation(PARALLEL):
        with interval(...):
            if mask:
                tmp = in_field
            if not mask:
                tmp = in_field + 1
            out_field = tmp
```
I have seen such cases (usually more complicated) occasionally occur in numerical code and given that the parallel model defines the semantics of an if-else statement exactly that way this appeared like the way to go. However I abandoned this approach at some point for several reasons:
- Many special cases like the following will not work and it is hard both to document and to convey to the user what triggers a warning and what not:
```python
def daa_4(in_field: Field[float], mask: Field[bool], out_field: Field[float]):
    with computation(PARALLEL):
        with interval(...):
            if mask:
                tmp = in_field
            mask = True
            if not mask:
                tmp = in_field + 1
            out_field = tmp
```
- If evaluating the condition is required to understand whether a variable is defined it should be best practice to refactor the code anyway.
- It makes sense to do these checks in a way that also applies to the new model. However there stencils can be composed increasing the amount of involved variables. Consequently the runtime would explode or if one limits the amount of variables the analysis would become useless.

Nonetheless such analysis might still be useful for other things in the future (e.g. generating specialized code for boundary conditions). Here are some insights and links in case I/someone revisits this again:
- As a rule of thumb until 5 variables it is faster to just try all conditions (german: https://de.wikipedia.org/wiki/Verfahren_nach_Quine_und_McCluskey#Anmerkung)
- https://en.wikipedia.org/wiki/Quine%E2%80%93McCluskey_algorithm
- https://second.wiki/wiki/resolventenmethode

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


