### PR TITLE
Functional: Unify all Symbol nodes in foast

### DIFF
--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -171,4 +171,4 @@ class FieldOperator(LocatedNode, SymbolTableTrait):
     id: SymbolName  # noqa: A003
     params: list[DataSymbol]
     body: list[Stmt]
-    closure: list[DataSymbol]
+    closure: list[Symbol]

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -16,8 +16,6 @@
 import re
 from typing import Generic, Optional, TypeVar, Union
 
-from pydantic import validator
-
 import eve
 from eve import Node
 from eve.traits import SymbolTableTrait

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -155,7 +155,7 @@ class Stmt(LocatedNode):
 
 
 class ExternalImport(Stmt):
-    symbols: list[DataSymbol]
+    symbols: list[Symbol]
 
 
 class Assign(Stmt):

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -55,6 +55,8 @@ FieldSymbol = Symbol[FieldTypeT]
 ScalarTypeT = TypeVar("ScalarTypeT", bound=common_types.ScalarType)
 ScalarSymbol = Symbol[ScalarTypeT]
 
+TupleTypeT = TypeVar("TupleTypeT", bound=common_types.TupleType)
+TupleSymbol = Symbol[TupleTypeT]
 
 class Expr(LocatedNode):
     type: Optional[common_types.SymbolType] = None  # noqa A003
@@ -159,7 +161,7 @@ class ExternalImport(Stmt):
 
 
 class Assign(Stmt):
-    target: FieldSymbol
+    target: Union[FieldSymbol, TupleSymbol]
     value: Expr
 
 

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -46,6 +46,16 @@ class Symbol(eve.GenericNode, LocatedNode, Generic[SymbolT]):
     namespace: Namespace = Namespace(Namespace.LOCAL)
 
 
+DataTypeT = TypeVar("DataTypeT", bound=common_types.DataType)
+DataSymbol = Symbol[DataTypeT]
+
+FieldTypeT = TypeVar("FieldTypeT", bound=common_types.FieldType)
+FieldSymbol = Symbol[FieldTypeT]
+
+ScalarTypeT = TypeVar("ScalarTypeT", bound=common_types.ScalarType)
+ScalarSymbol = Symbol[ScalarTypeT]
+
+
 class Expr(LocatedNode):
     type: Optional[common_types.SymbolType] = None  # noqa A003
 
@@ -145,11 +155,11 @@ class Stmt(LocatedNode):
 
 
 class ExternalImport(Stmt):
-    symbols: list[Symbol]
+    symbols: list[DataSymbol]
 
 
 class Assign(Stmt):
-    target: Symbol
+    target: FieldSymbol
     value: Expr
 
 
@@ -159,6 +169,6 @@ class Return(Stmt):
 
 class FieldOperator(LocatedNode, SymbolTableTrait):
     id: SymbolName  # noqa: A003
-    params: list[Symbol[common_types.DataType]]
+    params: list[DataSymbol]
     body: list[Stmt]
-    closure: list[Symbol]
+    closure: list[DataSymbol]

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -58,6 +58,7 @@ ScalarSymbol = Symbol[ScalarTypeT]
 TupleTypeT = TypeVar("TupleTypeT", bound=common_types.TupleType)
 TupleSymbol = Symbol[TupleTypeT]
 
+
 class Expr(LocatedNode):
     type: Optional[common_types.SymbolType] = None  # noqa A003
 

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -15,6 +15,7 @@
 
 import re
 from typing import Optional, Union
+
 from pydantic import validator
 
 import eve
@@ -164,5 +165,7 @@ class FieldOperator(LocatedNode, SymbolTableTrait):
     @validator("params")
     def validate_params_type(cls, params: list[Symbol]):
         assert all(
-            isinstance(param.type, (common_types.DeferredSymbolType, common_types.DataType)) for param in params)
+            isinstance(param.type, (common_types.DeferredSymbolType, common_types.DataType))
+            for param in params
+        )
         return params

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -240,7 +240,9 @@ class FieldOperatorTypeDeduction(NodeTranslator):
                         f"of type {refine_type}, instead of the expected type {node.type}"
                     ),
                 )
-            new_node = foast.Symbol(id=node.id, type=refine_type, location=node.location)
+            new_node = foast.Symbol[type(refine_type)](
+                id=node.id, type=refine_type, location=node.location
+            )
             symtable[new_node.id] = new_node
             return new_node
         return node

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -224,12 +224,12 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         new_target = self.visit(node.target, refine_type=new_value.type, **kwargs)
         return foast.Assign(target=new_target, value=new_value, location=node.location)
 
