### PR TITLE
Remove scipy intersphinx link, update sphinx link, and remove comment

### DIFF
--- a/docs/eve/conf.py
+++ b/docs/eve/conf.py
@@ -124,8 +124,7 @@ intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
 
 # ---- Options for Napoleon extension

--- a/docs/gt4py/_source/.gitignore
+++ b/docs/gt4py/_source/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/docs/gt4py/conf.py
+++ b/docs/gt4py/conf.py
@@ -108,8 +108,7 @@ intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
 
 # ---- Options for Napoleon extension

--- a/docs/gtc/conf.py
+++ b/docs/gtc/conf.py
@@ -122,8 +122,7 @@ intersphinx_mapping = {
     "attrs": ("https://www.attrs.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
 
 # ---- Options for Napoleon extension

--- a/src/gt4py/testing/suites.py
+++ b/src/gt4py/testing/suites.py
@@ -458,7 +458,6 @@ class StencilTestSuite(metaclass=SuiteMeta):
         assert isinstance(implementation, StencilObject)
         assert implementation.backend == test["backend"]
 
-        # Assert strict equality for Dawn backends
         for name, field_info in implementation.field_info.items():
             if field_info is None:
                 continue


### PR DESCRIPTION
## Description

- Removed scipy inventory, which is having issues.
- Update the sphinx link that moved.
- Remove an old comment.

Resolves #646.