### PR TITLE
Sync black versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ include_package_data = True
 python_requires = >= 3.8
 install_requires =
     attrs>=20.3
-    black==22.3.0
+    black>=22.3.0
     cached-property>=1.5
     click>=7.1
     jinja2>=2.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ include_package_data = True
 python_requires = >= 3.8
 install_requires =
     attrs>=20.3
-    black>=19.3b0
+    black==22.3.0
     cached-property>=1.5
     click>=7.1
     jinja2>=2.10


### PR DESCRIPTION
## Description

This ensures the same version of `black` is used in local development as in `pre-commit`.