### PR TITLE
Functional: Rename `ClosureRefs` to `CapturedVars`

### DIFF
--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -32,7 +32,7 @@ from functional.ffront.func_to_foast import FieldOperatorParser
 from functional.ffront.func_to_past import ProgramParser
 from functional.ffront.past_passes.type_deduction import ProgramTypeDeduction
 from functional.ffront.past_to_itir import ProgramLowering
-from functional.ffront.source_utils import ClosureRefs
+from functional.ffront.source_utils import CapturedVars
 from functional.iterator import ir as itir
 from functional.iterator.backend_executor import execute_program
 
@@ -89,7 +89,7 @@ class Program:
 
     Attributes:
         past_node: The node representing the program.
-        closure_refs: Mapping from names referenced in the program to the
+        captured_vars: Mapping from names referenced in the program to the
             actual values.
         externals: Dictionary of externals.
         backend: The backend to be used for code generation.
@@ -97,7 +97,7 @@ class Program:
     """
 
     past_node: past.Program
-    closure_refs: ClosureRefs
+    captured_vars: CapturedVars
     externals: dict[str, Any]
     backend: Optional[str]
     definition: Optional[types.FunctionType] = None
@@ -109,11 +109,11 @@ class Program:
         externals: Optional[dict] = None,
         backend: Optional[str] = None,
     ):
-        closure_refs = ClosureRefs.from_function(definition)
+        captured_vars = CapturedVars.from_function(definition)
         past_node = ProgramParser.apply_to_function(definition)
         return cls(
             past_node=past_node,
-            closure_refs=closure_refs,
+            captured_vars=captured_vars,
             externals={} if externals is None else externals,
             backend=backend,
             definition=definition,
@@ -133,7 +133,7 @@ class Program:
             else:
                 raise NotImplementedError("Only function closure vars are allowed currently.")
 
-        vars_ = collections.ChainMap(self.closure_refs.globals, self.closure_refs.nonlocals)
+        vars_ = collections.ChainMap(self.captured_vars.globals, self.captured_vars.nonlocals)
         if undefined := (set(vars_) - set(func_names)):
             raise RuntimeError(f"Reference to undefined symbol(s) `{', '.join(undefined)}`.")
         if not_callable := [name for name in func_names if not isinstance(vars_[name], GTCallable)]:
@@ -198,7 +198,7 @@ class FieldOperator(GTCallable):
 
     Attributes:
         foast_node: The node representing the field operator.
-        closure_refs: Mapping from names referenced in the program to the
+        captured_vars: Mapping from names referenced in the program to the
             actual values.
         externals: Dictionary of externals.
         backend: The backend to be used for code generation.
@@ -206,7 +206,7 @@ class FieldOperator(GTCallable):
     """
 
     foast_node: foast.FieldOperator
-    closure_refs: ClosureRefs
+    captured_vars: CapturedVars
     externals: dict[str, Any]
     backend: Optional[str]  # note: backend is only used if directly called
     definition: Optional[types.FunctionType] = None
@@ -218,11 +218,11 @@ class FieldOperator(GTCallable):
         externals: Optional[dict] = None,
         backend: Optional[str] = None,
     ):
-        closure_refs = ClosureRefs.from_function(definition)
+        captured_vars = CapturedVars.from_function(definition)
         foast_node = FieldOperatorParser.apply_to_function(definition)
         return cls(
             foast_node=foast_node,
-            closure_refs=closure_refs,
+            captured_vars=captured_vars,
             externals=externals or {},
             backend=backend,
             definition=definition,
@@ -280,14 +280,14 @@ class FieldOperator(GTCallable):
         past_node = ProgramTypeDeduction.apply(untyped_past_node)
 
         # inject stencil as a closure var into program
-        #  since ClosureRefs is immutable we have to resort to this rather ugly way of doing a copy
-        closure_refs = dataclasses.replace(
-            self.closure_refs, globals={**self.closure_refs.globals, name: self}
+        #  since CapturedVars is immutable we have to resort to this rather ugly way of doing a copy
+        captured_vars = dataclasses.replace(
+            self.captured_vars, globals={**self.captured_vars.globals, name: self}
         )
 
         return Program(
             past_node=past_node,
-            closure_refs=closure_refs,
+            captured_vars=captured_vars,
             externals=self.externals,
             backend=self.backend,
         )

--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -274,7 +274,7 @@ class FieldOperator(GTCallable):
                     location=loc,
                 )
             ],
