### PR TITLE
Re-enable cuda, numpy and dace tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,10 @@ def pytest_configure(config):
         "markers",
         "requires_gpu: mark tests that require a Nvidia GPU (assume cupy and cudatoolkit are installed)",
     )
+    config.addinivalue_line(
+        "markers",
+        "requires_dace: mark tests that require dace in the python environment",
+    )
     hyp.settings.load_profile("slow")
 
 

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -30,10 +30,12 @@ from gt4py import utils as gt_utils
 
 
 def _backend_name_as_param(name):
+    marks = []
     if gt_backend.from_name(name).storage_info["device"] == "gpu":
-        return pytest.param(name, marks=[pytest.mark.requires_gpu])
-    else:
-        return pytest.param(name)
+        marks.append(pytest.mark.requires_gpu)
+    if "dace" in name:
+        marks.append(pytest.mark.requires_dace)
+    return pytest.param(name, marks=marks)
 
 
 def make_backend_params(*names):
@@ -55,19 +57,6 @@ GPU_BACKENDS = [
     if gt_backend.from_name(name).storage_info["device"] == "gpu"
 ]
 ALL_BACKENDS = CPU_BACKENDS + GPU_BACKENDS
-
-INTERNAL_CPU_BACKENDS = [
-    _backend_name_as_param(name)
-    for name in _INTERNAL_BACKEND_NAMES
-    if gt_backend.from_name(name).storage_info["device"] == "cpu"
-]
-INTERNAL_GPU_BACKENDS = [
-    _backend_name_as_param(name)
-    for name in _INTERNAL_BACKEND_NAMES
-    if gt_backend.from_name(name).storage_info["device"] == "gpu"
-]
-
-INTERNAL_BACKENDS = INTERNAL_CPU_BACKENDS + INTERNAL_GPU_BACKENDS
 
 
 @pytest.fixture()

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -38,10 +38,6 @@ def _backend_name_as_param(name):
     return pytest.param(name, marks=marks)
 
 
-def make_backend_params(*names):
-    return map(_backend_name_as_param, names)
-
-
 _ALL_BACKEND_NAMES = list(gt_backend.REGISTRY.keys())
 
 

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -43,7 +43,6 @@ def make_backend_params(*names):
 
 
 _ALL_BACKEND_NAMES = list(gt_backend.REGISTRY.keys())
-_INTERNAL_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name.startswith("gt")]
 
 
 CPU_BACKENDS = [

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -21,7 +21,7 @@ from gt4py import gtscript
 from gt4py import storage as gt_storage
 from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, Field, computation, interval
 
-from ..definitions import ALL_BACKENDS, CPU_BACKENDS, INTERNAL_BACKENDS
+from ..definitions import ALL_BACKENDS, CPU_BACKENDS
 from .stencil_definitions import EXTERNALS_REGISTRY as externals_registry
 from .stencil_definitions import REGISTRY as stencil_definitions
 
@@ -508,7 +508,7 @@ class TestNegativeOrigin:
         assert output_field[0, 0, 0] == 1
 
 
-@pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_origin_k_fields(backend):
     @gtscript.stencil(backend=backend, rebuild=True)
     def k_to_ijk(outp: Field[np.float64], inp: Field[gtscript.K, np.float64]):

--- a/tests/test_integration/test_cpp_regression.py
+++ b/tests/test_integration/test_cpp_regression.py
@@ -25,7 +25,7 @@ import pytest
 import gt4py.backend as gt_backend
 import gt4py.storage as gt_store
 
-from ..definitions import INTERNAL_BACKENDS
+from ..definitions import ALL_BACKENDS
 from ..reference_cpp_regression import reference_module
 from .utils import id_version  # import fixture used by pytest
 from .utils import generate_test_module
@@ -257,7 +257,7 @@ def run_large_k_interval(backend, id_version, domain):
         )
 
 
-@pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 @pytest.mark.parametrize("function", REGISTRY)
 def test_cpp_regression(backend, id_version, function):
     function(gt_backend.from_name(backend), id_version)

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -796,8 +796,7 @@ class TestVariableKAndReadOutside(gt_testing.StencilTestSuite):
         "index": np.int32,
     }
     domain_range = [(2, 2), (2, 2), (2, 8)]
-    # exclude "numpy" due to #624
-    backends = [backend for backend in ALL_BACKENDS if backend.values[0] != "numpy"]
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(0.1, 10), axes="IJK", boundary=[(0, 0), (0, 0), (1, 0)]

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -21,7 +21,7 @@ from gt4py import gtscript
 from gt4py import testing as gt_testing
 from gt4py.gtscript import PARALLEL, I, J, computation, horizontal, interval, region
 
