### PR TITLE
Use the pretty printer in ir.Node.__str__

### DIFF
--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -1,9 +1,16 @@
 from typing import List, Union
 
-from eve import Node
+import eve
 from eve.traits import SymbolName, SymbolTableTrait
 from eve.type_definitions import SymbolRef
 from functional.iterator.util.sym_validation import validate_symbol_refs
+
+
+class Node(eve.Node):
+    def __str__(self):
+        from functional.iterator.pretty_printer import pformat
+
+        return pformat(self)
 
 
 class Sym(Node):  # helper

--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -19,6 +19,7 @@ class Sym(Node):  # helper
     id: SymbolName  # noqa: A003
 
 
+@noninstantiable
 class Expr(Node):
     ...
 

--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -3,9 +3,11 @@ from typing import List, Union
 import eve
 from eve.traits import SymbolName, SymbolTableTrait
 from eve.type_definitions import SymbolRef
+from eve.utils import noninstantiable
 from functional.iterator.util.sym_validation import validate_symbol_refs
 
 
+@noninstantiable
 class Node(eve.Node):
     def __str__(self):
         from functional.iterator.pretty_printer import pformat

--- a/tests/functional_tests/iterator_tests/test_ir.py
+++ b/tests/functional_tests/iterator_tests/test_ir.py
@@ -1,0 +1,17 @@
+import pytest
+
+from functional.iterator import ir
+
+
+def test_noninstantiable():
+    with pytest.raises(TypeError, match="non-instantiable"):
+        ir.Node()
+    with pytest.raises(TypeError, match="non-instantiable"):
+        ir.Expr()
+
+
+def test_str():
+    testee = ir.Lambda(params=[ir.Sym(id="x")], expr=ir.SymRef(id="x"))
+    expected = "λ(x) → x"
+    actual = str(testee)
+    assert actual == expected


### PR DESCRIPTION
## Description

Overrides the `functional.ir.Node.__str__` method to use the IR pretty printer.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


