### PR TITLE
Functional: Remove is_none

### DIFF
--- a/src/functional/iterator/builtins.py
+++ b/src/functional/iterator/builtins.py
@@ -21,7 +21,6 @@ __all__ = [
     "and_",
     "or_",
     "scan",
-    "is_none",
     "domain",
     "named_range",
 ]
@@ -56,11 +55,6 @@ def reduce(*args):
 
 @builtin_dispatch
 def scan(*args):
-    raise BackendNotSelectedError()
-
-
-@builtin_dispatch
-def is_none(*args):
     raise BackendNotSelectedError()
 
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -118,49 +118,6 @@ def reduce(fun, init):
     return sten
 
 
-class _None:
-    """Dummy object to allow execution of expression containing Nones in non-active path.
-
-    E.g.
-    `if_(is_none(state), 42, 42+state)`
-    here 42+state needs to be evaluatable even if is_none(state)
-
-    TODO: all possible arithmetic operations
-    """
-
-    def __add__(self, other):
-        return _None()
-
-    def __radd__(self, other):
-        return _None()
-
-    def __sub__(self, other):
-        return _None()
-
-    def __rsub__(self, other):
-        return _None()
-
-    def __mul__(self, other):
-        return _None()
-
-    def __rmul__(self, other):
-        return _None()
-
-    def __truediv__(self, other):
-        return _None()
-
-    def __rtruediv__(self, other):
-        return _None()
-
-    def __getitem__(self, i):
-        return _None()
-
-
-@builtins.is_none.register(EMBEDDED)
-def is_none(arg):
-    return isinstance(arg, _None)
-
-
 @builtins.domain.register(EMBEDDED)
 def domain(*args):
     return dict(args)
@@ -657,8 +614,6 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
                     _range = reversed(_range)
 
                 state = init
-                if state is None:
-                    state = _None()
                 col = []
                 for i in _range:
                     state = scan_pass(

--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -94,7 +94,6 @@ class Program(Node, SymbolTableTrait):
             "domain",
             "named_range",
             "lift",
-            "is_none",
             "make_tuple",
             "tuple_get",
             "reduce",

--- a/src/functional/iterator/tracing.py
+++ b/src/functional/iterator/tracing.py
@@ -121,11 +121,6 @@ def scan(*args):
     return _f("scan", *args)
 
 
-@iterator.builtins.is_none.register(TRACING)
-def is_none(*args):
-    return _f("is_none", *args)
-
-
 @iterator.builtins.make_tuple.register(TRACING)
 def make_tuple(*args):
     return _f("make_tuple", *args)

--- a/tests/functional_tests/iterator_tests/test_column_stencil.py
+++ b/tests/functional_tests/iterator_tests/test_column_stencil.py
@@ -78,12 +78,12 @@ def test_column_stencil_with_k_origin(backend, use_tmps):
 
 @fundef
 def sum_scanpass(state, inp):
-    return if_(is_none(state), deref(inp), state + deref(inp))
+    return state + deref(inp)
 
 
 @fundef
 def ksum(inp):
-    return scan(sum_scanpass, True, None)(inp)
+    return scan(sum_scanpass, True, 0.0)(inp)
 
 
 @fendef(column_axis=KDim)
@@ -122,7 +122,7 @@ def test_ksum_scan(backend, use_tmps):
 
 @fundef
 def ksum_back(inp):
-    return scan(sum_scanpass, False, None)(inp)
+    return scan(sum_scanpass, False, 0.0)(inp)
 
 
 @fendef(column_axis=KDim)


### PR DESCRIPTION
## Description

Removes the last uses and support of `is_none`. Optional return values in `deref` have been replaced by `can_deref` checks before.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


