### PR TITLE
Rename eve.xtyping.reveal_type to infer_type

### DIFF
--- a/src/eve/extended_typing.py
+++ b/src/eve/extended_typing.py
@@ -274,7 +274,7 @@ class CallableKwargsInfo:
     data: Dict[str, Any]
 
 
-def reveal_type(  # noqa: C901  # function is complex but well organized in independent cases
+def infer_type(  # noqa: C901  # function is complex but well organized in independent cases
     value: Any,
     *,
     annotate_callable_kwargs: bool = False,
@@ -289,36 +289,36 @@ def reveal_type(  # noqa: C901  # function is complex but well organized in inde
         none_as_type:  if ``True``, ``None`` hints will be transformed to ``type(None)``.
 
     Examples:
-        >>> reveal_type(3)
+        >>> infer_type(3)
         <class 'int'>
 
-        >>> reveal_type((3, "four"))
+        >>> infer_type((3, "four"))
         tuple[int, str]
 
-        >>> reveal_type((3, 4))
+        >>> infer_type((3, 4))
         tuple[int, ...]
 
-        >>> reveal_type(frozenset([1, 2, 3]))
+        >>> infer_type(frozenset([1, 2, 3]))
         frozenset[int]
 
-        >>> reveal_type({'a': 0, 'b': 1})
+        >>> infer_type({'a': 0, 'b': 1})
         dict[str, int]
 
-        >>> reveal_type({'a': 0, 'b': 'B'})
+        >>> infer_type({'a': 0, 'b': 'B'})
         dict[str, typing.Any]
 
-        >>> print("Result:", reveal_type(lambda a, b: a + b))
+        >>> print("Result:", infer_type(lambda a, b: a + b))
         Result: ...Callable[[typing.Any, typing.Any], typing.Any]
 
         >>> def f(a: int, b) -> int: ...
-        >>> print("Result:", reveal_type(f))
+        >>> print("Result:", infer_type(f))
         Result: ...Callable[[int, typing.Any], int]
 
         >>> def f(a: int, b) -> int: ...
-        >>> print("Result:", reveal_type(f))
+        >>> print("Result:", infer_type(f))
         Result: ...Callable[..., int]
 
-        >>> print("Result:", reveal_type(Dict[int, Union[int, float]]))
+        >>> print("Result:", infer_type(Dict[int, Union[int, float]]))
         Result: ...ict[int, typing.Union[int, float]]
 
     For advanced cases, using :func:`functools.singledispatch` with custom hooks
@@ -326,19 +326,19 @@ def reveal_type(  # noqa: C901  # function is complex but well organized in inde
 
     Example:
         >>> import functools, numbers
-        >>> extended_reveal_type = functools.singledispatch(reveal_type)
-        >>> @extended_reveal_type.register(int)
-        ... @extended_reveal_type.register(float)
-        ... @extended_reveal_type.register(complex)
-        ... def _reveal_type_number(value, *, annotate_callable_kwargs: bool = False):
+        >>> extended_infer_type = functools.singledispatch(infer_type)
+        >>> @extended_infer_type.register(int)
+        ... @extended_infer_type.register(float)
+        ... @extended_infer_type.register(complex)
+        ... def _infer_type_number(value, *, annotate_callable_kwargs: bool = False):
         ...    return numbers.Number
-        >>> extended_reveal_type(3.4)
+        >>> extended_infer_type(3.4)
         <class 'numbers.Number'>
-        >>> reveal_type(3.4)
+        >>> infer_type(3.4)
         <class 'float'>
 
     """
-    _reveal = _functools.partial(reveal_type, annotate_callable_kwargs=annotate_callable_kwargs)
+    _reveal = _functools.partial(infer_type, annotate_callable_kwargs=annotate_callable_kwargs)
 
     if isinstance(value, (_GenericAliasType, _TypingSpecialFormType)):
         return value

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -168,7 +168,7 @@ def make_symbol_type_from_value(value: Any) -> ct.SymbolType:
         symbol_type = value.__gt_type__()
 
     else:
-        type_ = xtyping.reveal_type(value, annotate_callable_kwargs=True)
+        type_ = xtyping.infer_type(value, annotate_callable_kwargs=True)
         symbol_type = make_symbol_type_from_typing(type_)
 
     if isinstance(symbol_type, (ct.DataType, ct.FunctionType, ct.OffsetType)):

--- a/tests/eve_tests/unit_tests/test_extended_typing.py
+++ b/tests/eve_tests/unit_tests/test_extended_typing.py
@@ -159,38 +159,38 @@ def test_eval_forward_ref():
     )
 
 
-def test_reveal_type():
-    assert xtyping.reveal_type(3) == int
+def test_infer_type():
+    assert xtyping.infer_type(3) == int
 
-    assert xtyping.reveal_type(None) is type(None)  # noqa: E721  # do not compare types
-    assert xtyping.reveal_type(type(None)) is type(None)  # noqa: E721  # do not compare types
-    assert xtyping.reveal_type(None, none_as_type=False) is None
-    assert xtyping.reveal_type(type(None), none_as_type=False) is None
+    assert xtyping.infer_type(None) is type(None)  # noqa: E721  # do not compare types
+    assert xtyping.infer_type(type(None)) is type(None)  # noqa: E721  # do not compare types
+    assert xtyping.infer_type(None, none_as_type=False) is None
+    assert xtyping.infer_type(type(None), none_as_type=False) is None
 
-    assert xtyping.reveal_type(Dict[str, int]) == Dict[str, int]
+    assert xtyping.infer_type(Dict[str, int]) == Dict[str, int]
 
-    assert xtyping.reveal_type({1, 2, 3}) == Set[int]
-    assert xtyping.reveal_type(frozenset({"1", "2", "3"})) == FrozenSet[str]
+    assert xtyping.infer_type({1, 2, 3}) == Set[int]
+    assert xtyping.infer_type(frozenset({"1", "2", "3"})) == FrozenSet[str]
 
-    assert xtyping.reveal_type({"a": [0], "b": [1]}) == Dict[str, List[int]]
+    assert xtyping.infer_type({"a": [0], "b": [1]}) == Dict[str, List[int]]
 
-    assert xtyping.reveal_type(str) == Type[str]
+    assert xtyping.infer_type(str) == Type[str]
 
     class A:
         ...
 
-    assert xtyping.reveal_type(A()) == A
-    assert xtyping.reveal_type(A) == Type[A]
+    assert xtyping.infer_type(A()) == A
+    assert xtyping.infer_type(A) == Type[A]
 
     def f1():
         ...
 
-    assert xtyping.reveal_type(f1) == Callable[[], Any]
+    assert xtyping.infer_type(f1) == Callable[[], Any]
 
     def f2(a: int, b: float) -> None:
         ...
 
-    assert xtyping.reveal_type(f2) == Callable[[int, float], type(None)]
+    assert xtyping.infer_type(f2) == Callable[[int, float], type(None)]
 
     def f3(
         a: Dict[Tuple[str, ...], List[int]],
@@ -200,7 +200,7 @@ def test_reveal_type():
         ...
 
     assert (
-        xtyping.reveal_type(f3)
+        xtyping.infer_type(f3)
         == Callable[
             [
                 Dict[Tuple[str, ...], List[int]],
@@ -214,9 +214,9 @@ def test_reveal_type():
     def f4(a: int, b: float, *, foo: Tuple[str, ...] = ()) -> None:
         ...
 
-    assert xtyping.reveal_type(f4) == Callable[[int, float], type(None)]
+    assert xtyping.infer_type(f4) == Callable[[int, float], type(None)]
     assert (
-        xtyping.reveal_type(f4, annotate_callable_kwargs=True)
+        xtyping.infer_type(f4, annotate_callable_kwargs=True)
         == Annotated[
             Callable[[int, float], type(None)], xtyping.CallableKwargsInfo({"foo": Tuple[str, ...]})
         ]


### PR DESCRIPTION
## Description

Rename `reveal_type()` eve function to `infer_type()` to avoid collisions with upcoming `reveal_type` func in Python 3.11
