### PR TITLE
functional: constants as lambda without args

### DIFF
--- a/src/functional/iterator/transforms/inline_lambdas.py
+++ b/src/functional/iterator/transforms/inline_lambdas.py
@@ -8,11 +8,15 @@ class InlineLambdas(NodeTranslator):
         node = self.generic_visit(node)
         if isinstance(node.fun, ir.Lambda):
             assert len(node.fun.params) == len(node.args)
-            refs = set.union(
-                *(
-                    arg.iter_tree().if_isinstance(ir.SymRef).getattr("id").to_set()
-                    for arg in node.args
+            refs = (
+                set.union(
+                    *(
+                        arg.iter_tree().if_isinstance(ir.SymRef).getattr("id").to_set()
+                        for arg in node.args
+                    )
                 )
+                if len(node.args) > 0
+                else set()
             )
             syms = node.fun.expr.iter_tree().if_isinstance(ir.Sym).getattr("id").to_set()
             clashes = refs & syms

--- a/tests/functional_tests/iterator_tests/test_constant.py
+++ b/tests/functional_tests/iterator_tests/test_constant.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from functional.iterator.builtins import *
+from functional.iterator.embedded import np_as_located_field
+from functional.iterator.runtime import *
+
+
+IDim = CartesianAxis("IDim")
+
+
+def test_constant():
+    @fundef
+    def add_constant(inp):
+        def constant_stencil():  # this is traced as a lambda, TODO directly feed iterator IR nodes
+            return 1
+
+        return deref(inp) + deref(lift(constant_stencil)())
+
+    inp = np_as_located_field(IDim)(np.asarray([0, 42]))
+    res = np_as_located_field(IDim)(np.zeros_like(inp))
+
+    add_constant[{IDim: range(2)}](
+        inp, out=res, offset_provider={}, backend="roundtrip", debug=True
+    )
+
+    assert np.allclose(res, np.asarray([1, 43]))


### PR DESCRIPTION
Demonstrates that iterator IR can deal with lambdas without arguments. Actually, by the existing passes a `deref(lift(lambda: a_const))` is already transformed to `a_const`.