-    def visit_FieldSymbol(
+    def visit_Symbol(
         self,
-        node: foast.FieldSymbol,
+        node: foast.Symbol,
         refine_type: Optional[common_types.FieldType] = None,
         **kwargs,
-    ) -> foast.FieldSymbol:
+    ) -> foast.Symbol:
         symtable = kwargs["symtable"]
         if refine_type:
             if not TypeInfo(node.type).can_be_refined_to(TypeInfo(refine_type)):
@@ -240,28 +240,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
                         f"of type {refine_type}, instead of the expected type {node.type}"
                     ),
                 )
-            new_node = foast.FieldSymbol(id=node.id, type=refine_type, location=node.location)
-            symtable[new_node.id] = new_node
-            return new_node
-        return node
-
-    def visit_TupleSymbol(
-        self,
-        node: foast.TupleSymbol,
-        refine_type: Optional[common_types.TupleType] = None,
-        **kwargs,
-    ) -> foast.TupleSymbol:
-        symtable = kwargs["symtable"]
-        if refine_type:
-            if not TypeInfo(node.type).can_be_refined_to(TypeInfo(refine_type)):
-                raise FieldOperatorTypeDeductionError.from_foast_node(
-                    node,
-                    msg=(
-                        "type inconsistency: expression was deduced to be "
-                        f"of type {refine_type}, instead of the expected type {node.type}"
-                    ),
-                )
-            new_node = foast.TupleSymbol(id=node.id, type=refine_type, location=node.location)
+            new_node = foast.Symbol(id=node.id, type=refine_type, location=node.location)
             symtable[new_node.id] = new_node
             return new_node
         return node
@@ -277,9 +256,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
                 location=node.location,
             )
         match new_value.type:
