### PR TITLE
Functional: Moved SymbolType nodes into common_types

### DIFF
--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -1,9 +1,10 @@
 import typing
-from typing import Optional, Union, Literal
-from eve.type_definitions import IntEnum
 from dataclasses import dataclass
+from typing import Literal, Optional, Union
 
+from eve.type_definitions import IntEnum
 from functional import common as func_common
+
 
 class ScalarKind(IntEnum):
     BOOL = 1
@@ -11,6 +12,7 @@ class ScalarKind(IntEnum):
     INT64 = 64
     FLOAT32 = 1032
     FLOAT64 = 1064
+
 
 class SymbolType:
     @classmethod
@@ -26,7 +28,8 @@ class SymbolType:
 
 @dataclass(frozen=True)
 class DeferredSymbolType(SymbolType):
-    "Dummy used to represent a type not yet inferred"
+    """Dummy used to represent a type not yet inferred."""
+
     constraint: typing.Optional[typing.Type[SymbolType]]
 
 

--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -1,0 +1,92 @@
+import typing
+from typing import Optional, Union, Literal
+from eve.type_definitions import IntEnum
+from dataclasses import dataclass
+
+from functional import common as func_common
+
+class ScalarKind(IntEnum):
+    BOOL = 1
+    INT32 = 32
+    INT64 = 64
+    FLOAT32 = 1032
+    FLOAT64 = 1064
+
+class SymbolType:
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, cls):
+            raise TypeError(f"Value is not a valid `{cls}`")
+        return v
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+
+@dataclass(frozen=True)
+class DeferredSymbolType(SymbolType):
+    "Dummy used to represent a type not yet inferred"
+    constraint: typing.Optional[typing.Type[SymbolType]]
+
+
+@dataclass(frozen=True)
+class SymbolTypeVariable(SymbolType):
+    id: str  # noqa A003
+    bound: typing.Type[SymbolType]
+
+
+@dataclass(frozen=True)
+class OffsetType(SymbolType):
+    ...
+
+    def __str__(self):
+        return f"Offset[{self.id}]"
+
+
+@dataclass(frozen=True)
+class DataType(SymbolType):
+    ...
+
+
+@dataclass(frozen=True)
+class ScalarType(DataType):
+    kind: ScalarKind
+    shape: Optional[list[int]] = None
+
+    def __str__(self):
+        kind_str = self.kind.name.lower()
+        if self.shape is None:
+            return kind_str
+        return f"{kind_str}{self.shape}"
+
+
+@dataclass(frozen=True)
+class TupleType(DataType):
+    types: list[DataType]
+
+    def __str__(self):
+        return f"tuple{self.types}"
+
+
+@dataclass(frozen=True)
+class FieldType(DataType):
+    dims: Union[list[func_common.Dimension], Literal[Ellipsis]]  # type: ignore[valid-type,misc]
+    dtype: ScalarType
+
+    def __str__(self):
+        dims = "..." if self.dims is Ellipsis else f"[{', '.join(dim.value for dim in self.dims)}]"
+        return f"Field[{dims}, dtype={self.dtype}]"
+
+
+@dataclass(frozen=True)
+class FunctionType(SymbolType):
+    args: list[DataType]
+    kwargs: dict[str, DataType]
+    returns: DataType
+
+    def __str__(self):
+        arg_strs = [str(arg) for arg in self.args]
+        kwarg_strs = [f"{key}: {value}" for key, value in self.kwargs]
+        args_str = ", ".join(*arg_strs, *kwarg_strs)
+        return f"({args_str}) -> {self.returns}"

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -22,6 +22,8 @@ from eve import Node
 from eve.traits import SymbolTableTrait
 from eve.type_definitions import IntEnum, SourceLocation, StrEnum, SymbolRef
 
+from functional.ffront import common_types as common_types
+
 
 class Namespace(StrEnum):
     LOCAL = "local"
@@ -29,79 +31,8 @@ class Namespace(StrEnum):
     EXTERNAL = "external"
 
 
-class ScalarKind(IntEnum):
-    BOOL = 1
-    INT32 = 32
-    INT64 = 64
-    FLOAT32 = 1032
-    FLOAT64 = 1064
-
-
 class Dimension(Node):
     name: str
-
-
-class SymbolType(Node):
-    ...
-
-
-class DeferredSymbolType(SymbolType):
-    constraint: typing.Optional[typing.Type[SymbolType]]
-
-
-class SymbolTypeVariable(SymbolType):
-    id: str  # noqa A003
-    bound: typing.Type[SymbolType]
-
-
-class OffsetType(SymbolType):
-    ...
-
-    def __str__(self):
-        return f"Offset[{self.id}]"
-
-
-class DataType(SymbolType):
-    ...
-
-
-class ScalarType(DataType):
-    kind: ScalarKind
-    shape: Optional[list[int]] = None
-
-    def __str__(self):
-        kind_str = self.kind.name.lower()
-        if self.shape is None:
-            return kind_str
-        return f"{kind_str}{self.shape}"
-
-
-class TupleType(DataType):
-    types: list[DataType]
-
-    def __str__(self):
-        return f"tuple{self.types}"
-
-
-class FieldType(DataType):
-    dims: Union[list[Dimension], Literal[Ellipsis]]  # type: ignore[valid-type,misc]
-    dtype: ScalarType
-
-    def __str__(self):
-        dims = "..." if self.dims is Ellipsis else f"[{', '.join(dim.name for dim in self.dims)}]"
-        return f"Field[{dims}, dtype={self.dtype}]"
-
-
-class FunctionType(SymbolType):
-    args: list[DataType]
-    kwargs: dict[str, DataType]
-    returns: DataType
-
-    def __str__(self):
-        arg_strs = [str(arg) for arg in self.args]
-        kwarg_strs = [f"{key}: {value}" for key, value in self.kwargs]
-        args_str = ", ".join(*arg_strs, *kwarg_strs)
-        return f"({args_str}) -> {self.returns}"
 
 
 class LocatedNode(Node):
@@ -114,32 +45,32 @@ class SymbolName(eve.traits.SymbolName):
 
 class Symbol(LocatedNode):
     id: SymbolName  # noqa: A003
-    type: SymbolType  # noqa A003
+    type: common_types.SymbolType  # noqa A003
     namespace: Namespace = Namespace(Namespace.LOCAL)
 
 
 class DataSymbol(Symbol):
-    type: Union[DataType, DeferredSymbolType]  # noqa A003
+    type: Union[common_types.DataType, common_types.DeferredSymbolType]  # noqa A003
 
 
 class FieldSymbol(DataSymbol):
-    type: Union[FieldType, DeferredSymbolType]  # noqa A003
+    type: Union[common_types.FieldType, common_types.DeferredSymbolType]  # noqa A003
 
 
 class TupleSymbol(DataSymbol):
