### PR TITLE
functional: Regression test for Cartesian Laplacian field view

### DIFF
--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -215,6 +215,11 @@ class FieldOperatorTypeDeduction(NodeTranslator):
         **kwargs,
     ) -> ct.SymbolType:
         left, right = TypeInfo(left_type), TypeInfo(right_type)
+
+        # TODO decide on if we support non-strict type checking
+        if left.type is None or right.type is None:
+            return None
+
         if (
             left.is_arithmetic_compatible
             and right.is_arithmetic_compatible

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -216,7 +216,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
     ) -> ct.SymbolType:
         left, right = TypeInfo(left_type), TypeInfo(right_type)
 
-        # TODO decide on if we support non-strict type checking
+        # if one type is `None` (not deduced, generic), we propagate `None`
         if left.type is None or right.type is None:
             return None
 

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -199,11 +199,31 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
             location=self._make_loc(node),
         )
 
+    @staticmethod
+    def _match_index(node: ast.expr) -> int:
+        if isinstance(node, ast.Constant):
+            return node.value
+        if (
+            isinstance(node, ast.UnaryOp)
+            and isinstance(node.op, ast.unaryop)
+            and isinstance(node.operand, ast.Constant)
+        ):
+            if isinstance(node.op, ast.USub):
+                return -node.operand.value
+            if isinstance(node.op, ast.UAdd):
+                return node.operand.value
+        raise ValueError(f"Not an index: {node}")
+
     def visit_Subscript(self, node: ast.Subscript, **kwargs) -> foast.Subscript:
-        if not isinstance(node.slice, ast.Constant):
-            raise self._make_syntax_error(node, message="""Subscript slicing not allowed!""")
+        try:
+            index = self._match_index(node.slice)
+        except ValueError:
+            raise self._make_syntax_error(node, message="""Only index is supported in subscript!""")
+
         return foast.Subscript(
-            value=self.visit(node.value), index=node.slice.value, location=self._make_loc(node)
+            value=self.visit(node.value),
+            index=index,
+            location=self._make_loc(node),
         )
 
     def visit_Tuple(self, node: ast.Tuple, **kwargs) -> foast.TupleExpr:

--- a/tests/functional_tests/ffront_tests/integration_tests/test_ffront_lap.py
+++ b/tests/functional_tests/ffront_tests/integration_tests/test_ffront_lap.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from functional.common import Field
+from functional.ffront.decorator import field_operator, program
+from functional.iterator.embedded import np_as_located_field
+from functional.iterator.runtime import CartesianAxis, offset
+
+
+IDim = CartesianAxis("IDim")
+JDim = CartesianAxis("JDim")
+
+Ioff = offset("Ioff")
+Joff = offset("Joff")
+
+
+@field_operator
+def lap(
+    in_field: Field[[IDim, JDim], "float"], a4: Field[[IDim, JDim], "float"]
+) -> Field[[IDim, JDim], "float"]:
+    return (
+        a4 * in_field
+        + in_field(Ioff[1])
+        + in_field(Joff[1])
+        + in_field(Ioff[-1])
+        + in_field(Joff[-1])
+    )
+
+
+@program
+def lap_program(
+    in_field: Field[[IDim, JDim], "float"],
+    a4: Field[[IDim, JDim], "float"],
+    out_field: Field[[IDim, JDim], "float"],
+):
+    lap(in_field, a4, out=out_field[1:-1, 1:-1])
+
+
+def expected_solution(inp):
+    return -4.0 * inp[1:-1, 1:-1] + inp[:-2, 1:-1] + inp[2:, 1:-1] + inp[1:-1, :-2] + inp[1:-1, 2:]
+
+
+def test_ffront_lap():
+    shape = (20, 20)
+    as_ij = np_as_located_field(IDim, JDim)
+    input = as_ij(np.fromfunction(lambda x, y: x ** 2 + y ** 2, shape))
+    a4 = as_ij(np.ones(shape) * -4.0)  # TODO support scalar field
+
+    result = as_ij(np.zeros_like(input))
+    lap_program(input, a4, result, offset_provider={"Ioff": IDim, "Joff": JDim})
+
+    assert np.allclose(np.asarray(result)[1:-1, 1:-1], expected_solution(np.asarray(input)))

