### PR TITLE
allow simple case field broadcasting.

### DIFF
--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -38,7 +38,17 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
     True
 
     """
-    if all([left.dims, right.dims]) and left.dims != right.dims:
+    both_dims_given = bool(left.dims and right.dims)
+    both_dims_given &= left.dims is not Ellipsis
+    both_dims_given &= right.dims is not Ellipsis
+    if both_dims_given and any(
+        [
+            ldim != rdim
+            for ldim, rdim in zip(
+                left.dims, right.dims  # type: ignore[arg-type]  # we know they are lists here
+            )
+        ]
+    ):
         return False
     return left.dtype == right.dtype
 
@@ -60,6 +70,8 @@ def broadcast_typeinfos(left: TypeInfo, right: TypeInfo) -> Optional[TypeInfo]:
     if not are_broadcast_compatible(left, right):
         return None
     if left.is_scalar and right.is_field_type:
+        return right
+    elif left.dims and right.dims and len(right.dims) > len(left.dims):
         return right
     return left
 

--- a/src/functional/ffront/type_info.py
+++ b/src/functional/ffront/type_info.py
@@ -135,7 +135,10 @@ class TypeInfo:
 
     @property
     def dims(self) -> Optional[list]:
-        return getattr(self.type, "dims", None)
+        result = getattr(self.type, "dims", None)
+        if result is Ellipsis:
+            return []
+        return result
 
     @property
     def dtype(self) -> Optional[ScalarType]:


### PR DESCRIPTION
## Description

Allow Field broadcasting in field view in the simple case that both fields have the same dimensions, except one has more.

Example:

`Field[[X, Y], dtype]` can be broadcast to `Field[[X, Y, Z], dtype]` but not to `Field[[Y, X], dtype]` or `Field[[Z, X, Y], dtype]`

This should be safe and is absolutely required for icon integration.

## Requirements

Before submitting this PR, please make sure:

- [ ] You have run the code checks, tests and documentation build successfully
- [ ] All fixes and all new functionality are tested and documentation is up to date
- [ ] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