-    type: Union[TupleType, DeferredSymbolType]  # noqa A003
+    type: Union[common_types.TupleType, common_types.DeferredSymbolType]  # noqa A003
 
 
 class Function(Symbol):
-    type: FunctionType  # noqa A003
+    type: common_types.FunctionType  # noqa A003
 
 
 class OffsetSymbol(Symbol):
-    type: OffsetType  # noqa A003
+    type: common_types.OffsetType  # noqa A003
 
 
 class Expr(LocatedNode):
-    type: Optional[SymbolType] = None  # noqa A003
+    type: Optional[common_types.SymbolType] = None  # noqa A003
 
 
 class Name(Expr):
@@ -148,7 +79,7 @@ class Name(Expr):
 
 class Constant(Expr):
     value: str
-    dtype: Union[DataType, str]
+    dtype: Union[common_types.DataType, str]
 
 
 class Subscript(Expr):

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -29,10 +29,6 @@ class Namespace(StrEnum):
     EXTERNAL = "external"
 
 
-class Dimension(Node):
-    name: str
-
-
 class LocatedNode(Node):
     location: SourceLocation
 

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -14,14 +14,12 @@
 
 
 import re
-import typing
-from typing import Literal, Optional, Union
+from typing import Optional, Union
 
 import eve
 from eve import Node
 from eve.traits import SymbolTableTrait
-from eve.type_definitions import IntEnum, SourceLocation, StrEnum, SymbolRef
-
+from eve.type_definitions import SourceLocation, StrEnum, SymbolRef
 from functional.ffront import common_types as common_types
 
 

--- a/src/functional/ffront/foast_passes/shift_recognition.py
+++ b/src/functional/ffront/foast_passes/shift_recognition.py
@@ -13,9 +13,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from typing import Union
 
-from functional.ffront import common_types
 import functional.ffront.field_operator_ast as foast
 from eve import NodeTranslator, SymbolTableTrait
+from functional.ffront import common_types
 
 
 class FieldOperatorShiftRecognition(NodeTranslator):

--- a/src/functional/ffront/foast_passes/shift_recognition.py
+++ b/src/functional/ffront/foast_passes/shift_recognition.py
@@ -13,6 +13,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from typing import Union
 
+from functional.ffront import common_types
 import functional.ffront.field_operator_ast as foast
 from eve import NodeTranslator, SymbolTableTrait
 
@@ -27,7 +28,7 @@ class FieldOperatorShiftRecognition(NodeTranslator):
         return cls().visit(node)
 
     def visit_Call(self, node: foast.Call, **kwargs) -> Union[foast.Call, foast.Shift]:
-        if isinstance(node.func.type, foast.FieldType):
+        if isinstance(node.func.type, common_types.FieldType):
             result = foast.Shift(
                 offsets=node.args, expr=node.func, location=node.location, type=node.func.type
             )

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -17,16 +17,17 @@ from typing import Optional, Type, TypeGuard
 import functional.ffront.field_operator_ast as foast
 from eve import NodeTranslator, SymbolTableTrait
 from functional.common import GTSyntaxError
+from functional.ffront import common_types
 
 
-def is_complete_symbol_type(fo_type: foast.SymbolType) -> TypeGuard[foast.SymbolType]:
+def is_complete_symbol_type(fo_type: common_types.SymbolType) -> TypeGuard[common_types.SymbolType]:
     """Figure out if the foast type is completely deduced."""
     match fo_type:
         case None:
             return False
-        case foast.DeferredSymbolType():
+        case common_types.DeferredSymbolType():
             return False
-        case foast.SymbolType():
+        case common_types.SymbolType():
             return True
     return False
 
@@ -38,7 +39,7 @@ class TypeInfo:
 
     Examples:
     ---------
-    >>> type_a = foast.ScalarType(kind=foast.ScalarKind.FLOAT64)
+    >>> type_a = common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)
     >>> typeinfo_a = TypeInfo(type_a)
     >>> typeinfo_a.is_complete
     True
@@ -56,7 +57,7 @@ class TypeInfo:
 
     """
 
-    type: foast.SymbolType  # noqa: A003
+    type: common_types.SymbolType  # noqa: A003
 
     @property
     def is_complete(self) -> bool:
@@ -67,7 +68,7 @@ class TypeInfo:
         return (not self.is_complete) and ((self.type is None) or (self.constraint is None))
 
     @property
-    def constraint(self) -> Optional[Type[foast.SymbolType]]:
+    def constraint(self) -> Optional[Type[common_types.SymbolType]]:
         """Find the constraint of a deferred type or the class of a complete type."""
         if self.is_complete:
             return self.type.__class__
@@ -77,29 +78,29 @@ class TypeInfo:
 
     @property
     def is_field_type(self) -> bool:
-        return issubclass(self.constraint, foast.FieldType) if self.constraint else False
+        return issubclass(self.constraint, common_types.FieldType) if self.constraint else False
 
     @property
     def is_scalar(self) -> bool:
-        return issubclass(self.constraint, foast.ScalarType) if self.constraint else False
+        return issubclass(self.constraint, common_types.ScalarType) if self.constraint else False
 
     @property
     def is_arithmetic_compatible(self) -> bool:
         match self.type:
-            case foast.FieldType(dtype=foast.ScalarType(kind=dtype_kind)) | foast.ScalarType(
+            case common_types.FieldType(dtype=common_types.ScalarType(kind=dtype_kind)) | common_types.ScalarType(
                 kind=dtype_kind
             ):
-                if dtype_kind is not foast.ScalarKind.BOOL:
+                if dtype_kind is not common_types.ScalarKind.BOOL:
                     return True
         return False
 
     @property
     def is_logics_compatible(self) -> bool:
         match self.type:
-            case foast.FieldType(dtype=foast.ScalarType(kind=dtype_kind)) | foast.ScalarType(
+            case common_types.FieldType(dtype=common_types.ScalarType(kind=dtype_kind)) | common_types.ScalarType(
                 kind=dtype_kind
             ):
-                if dtype_kind is foast.ScalarKind.BOOL:
+                if dtype_kind is common_types.ScalarKind.BOOL:
                     return True
         return False
 
@@ -125,10 +126,11 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
 
     Examples:
     ---------
-    >>> int_scalar_t = TypeInfo(foast.ScalarType(kind=foast.ScalarKind.INT64))
+    >>> int_scalar_t = TypeInfo(common_types.ScalarType(kind=common_types.ScalarKind.INT64))
     >>> are_broadcast_compatible(int_scalar_t, int_scalar_t)
     True
-    >>> int_field_t = TypeInfo(foast.FieldType(dtype=foast.ScalarType(kind=foast.ScalarKind.INT64), dims=...))
+    >>> int_field_t = TypeInfo(common_types.FieldType(dtype=common_types.ScalarType(kind=common_types.ScalarKind.INT64),
+    ...                         dims=...))
     >>> are_broadcast_compatible(int_field_t, int_scalar_t)
     True
 
@@ -143,7 +145,6 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
         return left.type == right.type
     return False
 
-
 def broadcast_typeinfos(left: TypeInfo, right: TypeInfo) -> TypeInfo:
     """
     Decide the result type of a binary operation between arguments of ``left`` and ``right`` type.
