### PR TITLE
Use `bool` instead of `np.bool`

### DIFF
--- a/src/gtc/numpy/npir_codegen.py
+++ b/src/gtc/numpy/npir_codegen.py
@@ -153,7 +153,11 @@ class NpirCodegen(TemplatedGenerator):
     LocalScalarAccess = ParamAccess = FormatTemplate("{name}")
 
     def visit_DataType(self, node: common.DataType, **kwargs: Any) -> Union[str, Collection[str]]:
-        return f"np.{node.name.lower()}"
+        # `np.bool` is a deprecated alias for the builtin `bool` or `np.bool_`.
+        if node not in {common.DataType.BOOL}:
+            return f"np.{node.name.lower()}"
+        else:
+            return node.name.lower()
 
     def visit_BuiltInLiteral(
         self, node: common.BuiltInLiteral, **kwargs


### PR DESCRIPTION
## Description

Uses `bool` instead of `np.bool`. Resolves the following warning:
```
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    BooleanTypes = (bool, np.bool,)
```