--- a/tests/functional_tests/ffront_tests/test_error_line_number.py
+++ b/tests/functional_tests/ffront_tests/test_error_line_number.py
@@ -1,0 +1,23 @@
+import pytest
+
+from functional.common import Field
+from functional.ffront.func_to_foast import FieldOperatorParser, FieldOperatorSyntaxError
+
+
+# NOTE: This test tests includes the current filename and the line number of the marked statement
+
+
+def test_invalid_syntax_error_empty_return():
+    """Field operator syntax errors point to the file, line and column."""
+
+    def wrong_syntax(inp: Field[..., float]):
+        return  # <-- this line triggers error
+
+    with pytest.raises(
+        FieldOperatorSyntaxError,
+        match=(
+            r"Invalid Field Operator Syntax: "
+            r"Empty return not allowed \(test_error_line_number.py, line 14\)"
+        ),
+    ):
+        _ = FieldOperatorParser.apply_to_function(wrong_syntax)

--- a/tests/functional_tests/ffront_tests/test_error_line_number.py
+++ b/tests/functional_tests/ffront_tests/test_error_line_number.py
@@ -4,7 +4,7 @@ from functional.common import Field
 from functional.ffront.func_to_foast import FieldOperatorParser, FieldOperatorSyntaxError
 
 
-# NOTE: This test tests includes the current filename and the line number of the marked statement
+# NOTE: This test is sensitive to filename and the line number of the marked statement
 
 
 def test_invalid_syntax_error_empty_return():

--- a/tests/functional_tests/ffront_tests/test_interface.py
+++ b/tests/functional_tests/ffront_tests/test_interface.py
@@ -67,22 +67,6 @@ LIFT = itir.SymRef(id=lift.fun.__name__)
 
 
 # --- Parsing ---
-def test_invalid_syntax_error_empty_return():
-    """Field operator syntax errors point to the file, line and column."""
-
-    def wrong_syntax(inp: Field[..., "float64"]):
-        return
-
-    with pytest.raises(
-        FieldOperatorSyntaxError,
-        match=(
-            r"Invalid Field Operator Syntax: "
-            r"Empty return not allowed \(test_interface.py, line 74\)"
-        ),
-    ):
-        _ = FieldOperatorParser.apply_to_function(wrong_syntax)
-
-
 def test_untyped_arg():
     """Field operator parameters must be type annotated."""
 
@@ -214,6 +198,15 @@ def test_bool_or():
         match=(r"`or` operator not allowed!"),
     ):
         _ = FieldOperatorParser.apply_to_function(bool_or)
+
+
+def test_shift():
+    Offset = 0  # for parsing it doesn't matter what this object is
+
+    def shifts(a: Field[..., "bool"]):
+        return a(Offset[1]) + a(Offset[-1])  # TODO we should test these cases separate
+
+    _ = FieldOperatorParser.apply_to_function(shifts)
 
 
 # --- External symbols ---

--- a/tests/functional_tests/ffront_tests/test_interface.py
+++ b/tests/functional_tests/ffront_tests/test_interface.py
@@ -200,15 +200,6 @@ def test_bool_or():
         _ = FieldOperatorParser.apply_to_function(bool_or)
 
 
-def test_shift():
-    Offset = 0  # for parsing it doesn't matter what this object is
-
-    def shifts(a: Field[..., "bool"]):
-        return a(Offset[1]) + a(Offset[-1])  # TODO we should test these cases separate
-
-    _ = FieldOperatorParser.apply_to_function(shifts)
-
-
 # --- External symbols ---
 def test_closure_symbols():
     import numpy as np

--- a/tests/functional_tests/ffront_tests/test_lowering.py
+++ b/tests/functional_tests/ffront_tests/test_lowering.py
@@ -104,6 +104,21 @@ def test_shift():
     assert lowered.expr == reference
 
 
+def test_negative_shift():
+    Ioff = offset("Ioff")
+
+    def shift_by_one(inp: Field[[IDim], float64]):
+        return inp(Ioff[-1])
+
+    # ast_passes
+    parsed = FieldOperatorParser.apply_to_function(shift_by_one)
+    lowered = FieldOperatorLowering.apply(parsed)
+
+    reference = im.deref_(im.shift_("Ioff", -1)("inp"))
+
+    assert lowered.expr == reference
+
+
 def test_temp_assignment():
     def copy_field(inp: Field[..., "float64"]):
         tmp = inp


### PR DESCRIPTION
Adds a Laplacian example in field view.

Fixes:
- allow offset with negative index
- workaround (to be discussed): if type of rhs or lhs of binop is not deduced (`None`), propagate a `None`.

Additional:
- moved filename and line sensitive test to separate file