@@ -152,8 +153,9 @@ def broadcast_typeinfos(left: TypeInfo, right: TypeInfo) -> TypeInfo:
 
     Examples:
     ---------
-    >>> int_scalar_t = TypeInfo(foast.ScalarType(kind=foast.ScalarKind.INT64))
-    >>> int_field_t = TypeInfo(foast.FieldType(dtype=foast.ScalarType(kind=foast.ScalarKind.INT64), dims=...))
+    >>> int_scalar_t = TypeInfo(common_types.ScalarType(kind=common_types.ScalarKind.INT64))
+    >>> int_field_t = TypeInfo(common_types.FieldType(dtype=common_types.ScalarType(kind=common_types.ScalarKind.INT64),
+    ...                         dims=...))
     >>> assert broadcast_typeinfos(int_field_t, int_scalar_t).type == int_field_t.type
 
     """
@@ -184,7 +186,8 @@ class FieldOperatorTypeDeduction(NodeTranslator):
     >>> assert untyped_fieldop.body[0].value.type is None
 
     >>> typed_fieldop = FieldOperatorTypeDeduction.apply(untyped_fieldop)
-    >>> assert typed_fieldop.body[0].value.type == foast.FieldType(dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64), dims=Ellipsis)
+    >>> assert typed_fieldop.body[0].value.type == common_types.FieldType(dtype=common_types.ScalarType(
+    ...     kind=common_types.ScalarKind.FLOAT64), dims=Ellipsis)
     """
 
     contexts = (SymbolTableTrait.symtable_merger,)
@@ -221,7 +224,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         return foast.Assign(target=new_target, value=new_value, location=node.location)
 
     def visit_FieldSymbol(
-        self, node: foast.FieldSymbol, refine_type: Optional[foast.FieldType] = None, **kwargs
+        self, node: foast.FieldSymbol, refine_type: Optional[common_types.FieldType] = None, **kwargs
     ) -> foast.FieldSymbol:
         symtable = kwargs["symtable"]
         if refine_type:
@@ -239,7 +242,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         return node
 
     def visit_TupleSymbol(
-        self, node: foast.TupleSymbol, refine_type: Optional[foast.TupleType] = None, **kwargs
+        self, node: foast.TupleSymbol, refine_type: Optional[common_types.TupleType] = None, **kwargs
     ) -> foast.TupleSymbol:
         symtable = kwargs["symtable"]
         if refine_type:
@@ -261,11 +264,11 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         new_type = None
         if kwargs.get("in_shift", False):
             return foast.Subscript(
-                value=new_value, index=node.index, type=foast.OffsetType(), location=node.location
+                value=new_value, index=node.index, type=common_types.OffsetType(), location=node.location
             )
         match new_value.type:
-            case foast.TupleType(types=types) | foast.FunctionType(
-                returns=foast.TupleType(types=types)
+            case common_types.TupleType(types=types) | common_types.FunctionType(
+                returns=common_types.TupleType(types=types)
             ):
                 new_type = types[node.index]
             case _:
@@ -292,10 +295,10 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         op: foast.BinaryOperator,
         *,
         parent: foast.BinOp,
-        left_type: foast.SymbolType,
-        right_type: foast.SymbolType,
+        left_type: common_types.SymbolType,
+        right_type: common_types.SymbolType,
         **kwargs,
-    ) -> foast.SymbolType:
+    ) -> common_types.SymbolType:
         if op in [
             foast.BinaryOperator.ADD,
             foast.BinaryOperator.SUB,
@@ -315,10 +318,10 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         op: foast.BinaryOperator,
         *,
         parent: foast.BinOp,
-        left_type: foast.SymbolType,
-        right_type: foast.SymbolType,
+        left_type: common_types.SymbolType,
+        right_type: common_types.SymbolType,
         **kwargs,
-    ) -> foast.SymbolType:
+    ) -> common_types.SymbolType:
         left, right = TypeInfo(left_type), TypeInfo(right_type)
         if (
             left.is_arithmetic_compatible
@@ -337,10 +340,10 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         op: foast.BinaryOperator,
         *,
         parent: foast.BinOp,
-        left_type: foast.SymbolType,
-        right_type: foast.SymbolType,
+        left_type: common_types.SymbolType,
+        right_type: common_types.SymbolType,
         **kwargs,
-    ) -> foast.SymbolType:
+    ) -> common_types.SymbolType:
         left, right = TypeInfo(left_type), TypeInfo(right_type)
         if (
             left.is_logics_compatible
@@ -366,7 +369,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         )
 
     def _is_unaryop_type_compatible(
-        self, op: foast.UnaryOperator, operand_type: foast.FieldType
+        self, op: foast.UnaryOperator, operand_type: common_types.FieldType
     ) -> bool:
         operand_ti = TypeInfo(operand_type)
         if op in [foast.UnaryOperator.UADD, foast.UnaryOperator.USUB]:
@@ -376,12 +379,12 @@ class FieldOperatorTypeDeduction(NodeTranslator):
 
     def visit_TupleExpr(self, node: foast.TupleExpr, **kwargs) -> foast.TupleExpr:
         new_elts = self.visit(node.elts, **kwargs)
-        new_type = foast.TupleType(types=[element.type for element in new_elts])
+        new_type = common_types.TupleType(types=[element.type for element in new_elts])
         return foast.TupleExpr(elts=new_elts, type=new_type, location=node.location)
 
     def visit_Call(self, node: foast.Call, **kwargs) -> foast.Call:
         new_func = self.visit(node.func, **kwargs)
