### PR TITLE
Remove FillFlushToLocalKCaches

### DIFF
--- a/src/gtc/passes/oir_pipeline.py
+++ b/src/gtc/passes/oir_pipeline.py
@@ -20,7 +20,6 @@ from typing import Callable, Optional, Protocol, Sequence, Type, Union
 from eve.visitors import NodeVisitor
 from gtc import oir
 from gtc.passes.oir_optimizations.caches import (
-    FillFlushToLocalKCaches,
     IJCacheDetection,
     KCacheDetection,
     PruneKCacheFills,
@@ -82,7 +81,6 @@ class DefaultPipeline(OirPipeline):
             KCacheDetection,
             PruneKCacheFills,
             PruneKCacheFlushes,
-            FillFlushToLocalKCaches,
         ]
 
     @property


### PR DESCRIPTION
## Description

Although this pass is disabled by default in the gtcpp backends, the pass causes issues when used with it. Therefore, it should be disabled from the default pipeline and added explicitly to gtc:cuda.