### PR TITLE
Do not interpolate mask when indexing with an ndarray

### DIFF
--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -217,13 +217,17 @@ class Storage(np.ndarray):
                 self.__dict__ = {**obj.__dict__, **self.__dict__}
                 self.is_stencil_view = False
                 if hasattr(obj, "_new_index"):
-                    index_iter = itertools.chain(
-                        obj._new_index, [slice(None, None)] * (len(obj.mask) - len(obj._new_index))
-                    )
-                    interpolated_mask = gt_utils.interpolate_mask(
-                        (isinstance(x, slice) for x in index_iter), obj.mask, False
-                    )
-                    self._mask = tuple(x & y for x, y in zip(obj.mask, interpolated_mask))
+                    if any(not isinstance(x, slice) for x in obj._new_index) and not isinstance(
+                        obj._new_index[0], np.ndarray
+                    ):
+                        index_iter = itertools.chain(
+                            obj._new_index,
+                            [slice(None, None)] * (len(obj.mask) - len(obj._new_index)),
+                        )
+                        interpolated_mask = gt_utils.interpolate_mask(
+                            (isinstance(x, slice) for x in index_iter), obj.mask, False
+                        )
+                        self._mask = tuple(x & y for x, y in zip(obj.mask, interpolated_mask))
                     delattr(obj, "_new_index")
                 if not hasattr(obj, "default_origin"):
                     self.is_stencil_view = True


### PR DESCRIPTION
## Description

This fixes a bug when indexing CPU storages using the numpy-style boolean ndarray.

Also makes a small optimization that skips mask propagation when all the axes are present.