### PR TITLE
Functional minor cosmetics

### DIFF
--- a/src/functional/ffront/dialect_parser.py
+++ b/src/functional/ffront/dialect_parser.py
@@ -116,7 +116,7 @@ class DialectParser(ast.NodeVisitor, Generic[DialectRootT]):
     def generic_visit(self, node: ast.AST) -> None:
         raise self._make_syntax_error(
             node,
-            message=f"Nodes of type {type(node).__module__}.{type(node).__name__} not supported in dialect.",
+            message=f"Nodes of type {type(node).__module__}.{type(node).__qualname__} not supported in dialect.",
         )
 
     def _make_loc(self, node: ast.AST) -> SourceLocation:

--- a/src/functional/ffront/dialect_parser.py
+++ b/src/functional/ffront/dialect_parser.py
@@ -125,9 +125,8 @@ class DialectParser(ast.NodeVisitor, Generic[DialectRootT]):
 
     def _make_syntax_error(self, node: ast.AST, *, message: str = "") -> DialectSyntaxError:
         err = self.syntax_error_cls.from_AST(
-            node, msg=message, filename=self.filename, text=self.source
+            node, msg=message, filename=self.filename, text=self.source, starting_line=self.starting_line
         )
-        err.lineno = (err.lineno or 1) + self.starting_line - 1
         return err
 
 
@@ -145,7 +144,7 @@ class DialectSyntaxError(common.GTSyntaxError):
         end_offset: int = None,
         text: Optional[str] = None,
     ):
-        msg = f"Invalid {self.dialect_name} Syntax: {msg}"
+        msg = f"Invalid {self.dialect_name} Syntax (`{filename}`:{lineno}): {msg}"
         super().__init__(msg, (filename, lineno, offset, text, end_lineno, end_offset))
 
     @classmethod
@@ -156,10 +155,13 @@ class DialectSyntaxError(common.GTSyntaxError):
         msg: str = "",
         filename: Optional[str] = None,
         text: Optional[str] = None,
+        # TODO(tehrengruber): remove when we preprocessed the ast to have the
+        #  correct line numbers)
+        starting_line = 0,
     ):
         return cls(
             msg,
-            lineno=node.lineno,
+            lineno=(node.lineno or 1) + starting_line - 1,
             offset=node.col_offset,
             filename=filename,
             end_lineno=node.end_lineno,

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -337,6 +337,3 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
             args=[self.visit(arg) for arg in node.args],
             location=self._make_loc(node),
         )
-
-    def generic_visit(self, node) -> None:
-        raise self._make_syntax_error(node)

--- a/src/functional/ffront/func_to_past.py
+++ b/src/functional/ffront/func_to_past.py
@@ -123,6 +123,3 @@ class ProgramParser(DialectParser[past.Program]):
     def visit_Constant(self, node: ast.Constant) -> past.Constant:
         symbol_type = symbol_makers.make_symbol_type_from_value(node.value)
         return past.Constant(value=node.value, type=symbol_type, location=self._make_loc(node))
-
-    def generic_visit(self, node) -> None:
-        raise self._make_syntax_error(node)

--- a/src/functional/ffront/func_to_past.py
+++ b/src/functional/ffront/func_to_past.py
@@ -21,11 +21,11 @@ from functional import common
 from functional.ffront import common_types
 from functional.ffront import program_ast as past
 from functional.ffront import symbol_makers
-from functional.ffront.dialect_parser import DialectParser
+from functional.ffront.dialect_parser import DialectParser, DialectSyntaxError
 from functional.ffront.past_passes.type_deduction import ProgramTypeDeduction
 
 
-class ProgramSyntaxError(common.GTSyntaxError):
+class ProgramSyntaxError(DialectSyntaxError):
     dialect_name = "Program"
 
 

--- a/src/functional/ffront/func_to_past.py
+++ b/src/functional/ffront/func_to_past.py
@@ -17,7 +17,6 @@ import ast
 import collections
 from dataclasses import dataclass
 
-from functional import common
 from functional.ffront import common_types
 from functional.ffront import program_ast as past
 from functional.ffront import symbol_makers

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -200,7 +200,7 @@ class ProgramLowering(NodeTranslator):
                     return itir.BoolLiteral(value=node.value)
                 case _:
                     raise NotImplementedError(
-                        "Scalars of kind {node.type.kind} not supported currently."
+                        f"Scalars of kind {node.type.kind} not supported currently."
                     )
 
         raise NotImplementedError("Only scalar literals supported currently.")


### PR DESCRIPTION
Minor cosmetics I found while working on RawIterator PR

- ~show filename and line number on syntax error~
- improve error message if Python ast node is not supported by dialect
- fix wrong base class of `ProgramSyntaxError`
- fix missing format string prefix