### PR TITLE
Functional: Remove Obsolete `__eq__` and `__hash__` Overloads

### DIFF
--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -47,9 +47,6 @@ class NoneLiteral(Expr):
 class OffsetLiteral(Expr):
     value: Union[int, str]
 
-    def __hash__(self):
-        return self.value.__hash__()
-
 
 class AxisLiteral(Expr):
     value: str

--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -74,12 +74,6 @@ class FunctionDefinition(Node, SymbolTableTrait):
     params: List[Sym]
     expr: Expr
 
-    def __eq__(self, other):
-        return isinstance(other, FunctionDefinition) and self.id == other.id
-
-    def __hash__(self):
-        return hash(self.id)
-
 
 class StencilClosure(Node):
     domain: Expr


### PR DESCRIPTION
## Description

Removes obsolete definitions of `__eq__` and `__hash__` in `functional.iterator.ir.FunctionDefinition` and `__hash__` from `functional.iterator.ir.OffsetLiteral` which override the value-comparability of EVE nodes.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


