### PR TITLE
Fix invalid use of identity comparison

### DIFF
--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -658,8 +658,11 @@ class _LvalueDimsValidator(NodeVisitor):
             raise ValueError(
                 f"Vertical loop type {vertical_loop_type} has no `loop_order` attribute"
             )
-        if not decl_type.__annotations__.get("dimensions") is Tuple[bool, bool, bool]:
-            raise ValueError(f"Field decl type {decl_type} has no `dimensions` attribute")
+        if not decl_type.__annotations__.get("dimensions") == Tuple[bool, bool, bool]:
+            raise ValueError(
+                f"Field decl type {decl_type} must have a `dimensions` "
+                "attribute of type `Tuple[bool, bool, bool]`."
+            )
         self.vertical_loop_type = vertical_loop_type
         self.decl_type = decl_type
 


### PR DESCRIPTION
I am not completely certain about the exact circumstances on why this only fails in the CI and only when pytest is run from the root directory of the GT4Py folder, but apparently parameterized types from `typing` are no singletons (or some other library is messing around in python internals). As a result some comparison using `is` instead of `==` is failing, which is fixed by this PR.