-            closure=[stencil_sym],
+            captured_vars=[stencil_sym],
             location=loc,
         )
         past_node = ProgramTypeDeduction.apply(untyped_past_node)

--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -127,9 +127,9 @@ class Program:
         fencil_itir_node = ProgramLowering.apply(self.past_node)
 
         func_names = []
-        for closure_var in self.past_node.closure:
-            if isinstance(closure_var.type, ct.FunctionType):
-                func_names.append(closure_var.id)
+        for captured_var in self.past_node.captured_vars:
+            if isinstance(captured_var.type, ct.FunctionType):
+                func_names.append(captured_var.id)
             else:
                 raise NotImplementedError("Only function closure vars are allowed currently.")
 

--- a/src/functional/ffront/field_operator_ast.py
+++ b/src/functional/ffront/field_operator_ast.py
@@ -163,4 +163,4 @@ class FieldOperator(LocatedNode, SymbolTableTrait):
     id: SymbolName  # noqa: A003
     params: list[DataSymbol]
     body: list[Stmt]
-    closure: list[Symbol]
+    captured_vars: list[Symbol]

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -110,7 +110,7 @@ class FieldOperatorTypeDeduction(NodeTranslator):
             id=node.id,
             params=self.visit(node.params, **kwargs),
             body=self.visit(node.body, **kwargs),
-            closure=self.visit(node.closure, **kwargs),
+            captured_vars=self.visit(node.captured_vars, **kwargs),
             location=node.location,
         )
 

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -83,11 +83,15 @@ class FieldOperatorTypeDeduction(NodeTranslator):
     >>> def example(a: "Field[..., float]", b: "Field[..., float]"):
     ...     return a + b
 
-    >>> sdef = SourceDefinition.from_function(example)
-    >>> cref = CapturedVars.from_function(example)
+    >>> source_definition = SourceDefinition.from_function(example)
+    >>> captured_vars = CapturedVars.from_function(example)
     >>> untyped_fieldop = FieldOperatorParser(
-    ...     source=sdef.source, filename=sdef.filename, starting_line=sdef.starting_line, captured_vars=cref, externals_defs={}
-    ... ).visit(ast.parse(sdef.source).body[0])
+    ...     source=source_definition.source,
+    ...     filename=source_definition.filename,
+    ...     starting_line=source_definition.starting_line,
+    ...     captured_vars=captured_vars,
+    ...     externals_defs={}
+    ... ).visit(ast.parse(source_definition.source).body[0])
     >>> assert untyped_fieldop.body[0].value.type is None
 
     >>> typed_fieldop = FieldOperatorTypeDeduction.apply(untyped_fieldop)

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -78,15 +78,15 @@ class FieldOperatorTypeDeduction(NodeTranslator):
     ---------
     >>> import ast
     >>> from functional.common import Field
-    >>> from functional.ffront.source_utils import SourceDefinition, ClosureRefs
+    >>> from functional.ffront.source_utils import SourceDefinition, CapturedVars
     >>> from functional.ffront.func_to_foast import FieldOperatorParser
     >>> def example(a: "Field[..., float]", b: "Field[..., float]"):
     ...     return a + b
 
     >>> sdef = SourceDefinition.from_function(example)
