### PR TITLE
Add gtc:dace:gpu backend

### DIFF
--- a/src/gt4py/backend/__init__.py
+++ b/src/gt4py/backend/__init__.py
@@ -35,7 +35,7 @@ from .gtc_backend import (
 
 
 try:
-    from .gtc_backend import GTCDaceBackend
+    from .gtc_backend import GTCDaceCPUBackend, GTCDaceGPUBackend
 except ImportError:
     pass
 

--- a/src/gt4py/backend/gtc_backend/__init__.py
+++ b/src/gt4py/backend/gtc_backend/__init__.py
@@ -24,6 +24,6 @@ from .numpy.backend import GTCNumpyBackend  # noqa: F401
 
 
 try:
-    from .dace.backend import GTCDaceBackend  # noqa: F401
+    from .dace.backend import GTCDaceCPUBackend, GTCDaceGPUBackend  # noqa: F401
 except ImportError:
     pass

--- a/src/gt4py/backend/gtc_backend/common.py
+++ b/src/gt4py/backend/gtc_backend/common.py
@@ -57,21 +57,24 @@ def pybuffer_to_sid(
     domain_dim_flags: Tuple[bool, bool, bool],
     data_ndim: int,
     stride_kind_index: int,
+    check_layout: bool = True,
     backend,
 ):
     domain_ndim = domain_dim_flags.count(True)
     sid_ndim = domain_ndim + data_ndim
 
-    as_sid = "as_cuda_sid" if backend.GT_BACKEND_T == "gpu" else "as_sid"
+    as_sid = "as_cuda_sid" if backend.storage_info["device"] == "gpu" else "as_sid"
 
     sid_def = """gt::{as_sid}<{ctype}, {sid_ndim},
-        gt::integral_constant<int, {unique_index}>, {unit_stride_dim}>({name})""".format(
+        gt::integral_constant<int, {unique_index}>{unit_stride_dim}>({name})""".format(
         name=name,
         ctype=ctype,
         unique_index=stride_kind_index,
         sid_ndim=sid_ndim,
         as_sid=as_sid,
-        unit_stride_dim=_get_unit_stride_dim(backend, domain_dim_flags, data_ndim),
+        unit_stride_dim=f", {_get_unit_stride_dim(backend, domain_dim_flags, data_ndim)}"
+        if check_layout
+        else "",
     )
     sid_def = "gt::sid::shift_sid_origin({sid_def}, {name}_origin)".format(
         sid_def=sid_def,

--- a/src/gt4py/backend/gtc_backend/common.py
+++ b/src/gt4py/backend/gtc_backend/common.py
@@ -29,6 +29,7 @@ from eve.codegen import MakoTemplate as as_mako
 from gt4py import backend as gt_backend
 from gt4py import ir as gt_ir
 from gt4py import utils as gt_utils
+from gt4py.backend import Backend
 from gt4py.backend.module_generator import BaseModuleGenerator, ModuleData
 from gt4py.definitions import AccessKind
 from gtc import gtir
@@ -57,8 +58,8 @@ def pybuffer_to_sid(
     domain_dim_flags: Tuple[bool, bool, bool],
     data_ndim: int,
     stride_kind_index: int,
+    backend: Backend,
     check_layout: bool = True,
-    backend,
 ):
     domain_ndim = domain_dim_flags.count(True)
     sid_ndim = domain_ndim + data_ndim

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -69,7 +69,8 @@ def _specialize_transient_strides(sdfg: dace.SDFG, layout_map):
             sdfg.remove_symbol(k)
 
 
-def _to_device(sdfg: dace.SDFG, device):
+def _to_device(sdfg: dace.SDFG, device: str) -> None:
+    """Updates sdfg in place."""
     if device == "gpu":
         for array in sdfg.arrays.values():
             array.storage = dace.StorageType.GPU_Global

--- a/src/gt4py/backend/gtc_backend/dace/backend.py
+++ b/src/gt4py/backend/gtc_backend/dace/backend.py
@@ -269,11 +269,10 @@ class DaCeComputationCodegen:
         field_extents = compute_fields_extents(oir, add_k=True)
 
         offset_dict: Dict[str, Tuple[int, int, int]] = {
-            k: (max(-v[0][0], 0), max(-v[1][0], 0), 0) for k, v in field_extents.items()
+            k: (max(-v[0][0], 0), max(-v[1][0], 0), -v[2][0]) for k, v in field_extents.items()
         }
         k_origins = {
-            field_name: max(boundary[0], 0)
-            for field_name, boundary in compute_k_boundary(ir).items()
+            field_name: boundary[0] for field_name, boundary in compute_k_boundary(ir).items()
         }
         for name, origin in k_origins.items():
             offset_dict[name] = (offset_dict[name][0], offset_dict[name][1], origin)

--- a/src/gt4py/backend/pyext_builder.py
+++ b/src/gt4py/backend/pyext_builder.py
@@ -122,6 +122,9 @@ def get_gt_pyext_build_opts(
         extra_compile_args["cxx"].append(
             "-isystem{}".format(os.path.join(dace_path, "runtime/include"))
         )
+        extra_compile_args["nvcc"].append(
+            "-isystem={}".format(os.path.join(dace_path, "runtime/include"))
+        )
 
     if add_profile_info:
         profile_flags = ["-pg"]

--- a/src/gtc/dace/expansion.py
+++ b/src/gtc/dace/expansion.py
@@ -997,7 +997,7 @@ class BlockVerticalLoopExpander(NaiveVerticalLoopExpander):
         for _, section in self.node.sections:
             for node, _ in section.all_nodes_recursive():
                 if isinstance(node, HorizontalExecutionLibraryNode):
-                    extent_bounding_box = extent_bounding_box | node.extent
+                    extent_bounding_box = extent_bounding_box & node.extent
 
         j_interval = oir.Interval(
             start=oir.AxisBound.from_start(extent_bounding_box[1][0]),

--- a/src/gtc/dace/expansion.py
+++ b/src/gtc/dace/expansion.py
@@ -926,6 +926,268 @@ class NaiveHorizontalExecutionExpander(OIRLibraryNodeExpander):
                 tasklet.in_connectors[edge.dst_conn] = dace.pointer(array.dtype)
 
 
+class BlockVerticalLoopExpander(NaiveVerticalLoopExpander):
+
+    default_tile_sizes = (64, 8)
+
+    def get_tiled_subset_strs(self, nsdfg, extent):
+        tile_sizes = self.node.tile_sizes or self.default_tile_sizes
+
+        access_collection = get_access_collection(nsdfg.sdfg)
+        region_fields = {
+            acc.field
+            for acc in access_collection.ordered_accesses()
+            if acc.horizontal_mask is not None
+        }
+
+        # collect inner subsets
+        inner_subsets: Dict[str, dace.subsets.Subset] = dict()
+        for state in nsdfg.sdfg.states():
+            for edge in state.edges():
+                if edge.data.data is not None:
+                    name = edge.data.data
+                    array: dace.data.Array = nsdfg.sdfg.arrays[name]
+                    dims = array_dimensions(array)
+
+                    ij_subset = dace.subsets.Range(edge.data.subset.ranges[: sum(dims[:2])])
+                    subset_union = inner_subsets.get(name, ij_subset)
+                    inner_subsets[name] = dace.subsets.union(subset_union, ij_subset)
+
+        # confine subset to tile
+        for name, subset in inner_subsets.items():
+            if name in region_fields:
+                continue
+            array: dace.data.Array = nsdfg.sdfg.arrays[name]
+            dims = array_dimensions(array)
+            if dims[0]:
+                irange = list(subset.ranges[0])
+                irange[0] += dace.symbol("tile_i")
+                irange[1] = dace.symbolic.pystr_to_symbolic(irange[1]).replace(
+                    dace.symbol("__I"),
+                    dace.symbolic.pystr_to_symbolic(f"min(tile_i+({tile_sizes[0]}),__I)"),
+                )
+                subset.ranges[0] = tuple(irange)
+            if dims[1]:
+                j_idx = 1 if dims[0] else 0
+                jrange = list(subset.ranges[j_idx])
+                jrange[0] += dace.symbol("tile_j")
+                jrange[1] = dace.symbolic.pystr_to_symbolic(jrange[1]).replace(
+                    dace.symbol("__J"),
+                    dace.symbolic.pystr_to_symbolic(f"min(tile_j+({tile_sizes[1]}),__J)"),
+                )
+                subset.ranges[1] = tuple(jrange)
+        for name, subset in inner_subsets.items():
+
+            array: dace.data.Array = nsdfg.sdfg.arrays[name]
+            dims = array_dimensions(array)
+            inner_subsets[name] = dace.subsets.Range(
+                subset.ranges + [(0, s - 1, 1) for s in array.shape[sum(dims[:2]) :]]
+            )
+        return {k: str(v) for k, v in inner_subsets.items()}
+
+    def _device_map_add_nodes(self, nsdfg):
+
+        self.res_state.add_node(nsdfg)
+
+        nsdfg.sdfg.parent = self.res_state
+        nsdfg.sdfg.parent_sdfg = self.res_state.parent
+        nsdfg.sdfg.parent_nsdfg_node = nsdfg
+
+        extent_bounding_box = Extent.zeros(2)
+        for _, section in self.node.sections:
+            for node, _ in section.all_nodes_recursive():
+                if isinstance(node, HorizontalExecutionLibraryNode):
+                    extent_bounding_box = extent_bounding_box | node.extent
+
+        j_interval = oir.Interval(
+            start=oir.AxisBound.from_start(extent_bounding_box[1][0]),
+            end=oir.AxisBound.from_end(extent_bounding_box[1][1]),
+        )
+        i_interval = oir.Interval(
+            start=oir.AxisBound.from_start(extent_bounding_box[0][0]),
+            end=oir.AxisBound.from_end(extent_bounding_box[0][1]),
+        )
+
+        i_range = get_interval_range_str(i_interval, "__I")
+        j_range = get_interval_range_str(j_interval, "__J")
+        tile_sizes = self.node.tile_sizes or self.default_tile_sizes
+        from collections import OrderedDict
+
+        ndrange = OrderedDict(
+            tile_j=f"{j_range}:{tile_sizes[1]}",
+            tile_i=f"{i_range}:{tile_sizes[0]}",
+        )
+
+        map_entry, map_exit = self.res_state.add_map(
+            self.node.name + "_device_map", ndrange, schedule=self.node.tiling_map_schedule
+        )
+        subset_strs = self.get_tiled_subset_strs(nsdfg, extent_bounding_box)
+        if not nsdfg.in_connectors:
+            self.res_state.add_edge(map_entry, None, nsdfg, None, dace.Memlet())
+        for name in nsdfg.in_connectors:
+            subset_all = ",".join(f"0:{s}" for s in self.res_sdfg.arrays[name].shape)
+            read_node = self.res_state.add_read(name)
+            self.res_state.add_edge_pair(
+                scope_node=map_entry,
+                external_node=read_node,
+                internal_node=nsdfg,
+                internal_connector=name,
+                internal_memlet=dace.Memlet.simple(name, subset_strs[name]),
+                external_memlet=dace.Memlet.simple(name, subset_all),
+                scope_connector=name,
+            )
+        if not nsdfg.out_connectors:
+            self.res_state.add_edge(nsdfg, None, map_exit, None, dace.Memlet())
+        for name in nsdfg.out_connectors:
+            subset_all = ",".join(f"0:{s}" for s in self.res_sdfg.arrays[name].shape)
+            write_node = self.res_state.add_write(name)
+            self.res_state.add_edge_pair(
+                scope_node=map_exit,
+                external_node=write_node,
+                internal_node=nsdfg,
+                internal_connector=name,
+                internal_memlet=dace.Memlet.simple(name, subset_strs[name]),
+                external_memlet=dace.Memlet.simple(name, subset_all),
+                scope_connector=name,
+            )
+
+    def _device_map_set_map_ranges(self, nsdfg):
+        tile_i_sym = dace.symbol("tile_i", dtype=dace.int32)
+        tile_j_sym = dace.symbol("tile_j", dtype=dace.int32)
+        global_I_sym = dace.symbol("__global_I", dtype=dace.int32)
+        global_J_sym = dace.symbol("__global_J", dtype=dace.int32)
+        state: dace.SDFGState
+        access_collection: AccessCollector.CartesianAccessCollection = get_access_collection(
+            self.node
+        )
+        region_fields = {
+            acc.field
+            for acc in access_collection.ordered_accesses()
+            if acc.horizontal_mask is not None
+        }
+        for edge, state in nsdfg.sdfg.all_edges_recursive():
+            if (
+                isinstance(edge.data, dace.InterstateEdge)
+                or edge.data.data is None
+                or edge.data.data not in region_fields
+            ):
+                continue
+
+            is_he_edge = isinstance(edge.dst, HorizontalExecutionLibraryNode) or isinstance(
+                edge.src, HorizontalExecutionLibraryNode
+            )
+            if is_he_edge:
+                if isinstance(edge.dst, HorizontalExecutionLibraryNode):
+                    node = edge.dst
+                else:
+                    node = edge.src
+                he_access_collection: AccessCollector.CartesianAccessCollection = (
+                    get_access_collection(node)
+                )
+                he_region_fields = {
+                    acc.field
+                    for acc in he_access_collection.ordered_accesses()
+                    if acc.horizontal_mask is not None
+                }
+            else:
+                he_region_fields = set()
+            if is_he_edge and edge.data.data not in he_region_fields:
+                dims = array_dimensions(self.res_sdfg.arrays[edge.data.data])
+                if dims[0]:
+                    irange = list(edge.data.subset.ranges[0])
+                    irange[0] += tile_i_sym
+                    irange[1] += tile_i_sym
+                    edge.data.subset.ranges[0] = tuple(irange)
+                if dims[1]:
+                    jrange = list(edge.data.subset.ranges[1 if dims[0] else 0])
+                    jrange[0] += tile_j_sym
+                    jrange[1] += tile_j_sym
+                    edge.data.subset.ranges[1 if dims[0] else 0] = tuple(jrange)
+            else:
+                edge.data.subset.replace(
+                    {
+                        dace.symbol("__I"): global_I_sym,
+                        dace.symbol("__J"): global_J_sym,
+                    }
+                )
+
+                array = state.parent.arrays[edge.data.data]
+                shape = list(dace.symbolic.pystr_to_symbolic(s) for s in array.shape)
+                for i, s in enumerate(shape):
+                    s = s.replace(dace.symbol("__I"), global_I_sym)
+                    s = s.replace(dace.symbol("__J"), global_J_sym)
+                    shape[i] = s
+                array.shape = tuple(shape)
+
+    def _device_map_fix_symbols(self, nsdfg):
+
+        tile_i_sym = dace.symbol("tile_i", dtype=dace.int32)
+        tile_j_sym = dace.symbol("tile_j", dtype=dace.int32)
+        global_I_sym = dace.symbol("__global_I", dtype=dace.int32)
+        global_J_sym = dace.symbol("__global_J", dtype=dace.int32)
+        tile_sizes = self.node.tile_sizes or self.default_tile_sizes
+        nsdfg.symbol_mapping["__I"] = dace.symbolic.pystr_to_symbolic(
+            f"min({tile_sizes[0]}, __I - tile_i )"
+        )
+        nsdfg.symbol_mapping["__J"] = dace.symbolic.pystr_to_symbolic(
+            f"min({tile_sizes[1]}, __J - tile_j )"
+        )
+
+        if "tile_i" not in nsdfg.sdfg.symbols:
+            nsdfg.sdfg.add_symbol("tile_i", dace.int32)
+        if "tile_j" not in nsdfg.sdfg.symbols:
+            nsdfg.sdfg.add_symbol("tile_j", dace.int32)
+        if "__global_I" not in nsdfg.sdfg.symbols:
+            nsdfg.sdfg.add_symbol("__global_I", dace.int32)
+        if "__global_J" not in nsdfg.sdfg.symbols:
+            nsdfg.sdfg.add_symbol("__global_J", dace.int32)
+
+        for node, _ in nsdfg.sdfg.all_nodes_recursive():
+            if isinstance(node, HorizontalExecutionLibraryNode):
+                node.index_symbols = ["(tile_i+i)", "(tile_j+j)", "0"]
+                node.global_domain_symbols = ["__global_I", "__global_J"]
+            elif isinstance(node, dace.nodes.NestedSDFG):
+                node.symbol_mapping["tile_i"] = tile_i_sym
+                node.symbol_mapping["tile_j"] = tile_j_sym
+                node.symbol_mapping["__global_I"] = global_I_sym
+                node.symbol_mapping["__global_J"] = global_J_sym
+                if "tile_i" not in node.sdfg.symbols:
+                    node.sdfg.add_symbol("tile_i", dace.int32)
+                if "tile_j" not in node.sdfg.symbols:
+                    node.sdfg.add_symbol("tile_j", dace.int32)
+                if "__global_I" not in node.sdfg.symbols:
+                    node.sdfg.add_symbol("__global_I", dace.int32)
+                if "__global_J" not in node.sdfg.symbols:
+                    node.sdfg.add_symbol("__global_J", dace.int32)
+
+        nsdfg.symbol_mapping["__global_I"] = dace.symbolic.pystr_to_symbolic("__I")
+        nsdfg.symbol_mapping["__global_J"] = dace.symbolic.pystr_to_symbolic("__J")
+        nsdfg.symbol_mapping["tile_i"] = tile_i_sym
+        nsdfg.symbol_mapping["tile_j"] = tile_j_sym
+
+    def device_map(self, nsdfg):
+        self._device_map_add_nodes(nsdfg)
+        self._device_map_set_map_ranges(nsdfg)
+        self._device_map_fix_symbols(nsdfg)
+
+
+class SequentialBlockLoopExpander(BlockVerticalLoopExpander):
+    def add_nodes_and_edges(self):
+        inner_expander = SequentialNaiveVerticalLoopExpander(
+            self.node, self.parent_state, self.parent_sdfg, fix_context_memlets=False
+        )
+        res_nsdfg = inner_expander.expand()
+        self.device_map(res_nsdfg)
+
+
+class ParallelBlockLoopExpander(BlockVerticalLoopExpander):
+    def add_nodes_and_edges(self):
+        res = ParallelNaiveVerticalLoopExpander(
+            self.node, self.parent_state, self.parent_sdfg, fix_context_memlets=False
+        ).expand()
+        self.device_map(res)
+
+
 @dace.library.register_expansion(VerticalLoopLibraryNode, "naive")
 class NaiveVerticalLoopExpansion(dace.library.ExpandTransformation):
     environments: List = []
@@ -940,6 +1202,22 @@ class NaiveVerticalLoopExpansion(dace.library.ExpandTransformation):
             return ParallelNaiveVerticalLoopExpander(node, parent_state, parent_sdfg).expand()
         else:
             return SequentialNaiveVerticalLoopExpander(node, parent_state, parent_sdfg).expand()
+
+
+@dace.library.register_expansion(VerticalLoopLibraryNode, "block")
+class BlockVerticalLoopExpansion(dace.library.ExpandTransformation):
+    environments: List = []
+
+    @staticmethod
+    def expansion(
+        node: "VerticalLoopLibraryNode", parent_state: dace.SDFGState, parent_sdfg: dace.SDFG
+    ) -> dace.nodes.NestedSDFG:
+        from gtc.common import LoopOrder
+
+        if node.loop_order == LoopOrder.PARALLEL:
+            return ParallelBlockLoopExpander(node, parent_state, parent_sdfg).expand()
+        else:
+            return SequentialBlockLoopExpander(node, parent_state, parent_sdfg).expand()
 
 
 @dace.library.register_expansion(HorizontalExecutionLibraryNode, "naive")

--- a/src/gtc/dace/utils.py
+++ b/src/gtc/dace/utils.py
@@ -490,3 +490,23 @@ def is_sdfg_equal(sdfg1: dace.SDFG, sdfg2: dace.SDFG):
         ):
             return False
     return True
+
+
+def layout_maker_factory(base_layout):
+    def layout_maker(mask):
+        ranks = []
+        for m, l in zip(mask, base_layout):
+            if m:
+                ranks.append(l)
+        if len(mask) > 3:
+            if base_layout[2] == 2:
+                ranks.extend(3 + c for c in range(len(mask) - 3))
+            else:
+                ranks.extend(-c for c in range(len(mask) - 3))
+
+        res_layout = [0] * len(ranks)
+        for i, idx in enumerate(np.argsort(ranks)):
+            res_layout[idx] = i
+        return tuple(res_layout)
+
+    return layout_maker

--- a/src/gtc/dace/utils.py
+++ b/src/gtc/dace/utils.py
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
-from typing import TYPE_CHECKING, Any, Collection, Dict, Iterator, List, Union
+from typing import TYPE_CHECKING, Any, Callable, Collection, Dict, Iterator, List, Tuple, Union
 
 import dace
 import dace.data
@@ -492,8 +492,8 @@ def is_sdfg_equal(sdfg1: dace.SDFG, sdfg2: dace.SDFG):
     return True
 
 
-def layout_maker_factory(base_layout):
-    def layout_maker(mask):
+def layout_maker_factory(base_layout: Tuple[int, ...]) -> Callable[[List[bool]], Tuple[int, ...]]:
+    def layout_maker(mask: List[bool]) -> Tuple[int, ...]:
         ranks = []
         for m, l in zip(mask, base_layout):
             if m:

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -156,7 +156,7 @@ def test_stage_merger_induced_interval_block_reordering(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_lower_dimensional_inputs(backend):
-    @gtscript.stencil(backend=backend)
+    @gtscript.stencil(backend=backend, debug_mode=True, verbose=True)
     def stencil(
         field_3d: gtscript.Field[gtscript.IJK, np.float_],
         field_2d: gtscript.Field[gtscript.IJ, np.float_],

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -156,7 +156,7 @@ def test_stage_merger_induced_interval_block_reordering(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_lower_dimensional_inputs(backend):
-    @gtscript.stencil(backend=backend, debug_mode=True, verbose=True)
+    @gtscript.stencil(backend=backend)
     def stencil(
         field_3d: gtscript.Field[gtscript.IJK, np.float_],
         field_2d: gtscript.Field[gtscript.IJ, np.float_],

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -386,10 +386,7 @@ def test_variable_offsets_and_while_loop(backend):
                 qout = qsum / (pe2[0, 0, 1] - pe2)
 
 
-# TODO: Enable DaCe
-@pytest.mark.parametrize(
-    "backend", [backend for backend in ALL_BACKENDS if backend.values[0] != "gtc:dace"]
-)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_nested_while_loop(backend):
     @gtscript.stencil(backend=backend)
     def stencil(

--- a/tests/test_integration/test_dace_parsing.py
+++ b/tests/test_integration/test_dace_parsing.py
@@ -33,7 +33,7 @@ def dace_env():
 
 @pytest.fixture
 def dace_stencil():
-    @gtscript.stencil(backend="gtc:dace")
+    @gtscript.stencil(backend="gtc:dace:cpu")
     def defn(inp: gtscript.Field[np.float64], outp: gtscript.Field[np.float64]):
         with computation(PARALLEL), interval(...):
             outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
@@ -50,13 +50,13 @@ def tuple_st(min_value, max_value):
 
 
 def test_basic():
-    @gtscript.stencil(backend="gtc:dace")
+    @gtscript.stencil(backend="gtc:dace:cpu")
     def defn(outp: gtscript.Field[np.float64], par: np.float64):
         with computation(PARALLEL), interval(...):
             outp = par  # noqa F841: local variable 'outp' is assigned to but never used
 
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     inp = 7.0
@@ -79,10 +79,14 @@ def test_origin_offsetting_frozen(dace_stencil, domain, outp_origin):
     )
 
     inp = gt_storage.from_array(
-        data=7.0, dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        data=7.0,
+        dtype=np.float64,
+        shape=(10, 10, 10),
+        default_origin=(0, 0, 0),
+        backend="gtc:dace:cpu",
     )
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     @dace.program
@@ -108,10 +112,14 @@ def test_origin_offsetting_frozen(dace_stencil, domain, outp_origin):
 def test_origin_offsetting_nofrozen(dace_stencil, domain, outp_origin):
 
     inp = gt_storage.from_array(
-        data=7.0, dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        data=7.0,
+        dtype=np.float64,
+        shape=(10, 10, 10),
+        default_origin=(0, 0, 0),
+        backend="gtc:dace:cpu",
     )
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     origin = {"inp": (0, 0, 0), "outp": outp_origin}
@@ -135,7 +143,7 @@ def test_origin_offsetting_nofrozen(dace_stencil, domain, outp_origin):
 
 
 def test_optional_arg_noprovide():
-    @gtscript.stencil(backend="gtc:dace")
+    @gtscript.stencil(backend="gtc:dace:cpu")
     def stencil(
         inp: gtscript.Field[np.float64],
         outp: gtscript.Field[np.float64],
@@ -154,10 +162,10 @@ def test_optional_arg_noprovide():
         dtype=np.float64,
         shape=(10, 10, 10),
         default_origin=(0, 0, 0),
-        backend="gtc:dace",
+        backend="gtc:dace:cpu",
     )
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     @dace.program
@@ -172,7 +180,7 @@ def test_optional_arg_noprovide():
 
 
 def test_optional_arg_provide():
-    @gtscript.stencil(backend="gtc:dace")
+    @gtscript.stencil(backend="gtc:dace:cpu")
     def stencil(
         inp: gtscript.Field[np.float64],
         unused_field: gtscript.Field[np.float64],
@@ -187,13 +195,17 @@ def test_optional_arg_provide():
     )
 
     inp = gt_storage.from_array(
-        data=7.0, dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        data=7.0,
+        dtype=np.float64,
+        shape=(10, 10, 10),
+        default_origin=(0, 0, 0),
+        backend="gtc:dace:cpu",
     )
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
     unused_field = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     @dace.program
@@ -208,7 +220,7 @@ def test_optional_arg_provide():
 
 
 def test_optional_arg_provide_aot():
-    @gtscript.stencil(backend="gtc:dace")
+    @gtscript.stencil(backend="gtc:dace:cpu")
     def stencil(
         inp: gtscript.Field[np.float64],
         unused_field: gtscript.Field[np.float64],
@@ -223,13 +235,17 @@ def test_optional_arg_provide_aot():
     )
 
     inp = gt_storage.from_array(
-        data=7.0, dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        data=7.0,
+        dtype=np.float64,
+        shape=(10, 10, 10),
+        default_origin=(0, 0, 0),
+        backend="gtc:dace:cpu",
     )
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
     unused_field = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     @dace.program
@@ -259,10 +275,14 @@ def test_nondace_raises():
     )
 
     inp = gt_storage.from_array(
-        data=7.0, dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        data=7.0,
+        dtype=np.float64,
+        shape=(10, 10, 10),
+        default_origin=(0, 0, 0),
+        backend="gtc:dace:cpu",
     )
     outp = gt_storage.zeros(
-        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace"
+        dtype=np.float64, shape=(10, 10, 10), default_origin=(0, 0, 0), backend="gtc:dace:cpu"
     )
 
     @dace.program

--- a/tests/test_integration/test_dace_parsing.py
+++ b/tests/test_integration/test_dace_parsing.py
@@ -27,7 +27,7 @@ def dace_env():
     with dace.config.temporary_config():
         dace.config.Config.set("compiler", "cpu", "args", value="")
         dace.config.Config.set("compiler", "allow_view_arguments", value=True)
-        dace.config.Config.set("default_build_folder", value=gt_cache_path)
+        dace.config.Config.set("default_build_folder", value=str(gt_cache_path))
         yield
 
 

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -604,7 +604,13 @@ class TestNon3DFields(gt_testing.StencilTestSuite):
         "field_out": np.float64,
     }
     domain_range = [(4, 10), (4, 10), (4, 10)]
-    backends = ["gtc:gt:cpu_ifirst", "gtc:gt:cpu_kfirst", "gtc:gt:gpu", "gtc:dace"]
+    backends = [
+        "gtc:gt:cpu_ifirst",
+        "gtc:gt:cpu_kfirst",
+        "gtc:gt:gpu",
+        "gtc:dace:cpu",
+        "gtc:dace:gpu",
+    ]
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="K", boundary=[(0, 0), (0, 0), (0, 0)]

--- a/tests/test_unittest/test_cli.py
+++ b/tests/test_unittest/test_cli.py
@@ -94,7 +94,8 @@ def nocli_backend(scope="module"):
 
 BACKEND_ROW_PATTERN_BY_NAME = {
     "gtc:cuda": r"^\s*gtc:cuda\s*cuda\s*python\s*Yes",
-    "gtc:dace": r"^\s*gtc:dace\s*c\+\+\s*python\s*Yes",
+    "gtc:dace:cpu": r"^\s*gtc:dace:cpu\s*c\+\+\s*python\s*Yes",
+    "gtc:dace:gpu": r"^\s*gtc:dace:gpu\s*cuda\s*python\s*Yes",
     "gtc:gt:cpu_ifirst": r"^\s*gtc:gt:cpu_ifirst\s*c\+\+\s*python\s*Yes",
     "gtc:gt:cpu_kfirst": r"^\s*gtc:gt:cpu_kfirst\s*c\+\+\s*python\s*Yes",
     "gtc:gt:gpu": r"^\s*gtc:gt:gpu\s*cuda\s*python\s*Yes",


### PR DESCRIPTION
This PR adds the `gtc:dace:gpu` backend and renames `gtc:dace` to `gtc:dace:cpu`. 

This is done based on the soon-to-be-outdated expansion that is currently in `master`.  The intention is to already adapt the infrastructure for a dace GPU backend such that the backend refactor can be meaningfully be broken down to more digestable chunks. 

ToDo:
- [x] test with fv3core