### PR TITLE
Set dacecache inside .gt_cache_pytest_*

### DIFF
--- a/tests/test_integration/test_dace_parsing.py
+++ b/tests/test_integration/test_dace_parsing.py
@@ -1,9 +1,11 @@
+import pathlib
 import re
 
 import hypothesis.strategies as hyp_st
 import numpy as np
 import pytest
 
+import gt4py.config
 from gt4py import gtscript
 from gt4py import storage as gt_storage
 from gt4py.gtscript import PARALLEL, computation, interval
@@ -17,9 +19,14 @@ pytestmark = pytest.mark.usefixtures("dace_env")
 
 @pytest.fixture(scope="module")
 def dace_env():
+    gt_cache_path = (
+        pathlib.Path(gt4py.config.cache_settings["root_path"])
+        / gt4py.config.cache_settings["dir_name"]
+        / "dacecache"
+    )
     with dace.config.set_temporary("compiler", "cpu", "args", value=""), dace.config.set_temporary(
         "compiler", "allow_view_arguments", value=True
-    ):
+    ), dace.config.set_temporary("default_build_folder", value=gt_cache_path):
         yield
 
 

--- a/tests/test_integration/test_dace_parsing.py
+++ b/tests/test_integration/test_dace_parsing.py
@@ -24,9 +24,10 @@ def dace_env():
         / gt4py.config.cache_settings["dir_name"]
         / "dacecache"
     )
-    with dace.config.set_temporary("compiler", "cpu", "args", value=""), dace.config.set_temporary(
-        "compiler", "allow_view_arguments", value=True
-    ), dace.config.set_temporary("default_build_folder", value=gt_cache_path):
+    with dace.config.temporary_config():
+        dace.config.Config.set("compiler", "cpu", "args", value="")
+        dace.config.Config.set("compiler", "allow_view_arguments", value=True)
+        dace.config.Config.set("default_build_folder", value=gt_cache_path)
         yield
 
 


### PR DESCRIPTION
This PR sets the dacecache folder to inside .gt_cache_pytest_* folder to avoid issues with cached dace configs.