### PR TITLE
Use centralized extent analysis in dace

### DIFF
--- a/src/gtc/dace/expansion.py
+++ b/src/gtc/dace/expansion.py
@@ -390,8 +390,8 @@ class NaiveVerticalLoopExpander(OIRLibraryNodeExpander):
                     off: Tuple[int, int]
                     for off in offsets:
                         origin = (
-                            -off[0] - he.iteration_space.i_interval.start.offset,
-                            -off[1] - he.iteration_space.j_interval.start.offset,
+                            -off[0] - he.extent[0][0],
+                            -off[1] - he.extent[1][0],
                         )
                         if name not in origins:
                             origins[name] = origin
@@ -437,8 +437,8 @@ class NaiveVerticalLoopExpander(OIRLibraryNodeExpander):
                 off: Tuple[int, int, int]
                 for off in offsets:
                     origin = (
-                        -off[0] - he.iteration_space.i_interval.start.offset,
-                        -off[1] - he.iteration_space.j_interval.start.offset,
+                        -off[0] - he.extent[0][0],
+                        -off[1] - he.extent[1][0],
                     )
                     if name not in section_origins:
                         section_origins[name] = origin
@@ -672,8 +672,8 @@ class NaiveHorizontalExecutionExpander(OIRLibraryNodeExpander):
 
         for name, origin in origins.items():
             origins[name] = (
-                -origin[0] - self.node.iteration_space.i_interval.start.offset,
-                -origin[1] - self.node.iteration_space.j_interval.start.offset,
+                -origin[0] - self.node.extent[0][0],
+                -origin[1] - self.node.extent[1][0],
                 -origin[2],
             )
         return origins
@@ -795,9 +795,17 @@ class NaiveHorizontalExecutionExpander(OIRLibraryNodeExpander):
         in_memlets, out_memlets = self.get_innermost_memlets()
         from collections import OrderedDict
 
+        j_interval = oir.Interval(
+            start=oir.AxisBound.from_start(self.node.extent[1][0]),
+            end=oir.AxisBound.from_end(self.node.extent[1][1]),
+        )
+        i_interval = oir.Interval(
+            start=oir.AxisBound.from_start(self.node.extent[0][0]),
+            end=oir.AxisBound.from_end(self.node.extent[0][1]),
+        )
         map_ranges = OrderedDict(
-            j=get_interval_range_str(self.node.iteration_space.j_interval, "__J"),
-            i=get_interval_range_str(self.node.iteration_space.i_interval, "__I"),
+            j=get_interval_range_str(j_interval, "__J"),
+            i=get_interval_range_str(i_interval, "__I"),
         )
         inputs = [name[len("IN_") :] for name in self.node.in_connectors]
         outputs = [name[len("OUT_") :] for name in self.node.out_connectors]

--- a/src/gtc/dace/nodes.py
+++ b/src/gtc/dace/nodes.py
@@ -27,14 +27,10 @@ import dace.subsets
 import networkx as nx
 from dace import library
 
+from gt4py.definitions import Extent
 from gtc import oir
 from gtc.common import DataType, LoopOrder, SourceLocation, VariableKOffset, typestr_to_data_type
-from gtc.dace.utils import (
-    CartesianIterationSpace,
-    OIRFieldRenamer,
-    dace_dtype_to_typestr,
-    get_node_name_mapping,
-)
+from gtc.dace.utils import OIRFieldRenamer, dace_dtype_to_typestr, get_node_name_mapping
 from gtc.oir import CacheDesc, HorizontalExecution, Interval, VerticalLoop, VerticalLoopSection
 
 
@@ -184,9 +180,7 @@ class HorizontalExecutionLibraryNode(OIRLibraryNode):
     default_implementation = "naive"
 
     _oir_node: Union[HorizontalExecution, PreliminaryHorizontalExecution] = None
-    iteration_space = dace.properties.Property(
-        dtype=CartesianIterationSpace, default=None, allow_none=True
-    )
+    extent = dace.properties.Property(dtype=Extent, default=None, allow_none=True)
 
     map_schedule = dace.properties.EnumProperty(
         dtype=dace.ScheduleType, default=dace.ScheduleType.Default
@@ -200,7 +194,7 @@ class HorizontalExecutionLibraryNode(OIRLibraryNode):
         self,
         name="unnamed_vloop",
         oir_node: HorizontalExecution = None,
-        iteration_space: CartesianIterationSpace = None,
+        extent: Extent = None,
         debuginfo: dace.dtypes.DebugInfo = None,
         *args,
         **kwargs,
@@ -208,7 +202,7 @@ class HorizontalExecutionLibraryNode(OIRLibraryNode):
         if oir_node is not None:
             name = "HorizontalExecution_" + str(id(oir_node))
             self._oir_node = oir_node
-            self.iteration_space = iteration_space
+            self.extent = extent
 
         super().__init__(name=name, *args, **kwargs)
         if debuginfo is None and oir_node is not None and oir_node.loc is not None:

--- a/src/gtc/passes/oir_dace_optimizations/horizontal_execution_merging.py
+++ b/src/gtc/passes/oir_dace_optimizations/horizontal_execution_merging.py
@@ -78,13 +78,13 @@ def offsets_match(
     return not conflicting
 
 
-def iteration_space_compatible(
+def extents_compatible(
     left: HorizontalExecutionLibraryNode,
     right: HorizontalExecutionLibraryNode,
     api_fields: Set[str],
 ):
 
-    if left.iteration_space == right.iteration_space:
+    if left.extent == right.extent:
         return True
 
     for conn_name in set(left.out_connectors) | set(right.out_connectors):
@@ -222,9 +222,7 @@ class GraphMerging(SingleStateTransformation):
         if len(protected_intermediate_names & output_names) > 0:
             return False
 
-        return offsets_match(left, right) and iteration_space_compatible(
-            left, right, self.api_fields
-        )
+        return offsets_match(left, right) and extents_compatible(left, right, self.api_fields)
 
     def _merge_source_locations(
         self, left: HorizontalExecutionLibraryNode, right: HorizontalExecutionLibraryNode
@@ -254,7 +252,7 @@ class GraphMerging(SingleStateTransformation):
                 body=left.as_oir().body + right.as_oir().body,
                 declarations=left.as_oir().declarations + right.as_oir().declarations,
             ),
-            iteration_space=left.iteration_space,
+            extent=left.extent,
             debuginfo=dinfo,
         )
         state.add_node(res)


### PR DESCRIPTION
This cleans up the extent analysis in the DaCe backend and relies on existing/recently merged utilities.  

This helps avoid a large part of the diff to the gtc:dace backend for the horizontal regions.