-        if isinstance(new_func.type, foast.FieldType):
+        if isinstance(new_func.type, common_types.FieldType):
             new_args = self.visit(node.args, in_shift=True, **kwargs)
             return foast.Call(func=new_func, args=new_args, location=node.location)
         return foast.Call(

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -87,9 +87,9 @@ class TypeInfo:
     @property
     def is_arithmetic_compatible(self) -> bool:
         match self.type:
-            case common_types.FieldType(dtype=common_types.ScalarType(kind=dtype_kind)) | common_types.ScalarType(
-                kind=dtype_kind
-            ):
+            case common_types.FieldType(
+                dtype=common_types.ScalarType(kind=dtype_kind)
+            ) | common_types.ScalarType(kind=dtype_kind):
                 if dtype_kind is not common_types.ScalarKind.BOOL:
                     return True
         return False
@@ -97,9 +97,9 @@ class TypeInfo:
     @property
     def is_logics_compatible(self) -> bool:
         match self.type:
-            case common_types.FieldType(dtype=common_types.ScalarType(kind=dtype_kind)) | common_types.ScalarType(
-                kind=dtype_kind
-            ):
+            case common_types.FieldType(
+                dtype=common_types.ScalarType(kind=dtype_kind)
+            ) | common_types.ScalarType(kind=dtype_kind):
                 if dtype_kind is common_types.ScalarKind.BOOL:
                     return True
         return False
@@ -144,6 +144,7 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
     elif left.is_scalar and right.is_scalar:
         return left.type == right.type
     return False
+
 
 def broadcast_typeinfos(left: TypeInfo, right: TypeInfo) -> TypeInfo:
     """
@@ -224,7 +225,10 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         return foast.Assign(target=new_target, value=new_value, location=node.location)
 
     def visit_FieldSymbol(
-        self, node: foast.FieldSymbol, refine_type: Optional[common_types.FieldType] = None, **kwargs
+        self,
+        node: foast.FieldSymbol,
+        refine_type: Optional[common_types.FieldType] = None,
+        **kwargs,
     ) -> foast.FieldSymbol:
         symtable = kwargs["symtable"]
         if refine_type:
@@ -242,7 +246,10 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         return node
 
     def visit_TupleSymbol(
-        self, node: foast.TupleSymbol, refine_type: Optional[common_types.TupleType] = None, **kwargs
+        self,
+        node: foast.TupleSymbol,
+        refine_type: Optional[common_types.TupleType] = None,
+        **kwargs,
     ) -> foast.TupleSymbol:
         symtable = kwargs["symtable"]
         if refine_type:
@@ -264,7 +271,10 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         new_type = None
         if kwargs.get("in_shift", False):
             return foast.Subscript(
-                value=new_value, index=node.index, type=common_types.OffsetType(), location=node.location
+                value=new_value,
+                index=node.index,
+                type=common_types.OffsetType(),
+                location=node.location,
             )
         match new_value.type:
             case common_types.TupleType(types=types) | common_types.FunctionType(

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -17,6 +17,7 @@ from typing import Iterator, Optional, Union
 import factory
 
 from eve import NodeTranslator
+from functional.ffront import common_types
 from functional.ffront import field_operator_ast as foast
 from functional.iterator import ir as itir
 
@@ -116,7 +117,7 @@ class ItirShiftFactory(ItirFunCallFactory):
 
 
 def _name_is_field(name: foast.Name) -> bool:
-    return isinstance(name.type, foast.FieldType)
+    return isinstance(name.type, common_types.FieldType)
 
 
 class FieldOperatorLowering(NodeTranslator):

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -28,10 +28,9 @@ from typing import Any, Optional, Union
 from eve import typingx
 from eve.type_definitions import SourceLocation
 from functional import common
-from functional.ffront import fbuiltins
+from functional.ffront import common_types, fbuiltins
 from functional.ffront import field_operator_ast as foast
 from functional.ffront import symbol_makers
-from functional.ffront import common_types
 from functional.ffront.ast_passes import (
     SingleAssignTargetPass,
     SingleStaticAssignPass,

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -31,6 +31,7 @@ from functional import common
 from functional.ffront import fbuiltins
 from functional.ffront import field_operator_ast as foast
 from functional.ffront import symbol_makers
+from functional.ffront import common_types
 from functional.ffront.ast_passes import (
     SingleAssignTargetPass,
     SingleStaticAssignPass,
@@ -383,15 +384,15 @@ class FieldOperatorParser(ast.NodeVisitor):
             raise self._make_syntax_error(node, message="Can only assign to names!")
         new_value = self.visit(node.value)
         target_symbol_type = foast.FieldSymbol
-        constraint_type = foast.FieldType
+        constraint_type = common_types.FieldType
         if isinstance(new_value, foast.TupleExpr):
             target_symbol_type = foast.TupleSymbol
-            constraint_type = foast.TupleType
+            constraint_type = common_types.TupleType
         return foast.Assign(
             target=target_symbol_type(
                 id=target.id,
                 location=self._make_loc(target),
-                type=foast.DeferredSymbolType(constraint=constraint_type),
+                type=common_types.DeferredSymbolType(constraint=constraint_type),
             ),
             value=new_value,
             location=self._make_loc(node),
@@ -412,7 +413,7 @@ class FieldOperatorParser(ast.NodeVisitor):
                 annotation, global_ns=global_ns, local_ns=local_ns
             )
         else:
-            target_type = foast.DeferredSymbolType()
+            target_type = common_types.DeferredSymbolType()
 
         return foast.Assign(
             target=foast.FieldSymbol(

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -25,8 +25,8 @@ import numpy.typing as npt
 from eve import typingx
 from eve.type_definitions import SourceLocation
 from functional import common
-from functional.ffront import field_operator_ast as foast
 from functional.ffront import common_types
+from functional.ffront import field_operator_ast as foast
 from functional.iterator import runtime
 
 

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -26,10 +26,11 @@ from eve import typingx
 from eve.type_definitions import SourceLocation
 from functional import common
 from functional.ffront import field_operator_ast as foast
+from functional.ffront import common_types
 from functional.iterator import runtime
 
 
-def make_scalar_kind(dtype: npt.DTypeLike) -> foast.ScalarKind:
+def make_scalar_kind(dtype: npt.DTypeLike) -> common_types.ScalarKind:
     try:
         dt = np.dtype(dtype)
     except TypeError as err:
@@ -38,15 +39,15 @@ def make_scalar_kind(dtype: npt.DTypeLike) -> foast.ScalarKind:
     if dt.shape == () and dt.fields is None:
         match dt:
             case np.bool_:
-                return foast.ScalarKind.BOOL
+                return common_types.ScalarKind.BOOL
             case np.int32:
-                return foast.ScalarKind.INT32
+                return common_types.ScalarKind.INT32
             case np.int64:
-                return foast.ScalarKind.INT64
+                return common_types.ScalarKind.INT64
             case np.float32:
-                return foast.ScalarKind.FLOAT32
+                return common_types.ScalarKind.FLOAT32
             case np.float64:
-                return foast.ScalarKind.FLOAT64
+                return common_types.ScalarKind.FLOAT64
             case _:
                 raise common.GTTypeError(f"Impossible to map '{dtype}' value to a ScalarKind")
     else:
@@ -58,7 +59,7 @@ def make_symbol_type_from_typing(
     *,
     global_ns: Optional[dict[str, Any]] = None,
     local_ns: Optional[dict[str, Any]] = None,
-) -> foast.SymbolType:
+) -> common_types.SymbolType:
     recursive_make_symbol = functools.partial(
         make_symbol_type_from_typing, global_ns=global_ns, local_ns=local_ns
     )
@@ -94,7 +95,7 @@ def make_symbol_type_from_typing(
 
     match canonical_type:
         case type() as t if issubclass(t, (bool, int, float, np.generic)):
-            return foast.ScalarType(kind=make_scalar_kind(type_hint))
+            return common_types.ScalarType(kind=make_scalar_kind(type_hint))
 
         case builtins.tuple:
             if not args:
@@ -103,7 +104,7 @@ def make_symbol_type_from_typing(
                 )
             if Ellipsis in args:
                 raise FieldOperatorTypeError(f"Unbound tuples ({type_hint}) are not allowed!")
-            return foast.TupleType(types=[recursive_make_symbol(arg) for arg in args])
+            return common_types.TupleType(types=[recursive_make_symbol(arg) for arg in args])
 
         case common.Field:
             if (n_args := len(args)) != 2:
@@ -111,13 +112,13 @@ def make_symbol_type_from_typing(
                     f"Field type requires two arguments, got {n_args}! ({type_hint})"
                 )
 
-            dims: Union[Ellipsis, list[foast.Dimension]] = []
+            dims: Union[Ellipsis, list[common.Dimension]] = []
             dim_arg, dtype_arg = args
             if isinstance(dim_arg, list):
                 for d in dim_arg:
                     if not isinstance(d, common.Dimension):
                         raise FieldOperatorTypeError(f"Invalid field dimension definition '{d}'")
-                    dims.append(foast.Dimension(name=d.value))
+                    dims.append(d)
             elif dim_arg is Ellipsis:
                 dims = dim_arg
             else:
@@ -129,11 +130,11 @@ def make_symbol_type_from_typing(
                 raise FieldOperatorTypeError(
                     "Field dtype argument must be a scalar type (got '{dtype}')!"
                 ) from error
-            if not isinstance(dtype, foast.ScalarType):
+            if not isinstance(dtype, common_types.ScalarType):
                 raise FieldOperatorTypeError(
                     "Field dtype argument must be a scalar type (got '{dtype}')!"
                 )
-            return foast.FieldType(dims=dims, dtype=dtype)
+            return common_types.FieldType(dims=dims, dtype=dtype)
 
         case collections.abc.Callable:
             if not args:
@@ -155,11 +156,11 @@ def make_symbol_type_from_typing(
                 for arg, arg_type in kwargs_info[0].data.items()
             }
 
-            return foast.FunctionType(
+            return common_types.FunctionType(
                 args=args, kwargs=kwargs, returns=recursive_make_symbol(return_type)
             )
         case runtime.Offset:
-            return foast.OffsetType()
+            return common_types.OffsetType()
 
     raise FieldOperatorTypeError(f"'{type_hint}' type is not supported")
 
@@ -172,16 +173,16 @@ def make_symbol_from_value(
 
     symbol_type = make_symbol_type_from_typing(value)
 
-    if isinstance(symbol_type, foast.DataType):
+    if isinstance(symbol_type, common_types.DataType):
         return foast.DataSymbol(id=name, type=symbol_type, namespace=namespace, location=location)
-    elif isinstance(symbol_type, foast.FunctionType):
+    elif isinstance(symbol_type, common_types.FunctionType):
         return foast.Function(
             id=name,
             type=symbol_type,
             namespace=namespace,
             location=location,
         )
-    elif isinstance(symbol_type, foast.OffsetType):
+    elif isinstance(symbol_type, common_types.OffsetType):
         return foast.OffsetSymbol(id=name, type=symbol_type, namespace=namespace, location=location)
     else:
         raise common.GTTypeError(f"Impossible to map '{value}' value to a Symbol")

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -65,6 +65,7 @@ def fencil_from_fop(
         closures=[closure],
     )
 
+
 # todo(tehrengruber): dim and size are implicitly given bys out_names. Get values from there
 def program_from_fop(
     node: itir.FunctionDefinition, out_names: list[str], dim: CartesianAxis, size: int
@@ -75,6 +76,7 @@ def program_from_fop(
         fencil_definitions=[fencil_from_fop(node, out_names=out_names, domain=domain)],
         setqs=[],
     )
+
 
 # todo(tehrengruber): dim and size are implicitly given bys out_names. Get values from there
 def program_from_function(

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -65,7 +65,7 @@ def fencil_from_fop(
         closures=[closure],
     )
 
-
+# todo(tehrengruber): dim and size are implicitly given bys out_names. Get values from there
 def program_from_fop(
     node: itir.FunctionDefinition, out_names: list[str], dim: CartesianAxis, size: int
 ) -> itir.Program:
@@ -76,7 +76,7 @@ def program_from_fop(
         setqs=[],
     )
 
-
+# todo(tehrengruber): dim and size are implicitly given bys out_names. Get values from there
 def program_from_function(
     func, out_names: list[str], dim: CartesianAxis, size: int
 ) -> itir.Program:

--- a/tests/functional_tests/ffront_tests/test_interface.py
+++ b/tests/functional_tests/ffront_tests/test_interface.py
@@ -125,7 +125,8 @@ def test_return_type():
     parsed = FieldOperatorParser.apply_to_function(rettype)
 
     assert parsed.body[-1].value.type == common_types.FieldType(
-        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
+        dims=Ellipsis,
+        dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None),
     )
 
 
@@ -199,7 +200,8 @@ def test_temp_assignment():
     parsed = FieldOperatorParser.apply_to_function(copy_field)
 
     assert parsed.symtable_["tmp$0"].type == common_types.FieldType(
-        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
+        dims=Ellipsis,
+        dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None),
     )
 
     lowered = FieldOperatorLowering.apply(parsed)

--- a/tests/functional_tests/ffront_tests/test_interface.py
+++ b/tests/functional_tests/ffront_tests/test_interface.py
@@ -25,6 +25,7 @@ import pytest
 
 import functional.ffront.field_operator_ast as foast
 from functional.common import Field
+from functional.ffront import common_types
 from functional.ffront.fbuiltins import float32, float64, int64
 from functional.ffront.foast_passes.type_deduction import FieldOperatorTypeDeductionError
 from functional.ffront.foast_to_itir import FieldOperatorLowering
@@ -83,7 +84,7 @@ def test_invalid_syntax_error_empty_return():
         FieldOperatorSyntaxError,
         match=(
             r"Invalid Field Operator Syntax: "
-            r"Empty return not allowed \(test_interface.py, line 80\)"
+            r"Empty return not allowed \(test_interface.py, line 81\)"
         ),
     ):
         _ = FieldOperatorParser.apply_to_function(wrong_syntax)
@@ -123,8 +124,8 @@ def test_return_type():
 
     parsed = FieldOperatorParser.apply_to_function(rettype)
 
-    assert parsed.body[-1].value.type == foast.FieldType(
-        dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64, shape=None)
+    assert parsed.body[-1].value.type == common_types.FieldType(
+        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
     )
 
 
@@ -197,8 +198,8 @@ def test_temp_assignment():
 
     parsed = FieldOperatorParser.apply_to_function(copy_field)
 
-    assert parsed.symtable_["tmp$0"].type == foast.FieldType(
-        dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64, shape=None)
+    assert parsed.symtable_["tmp$0"].type == common_types.FieldType(
+        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
     )
 
     lowered = FieldOperatorLowering.apply(parsed)
@@ -522,11 +523,11 @@ def test_closure_symbols():
         return a, b
 
     parsed = FieldOperatorParser.apply_to_function(operator_with_refs)
-    assert parsed.symtable_["nonlocal_float"].type == foast.ScalarType(
-        kind=foast.ScalarKind.FLOAT64, shape=None
+    assert parsed.symtable_["nonlocal_float"].type == common_types.ScalarType(
+        kind=common_types.ScalarKind.FLOAT64, shape=None
     )
-    assert parsed.symtable_["nonlocal_np_scalar"].type == foast.ScalarType(
-        kind=foast.ScalarKind.FLOAT32, shape=None
+    assert parsed.symtable_["nonlocal_np_scalar"].type == common_types.ScalarType(
+        kind=common_types.ScalarKind.FLOAT32, shape=None
     )
     assert "nonlocal_unused" not in parsed.symtable_
 
@@ -545,10 +546,10 @@ def test_external_symbols():
         operator_with_externals,
         externals=dict(ext_float=2.3, ext_np_scalar=np.float32(3.4), ext_unused=0),
     )
-    assert parsed.symtable_["ext_float"].type == foast.ScalarType(
-        kind=foast.ScalarKind.FLOAT64, shape=None
+    assert parsed.symtable_["ext_float"].type == common_types.ScalarType(
+        kind=common_types.ScalarKind.FLOAT64, shape=None
     )
-    assert parsed.symtable_["ext_np_scalar"].type == foast.ScalarType(
-        kind=foast.ScalarKind.FLOAT32, shape=None
+    assert parsed.symtable_["ext_np_scalar"].type == common_types.ScalarType(
+        kind=common_types.ScalarKind.FLOAT32, shape=None
     )
     assert "ext_unused" not in parsed.symtable_

--- a/tests/functional_tests/ffront_tests/test_symbol_makers.py
+++ b/tests/functional_tests/ffront_tests/test_symbol_makers.py
@@ -21,9 +21,9 @@ import pytest
 
 from eve import typingx
 from functional import common
+from functional.ffront import common_types
 from functional.ffront import field_operator_ast as foast
 from functional.ffront import symbol_makers
-from functional.ffront import common_types
 from functional.ffront.fbuiltins import Field, float64
 
 
@@ -88,7 +88,9 @@ def test_invalid_scalar_kind():
         ),
         (
             common.Field[..., float],
-            common_types.FieldType(dims=..., dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
+            common_types.FieldType(
+                dims=..., dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)
+            ),
         ),
         (
             common.Field[[IDim, JDim], float],
@@ -111,8 +113,14 @@ def test_invalid_scalar_kind():
             ),
         ),
         (typing.ForwardRef("float"), common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
-        (typing.Annotated[float, "foo"], common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
-        (typing.Annotated["float", "foo", "bar"], common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
+        (
+            typing.Annotated[float, "foo"],
+            common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
+        ),
+        (
+            typing.Annotated["float", "foo", "bar"],
+            common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
+        ),
         (
             typing.Annotated[typing.ForwardRef("float"), "foo"],
             common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),

--- a/tests/functional_tests/ffront_tests/test_symbol_makers.py
+++ b/tests/functional_tests/ffront_tests/test_symbol_makers.py
@@ -23,6 +23,7 @@ from eve import typingx
 from functional import common
 from functional.ffront import field_operator_ast as foast
 from functional.ffront import symbol_makers
+from functional.ffront import common_types
 from functional.ffront.fbuiltins import Field, float64
 
 
@@ -39,11 +40,11 @@ JDim = common.Dimension("JDim")
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ("float", foast.ScalarKind.FLOAT64),
-        (float, foast.ScalarKind.FLOAT64),
-        (np.float64, foast.ScalarKind.FLOAT64),
-        (np.dtype(float), foast.ScalarKind.FLOAT64),
-        (CustomInt32DType(), foast.ScalarKind.INT32),
+        ("float", common_types.ScalarKind.FLOAT64),
+        (float, common_types.ScalarKind.FLOAT64),
+        (np.float64, common_types.ScalarKind.FLOAT64),
+        (np.dtype(float), common_types.ScalarKind.FLOAT64),
+        (CustomInt32DType(), common_types.ScalarKind.INT32),
     ],
 )
 def test_valid_scalar_kind(value, expected):
@@ -58,28 +59,28 @@ def test_invalid_scalar_kind():
 @pytest.mark.parametrize(
     "value,expected",
     [
-        (bool, foast.ScalarType(kind=foast.ScalarKind.BOOL)),
-        (np.int32, foast.ScalarType(kind=foast.ScalarKind.INT32)),
-        (float, foast.ScalarType(kind=foast.ScalarKind.FLOAT64)),
-        ("float", foast.ScalarType(kind=foast.ScalarKind.FLOAT64)),
+        (bool, common_types.ScalarType(kind=common_types.ScalarKind.BOOL)),
+        (np.int32, common_types.ScalarType(kind=common_types.ScalarKind.INT32)),
+        (float, common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
+        ("float", common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
         (
             typing.Tuple[int, float],
-            foast.TupleType(
+            common_types.TupleType(
                 types=[
-                    foast.ScalarType(kind=foast.ScalarKind.INT64),
-                    foast.ScalarType(kind=foast.ScalarKind.FLOAT64),
+                    common_types.ScalarType(kind=common_types.ScalarKind.INT64),
+                    common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
                 ]
             ),
         ),
         (
             tuple[bool, typing.Tuple[int, float]],
-            foast.TupleType(
+            common_types.TupleType(
                 types=[
-                    foast.ScalarType(kind=foast.ScalarKind.BOOL),
-                    foast.TupleType(
+                    common_types.ScalarType(kind=common_types.ScalarKind.BOOL),
+                    common_types.TupleType(
                         types=[
-                            foast.ScalarType(kind=foast.ScalarKind.INT64),
-                            foast.ScalarType(kind=foast.ScalarKind.FLOAT64),
+                            common_types.ScalarType(kind=common_types.ScalarKind.INT64),
+                            common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
                         ]
                     ),
                 ]
@@ -87,34 +88,34 @@ def test_invalid_scalar_kind():
         ),
         (
             common.Field[..., float],
-            foast.FieldType(dims=..., dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64)),
+            common_types.FieldType(dims=..., dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
         ),
         (
             common.Field[[IDim, JDim], float],
-            foast.FieldType(
-                dims=[foast.Dimension(name="IDim"), foast.Dimension(name="JDim")],
-                dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64),
+            common_types.FieldType(
+                dims=[common.Dimension("IDim"), common.Dimension("JDim")],
+                dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
             ),
         ),
         (
             typing.Annotated[
                 typing.Callable[["float", int], int], typingx.CallableKwargsInfo(data={})
             ],
-            foast.FunctionType(
+            common_types.FunctionType(
                 args=[
-                    foast.ScalarType(kind=foast.ScalarKind.FLOAT64),
-                    foast.ScalarType(kind=foast.ScalarKind.INT64),
+                    common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
+                    common_types.ScalarType(kind=common_types.ScalarKind.INT64),
                 ],
                 kwargs={},
-                returns=foast.ScalarType(kind=foast.ScalarKind.INT64),
+                returns=common_types.ScalarType(kind=common_types.ScalarKind.INT64),
             ),
         ),
-        (typing.ForwardRef("float"), foast.ScalarType(kind=foast.ScalarKind.FLOAT64)),
-        (typing.Annotated[float, "foo"], foast.ScalarType(kind=foast.ScalarKind.FLOAT64)),
-        (typing.Annotated["float", "foo", "bar"], foast.ScalarType(kind=foast.ScalarKind.FLOAT64)),
+        (typing.ForwardRef("float"), common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
+        (typing.Annotated[float, "foo"], common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
+        (typing.Annotated["float", "foo", "bar"], common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)),
         (
             typing.Annotated[typing.ForwardRef("float"), "foo"],
-            foast.ScalarType(kind=foast.ScalarKind.FLOAT64),
+            common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64),
         ),
     ],
 )

--- a/tests/functional_tests/ffront_tests/test_type_deduction.py
+++ b/tests/functional_tests/ffront_tests/test_type_deduction.py
@@ -15,6 +15,7 @@
 import pytest
 
 from functional.common import Dimension
+from functional.ffront import common_types
 from functional.ffront import field_operator_ast as foast
 from functional.ffront.fbuiltins import Field, float64, int64
 from functional.ffront.foast_passes.type_deduction import FieldOperatorTypeDeductionError, TypeInfo
@@ -36,7 +37,7 @@ def type_info_cases():
             },
         ),
         (
-            foast.DeferredSymbolType(constraint=None),
+            common_types.DeferredSymbolType(constraint=None),
             {
                 "is_complete": False,
                 "is_any_type": True,
@@ -48,11 +49,11 @@ def type_info_cases():
             },
         ),
         (
-            foast.DeferredSymbolType(constraint=foast.ScalarType),
+            common_types.DeferredSymbolType(constraint=common_types.ScalarType),
             {
                 "is_complete": False,
                 "is_any_type": False,
-                "constraint": foast.ScalarType,
+                "constraint": common_types.ScalarType,
                 "is_field_type": False,
                 "is_scalar": True,
                 "is_arithmetic_compatible": False,
@@ -60,11 +61,11 @@ def type_info_cases():
             },
         ),
         (
-            foast.DeferredSymbolType(constraint=foast.FieldType),
+            common_types.DeferredSymbolType(constraint=common_types.FieldType),
             {
                 "is_complete": False,
                 "is_any_type": False,
-                "constraint": foast.FieldType,
+                "constraint": common_types.FieldType,
                 "is_field_type": True,
                 "is_scalar": False,
                 "is_arithmetic_compatible": False,
@@ -72,11 +73,11 @@ def type_info_cases():
             },
         ),
         (
-            foast.ScalarType(kind=foast.ScalarKind.INT64),
+            common_types.ScalarType(kind=common_types.ScalarKind.INT64),
             {
                 "is_complete": True,
                 "is_any_type": False,
-                "constraint": foast.ScalarType,
+                "constraint": common_types.ScalarType,
                 "is_field_type": False,
                 "is_scalar": True,
                 "is_arithmetic_compatible": True,
@@ -84,11 +85,11 @@ def type_info_cases():
             },
         ),
         (
-            foast.FieldType(dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.BOOL)),
+            common_types.FieldType(dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.BOOL)),
             {
                 "is_complete": True,
                 "is_any_type": False,
-                "constraint": foast.FieldType,
+                "constraint": common_types.FieldType,
                 "is_field_type": True,
                 "is_scalar": False,
                 "is_arithmetic_compatible": False,
@@ -106,8 +107,8 @@ def test_type_info_basic(symbol_type, expected):
 
 
 def test_type_info_refinable_complete_complete():
-    complete_type = foast.ScalarType(kind=foast.ScalarKind.INT64)
-    other_complete_type = foast.ScalarType(kind=foast.ScalarKind.FLOAT64)
+    complete_type = common_types.ScalarType(kind=common_types.ScalarKind.INT64)
+    other_complete_type = common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64)
     type_info_a = TypeInfo(complete_type)
     type_info_b = TypeInfo(other_complete_type)
     assert type_info_a.can_be_refined_to(TypeInfo(complete_type))
@@ -116,26 +117,26 @@ def test_type_info_refinable_complete_complete():
 
 def test_type_info_refinable_incomplete_complete():
     complete_type = TypeInfo(
-        foast.FieldType(dtype=foast.ScalarType(kind=foast.ScalarKind.BOOL), dims=Ellipsis)
+        common_types.FieldType(dtype=common_types.ScalarType(kind=common_types.ScalarKind.BOOL), dims=Ellipsis)
     )
     assert TypeInfo(None).can_be_refined_to(complete_type)
-    assert TypeInfo(foast.DeferredSymbolType(constraint=None)).can_be_refined_to(complete_type)
-    assert TypeInfo(foast.DeferredSymbolType(constraint=foast.FieldType)).can_be_refined_to(
+    assert TypeInfo(common_types.DeferredSymbolType(constraint=None)).can_be_refined_to(complete_type)
+    assert TypeInfo(common_types.DeferredSymbolType(constraint=common_types.FieldType)).can_be_refined_to(
         complete_type
     )
-    assert not TypeInfo(foast.DeferredSymbolType(constraint=foast.OffsetType)).can_be_refined_to(
+    assert not TypeInfo(common_types.DeferredSymbolType(constraint=common_types.OffsetType)).can_be_refined_to(
         complete_type
     )
 
 
 def test_type_info_refinable_incomplete_incomplete():
-    target_type = TypeInfo(foast.DeferredSymbolType(constraint=foast.ScalarType))
+    target_type = TypeInfo(common_types.DeferredSymbolType(constraint=common_types.ScalarType))
     assert TypeInfo(None).can_be_refined_to(target_type)
-    assert TypeInfo(foast.DeferredSymbolType(constraint=None)).can_be_refined_to(target_type)
-    assert TypeInfo(foast.DeferredSymbolType(constraint=foast.ScalarType)).can_be_refined_to(
+    assert TypeInfo(common_types.DeferredSymbolType(constraint=None)).can_be_refined_to(target_type)
+    assert TypeInfo(common_types.DeferredSymbolType(constraint=common_types.ScalarType)).can_be_refined_to(
         target_type
     )
-    assert not TypeInfo(foast.DeferredSymbolType(constraint=foast.FieldType)).can_be_refined_to(
+    assert not TypeInfo(common_types.DeferredSymbolType(constraint=common_types.FieldType)).can_be_refined_to(
         target_type
     )
 
@@ -149,11 +150,11 @@ def test_unpack_assign():
 
     parsed = FieldOperatorParser.apply_to_function(unpack_explicit_tuple)
 
-    assert parsed.symtable_["tmp_a$0"].type == foast.FieldType(
-        dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64, shape=None)
+    assert parsed.symtable_["tmp_a$0"].type == common_types.FieldType(
+        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
     )
-    assert parsed.symtable_["tmp_b$0"].type == foast.FieldType(
-        dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64, shape=None)
+    assert parsed.symtable_["tmp_b$0"].type == common_types.FieldType(
+        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
     )
 
 
@@ -164,13 +165,13 @@ def test_assign_tuple():
 
     parsed = FieldOperatorParser.apply_to_function(temp_tuple)
 
-    assert parsed.symtable_["tmp$0"].type == foast.TupleType(
+    assert parsed.symtable_["tmp$0"].type == common_types.TupleType(
         types=[
-            foast.FieldType(
-                dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.FLOAT64, shape=None)
+            common_types.FieldType(
+                dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
             ),
-            foast.FieldType(
-                dims=Ellipsis, dtype=foast.ScalarType(kind=foast.ScalarKind.INT64, shape=None)
+            common_types.FieldType(
+                dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.INT64, shape=None)
             ),
         ]
     )

--- a/tests/functional_tests/ffront_tests/test_type_deduction.py
+++ b/tests/functional_tests/ffront_tests/test_type_deduction.py
@@ -85,7 +85,9 @@ def type_info_cases():
             },
         ),
         (
-            common_types.FieldType(dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.BOOL)),
+            common_types.FieldType(
+                dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.BOOL)
+            ),
             {
                 "is_complete": True,
                 "is_any_type": False,
@@ -117,28 +119,32 @@ def test_type_info_refinable_complete_complete():
 
 def test_type_info_refinable_incomplete_complete():
     complete_type = TypeInfo(
-        common_types.FieldType(dtype=common_types.ScalarType(kind=common_types.ScalarKind.BOOL), dims=Ellipsis)
+        common_types.FieldType(
+            dtype=common_types.ScalarType(kind=common_types.ScalarKind.BOOL), dims=Ellipsis
+        )
     )
     assert TypeInfo(None).can_be_refined_to(complete_type)
-    assert TypeInfo(common_types.DeferredSymbolType(constraint=None)).can_be_refined_to(complete_type)
-    assert TypeInfo(common_types.DeferredSymbolType(constraint=common_types.FieldType)).can_be_refined_to(
+    assert TypeInfo(common_types.DeferredSymbolType(constraint=None)).can_be_refined_to(
         complete_type
     )
-    assert not TypeInfo(common_types.DeferredSymbolType(constraint=common_types.OffsetType)).can_be_refined_to(
-        complete_type
-    )
+    assert TypeInfo(
+        common_types.DeferredSymbolType(constraint=common_types.FieldType)
+    ).can_be_refined_to(complete_type)
+    assert not TypeInfo(
+        common_types.DeferredSymbolType(constraint=common_types.OffsetType)
+    ).can_be_refined_to(complete_type)
 
 
 def test_type_info_refinable_incomplete_incomplete():
     target_type = TypeInfo(common_types.DeferredSymbolType(constraint=common_types.ScalarType))
     assert TypeInfo(None).can_be_refined_to(target_type)
     assert TypeInfo(common_types.DeferredSymbolType(constraint=None)).can_be_refined_to(target_type)
-    assert TypeInfo(common_types.DeferredSymbolType(constraint=common_types.ScalarType)).can_be_refined_to(
-        target_type
-    )
-    assert not TypeInfo(common_types.DeferredSymbolType(constraint=common_types.FieldType)).can_be_refined_to(
-        target_type
-    )
+    assert TypeInfo(
+        common_types.DeferredSymbolType(constraint=common_types.ScalarType)
+    ).can_be_refined_to(target_type)
+    assert not TypeInfo(
+        common_types.DeferredSymbolType(constraint=common_types.FieldType)
+    ).can_be_refined_to(target_type)
 
 
 def test_unpack_assign():
@@ -151,10 +157,12 @@ def test_unpack_assign():
     parsed = FieldOperatorParser.apply_to_function(unpack_explicit_tuple)
 
     assert parsed.symtable_["tmp_a$0"].type == common_types.FieldType(
-        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
+        dims=Ellipsis,
+        dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None),
     )
     assert parsed.symtable_["tmp_b$0"].type == common_types.FieldType(
-        dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
+        dims=Ellipsis,
+        dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None),
     )
 
 
@@ -168,10 +176,12 @@ def test_assign_tuple():
     assert parsed.symtable_["tmp$0"].type == common_types.TupleType(
         types=[
             common_types.FieldType(
-                dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None)
+                dims=Ellipsis,
+                dtype=common_types.ScalarType(kind=common_types.ScalarKind.FLOAT64, shape=None),
             ),
             common_types.FieldType(
-                dims=Ellipsis, dtype=common_types.ScalarType(kind=common_types.ScalarKind.INT64, shape=None)
+                dims=Ellipsis,
+                dtype=common_types.ScalarType(kind=common_types.ScalarKind.INT64, shape=None),
             ),
         ]
     )


### PR DESCRIPTION
## Description

Moved SymbolType nodes into common_types and made them regular python dataclasses (preperation for prgast).

I propose we merge this rather soon as there are quite some code changes in here. Additionally I've added some info to the [design notes document](https://hackmd.io/QqcxL37aSTaIw28Wyyv0rg).

## Requirements

Before submitting this PR, please make sure:

- [ ] You have run the code checks, tests and documentation build successfully
- [ ] All fixes and all new functionality are tested and documentation is up to date
- [ ] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