-            case common_types.TupleType(types=types) | common_types.FunctionType(
-                returns=common_types.TupleType(types=types)
-            ):
+            case common_types.TupleType(types=types):
                 new_type = types[node.index]
             case _:
                 raise FieldOperatorTypeDeductionError.from_foast_node(

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -171,9 +171,11 @@ class FieldOperatorLowering(NodeTranslator):
         result = self.visit(node.value, **kwargs)
         return result
 
-    def visit_FieldSymbol(
-        self, node: foast.FieldSymbol, *, symtable: dict[str, foast.Symbol], **kwargs
+    def visit_Symbol(
+        self, node: foast.Symbol, *, symtable: dict[str, foast.Symbol], **kwargs
     ) -> itir.Sym:
+        if not isinstance(node.type, common_types.FieldType):
+            raise NotImplementedError("Only Field symbols are supported right now.")
         return itir.Sym(id=node.id)
 
     def visit_Name(

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -217,7 +217,7 @@ class FieldOperatorParser(ast.NodeVisitor):
     >>> foast_tree  # doctest: +ELLIPSIS
     FieldOperator(..., id='field_op', ...)
     >>> foast_tree.params  # doctest: +ELLIPSIS
-    [FieldSymbol(..., id='inp', ...)]
+    [Symbol(..., id='inp', type=FieldType(...), ...)]
     >>> foast_tree.body  # doctest: +ELLIPSIS
     [Return(..., value=Name(..., id='inp'))]
 

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -217,7 +217,7 @@ class FieldOperatorParser(ast.NodeVisitor):
     >>> foast_tree  # doctest: +ELLIPSIS
     FieldOperator(..., id='field_op', ...)
     >>> foast_tree.params  # doctest: +ELLIPSIS
-    [Symbol(..., id='inp', type=FieldType(...), ...)]
+    [Symbol[DataType](..., id='inp', type=FieldType(...), ...)]
     >>> foast_tree.body  # doctest: +ELLIPSIS
     [Return(..., value=Name(..., id='inp'))]
 

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -217,7 +217,7 @@ class FieldOperatorParser(ast.NodeVisitor):
     >>> foast_tree  # doctest: +ELLIPSIS
     FieldOperator(..., id='field_op', ...)
     >>> foast_tree.params  # doctest: +ELLIPSIS
-    [Symbol[DataType](..., id='inp', type=FieldType(...), ...)]
+    [Symbol[DataTypeT](..., id='inp', type=FieldType(...), ...)]
     >>> foast_tree.body  # doctest: +ELLIPSIS
     [Return(..., value=Name(..., id='inp'))]
 

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -362,14 +362,18 @@ class FieldOperatorParser(ast.NodeVisitor):
 
         return foast.ExternalImport(symbols=symbols, location=self._make_loc(node))
 
-    def visit_arguments(self, node: ast.arguments) -> list[foast.Symbol]:
+    def visit_arguments(self, node: ast.arguments) -> list[foast.DataSymbol]:
         return [self.visit_arg(arg) for arg in node.args]
 
-    def visit_arg(self, node: ast.arg) -> foast.Symbol:
+    def visit_arg(self, node: ast.arg) -> foast.DataSymbol:
         if (annotation := self.closure_refs.annotations.get(node.arg, None)) is None:
             raise self._make_syntax_error(node, message="Untyped parameters not allowed!")
         new_type = symbol_makers.make_symbol_type_from_typing(annotation)
-        return foast.Symbol(id=node.arg, location=self._make_loc(node), type=new_type)
+        if not isinstance(new_type, common_types.DataType):
+            raise self._make_syntax_error(
+                node, message="Only arguments of type DataType are allowed."
+            )
+        return foast.DataSymbol(id=node.arg, location=self._make_loc(node), type=new_type)
 
     def visit_Assign(self, node: ast.Assign, **kwargs) -> foast.Assign:
         target = node.targets[0]  # there is only one element after assignment passes
@@ -382,7 +386,7 @@ class FieldOperatorParser(ast.NodeVisitor):
         if isinstance(new_value, foast.TupleExpr):
             constraint_type = common_types.TupleType
         return foast.Assign(
-            target=foast.Symbol(
+            target=foast.FieldSymbol(
                 id=target.id,
                 location=self._make_loc(target),
                 type=common_types.DeferredSymbolType(constraint=constraint_type),
@@ -402,14 +406,14 @@ class FieldOperatorParser(ast.NodeVisitor):
             global_ns = {**fbuiltins.BUILTINS, **self.closure_refs.globals}
             local_ns = self.closure_refs.nonlocals
             annotation = eval(node.annotation.value, global_ns, local_ns)
-            target_type = target_type = symbol_makers.make_symbol_type_from_typing(
+            target_type = symbol_makers.make_symbol_type_from_typing(
                 annotation, global_ns=global_ns, local_ns=local_ns
             )
         else:
             target_type = common_types.DeferredSymbolType()
 
         return foast.Assign(
-            target=foast.Symbol(
+            target=foast.Symbol[common_types.FieldType](
                 id=node.target.id,
                 location=self._make_loc(node.target),
                 type=target_type,

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -362,14 +362,14 @@ class FieldOperatorParser(ast.NodeVisitor):
 
         return foast.ExternalImport(symbols=symbols, location=self._make_loc(node))
 
-    def visit_arguments(self, node: ast.arguments) -> list[foast.FieldSymbol]:
+    def visit_arguments(self, node: ast.arguments) -> list[foast.Symbol]:
         return [self.visit_arg(arg) for arg in node.args]
 
-    def visit_arg(self, node: ast.arg) -> foast.FieldSymbol:
+    def visit_arg(self, node: ast.arg) -> foast.Symbol:
         if (annotation := self.closure_refs.annotations.get(node.arg, None)) is None:
             raise self._make_syntax_error(node, message="Untyped parameters not allowed!")
         new_type = symbol_makers.make_symbol_type_from_typing(annotation)
-        return foast.FieldSymbol(id=node.arg, location=self._make_loc(node), type=new_type)
+        return foast.Symbol(id=node.arg, location=self._make_loc(node), type=new_type)
 
     def visit_Assign(self, node: ast.Assign, **kwargs) -> foast.Assign:
         target = node.targets[0]  # there is only one element after assignment passes
@@ -378,13 +378,11 @@ class FieldOperatorParser(ast.NodeVisitor):
         if not isinstance(target, ast.Name):
             raise self._make_syntax_error(node, message="Can only assign to names!")
         new_value = self.visit(node.value)
-        target_symbol_type = foast.FieldSymbol
         constraint_type = common_types.FieldType
         if isinstance(new_value, foast.TupleExpr):
-            target_symbol_type = foast.TupleSymbol
             constraint_type = common_types.TupleType
         return foast.Assign(
-            target=target_symbol_type(
+            target=foast.Symbol(
                 id=target.id,
                 location=self._make_loc(target),
                 type=common_types.DeferredSymbolType(constraint=constraint_type),
@@ -411,7 +409,7 @@ class FieldOperatorParser(ast.NodeVisitor):
             target_type = common_types.DeferredSymbolType()
 
         return foast.Assign(
-            target=foast.FieldSymbol(
+            target=foast.Symbol(
                 id=node.target.id,
                 location=self._make_loc(node.target),
                 type=target_type,

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -168,8 +168,10 @@ def make_symbol_type_from_typing(
 def make_symbol_from_value(
     name: str, value: Any, namespace: foast.Namespace, location: SourceLocation
 ) -> foast.Symbol:
-    """Make a symbol node from a python value."""
-    assert not isinstance(value, type) and type(value).__module__ != "typing"
+    """Make a symbol node from a Python value."""
+    if isinstance(value, type) or type(value).__module__ == "typing":
+        # we don't have types of types so disallow this
+        raise ValueError("The type of a symbol can not be a type itself.")
     type_ = typingx.get_typing(value, annotate_callable_kwargs=True)
 
     symbol_type = make_symbol_type_from_typing(type_)

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -169,13 +169,14 @@ def make_symbol_from_value(
     name: str, value: Any, namespace: foast.Namespace, location: SourceLocation
 ) -> foast.Symbol:
     """Make a symbol node from a python value."""
-
     assert not isinstance(value, type) and type(value).__module__ != "typing"
     type_ = typingx.get_typing(value, annotate_callable_kwargs=True)
 
     symbol_type = make_symbol_type_from_typing(type_)
 
-    if isinstance(symbol_type, (common_types.DataType, common_types.FunctionType, common_types.OffsetType)):
+    if isinstance(
+        symbol_type, (common_types.DataType, common_types.FunctionType, common_types.OffsetType)
+    ):
         return foast.Symbol(id=name, type=symbol_type, namespace=namespace, location=location)
     else:
         raise common.GTTypeError(f"Impossible to map '{value}' value to a Symbol")

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -179,7 +179,9 @@ def make_symbol_from_value(
     if isinstance(
         symbol_type, (common_types.DataType, common_types.FunctionType, common_types.OffsetType)
     ):
-        return foast.Symbol(id=name, type=symbol_type, namespace=namespace, location=location)
+        return foast.Symbol[type(symbol_type)](
+            id=name, type=symbol_type, namespace=namespace, location=location
+        )
     else:
         raise common.GTTypeError(f"Impossible to map '{value}' value to a Symbol")
 

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -168,22 +168,15 @@ def make_symbol_type_from_typing(
 def make_symbol_from_value(
     name: str, value: Any, namespace: foast.Namespace, location: SourceLocation
 ) -> foast.Symbol:
-    if not isinstance(value, type) or type(value).__module__ != "typing":
-        value = typingx.get_typing(value, annotate_callable_kwargs=True)
+    """Make a symbol node from a python value."""
 
-    symbol_type = make_symbol_type_from_typing(value)
+    assert not isinstance(value, type) and type(value).__module__ != "typing"
+    type_ = typingx.get_typing(value, annotate_callable_kwargs=True)
 
-    if isinstance(symbol_type, common_types.DataType):
-        return foast.DataSymbol(id=name, type=symbol_type, namespace=namespace, location=location)
-    elif isinstance(symbol_type, common_types.FunctionType):
-        return foast.Function(
-            id=name,
-            type=symbol_type,
-            namespace=namespace,
-            location=location,
-        )
-    elif isinstance(symbol_type, common_types.OffsetType):
-        return foast.OffsetSymbol(id=name, type=symbol_type, namespace=namespace, location=location)
+    symbol_type = make_symbol_type_from_typing(type_)
+
+    if isinstance(symbol_type, (common_types.DataType, common_types.FunctionType, common_types.OffsetType)):
+        return foast.Symbol(id=name, type=symbol_type, namespace=namespace, location=location)
     else:
         raise common.GTTypeError(f"Impossible to map '{value}' value to a Symbol")
 


### PR DESCRIPTION
## Description

The FOAST currently has various nodes subclassing `Symbol`, i.e. `DataSymbol`, `FieldSymbol`, `TupleSymbol`, `Function`, `OffsetSymbol`. As such the decision on what type a symbol has needs to be done when creating the symbol, i.e. at the syntax level before the type inference/deduction is run. Let's look at how this works __currently__:

- Assign: `Symbol` can be either a `Field` or a `Tuple`. By default everything is a `Field` unless there is a `TupleExpr` on the rhs. This is problematic as soon as one tries to add more types, e.g. scalars, as we don't know what the type of the right hand side is until we run type inference. As an example consider `some_scalar = 1+some_external` or a function call returning a scalar or tuple.
- Field operator parameters: Everything is a field. If we want scalar parameters in the future, the Python -> FOAST parsing needs to understand the annotation and emit a different symbol. By our guiding principles we want lean visitors and the type of a symbol already has all information.
- External from value: Since the value is known so is its type -> works

This PR removes all of the various types of `Symbol` nodes and uses only `Symbol` itself with the respective type information. This solves the aforementioned problems, reduces the complexity of the FOAST and avoids duplicating type information when expressed both in the node type and the `type` attribute of a Symbol. It comes at the additional cost of needing validators when only certain types are allowed (see changes in `FieldOperator` node).

Side note: This PR originated from my PRGAST work where I recognized that I need to duplicate all of the different types of Symbols and generalize `make_symbol_from_value`. After this PR I only need to duplicate one node and generalizing`make_symbol_from_value` is straightforward.

