### PR TITLE
Functional: @raw_itir_stencil decorator

### DIFF
--- a/tests/functional_tests/ffront_tests/test_program.py
+++ b/tests/functional_tests/ffront_tests/test_program.py
@@ -406,6 +406,29 @@ def test_copy_restricted_execution(copy_restrict_program_def):
     assert np.allclose(out_field_ref, out_field)
 
 
+def test_calling_fo_from_fo_execution(identity_def):
+    size = 10
+    in_field = np_as_located_field(IDim)(2*np.ones((size)))
+    out_field = np_as_located_field(IDim)(np.zeros((size)))
+    out_field_ref = np_as_located_field(IDim)(2*2*2*np.ones((size)))
+
+    @field_operator
+    def pow_two(field: Field[[IDim], "float64"]) -> Field[[IDim], "float64"]:
+        return field*field
+
+    @field_operator
+    def pow_three(field: Field[[IDim], "float64"]) -> Field[[IDim], "float64"]:
+        return field*pow_two(field)
+
+    @program
+    def fo_from_fo_program(in_field: Field[[IDim], "float64"], out_field: Field[[IDim], "float64"]):
+        pow_three(in_field, out=out_field)
+
+    fo_from_fo_program(in_field, out_field, offset_provider={})
+
+    assert np.allclose(out_field, out_field_ref)
+
+
 def test_raw_it_ir_stencil():
     @raw_itir_stencil
     def add_self(arg: Field[[IDim], "float64"]) -> Field[[IDim], "float64"]:


### PR DESCRIPTION
Some features, e.g. reductions, are still in the working or missing in the frontend. This PR adds an additional decorator `@raw_itir_stencil` that may be used inside programs or field operators to inject raw iterator IR nodes. The signature of the function needs to follow the rules of how FieldOperators are typed for the time beeing.

Example:
```python
@raw_itir_stencil
def add_self(arg: Field[[IDim], "float64"]) -> Field[[IDim], "float64"]:
    return itir.FunCall(fun=itir.SymRef(id="plus"), args=[
        itir.FunCall(fun=itir.SymRef(id="deref"), args=[arg]),
        itir.FunCall(fun=itir.SymRef(id="deref"), args=[arg])])

@program
def raw_copy_program(in_field: Field[[IDim], "float64"], out_field: Field[[IDim], "float64"]):
    add_self(in_field, out=out_field)
```