### PR TITLE
Use make_module_from_file in gtc:numpy

### DIFF
--- a/src/gt4py/backend/gtc_backend/numpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/numpy/backend.py
@@ -43,13 +43,15 @@ if TYPE_CHECKING:
 
 class GTCModuleGenerator(BaseModuleGenerator):
     def generate_imports(self) -> str:
-        comp_file = f"{self.builder.caching.module_prefix}computation{self.builder.caching.module_postfix}.py"
+        comp_pkg = (
+            self.builder.caching.module_prefix + "computation" + self.builder.caching.module_postfix
+        )
         return "\n".join(
             [
                 *super().generate_imports().splitlines(),
                 "import pathlib",
                 "from gt4py.utils import make_module_from_file",
-                f'computation = make_module_from_file("computation", pathlib.Path(__file__).parent / "{comp_file}")',
+                f'computation = make_module_from_file("{comp_pkg}", pathlib.Path(__file__).parent / "{comp_pkg}.py")',
             ]
         )
 

--- a/src/gt4py/backend/gtc_backend/numpy/backend.py
+++ b/src/gt4py/backend/gtc_backend/numpy/backend.py
@@ -43,20 +43,13 @@ if TYPE_CHECKING:
 
 class GTCModuleGenerator(BaseModuleGenerator):
     def generate_imports(self) -> str:
-        comp_pkg = (
-            self.builder.caching.module_prefix + "computation" + self.builder.caching.module_postfix
-        )
+        comp_file = f"{self.builder.caching.module_prefix}computation{self.builder.caching.module_postfix}.py"
         return "\n".join(
             [
                 *super().generate_imports().splitlines(),
-                "import sys",
                 "import pathlib",
-                "import numpy",
-                "path_backup = sys.path.copy()",
-                "sys.path.append(str(pathlib.Path(__file__).parent))",
-                f"import {comp_pkg} as computation",
-                "sys.path = path_backup",
-                "del path_backup",
+                "from gt4py.utils import make_module_from_file",
+                f'computation = make_module_from_file("computation", pathlib.Path(__file__).parent / "{comp_file}")',
             ]
         )
 

--- a/tests/test_unittest/test_backend_api.py
+++ b/tests/test_unittest/test_backend_api.py
@@ -82,7 +82,9 @@ def test_generate_bindings(backend, tmp_path):
         # standalone python computation module imported by stencil module
         result = builder.backend.generate_bindings("python")
         assert "init_1.py" in result
-        assert re.search(r"import computation", result["init_1.py"], re.MULTILINE)
+        assert re.search(
+            r"computation = make_module_from_file\(.*\)", result["init_1.py"], re.MULTILINE
+        )
     else:
         # assumption: only gt backends support python bindings for other languages than python
         if backend.name.startswith("gtc:"):


### PR DESCRIPTION
## Description

Use a load-retry loop with importlib instead of editing `sys.path` in the `gtc:numpy` backend.

Resolves https://github.com/GridTools/gt4py/issues/714.