### PR TITLE
Remove Setq

### DIFF
--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -143,7 +143,7 @@ class Program:
         lowered_funcs = [vars_[name].__gt_itir__() for name in func_names]
 
         return itir.Program(
-            function_definitions=lowered_funcs, fencil_definitions=[fencil_itir_node], setqs=[]
+            function_definitions=lowered_funcs, fencil_definitions=[fencil_itir_node]
         )
 
     def _validate_args(self, *args, **kwargs) -> None:

--- a/src/functional/iterator/backends/lisp.py
+++ b/src/functional/iterator/backends/lisp.py
@@ -17,7 +17,6 @@ class ToLispLike(TemplatedGenerator):
         """
     {''.join(function_definitions)}
     {''.join(fencil_definitions)}
-    {''.join(setqs)}
     """
     )
     StencilClosure = as_fmt(

--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -68,11 +68,6 @@ class FunctionDefinition(Node, SymbolTableTrait):
         return hash(self.id)
 
 
-class Setq(Node):
-    id: SymbolName  # noqa: A003
-    expr: Expr
-
-
 class StencilClosure(Node):
     domain: Expr
     stencil: Expr
@@ -89,7 +84,6 @@ class FencilDefinition(Node, SymbolTableTrait):
 class Program(Node, SymbolTableTrait):
     function_definitions: List[FunctionDefinition]
     fencil_definitions: List[FencilDefinition]
-    setqs: List[Setq]
 
     builtin_functions = list(
         Sym(id=name)

--- a/src/functional/iterator/tracing.py
+++ b/src/functional/iterator/tracing.py
@@ -345,7 +345,7 @@ def trace(fun, args):
             params=list(Sym(id=param) for param in param_names),
             closures=Tracer.closures,
         )
-        return Program(function_definitions=Tracer.fundefs, fencil_definitions=[fencil], setqs=[])
+        return Program(function_definitions=Tracer.fundefs, fencil_definitions=[fencil])
 
 
 def fendef_tracing(fun, *args, **kwargs):

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -74,7 +74,6 @@ def program_from_fop(
     return itir.Program(
         function_definitions=[node],
         fencil_definitions=[fencil_from_fop(node, out_name=out_name, domain=domain)],
-        setqs=[],
     )
 
 


### PR DESCRIPTION
## Description

Setq statements (aka global let statements) are currently not properly supported and thus removed from the IR.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


