### PR TITLE
Bump C++ standard to C++17

### DIFF
--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -78,7 +78,7 @@ def get_gt_pyext_build_opts(
 
     extra_compile_args = dict(
         cxx=[
-            "-std=c++14",
+            "-std=c++17",
             "-ftemplate-depth={}".format(gt_config.build_settings["cpp_template_depth"]),
             "-fvisibility=hidden",
             "-fPIC",
@@ -89,7 +89,7 @@ def get_gt_pyext_build_opts(
             *extra_compile_args_from_config["cxx"],
         ],
         nvcc=[
-            "-std=c++14",
+            "-std=c++17",
             "-ftemplate-depth={}".format(gt_config.build_settings["cpp_template_depth"]),
             "-arch=sm_{}".format(cuda_arch),
             "-isystem={}".format(gt_include_path),


### PR DESCRIPTION
## Description

Bump C++ standard to C++17 as recent versions of GridTools use `C++17`.

In particular older GCC versions otherwise fail with errors messages ala:
```
include/gridtools/meta/find.hpp:26:65: error: 'is_same_v' is not a member of 'std'
             static constexpr bool values[sizeof...(Ts)] = {std::is_same_v<Ts, Key>...};
```

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