-from ..definitions import INTERNAL_BACKENDS
+from ..definitions import ALL_BACKENDS
 from .stencil_definitions import optional_field, two_optional_fields
 
 
@@ -31,7 +31,7 @@ class TestIdentity(gt_testing.StencilTestSuite):
 
     dtypes = {("field_a",): (np.float64, np.float32)}
     domain_range = [(1, 25), (1, 25), (1, 25)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(field_a):
@@ -49,7 +49,7 @@ class TestCopy(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 25), (1, 25), (1, 25)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         field_b=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -68,7 +68,7 @@ class TestAugAssign(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 25), (1, 25), (1, 25)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         field_b=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -92,7 +92,7 @@ class TestGlobalScale(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         SCALE_FACTOR=gt_testing.global_name(one_of=(1.0, 1e3, 1e6)),
         field_a=gt_testing.field(in_range=(-1, 1), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -114,7 +114,7 @@ class TestParametricScale(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         scale=gt_testing.parameter(in_range=(-100, 100)),
@@ -139,7 +139,7 @@ class TestParametricMix(gt_testing.StencilTestSuite):
         ("weight", "alpha_factor"): np.float_,
     }
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         USE_ALPHA=gt_testing.global_name(one_of=(True, False)),
         field_a=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -178,7 +178,7 @@ class TestParametricMix(gt_testing.StencilTestSuite):
 class TestHeatEquation_FTCS_3D(gt_testing.StencilTestSuite):
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         u=gt_testing.field(in_range=(-10, 10), extent=[(-1, 1), (0, 0), (0, 0)]),
         v=gt_testing.field(in_range=(-10, 10), extent=[(0, 0), (-1, 1), (0, 0)]),
@@ -207,7 +207,7 @@ class TestHorizontalDiffusion(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         u=gt_testing.field(in_range=(-10, 10), boundary=[(2, 2), (2, 2), (0, 0)]),
         diffusion=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -270,7 +270,7 @@ class TestHorizontalDiffusionSubroutines(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         fwd_diff=gt_testing.global_name(singleton=wrap1arg2return),
         u=gt_testing.field(in_range=(-10, 10), boundary=[(2, 2), (2, 2), (0, 0)]),
@@ -304,7 +304,7 @@ class TestHorizontalDiffusionSubroutines2(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         fwd_diff=gt_testing.global_name(singleton=fwd_diff_op_xy),
         BRANCH=gt_testing.global_name(one_of=(True, False)),
@@ -344,7 +344,7 @@ class TestRuntimeIfFlat(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(outfield):
@@ -365,7 +365,7 @@ class TestRuntimeIfNested(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (1, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(outfield):
@@ -393,7 +393,7 @@ class Test3FoldNestedIf(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(3, 3), (3, 3), (3, 3)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(field_a=gt_testing.field(in_range=(-1, 1), boundary=[(0, 0), (0, 0), (0, 0)]))
 
     def definition(field_a):
@@ -414,7 +414,7 @@ class TestRuntimeIfNestedDataDependent(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(3, 3), (3, 3), (3, 3)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         factor=gt_testing.parameter(in_range=(-100, 100)),
         field_a=gt_testing.field(in_range=(-1, 1), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -450,7 +450,7 @@ class TestTernaryOp(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         infield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 1), (0, 0)]),
         outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -473,7 +473,7 @@ class TestThreeWayAnd(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         a=gt_testing.parameter(in_range=(-100, 100)),
@@ -497,7 +497,7 @@ class TestThreeWayOr(gt_testing.StencilTestSuite):
 
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
         a=gt_testing.parameter(in_range=(-100, 100)),
@@ -520,7 +520,7 @@ class TestThreeWayOr(gt_testing.StencilTestSuite):
 class TestOptionalField(gt_testing.StencilTestSuite):
     dtypes = (np.float_,)
     domain_range = [(1, 32), (1, 32), (1, 32)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         PHYS_TEND=gt_testing.global_name(one_of=(False, True)),
         in_field=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
@@ -540,7 +540,7 @@ class TestOptionalField(gt_testing.StencilTestSuite):
 
 
 class TestNotSpecifiedOptionalField(TestOptionalField):
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = TestOptionalField.symbols.copy()
     symbols["PHYS_TEND"] = gt_testing.global_name(one_of=(False,))
     symbols["phys_tend"] = gt_testing.none()
@@ -549,7 +549,7 @@ class TestNotSpecifiedOptionalField(TestOptionalField):
 class TestTwoOptionalFields(gt_testing.StencilTestSuite):
     dtypes = (np.float_,)
     domain_range = [(1, 32), (1, 32), (1, 32)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = dict(
         PHYS_TEND_A=gt_testing.global_name(one_of=(False, True)),
         PHYS_TEND_B=gt_testing.global_name(one_of=(False, True)),
@@ -591,7 +591,7 @@ class TestTwoOptionalFields(gt_testing.StencilTestSuite):
 
 
 class TestNotSpecifiedTwoOptionalFields(TestTwoOptionalFields):
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = TestTwoOptionalFields.symbols.copy()
     symbols["PHYS_TEND_A"] = gt_testing.global_name(one_of=(False,))
     symbols["phys_tend_a"] = gt_testing.none()
@@ -693,7 +693,7 @@ class TestReadOutsideKInterval1(gt_testing.StencilTestSuite):
         "field_out": np.float64,
     }
     domain_range = [(4, 4), (4, 4), (4, 4)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (1, 1)]
@@ -719,7 +719,7 @@ class TestReadOutsideKInterval2(gt_testing.StencilTestSuite):
         "field_out": np.float64,
     }
     domain_range = [(4, 4), (4, 4), (4, 4)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 1)]
@@ -743,7 +743,7 @@ class TestReadOutsideKInterval3(gt_testing.StencilTestSuite):
         "field_out": np.float64,
     }
     domain_range = [(4, 4), (4, 4), (4, 4)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (1, 0)]
@@ -768,7 +768,7 @@ class TestVariableKRead(gt_testing.StencilTestSuite):
         "index": np.int32,
     }
     domain_range = [(2, 2), (2, 2), (2, 8)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]
@@ -797,7 +797,7 @@ class TestVariableKAndReadOutside(gt_testing.StencilTestSuite):
     }
     domain_range = [(2, 2), (2, 2), (2, 8)]
     # exclude "numpy" due to #624
-    backends = [backend for backend in INTERNAL_BACKENDS if backend.values[0] != "numpy"]
+    backends = [backend for backend in ALL_BACKENDS if backend.values[0] != "numpy"]
     symbols = {
         "field_in": gt_testing.field(
             in_range=(0.1, 10), axes="IJK", boundary=[(0, 0), (0, 0), (1, 0)]
@@ -827,7 +827,7 @@ class TestDiagonalKOffset(gt_testing.StencilTestSuite):
         "field_out": np.float64,
     }
     domain_range = [(2, 2), (2, 2), (2, 8)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(0.1, 10), axes="IJK", boundary=[(0, 0), (1, 0), (0, 1)]
@@ -854,7 +854,7 @@ class TestHorizontalRegions(gt_testing.StencilTestSuite):
         "field_out": np.float32,
     }
     domain_range = [(4, 4), (4, 4), (2, 2)]
-    backends = INTERNAL_BACKENDS
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]

--- a/tests/test_unittest/test_call_interface.py
+++ b/tests/test_unittest/test_call_interface.py
@@ -22,7 +22,7 @@ import gt4py.gtscript as gtscript
 import gt4py.storage as gt_storage
 from gt4py.gtscript import Field, K
 
-from ..definitions import INTERNAL_BACKENDS, INTERNAL_CPU_BACKENDS
+from ..definitions import ALL_BACKENDS, CPU_BACKENDS
 
 
 def base_stencil(
@@ -162,7 +162,7 @@ def avg_stencil(in_field: Field[np.float64], out_field: Field[np.float64]):  # t
         )
 
 
-@pytest.mark.parametrize("backend", INTERNAL_CPU_BACKENDS)
+@pytest.mark.parametrize("backend", CPU_BACKENDS)
 def test_default_arguments(backend):
     branch_true = gtscript.stencil(
         backend=backend, definition=a_stencil, externals={"BRANCH": True}, rebuild=True
@@ -216,7 +216,7 @@ def test_default_arguments(backend):
         branch_false(arg1, arg2, arg3, par1=2.0, par2=5.0)
 
 
-@pytest.mark.parametrize("backend", INTERNAL_CPU_BACKENDS)
+@pytest.mark.parametrize("backend", CPU_BACKENDS)
 def test_halo_checks(backend):
     stencil = gtscript.stencil(definition=avg_stencil, backend=backend)
 
@@ -443,7 +443,7 @@ class TestDataDimensions:
             )
 
 
-@pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_origin_unchanged(backend):
     @gtscript.stencil(backend=backend)
     def calc_damp(outp: Field[float], inp: Field[K, float]):

--- a/tests/test_unittest/test_cli.py
+++ b/tests/test_unittest/test_cli.py
@@ -25,7 +25,7 @@ from click.testing import CliRunner
 from gt4py import backend, cli
 from gt4py.backend.base import CLIBackendMixin
 
-from ..definitions import INTERNAL_BACKENDS
+from ..definitions import ALL_BACKENDS
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def clirunner():
 
 @pytest.fixture(
     params=[
-        *INTERNAL_BACKENDS,  # gtc backends require definition ir as input, for now we skip the tests
+        *ALL_BACKENDS,  # gtc backends require definition ir as input, for now we skip the tests
         pytest.param(
             "nocli",
         ),

--- a/tests/test_unittest/test_exec_info.py
+++ b/tests/test_unittest/test_exec_info.py
@@ -26,7 +26,7 @@ from gt4py import backend as gt_backend
 from gt4py import gtscript
 from gt4py import storage as gt_storage
 
-from ..definitions import INTERNAL_BACKENDS
+from ..definitions import ALL_BACKENDS
 
 
 class TestExecInfo:
@@ -189,7 +189,7 @@ class TestExecInfo:
                 assert stencil_info["total_run_cpp_time"] > stencil_info["run_cpp_time"]
 
     @given(data=hyp_st.data())
-    @pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+    @pytest.mark.parametrize("backend", ALL_BACKENDS)
     def test_backcompatibility(self, data, backend):
         # set backend as instance attribute
         self.backend = backend
@@ -232,7 +232,7 @@ class TestExecInfo:
         assert type(self.diffusion).__name__ not in exec_info
 
     @given(data=hyp_st.data())
-    @pytest.mark.parametrize("backend", INTERNAL_BACKENDS)
+    @pytest.mark.parametrize("backend", ALL_BACKENDS)
     def test_aggregate(self, data, backend):
         # set backend as instance attribute
         self.backend = backend

--- a/tests/test_unittest/test_lazy_stencil.py
+++ b/tests/test_unittest/test_lazy_stencil.py
@@ -24,7 +24,7 @@ from gt4py.gtscript import PARALLEL, Field, computation, interval
 from gt4py.lazy_stencil import LazyStencil
 from gt4py.stencil_builder import StencilBuilder
 
-from ..definitions import INTERNAL_BACKENDS
+from ..definitions import ALL_BACKENDS
 
 
 def copy_stencil_definition(out_f: Field[float], in_f: Field[float]):  # type: ignore
@@ -46,7 +46,7 @@ def frontend(request):
     yield gt4py.frontend.from_name(request.param)
 
 
-@pytest.fixture(params=INTERNAL_BACKENDS)
+@pytest.fixture(params=ALL_BACKENDS)
 def backend_name(request):
     yield request.param
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
 [testenv:py{38,39}-internal-{cuda,cuda90,cuda91,cuda92,cuda100,cuda101}]
 commands =
     pip list
-    pytest --cache-clear --cov -v -m "requires_gpu and not requries_dace" {posargs}
+    pytest --cache-clear --cov -v -m "requires_gpu and not requires_dace" {posargs}
     pytest --doctest-modules --cov --cov-append {envsitepackagesdir}/eve
 
 [testenv:py{38,39}-all-{cuda,cuda90,cuda91,cuda92,cuda100,cuda101}]

--- a/tox.ini
+++ b/tox.ini
@@ -30,13 +30,24 @@ extras =
     cuda100: cuda100
     cuda101: cuda101
 
-[testenv:py{38,39}-{internal,all}-cpu]
+[testenv:py{38,39}-internal-cpu]
+commands =
+    pip list
+    pytest --cache-clear --cov -v -m "not requires_gpu and not requires_dace" {posargs}
+    pytest --doctest-modules --cov --cov-append {envsitepackagesdir}/eve
+[testenv:py{38,39}-all-cpu]
 commands =
     pip list
     pytest --cache-clear --cov -v -m "not requires_gpu" {posargs}
     pytest --doctest-modules --cov --cov-append {envsitepackagesdir}/eve
 
-[testenv:py{38,39}-{internal,all}-{cuda,cuda90,cuda91,cuda92,cuda100,cuda101}]
+[testenv:py{38,39}-internal-{cuda,cuda90,cuda91,cuda92,cuda100,cuda101}]
+commands =
+    pip list
+    pytest --cache-clear --cov -v -m "requires_gpu and not requries_dace" {posargs}
+    pytest --doctest-modules --cov --cov-append {envsitepackagesdir}/eve
+
+[testenv:py{38,39}-all-{cuda,cuda90,cuda91,cuda92,cuda100,cuda101}]
 commands =
     pip list
     pytest --cache-clear --cov -v -m "requires_gpu" {posargs}


### PR DESCRIPTION
Many tests currently exclude cuda, numpy and dace:* backends due to the use of INTERNAL_BACKENDS which filters based on the backend name starting with "gt". 

This PR removes this filter and instead adds a requires_dace marker that can be used to exclude dace tests as necessary. 