-    >>> cref = ClosureRefs.from_function(example)
+    >>> cref = CapturedVars.from_function(example)
     >>> untyped_fieldop = FieldOperatorParser(
-    ...     source=sdef.source, filename=sdef.filename, starting_line=sdef.starting_line, closure_refs=cref, externals_defs={}
+    ...     source=sdef.source, filename=sdef.filename, starting_line=sdef.starting_line, captured_vars=cref, externals_defs={}
     ... ).visit(ast.parse(sdef.source).body[0])
     >>> assert untyped_fieldop.body[0].value.type is None
 

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -89,7 +89,7 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
 
     def visit_FunctionDef(self, node: ast.FunctionDef, **kwargs) -> foast.FieldOperator:
         vars_ = collections.ChainMap(self.captured_vars.globals, self.captured_vars.nonlocals)
-        closure = [
+        captured_vars = [
             foast.Symbol(
                 id=name,
                 type=symbol_makers.make_symbol_type_from_value(val),
@@ -103,7 +103,7 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
             id=node.name,
             params=self.visit(node.args),
             body=self.visit_stmt_list(node.body),
-            closure=closure,
+            captured_vars=captured_vars,
             location=self._make_loc(node),
         )
 

--- a/src/functional/ffront/func_to_foast.py
+++ b/src/functional/ffront/func_to_foast.py
@@ -88,7 +88,7 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
         return FieldOperatorTypeDeduction.apply(dialect_ast)
 
     def visit_FunctionDef(self, node: ast.FunctionDef, **kwargs) -> foast.FieldOperator:
-        vars_ = collections.ChainMap(self.closure_refs.globals, self.closure_refs.nonlocals)
+        vars_ = collections.ChainMap(self.captured_vars.globals, self.captured_vars.nonlocals)
         closure = [
             foast.Symbol(
                 id=name,
@@ -143,7 +143,7 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
         return [self.visit_arg(arg) for arg in node.args]
 
     def visit_arg(self, node: ast.arg) -> foast.DataSymbol:
-        if (annotation := self.closure_refs.annotations.get(node.arg, None)) is None:
+        if (annotation := self.captured_vars.annotations.get(node.arg, None)) is None:
             raise self._make_syntax_error(node, message="Untyped parameters not allowed!")
         new_type = symbol_makers.make_symbol_type_from_typing(annotation)
         if not isinstance(new_type, common_types.DataType):
@@ -180,8 +180,8 @@ class FieldOperatorParser(DialectParser[foast.FieldOperator]):
             assert isinstance(
                 node.annotation, ast.Constant
             ), "Annotations should be ast.Constant(string). Use StringifyAnnotationsPass"
-            global_ns = {**fbuiltins.BUILTINS, **self.closure_refs.globals}
-            local_ns = self.closure_refs.nonlocals
+            global_ns = {**fbuiltins.BUILTINS, **self.captured_vars.globals}
+            local_ns = self.captured_vars.nonlocals
             annotation = eval(node.annotation.value, global_ns, local_ns)
             target_type = symbol_makers.make_symbol_type_from_typing(
                 annotation, global_ns=global_ns, local_ns=local_ns

--- a/src/functional/ffront/func_to_past.py
+++ b/src/functional/ffront/func_to_past.py
@@ -40,7 +40,7 @@ class ProgramParser(DialectParser[past.Program]):
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> past.Program:
         vars_ = collections.ChainMap(self.captured_vars.globals, self.captured_vars.nonlocals)
-        closure = [
+        captured_vars = [
             past.Symbol(
                 id=name,
                 type=symbol_makers.make_symbol_type_from_value(val),
@@ -54,7 +54,7 @@ class ProgramParser(DialectParser[past.Program]):
             id=node.name,
             params=self.visit(node.args),
             body=[self.visit(node) for node in node.body],
-            closure=closure,
+            captured_vars=captured_vars,
             location=self._make_loc(node),
         )
 

--- a/src/functional/ffront/func_to_past.py
+++ b/src/functional/ffront/func_to_past.py
@@ -40,7 +40,7 @@ class ProgramParser(DialectParser[past.Program]):
         return ProgramTypeDeduction.apply(output_node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> past.Program:
-        vars_ = collections.ChainMap(self.closure_refs.globals, self.closure_refs.nonlocals)
+        vars_ = collections.ChainMap(self.captured_vars.globals, self.captured_vars.nonlocals)
         closure = [
             past.Symbol(
                 id=name,
@@ -63,7 +63,7 @@ class ProgramParser(DialectParser[past.Program]):
         return [self.visit_arg(arg) for arg in node.args]
 
     def visit_arg(self, node: ast.arg) -> past.DataSymbol:
-        if (annotation := self.closure_refs.annotations.get(node.arg, None)) is None:
+        if (annotation := self.captured_vars.annotations.get(node.arg, None)) is None:
             raise self._make_syntax_error(node, message="Untyped parameters not allowed!")
         new_type = symbol_makers.make_symbol_type_from_typing(annotation)
         if not isinstance(new_type, common_types.DataType):

--- a/src/functional/ffront/program_ast.py
+++ b/src/functional/ffront/program_ast.py
@@ -93,4 +93,4 @@ class Program(LocatedNode, SymbolTableTrait):
     id: SymbolName  # noqa: A003
     params: list[Symbol[common_types.DataType]]
     body: list[Call]
-    closure: list[Symbol]
+    captured_vars: list[Symbol]

--- a/src/functional/ffront/source_utils.py
+++ b/src/functional/ffront/source_utils.py
@@ -47,7 +47,7 @@ def make_source_definition_from_function(func: Callable) -> SourceDefinition:
     return SourceDefinition(source, filename, starting_line)
 
 
-def make_closure_refs_from_function(func: Callable) -> ClosureRefs:
+def make_captured_vars_from_function(func: Callable) -> CapturedVars:
     (nonlocals, globals, inspect_builtins, inspect_unbound) = inspect.getclosurevars(  # noqa: A001
         func
     )
@@ -57,7 +57,7 @@ def make_closure_refs_from_function(func: Callable) -> ClosureRefs:
     unbound -= builtins
     annotations = typingx.get_type_hints(func)
 
-    return ClosureRefs(nonlocals, globals, annotations, builtins, unbound)
+    return CapturedVars(nonlocals, globals, annotations, builtins, unbound)
 
 
 def make_symbol_names_from_source(source: str, filename: str = MISSING_FILENAME) -> SymbolNames:
@@ -139,12 +139,16 @@ class SourceDefinition:
 
 
 @dataclass(frozen=True)
-class ClosureRefs:
+class CapturedVars:
     """
-    Mappings from names used in a Python function to the actual values.
+    Mappings from external names used in a function to the actual values.
 
-    It can be created from an actual function object using :meth:`from_function()`.
-    It also supports unpacking.
+    It can be created from an actual Python function object using
+    :meth:`from_function()`. It also supports unpacking.
+
+    .. note::
+        To avoid a name conflict with :class:`inspect.ClosureVars` we use a
+        different name here.
     """
 
     nonlocals: Mapping[str, Any]
@@ -160,7 +164,7 @@ class ClosureRefs:
         yield self.builtins
         yield self.unbound
 
-    from_function = staticmethod(make_closure_refs_from_function)
+    from_function = staticmethod(make_captured_vars_from_function)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This PR renames the `ClosureRefs` datastructure in the functional frontend to `CapturedVars`. The name `ClosureRefs` is not optimal (in my opinion) as the noun reference has a different meaning in computer science that is not meant here. The datastructure holds essentially the same information as `inspect.getclosurevars` which returns a named tuple `ClosureVars`. To avoid a name collision, the name `CapturedVars` was choosen (expressing that it holds the variables captured inside a function). Additionally the `closure` attribute of `past.Program` and `foast.FieldOperator` has been renamed, both because it does not actually store a closure and to reflect the change.