### PR TITLE
Fix Bug in Eve Exception Handling

### DIFF
--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -687,11 +687,11 @@ class TemplatedGenerator(NodeVisitor):
                     )
                 except TemplateRenderingError as e:
                     # Raise a new exception with extra information keeping the original cause
+                    e.info["node"] = node
                     raise TemplateRenderingError(
                         f"Error in '{key}' template when rendering node '{node}'.\n"
                         + getattr(e, "message", str(e)),
                         **e.info,
-                        node=node,
                     ) from e.__cause__
 
         elif isinstance(node, (list, tuple, collections.abc.Set)) or (


### PR DESCRIPTION
## Description

In some cases when a TemplateRenderingError should be raised, instead a key error pops up due to a bug in the exception handling.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


