### PR TITLE
Centralize additional file cache

### DIFF
--- a/src/gt4py/backend/gtc_backend/common.py
+++ b/src/gt4py/backend/gtc_backend/common.py
@@ -17,6 +17,7 @@
 
 import abc
 import os
+import pathlib
 import textwrap
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
@@ -305,10 +306,11 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
             stencil_ir = self.builder.gtir
         # Generate source
         if not self.builder.options._impl_opts.get("disable-code-generation", False):
-            gt_pyext_sources: Dict[str, Any] = self.make_extension_sources(stencil_ir=stencil_ir)
-            gt_pyext_sources = {**gt_pyext_sources["computation"], **gt_pyext_sources["bindings"]}
+            gt_pyext_files: Dict[str, Any] = self.make_extension_sources(stencil_ir=stencil_ir)
+            gt_pyext_sources = {**gt_pyext_files["computation"], **gt_pyext_files["bindings"]}
         else:
             # Pass NOTHING to the self.builder means try to reuse the source code files
+            gt_pyext_files = {}
             gt_pyext_sources = {
                 key: gt_utils.NOTHING for key in self.PYEXT_GENERATOR_CLASS.TEMPLATE_FILES.keys()
             }
@@ -332,6 +334,12 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
 
         result = self.build_extension_module(gt_pyext_sources, pyext_opts, uses_cuda=uses_cuda)
 
+        for filename, content in gt_pyext_files.get("info", {}).items():
+            stencil_cache_dir = pathlib.Path(
+                os.path.relpath(self.builder.module_path.parent, pathlib.Path.cwd())
+            )
+            with open(stencil_cache_dir / filename, "w+") as handle:
+                handle.write(content)
         if build_info is not None:
             build_info["build_time"] = time.perf_counter() - start_time
 

--- a/src/gt4py/backend/gtc_backend/common.py
+++ b/src/gt4py/backend/gtc_backend/common.py
@@ -305,8 +305,9 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
         if not stencil_ir:
             stencil_ir = self.builder.gtir
         # Generate source
+        gt_pyext_files: Dict[str, Any]
         if not self.builder.options._impl_opts.get("disable-code-generation", False):
-            gt_pyext_files: Dict[str, Any] = self.make_extension_sources(stencil_ir=stencil_ir)
+            gt_pyext_files = self.make_extension_sources(stencil_ir=stencil_ir)
             gt_pyext_sources = {**gt_pyext_files["computation"], **gt_pyext_files["bindings"]}
         else:
             # Pass NOTHING to the self.builder means try to reuse the source code files

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type
 import dace
 import numpy as np
 from dace.sdfg.utils import fuse_states, inline_sdfgs
+from dace.serialize import dumps
 
 from eve import codegen
 from eve.codegen import MakoTemplate as as_mako
@@ -106,6 +107,8 @@ class GTCDaCeExtGenerator(BackendCodegen):
         oir_node = oir_pipeline.run(base_oir)
         sdfg = OirSDFGBuilder().visit(oir_node)
 
+        unexpanded_sdfg_json = dumps(sdfg.to_json())
+
         sdfg = _expand_and_finalize_sdfg(stencil_ir, sdfg, self.backend.storage_info["layout_map"])
 
         for tmp_sdfg in sdfg.all_sdfgs_recursive():
@@ -129,6 +132,7 @@ class GTCDaCeExtGenerator(BackendCodegen):
         sources = {
             "computation": {"computation.hpp": implementation},
             "bindings": {"bindings.cpp": bindings},
+            "info": {self.backend.builder.module_name + ".sdfg": unexpanded_sdfg_json},
         }
         return sources
 

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -107,20 +107,12 @@ class GTCDaCeExtGenerator(BackendCodegen):
         oir_node = oir_pipeline.run(base_oir)
         sdfg = OirSDFGBuilder().visit(oir_node)
 
-        unexpanded_sdfg_json = dumps(sdfg.to_json())
-
-        sdfg = _expand_and_finalize_sdfg(stencil_ir, sdfg, self.backend.storage_info["layout_map"])
-
         for tmp_sdfg in sdfg.all_sdfgs_recursive():
             tmp_sdfg.transformation_hist = []
             tmp_sdfg.orig_sdfg = None
+        unexpanded_sdfg_json = dumps(sdfg.to_json())
 
-        sdfg.save(
-            self.backend.builder.module_path.joinpath(
-                os.path.dirname(self.backend.builder.module_path),
-                self.backend.builder.module_name + ".sdfg",
-            )
-        )
+        sdfg = _expand_and_finalize_sdfg(stencil_ir, sdfg, self.backend.storage_info["layout_map"])
 
         sources: Dict[str, Dict[str, str]]
         implementation = DaCeComputationCodegen.apply(stencil_ir, sdfg)


### PR DESCRIPTION
The DaCe backend saves SDFG in addtition to the source files used for compilation or bindings, which are used if the stencils are used in a dace-orchestrated context.

To avoid saving files in different places, this functionality was already added with #713 but implicitly removed by the concurrently developed #673, which moved the file generation to a different code path.

This PR reinstates that.