### PR TITLE
Functional: Return Iterator of Tuple in Lifted Scan

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -670,11 +670,10 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
                     col = np.flip(col)
 
                 if isinstance(col[0], tuple):
-                    # transpose to get tuple of columns as np array
-                    # TODO assert all entries in col have the same tuple size
-                    col = tuple(map(np.asarray, (map(list, zip(*col)))))
+                    dtype = ", ".join(np.dtype(type(c)).str for c in col[0])
+                    return np.asarray(col, dtype=dtype)
 
-                return col
+                return np.asarray(col)
 
             return impl
 

--- a/tests/functional_tests/iterator_tests/test_vertical_advection.py
+++ b/tests/functional_tests/iterator_tests/test_vertical_advection.py
@@ -8,57 +8,23 @@ from functional.iterator.runtime import *
 
 @fundef
 def tridiag_forward(state, a, b, c, d):
-    # not tracable
-    # if is_none(state):
-    #     cp_k = deref(c) / deref(b)
-    #     dp_k = deref(d) / deref(b)
-    # else:
-    #     cp_km1, dp_km1 = state
-    #     cp_k = deref(c) / (deref(b) - deref(a) * cp_km1)
-    #     dp_k = (deref(d) - deref(a) * dp_km1) / (deref(b) - deref(a) * cp_km1)
-    # return make_tuple(cp_k, dp_k)
-
-    # variant a
-    # return if_(
-    #     is_none(state),
-    #     make_tuple(deref(c) / deref(b), deref(d) / deref(b)),
-    #     make_tuple(
-    #         deref(c) / (deref(b) - deref(a) * tuple_get(0, state)),
-    #         (deref(d) - deref(a) * tuple_get(1, state))
-    #         / (deref(b) - deref(a) * tuple_get(0, state)),
-    #     ),
-    # )
-
-    # variant b
-    def initial():
-        return make_tuple(deref(c) / deref(b), deref(d) / deref(b))
-
-    def step():
-        return make_tuple(
-            deref(c) / (deref(b) - deref(a) * tuple_get(0, state)),
-            (deref(d) - deref(a) * tuple_get(1, state))
-            / (deref(b) - deref(a) * tuple_get(0, state)),
-        )
-
-    return if_(is_none(state), initial, step)()
+    return make_tuple(
+        deref(c) / (deref(b) - deref(a) * tuple_get(0, state)),
+        (deref(d) - deref(a) * tuple_get(1, state)) / (deref(b) - deref(a) * tuple_get(0, state)),
+    )
 
 
 @fundef
 def tridiag_backward(x_kp1, cp, dp):
-    # if is_none(x_kp1):
-    #     x_k = deref(dp)
-    # else:
-    #     x_k = deref(dp) - deref(cp) * x_kp1
-    # return x_k
-    return if_(is_none(x_kp1), deref(dp), deref(dp) - deref(cp) * x_kp1)
+    return deref(dp) - deref(cp) * x_kp1
 
 
 @fundef
 def solve_tridiag(a, b, c, d):
-    tup = lift(scan(tridiag_forward, True, None))(a, b, c, d)
+    tup = lift(scan(tridiag_forward, True, make_tuple(0.0, 0.0)))(a, b, c, d)
     cp = tuple_get(0, tup)
     dp = tuple_get(1, tup)
-    return scan(tridiag_backward, False, None)(cp, dp)
+    return scan(tridiag_backward, False, 0.0)(cp, dp)
 
 
 @pytest.fixture

--- a/tests/functional_tests/iterator_tests/test_vertical_advection.py
+++ b/tests/functional_tests/iterator_tests/test_vertical_advection.py
@@ -15,16 +15,17 @@ def tridiag_forward(state, a, b, c, d):
 
 
 @fundef
-def tridiag_backward(x_kp1, cp, dp):
-    return deref(dp) - deref(cp) * x_kp1
+def tridiag_backward(x_kp1, cpdp):
+    cpdpv = deref(cpdp)
+    cp = tuple_get(0, cpdpv)
+    dp = tuple_get(1, cpdpv)
+    return dp - cp * x_kp1
 
 
 @fundef
 def solve_tridiag(a, b, c, d):
-    tup = lift(scan(tridiag_forward, True, make_tuple(0.0, 0.0)))(a, b, c, d)
-    cp = tuple_get(0, tup)
-    dp = tuple_get(1, tup)
-    return scan(tridiag_backward, False, 0.0)(cp, dp)
+    cpdp = lift(scan(tridiag_forward, True, make_tuple(0.0, 0.0)))(a, b, c, d)
+    return scan(tridiag_backward, False, 0.0)(cpdp)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Lifting scans still returned a tuple of iterators instead of an iterator of tuple (and thus was not following ADR0004). Further removes unnecessary conditionals in tridiagonal solver.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


