### PR TITLE
functional: More type validation tools for eve

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,8 @@ repos:
   rev: v0.942
   hooks:
   - id: mypy
+    additional_dependencies:
+    - types-frozendict
     exclude: |
       (?x)^(
       src/eve/datamodels.py | # until datamodels is upgraded to 3.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     click>=7.1
     cytoolz>=0.11
     devtools>=0.5
+    frozendict>=2.3
     jinja2>=2.10
     mako>=1.1
     networkx>=2.4

--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Eve framework to support development of DSL toolchains in pure Python.
+"""Eve framework with general utils for development of DSL toolchains in Python.
 
 The internal dependencies between modules are the following (each line depends
 on some of the previous ones):

--- a/src/eve/concepts.py
+++ b/src/eve/concepts.py
@@ -27,7 +27,6 @@ import pydantic.generics
 from . import iterators, utils
 from .extended_typing import (
     Any,
-    ClassVar,
     Dict,
     Generator,
     List,
@@ -182,9 +181,6 @@ class BaseNode(pydantic.BaseModel, metaclass=NodeMetaclass):
             typically to cache derived, non-essential information on the node.
 
     """
-
-    #__node_impl_fields__: ClassVar[NodeImplFieldMetadataDict]
-    #__node_children__: ClassVar[NodeChildrenMetadataDict]
 
     def iter_impl_fields(self) -> Generator[Tuple[str, Any], None, None]:
         for name in self.__node_impl_fields__.keys():

--- a/src/eve/concepts.py
+++ b/src/eve/concepts.py
@@ -183,8 +183,8 @@ class BaseNode(pydantic.BaseModel, metaclass=NodeMetaclass):
 
     """
 
-    __node_impl_fields__: ClassVar[NodeImplFieldMetadataDict]
-    __node_children__: ClassVar[NodeChildrenMetadataDict]
+    #__node_impl_fields__: ClassVar[NodeImplFieldMetadataDict]
+    #__node_children__: ClassVar[NodeChildrenMetadataDict]
 
     def iter_impl_fields(self) -> Generator[Tuple[str, Any], None, None]:
         for name in self.__node_impl_fields__.keys():

--- a/src/eve/extended_typing.py
+++ b/src/eve/extended_typing.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import dataclasses as _dataclasses
 import functools as _functools
 import inspect as _inspect
-import pprint as _pprint
 import sys as _sys
 import types as _types
 import typing as _typing

--- a/src/eve/extended_typing.py
+++ b/src/eve/extended_typing.py
@@ -32,6 +32,7 @@ from typing import *  # noqa: F403
 import frozendict as _frozendict
 from typing_extensions import *  # type: ignore[misc]  # noqa: F403
 
+
 if _sys.version_info >= (3, 9):
     # Standard library already supports PEP 585 (Type Hinting Generics In Standard Collections)
     from builtins import (  # type: ignore[misc]  # isort:skip
@@ -120,9 +121,16 @@ def __dir__() -> List[str]:
 
 # Common type aliases
 _T_co = TypeVar("_T_co", covariant=True)
-_T_contra = TypeVar("_T_contra", contravariant=True)
 FrozenList: TypeAlias = Tuple[_T_co, ...]
-FrozenDict: TypeAlias = _frozendict.frozendict[_T_contra, _T_co]
+
+_T_contra = TypeVar("_T_contra", contravariant=True)
+if _sys.version_info >= (3, 9):
+    FrozenDict: TypeAlias = _frozendict.frozendict[_T_contra, _T_co]
+else:
+
+    class FrozenDict(_frozendict.frozendict, Generic[_T_contra, _T_co]):  # type: ignore[no-redef]  # mypy consider this a redefinition
+        ...
+
 
 NoArgsCallable = Callable[[], Any]
 
@@ -152,7 +160,7 @@ StdGenericAliasType: Final[Type] = (
 
 _TypingSpecialFormType: Final[Type] = _typing._SpecialForm
 _TypingGenericAliasType: Final[Type] = (
-    _typing._BaseGenericAlias if _sys.version_info >= (3, 9) else _typing._GenericAlias
+    _typing._BaseGenericAlias if _sys.version_info >= (3, 9) else _typing._GenericAlias  # type: ignore[attr-defined]  # _BaseGenericAlias is not exported in stub
 )
 
 

--- a/src/eve/extended_typing.py
+++ b/src/eve/extended_typing.py
@@ -121,14 +121,13 @@ def __dir__() -> List[str]:
 
 # Common type aliases
 _T_co = TypeVar("_T_co", covariant=True)
-FrozenList: TypeAlias = Tuple[_T_co, ...]
-
 _T_contra = TypeVar("_T_contra", contravariant=True)
+FrozenList: TypeAlias = Tuple[_T_co, ...]
 if _sys.version_info >= (3, 9):
     FrozenDict: TypeAlias = _frozendict.frozendict[_T_contra, _T_co]
 else:
 
-    class FrozenDict(_frozendict.frozendict, Generic[_T_contra, _T_co]):  # type: ignore[no-redef]  # mypy consider this a redefinition
+    class FrozenDict(_frozendict.frozendict, Generic[_T_contra, _T_co]):  # type: ignore[no-redef]  # mypy consider this  a redefinition
         ...
 
 
@@ -160,7 +159,7 @@ StdGenericAliasType: Final[Type] = (
 
 _TypingSpecialFormType: Final[Type] = _typing._SpecialForm
 _TypingGenericAliasType: Final[Type] = (
-    _typing._BaseGenericAlias if _sys.version_info >= (3, 9) else _typing._GenericAlias  # type: ignore[attr-defined]  # _BaseGenericAlias is not exported in stub
+    _typing._BaseGenericAlias if _sys.version_info >= (3, 9) else _typing._GenericAlias  # type: ignore[attr-defined]  # _BaseGenericAlias / _GenericAlias are not exported in stub
 )
 
 

--- a/src/eve/extended_typing.py
+++ b/src/eve/extended_typing.py
@@ -169,6 +169,11 @@ _V = TypeVar("_V")
 
 
 class NonDataDescriptor(Protocol[_C, _V]):
+    """Typing protocol for non-data descriptor classes.
+
+    See https://docs.python.org/3/howto/descriptor.html for further information.
+    """
+
     @overload
     def __get__(
         self, _instance: Literal[None], _owner_type: Optional[Type[_C]] = None
@@ -188,6 +193,11 @@ class NonDataDescriptor(Protocol[_C, _V]):
 
 
 class DataDescriptor(NonDataDescriptor[_C, _V], Protocol):
+    """Typing protocol for data descriptor classes.
+
+    See https://docs.python.org/3/howto/descriptor.html for further information.
+    """
+
     def __set__(self, _instance: _C, _value: _V) -> None:
         ...
 
@@ -227,7 +237,8 @@ _T = TypeVar("_T")
 
 
 def get_actual_type(obj: _T) -> Type[_T]:
-    return _TypingGenericAliasType if isinstance(obj, _TypingGenericAliasType) else type(obj)
+    """Return type of an object (also working for GenericAlias instances which pretend to be an actual type)."""
+    return StdGenericAliasType if isinstance(obj, StdGenericAliasType) else type(obj)
 
 
 def _has_custom_hash(type_: Type) -> bool:

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -23,11 +23,12 @@ import ast
 import enum
 import functools
 import re
+import sys
 
 import pydantic
 import xxhash
 from boltons.typeutils import classproperty as classproperty  # noqa: F401
-from frozendict import frozendict as frozendict  # noqa: F401
+from frozendict import frozendict as _frozendict  # noqa: F401
 from pydantic import validator  # noqa
 from pydantic import (  # noqa: F401
     NegativeFloat,
@@ -41,10 +42,23 @@ from pydantic import (  # noqa: F401
 )
 from pydantic.types import ConstrainedStr
 
-from .extended_typing import Any, Callable, Generator, NoReturn, Optional, Tuple, Type, Union, final
+from . import extended_typing as xtyping
+from .extended_typing import (
+    Any,
+    Callable,
+    Final,
+    Generator,
+    NoReturn,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    final,
+)
 
 
-frozenlist = tuple
+frozenlist: Final = tuple
+frozendict: Final = _frozendict if sys.version_info >= (3, 9) else xtyping.FrozenDict
 
 
 @final

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -24,11 +24,11 @@ import enum
 import functools
 import re
 
-import boltons.typeutils
 import pydantic
 import xxhash
-from boltons.typeutils import classproperty  # noqa: F401
-from pydantic import validator  # noqa: F401
+from boltons.typeutils import classproperty as classproperty  # noqa: F401
+from frozendict import frozendict as frozendict  # noqa: F401
+from pydantic import validator  # noqa
 from pydantic import (  # noqa: F401
     NegativeFloat,
     NegativeInt,
@@ -41,12 +41,21 @@ from pydantic import (  # noqa: F401
 )
 from pydantic.types import ConstrainedStr
 
-from .extended_typing import Any, Callable, Generator, Optional, Tuple, Type, Union
+from .extended_typing import Any, Callable, Generator, NoReturn, Optional, Tuple, Type, Union, final
+
+
+@final
+class NothingType(type):
+    def __bool__(cls) -> bool:
+        return False
 
 
 #: Marker value used to avoid confusion with `None`
 #: (specially in contexts where `None` could be a valid value)
-NOTHING = boltons.typeutils.make_sentinel(name="NOTHING", var_name="NOTHING")
+@final
+class NOTHING(metaclass=NothingType):
+    def __new__(cls: type) -> NoReturn:  # type: ignore[misc]  # should return an instance
+        raise TypeError(f"{cls.__name__} is used as a sentinel value and cannot be instantiated.")
 
 
 #: Typing definitions for `__get_validators__()` methods

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -43,6 +43,8 @@ from pydantic.types import ConstrainedStr
 
 from .extended_typing import Any, Callable, Generator, NoReturn, Optional, Tuple, Type, Union, final
 
+frozenlist = tuple
+
 
 @final
 class NothingType(type):

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -43,6 +43,7 @@ from pydantic.types import ConstrainedStr
 
 from .extended_typing import Any, Callable, Generator, NoReturn, Optional, Tuple, Type, Union, final
 
+
 frozenlist = tuple
 
 

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -63,14 +63,15 @@ frozendict: Final = _frozendict if sys.version_info >= (3, 9) else xtyping.Froze
 
 @final
 class NothingType(type):
+    """Metaclass for :class:`NOTHING` marker."""
     def __bool__(cls) -> bool:
         return False
 
 
-#: Marker value used to avoid confusion with `None`
-#: (specially in contexts where `None` could be a valid value)
 @final
 class NOTHING(metaclass=NothingType):
+    """Marker to avoid confusion with `None` in contexts where `None` could be a valid value."""
+
     def __new__(cls: type) -> NoReturn:  # type: ignore[misc]  # should return an instance
         raise TypeError(f"{cls.__name__} is used as a sentinel value and cannot be instantiated.")
 

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -63,7 +63,7 @@ frozendict: Final = _frozendict if sys.version_info >= (3, 9) else xtyping.Froze
 
 @final
 class NothingType(type):
-    """Metaclass for :class:`NOTHING` marker."""
+    """Metaclass of :class:`NOTHING` setting its bool value to False."""
 
     def __bool__(cls) -> bool:
         return False

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -64,6 +64,7 @@ frozendict: Final = _frozendict if sys.version_info >= (3, 9) else xtyping.Froze
 @final
 class NothingType(type):
     """Metaclass for :class:`NOTHING` marker."""
+
     def __bool__(cls) -> bool:
         return False
 

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -37,11 +37,15 @@ from .extended_typing import (
     Type,
     TypeAnnotation,
     TypeVar,
+    Union,
+    final,
+    overload,
+    runtime_checkable,
 )
 
 
 # Protocols
-@xtyping.runtime_checkable
+@runtime_checkable
 class TypeValidator(Protocol):
     @abc.abstractmethod
     def __call__(
@@ -96,9 +100,9 @@ class FixedTypeValidator(Protocol):
         ...
 
 
-@xtyping.runtime_checkable
+@runtime_checkable
 class TypeValidatorFactory(Protocol):
-    @xtyping.overload
+    @overload
     def __call__(
         self,
         type_annotation: TypeAnnotation,
@@ -111,7 +115,7 @@ class TypeValidatorFactory(Protocol):
     ) -> FixedTypeValidator:
         ...
 
-    @xtyping.overload
+    @overload
     def __call__(  # noqa: F811  # redefinion of unused member
         self,
         type_annotation: TypeAnnotation,
@@ -119,7 +123,7 @@ class TypeValidatorFactory(Protocol):
         *,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: bool = True,
+        required: bool,
         **kwargs: Any,
     ) -> Optional[FixedTypeValidator]:
         ...
@@ -147,7 +151,7 @@ class TypeValidatorFactory(Protocol):
 
 
 # Implementations
-@xtyping.final
+@final
 @dataclasses.dataclass(frozen=True)
 class SimpleTypeValidatorFactory(TypeValidatorFactory):
     """A simple :class:`TypeValidatorFactory` implementation.
@@ -158,7 +162,7 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         strict_int (bool): do not accept ``bool`` values as ``int`` (default: ``True``).
     """
 
-    @xtyping.overload
+    @overload
     def __call__(
         self,
         type_annotation: TypeAnnotation,
@@ -171,7 +175,7 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
     ) -> FixedTypeValidator:
         ...
 
-    @xtyping.overload
+    @overload
     def __call__(  # noqa: F811  # redefinion of unused member
         self,
         type_annotation: TypeAnnotation,
@@ -230,7 +234,7 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
             origin_type = xtyping.get_origin(type_annotation)
             type_args = xtyping.get_args(type_annotation)
 
-            if origin_type is xtyping.Literal:
+            if origin_type is Literal:
                 if len(type_args) == 1:
                     return self.make_is_literal(name, type_args[0])
                 else:
@@ -240,7 +244,7 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                         error_type=TypeError,
                     )
 
-            if origin_type is xtyping.Union:
+            if origin_type is Union:
                 has_none = False
                 validators = []
                 for t in type_args:

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -480,7 +480,8 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
 
 #: Public (with optional cache) entry point for :class:`SimpleTypeValidatorFactory`.
 simple_type_validator_factory: Final = cast(
-    TypeValidatorFactory, utils.optional_lru_cache(SimpleTypeValidatorFactory(), typed=True)
+    TypeValidatorFactory,
+    utils.optional_lru_cache(SimpleTypeValidatorFactory(), typed=True),  # type: ignore[arg-type]
 )
 
 

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -38,6 +38,7 @@ from .extended_typing import (
     TypeAnnotation,
     TypeVar,
     Union,
+    cast,
     final,
     overload,
     runtime_checkable,
@@ -108,9 +109,9 @@ class TypeValidatorFactory(Protocol):
         type_annotation: TypeAnnotation,
         name: Optional[str] = None,
         *,
+        required: Literal[True] = True,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: Literal[True] = True,
         **kwargs: Any,
     ) -> FixedTypeValidator:
         ...
@@ -121,9 +122,9 @@ class TypeValidatorFactory(Protocol):
         type_annotation: TypeAnnotation,
         name: Optional[str] = None,
         *,
+        required: bool = True,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: bool,
         **kwargs: Any,
     ) -> Optional[FixedTypeValidator]:
         ...
@@ -134,9 +135,9 @@ class TypeValidatorFactory(Protocol):
         type_annotation: TypeAnnotation,
         name: Optional[str] = None,
         *,
+        required: bool = True,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: bool = True,
         **kwargs: Any,
     ) -> Optional[FixedTypeValidator]:
         """Protocol for :class:`FixedTypeValidator`s.
@@ -168,9 +169,9 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         type_annotation: TypeAnnotation,
         name: Optional[str] = None,
         *,
+        required: Literal[True] = True,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: Literal[True] = True,
         **kwargs: Any,
     ) -> FixedTypeValidator:
         ...
@@ -181,9 +182,9 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         type_annotation: TypeAnnotation,
         name: Optional[str] = None,
         *,
+        required: bool = True,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: bool = True,
         **kwargs: Any,
     ) -> Optional[FixedTypeValidator]:
         ...
@@ -193,9 +194,9 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         type_annotation: TypeAnnotation,
         name: Optional[str] = None,
         *,
+        required: bool = True,
         globalns: Optional[Dict[str, Any]] = None,
         localns: Optional[Dict[str, Any]] = None,
-        required: bool = True,
         **kwargs: Any,
     ) -> Optional[FixedTypeValidator]:
         if name is None:
@@ -478,8 +479,8 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
 
 
 #: Public (with optional cache) entry point for :class:`SimpleTypeValidatorFactory`.
-simple_type_validator_factory: Final = utils.optional_lru_cache(
-    SimpleTypeValidatorFactory(), typed=True
+simple_type_validator_factory: Final = cast(
+    TypeValidatorFactory, utils.optional_lru_cache(SimpleTypeValidatorFactory(), typed=True)
 )
 
 
@@ -500,7 +501,7 @@ def simple_type_validator(
     Keyword Arguments:
         strict_int (bool): do not accept ``bool`` values as ``int`` (default: ``True``).
     """
-    type_validator = simple_type_validator_factory(
+    type_validator: Optional[FixedTypeValidator] = simple_type_validator_factory(
         type_annotation, name=name, globalns=globalns, localns=localns, required=required, **kwargs
     )
     if type_validator is not None:

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -435,7 +435,7 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         value_validator: FixedTypeValidator,
         mapping_validator: Optional[FixedTypeValidator] = None,
     ) -> FixedTypeValidator:
-        """Create an ``FixedTypeValidator`` validator for deep checks of typed iterables."""
+        """Create an ``FixedTypeValidator`` validator for deep checks of typed mappings."""
 
         def _is_mapping_of(value: Any, **kwargs: Any) -> None:
             if mapping_validator is not None:

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -1,0 +1,507 @@
+# -*- coding: utf-8 -*-
+#
+# Eve Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2014-2021, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Generic interface and implementations of run-time type validation for arbitrary values."""
+
+
+from __future__ import annotations
+
+import abc
+import collections.abc
+import dataclasses
+import functools
+
+from . import exceptions, extended_typing as xtyping, utils
+from .extended_typing import (
+    Any,
+    Dict,
+    Final,
+    ForwardRef,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    Type,
+    TypeAnnotation,
+    TypeVar,
+)
+
+
+# Protocols
+@xtyping.runtime_checkable
+class TypeValidator(Protocol):
+    @abc.abstractmethod
+    def __call__(
+        self,
+        value: Any,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Protocol for callables checking that ``value`` matches ``type_annotation``.
+
+        Arguments:
+            value: value to be checked against the typing annotation.
+            type_annotation: a valid typing annotation.
+            name: the name of the checked value (used for error messages).
+
+        Keyword Arguments:
+            globalns: globals dict used in the evaluation of the annotations.
+            localns: locals dict used in the evaluation of the annotations.
+            required: if ``True``, raise ``ValueError`` when provided type annotation is not supported.
+            **kwargs: arbitrary implementation-defined arguments (e.g. for memoization).
+
+        Raises:
+            TypeError: if there is a type mismatch.
+            ValueError: if ``required is True`` and ``type_annotation`` is not supported.
+        """
+        ...
+
+
+class FixedTypeValidator(Protocol):
+    @abc.abstractmethod
+    def __call__(
+        self,
+        value: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Protocol for callables checking that ``value`` matches a fixed type_annotation.
+
+        Arguments:
+            value: value to be checked against the typing annotation.
+
+        Keyword Arguments:
+            **kwargs: arbitrary implementation-defined arguments (e.g. for memoization).
+
+        Raises:
+            TypeError: if there is a type mismatch.
+        """
+        ...
+
+
+@xtyping.runtime_checkable
+class TypeValidatorFactory(Protocol):
+    @xtyping.overload
+    def __call__(
+        self,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: Literal[True] = True,
+        **kwargs: Any,
+    ) -> FixedTypeValidator:
+        ...
+
+    @xtyping.overload
+    def __call__(  # noqa: F811  # redefinion of unused member
+        self,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: bool = True,
+        **kwargs: Any,
+    ) -> Optional[FixedTypeValidator]:
+        ...
+
+    @abc.abstractmethod
+    def __call__(  # noqa: F811  # redefinion of unused member
+        self,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: bool = True,
+        **kwargs: Any,
+    ) -> Optional[FixedTypeValidator]:
+        """Protocol for :class:`FixedTypeValidator`s.
+
+        The arguments match the specification in :class:`TypeValidator`.
+
+        Raises:
+            TypeError: if there is a type mismatch.
+            ValueError: if ``required is True`` and ``type_annotation`` is not supported.
+        """
+        ...
+
+
+# Implementations
+@xtyping.final
+@dataclasses.dataclass(frozen=True)
+class SimpleTypeValidatorFactory(TypeValidatorFactory):
+    """A simple :class:`TypeValidatorFactory` implementation.
+
+    Check :class:`FixedTypeValidator` and :class:`TypeValidatorFactory` for details.
+
+    Keyword Arguments:
+        strict_int (bool): do not accept ``bool`` values as ``int`` (default: ``True``).
+    """
+
+    @xtyping.overload
+    def __call__(
+        self,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: Literal[True] = True,
+        **kwargs: Any,
+    ) -> FixedTypeValidator:
+        ...
+
+    @xtyping.overload
+    def __call__(  # noqa: F811  # redefinion of unused member
+        self,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: bool = True,
+        **kwargs: Any,
+    ) -> Optional[FixedTypeValidator]:
+        ...
+
+    def __call__(  # noqa: F811,C901  # redefinion of unused member / complex but well organized in cases
+        self,
+        type_annotation: TypeAnnotation,
+        name: Optional[str] = None,
+        *,
+        globalns: Optional[Dict[str, Any]] = None,
+        localns: Optional[Dict[str, Any]] = None,
+        required: bool = True,
+        **kwargs: Any,
+    ) -> Optional[FixedTypeValidator]:
+        if name is None:
+            name = "<value>"
+
+        make_recursive = functools.partial(
+            self.__call__, name=name, globalns=globalns, localns=localns, **kwargs
+        )
+
+        try:
+            # Non-generic types
+            if xtyping.is_actual_type(type_annotation) and not isinstance(
+                None, type_annotation  # NoneType is a different case
+            ):
+                assert not xtyping.get_args(type_annotation)
+                if type_annotation is int and kwargs.get("strict_int", True):
+                    return self.make_is_instance_of_int(name)
+                else:
+                    return self.make_is_instance_of(name, type_annotation)
+
+            if isinstance(type_annotation, TypeVar):
+                if type_annotation.__bound__:
+                    return self.make_is_instance_of(name, type_annotation.__bound__)
+                else:
+                    return self._make_is_any(name)
+
+            if isinstance(type_annotation, ForwardRef):
+                return make_recursive(
+                    xtyping.eval_forward_ref(type_annotation, globalns=globalns, localns=localns)
+                )
+
+            if type_annotation is Any:
+                return self._make_is_any(name)
+
+            # Generic and parametrized type hints
+            origin_type = xtyping.get_origin(type_annotation)
+            type_args = xtyping.get_args(type_annotation)
+
+            if origin_type is xtyping.Literal:
+                if len(type_args) == 1:
+                    return self.make_is_literal(name, type_args[0])
+                else:
+                    return self.combine_validators_as_or(
+                        name,
+                        *(self.make_is_literal(name, a) for a in type_args),
+                        error_type=TypeError,
+                    )
+
+            if origin_type is xtyping.Union:
+                has_none = False
+                validators = []
+                for t in type_args:
+                    if t in (type(None), None):
+                        has_none = True
+                    else:
+                        if (v := make_recursive(t)) is None:
+                            raise exceptions.EveValueError(f"{t} type annotation is not supported.")
+                        validators.append(v)
+
+                validator = (
+                    self.combine_validators_as_or(name, *validators)
+                    if len(validators) > 1
+                    else validators[0]
+                )
+                return self.combine_optional(name, validator) if has_none else validator
+
+            if isinstance(origin_type, type):
+                # Deal with generic collections
+                if issubclass(origin_type, tuple):
+                    if len(type_args) == 2 and (type_args[1] is Ellipsis):
+                        # Tuple as an immutable sequence type (e.g. Tuple[int, ...])
+                        if (member_validator := make_recursive(type_args[0])) is None:
+                            raise exceptions.EveValueError(
+                                f"{type_args[0]} type annotation is not supported."
+                            )
+
+                        return self.make_is_iterable_of(
+                            name,
+                            member_validator,
+                            iterable_validator=self.make_is_instance_of(name, origin_type),
+                        )
+
+                    else:
+                        # Tuple as a heterogeneous container (e.g. Tuple[int, float])
+                        item_validators = []
+                        for t in type_args:
+                            if (v := make_recursive(t)) is None:
+                                raise exceptions.EveValueError(
+                                    f"{t} type annotation is not supported."
+                                )
+                            item_validators.append(v)
+
+                        return self.make_is_tuple_of(name, tuple(item_validators), origin_type)
+
+                if issubclass(origin_type, (collections.abc.Sequence, collections.abc.Set)):
+                    assert len(type_args) == 1
+                    if (member_validator := make_recursive(type_args[0])) is None:
+                        raise exceptions.EveValueError(
+                            f"{type_args[0]} type annotation is not supported."
+                        )
+
+                    return self.make_is_iterable_of(
+                        name,
+                        member_validator,
+                        iterable_validator=self.make_is_instance_of(name, origin_type),
+                    )
+
+                if issubclass(origin_type, collections.abc.Mapping):
+                    assert len(type_args) == 2
+                    if (key_validator := make_recursive(type_args[0])) is None:
+                        raise exceptions.EveValueError(
+                            f"{type_args[0]} type annotation is not supported."
+                        )
+                    if (value_validator := make_recursive(type_args[1])) is None:
+                        raise exceptions.EveValueError(
+                            f"{type_args[1]} type annotation is not supported."
+                        )
+
+                    return self.make_is_mapping_of(
+                        name,
+                        key_validator,
+                        value_validator,
+                        mapping_validator=self.make_is_instance_of(name, origin_type),
+                    )
+
+            # TODO(egparedes): add support for Callables
+            raise exceptions.EveValueError(f"{type_annotation} type annotation is not supported.")
+
+        except exceptions.EveValueError as error:
+            if required:
+                raise error
+
+        assert bool(required) is False
+
+        return None
+
+    @staticmethod
+    def _make_is_any(name: str) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for any type."""
+
+        def _is_any(value: Any, **kwargs: Any) -> None:
+            pass
+
+        return _is_any
+
+    @staticmethod
+    def make_is_instance_of(name: str, type_: type) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for a specific type."""
+
+        def _is_instance_of(value: Any, **kwargs: Any) -> None:
+            if not isinstance(value, type_):
+                raise TypeError(
+                    f"'{name}' must be {type_} (got '{value}' that is a {type(value)})."
+                )
+
+        return _is_instance_of
+
+    @staticmethod
+    def make_is_instance_of_int(name: str) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for ``int`` values which fails with ``bool`` values."""
+
+        def _is_instance_of_int(value: Any, **kwargs: Any) -> None:
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(f"'{name}' must be {int} (got '{value}' that is a {type(value)}).")
+
+        return _is_instance_of_int
+
+    @staticmethod
+    def make_is_literal(name: str, literal_value: Any) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for a literal value."""
+        if isinstance(literal_value, bool):
+
+            def _is_literal(value: Any, **kwargs: Any) -> None:
+                if value is not literal_value:
+                    raise TypeError(
+                        f"Provided value '{value}' for '{name}' does not match literal {literal_value}."
+                    )
+
+        else:
+
+            def _is_literal(value: Any, **kwargs: Any) -> None:
+                if value != literal_value:
+                    raise TypeError(
+                        f"Provided value '{value}' for '{name}' does not match literal {literal_value}."
+                    )
+
+        return _is_literal
+
+    @staticmethod
+    def make_is_tuple_of(
+        name: str, item_validators: Sequence[FixedTypeValidator], tuple_type: type[tuple]
+    ) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for tuple types."""
+
+        def _is_tuple_of(value: Any, **kwargs: Any) -> None:
+            if not isinstance(value, tuple_type):
+                raise TypeError(
+                    f"In '{name}' validation, got '{value}' that is a {type(value)} instead of {tuple_type}."
+                )
+            if len(value) != len(item_validators):
+                raise TypeError(
+                    f"In '{name}' validation, got '{value}' tuple which contains {len(value)} elements instead of {len(item_validators)}."
+                )
+
+            _i = None
+            item_value = ""
+            try:
+                for _i, (item_value, item_validator) in enumerate(zip(value, item_validators)):
+                    item_validator(item_value)
+            except Exception as e:
+                raise TypeError(
+                    f"In '{name}' validation, tuple '{value}' contains invalid value '{item_value}' at position {_i}."
+                ) from e
+
+        return _is_tuple_of
+
+    @staticmethod
+    def make_is_iterable_of(
+        name: str,
+        member_validator: FixedTypeValidator,
+        iterable_validator: Optional[FixedTypeValidator] = None,
+    ) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for deep checks of typed iterables."""
+
+        def _is_iterable_of(value: Any, **kwargs: Any) -> None:
+            if iterable_validator is not None:
+                iterable_validator(value, **kwargs)
+
+            for member in value:
+                member_validator(member, **kwargs)
+
+        return _is_iterable_of
+
+    @staticmethod
+    def make_is_mapping_of(
+        name: str,
+        key_validator: FixedTypeValidator,
+        value_validator: FixedTypeValidator,
+        mapping_validator: Optional[FixedTypeValidator] = None,
+    ) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for deep checks of typed iterables."""
+
+        def _is_mapping_of(value: Any, **kwargs: Any) -> None:
+            if mapping_validator is not None:
+                mapping_validator(value, **kwargs)
+
+            for k in value:
+                key_validator(k, **kwargs)
+                value_validator(value[k], **kwargs)
+
+        return _is_mapping_of
+
+    @staticmethod
+    def combine_optional(name: str, actual_validator: FixedTypeValidator) -> FixedTypeValidator:
+        """Create an ``FixedTypeValidator`` validator for an optional constraint."""
+
+        def _is_optional(value: Any, **kwargs: Any) -> None:
+            if value is not None:
+                actual_validator(value, **kwargs)
+
+        return _is_optional
+
+    @staticmethod
+    def combine_validators_as_or(
+        name: str, *validators: FixedTypeValidator, error_type: Type[Exception] = TypeError
+    ) -> FixedTypeValidator:
+        def _combined_validator(value: Any, **kwargs: Any) -> None:
+            for v in validators:
+                try:
+                    v(value, **kwargs)
+                    break
+                except Exception:
+                    pass
+            else:
+                raise error_type(
+                    f"In '{name}' validation, provided value '{value}' fails for all the possible validators."
+                )
+
+        return _combined_validator
+
+
+#: Public (with optional cache) entry point for :class:`SimpleTypeValidatorFactory`.
+simple_type_validator_factory: Final = utils.optional_lru_cache(
+    SimpleTypeValidatorFactory(), typed=True
+)
+
+
+def simple_type_validator(
+    value: Any,
+    type_annotation: TypeAnnotation,
+    name: Optional[str] = None,
+    *,
+    globalns: Optional[Dict[str, Any]] = None,
+    localns: Optional[Dict[str, Any]] = None,
+    required: bool = True,
+    **kwargs: Any,
+) -> None:
+    """A simple :class:`TypeValidator` implementation.
+
+    Check :class:`TypeValidator` and :class:`SimpleTypeValidatorFactory` for details.
+
+    Keyword Arguments:
+        strict_int (bool): do not accept ``bool`` values as ``int`` (default: ``True``).
+    """
+    type_validator = simple_type_validator_factory(
+        type_annotation, name=name, globalns=globalns, localns=localns, required=required, **kwargs
+    )
+    if type_validator is not None:
+        type_validator(value, **kwargs)
+
+
+# TODO(egparedes): add other implementations for advanced 3rd-party validators
+# TODO(egparedes): e.g. 'typeguard' and specially 'beartype'

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -489,7 +489,7 @@ def simple_type_validator(
     required: bool = True,
     **kwargs: Any,
 ) -> None:
-    """A simple :class:`TypeValidator` implementation.
+    """Check that value verifies a type definition (a simple :class:`TypeValidator` implementation).
 
     Check :class:`TypeValidator` and :class:`SimpleTypeValidatorFactory` for details.
 

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -493,7 +493,7 @@ def simple_type_validator(
     required: bool = True,
     **kwargs: Any,
 ) -> None:
-    """Check that value verifies a type definition (a simple :class:`TypeValidator` implementation).
+    """Check that value satisfies a type definition (a simple :class:`TypeValidator` implementation).
 
     Check :class:`TypeValidator` and :class:`SimpleTypeValidatorFactory` for details.
 

--- a/src/eve/type_validation.py
+++ b/src/eve/type_validation.py
@@ -39,7 +39,6 @@ from .extended_typing import (
     TypeVar,
     Union,
     cast,
-    final,
     overload,
     runtime_checkable,
 )
@@ -152,7 +151,6 @@ class TypeValidatorFactory(Protocol):
 
 
 # Implementations
-@final
 @dataclasses.dataclass(frozen=True)
 class SimpleTypeValidatorFactory(TypeValidatorFactory):
     """A simple :class:`TypeValidatorFactory` implementation.

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -35,24 +35,26 @@ import uuid
 import warnings
 
 import xxhash
-from boltons.iterutils import flatten, flatten_iter, is_collection  # noqa: F401
-from boltons.strutils import (  # noqa: F401
-    a10n,
-    asciify,
-    format_int_list,
-    iter_splitlines,
-    parse_int_list,
-    slugify,
-    unwrap_text,
+from boltons.iterutils import (  # noqa: F401
+    flatten as flatten,
+    flatten_iter as flatten_iter,
+    is_collection as is_collection,
 )
-from boltons.typeutils import classproperty  # noqa: F401
+from boltons.strutils import (  # noqa: F401
+    a10n as a10n,
+    asciify as asciify,
+    format_int_list as format_int_list,
+    iter_splitlines as iter_splitlines,
+    parse_int_list as parse_int_list,
+    slugify as slugify,
+    unwrap_text as unwrap_text,
+)
 
 from .extended_typing import (
     Any,
     Callable,
     Collection,
     Dict,
-    Final,
     Generic,
     Iterable,
     Iterator,
@@ -65,7 +67,7 @@ from .extended_typing import (
     TypeVar,
     Union,
 )
-from .type_definitions import NOTHING
+from .type_definitions import NOTHING, NothingType
 
 
 try:
@@ -255,9 +257,12 @@ def optional_lru_cache(
         def inner(*args: Any, **kwargs: Any) -> Any:
             try:
                 return cached(*args, **kwargs)
-            except TypeError:
-                # Catch errors due to non-hashable arguments and fallback to original function
-                return func(*args, **kwargs)
+            except TypeError as error:
+                if error.args and error.args[0].startswith("unhashable"):
+                    # Catch errors due to non-hashable arguments and fallback to original function
+                    return func(*args, **kwargs)
+                else:
+                    raise error
 
         return inner
 
@@ -480,22 +485,25 @@ class FrozenNamespace(types.SimpleNamespace, Generic[T]):
         return self.__dict__.values()
 
 
-if sys.version_info >= (3, 10):
-    field_: Final = dataclasses.field
-else:
-
-    @functools.wraps(dataclasses.field)
-    def field_(*, kw_only: Optional[bool] = None, **kwargs: Any) -> dataclasses.Field:
-        return dataclasses.field(**kwargs)
-
-
 @dataclasses.dataclass
 class UIDGenerator:
     """Simple unique id generator using different methods."""
 
-    prefix: Optional[str] = field_(default=None, kw_only=True)
-    width: Optional[int] = field_(default=None, kw_only=True)
-    warn_unsafe: Optional[bool] = field_(default=None, kw_only=True)
+    prefix: Optional[str] = (
+        dataclasses.field(default=None, kw_only=True)
+        if sys.version_info >= (3, 10)
+        else dataclasses.field(default=None)
+    )
+    width: Optional[int] = (
+        dataclasses.field(default=None, kw_only=True)
+        if sys.version_info >= (3, 10)
+        else dataclasses.field(default=None)
+    )
+    warn_unsafe: Optional[bool] = (
+        dataclasses.field(default=None, kw_only=True)
+        if sys.version_info >= (3, 10)
+        else dataclasses.field(default=None)
+    )
 
     #: Constantly increasing counter for generation of sequential unique ids
     _counter: Iterator[int] = dataclasses.field(
@@ -1069,7 +1077,10 @@ class XIterable(Iterable[T]):
         ...
 
     def islice(
-        self, __start_or_stop: int, __stop_or_nothing: Union[int, NOTHING] = NOTHING, step: int = 1
+        self,
+        __start_or_stop: int,
+        __stop_or_nothing: Union[int, NothingType] = NOTHING,
+        step: int = 1,
     ) -> XIterable[T]:
         """Select elements from an iterable.
 
@@ -1095,6 +1106,7 @@ class XIterable(Iterable[T]):
             start = 0
             stop = __start_or_stop
         else:
+            assert isinstance(__stop_or_nothing, int)
             start = __start_or_stop
             stop = __stop_or_nothing
         return XIterable(itertools.islice(self.iterator, start, stop, step))
@@ -1281,8 +1293,8 @@ class XIterable(Iterable[T]):
         bin_op_func: Callable[[S, T], S],
         key: str,
         *,
-        init: Union[S, NOTHING],
         as_dict: Literal[False],
+        init: Union[S, NothingType],
     ) -> XIterable[Tuple[str, S]]:
         ...
 
@@ -1293,8 +1305,8 @@ class XIterable(Iterable[T]):
         key: str,
         __attr_keys1: str,
         *attr_keys: str,
-        init: Union[S, NOTHING],
         as_dict: Literal[False],
+        init: Union[S, NothingType],
     ) -> XIterable[Tuple[Tuple[str, ...], S]]:
         ...
 
@@ -1304,8 +1316,8 @@ class XIterable(Iterable[T]):
         bin_op_func: Callable[[S, T], S],
         key: str,
         *,
-        init: Union[S, NOTHING],
         as_dict: Literal[True],
+        init: Union[S, NothingType],
     ) -> Dict[str, S]:
         ...
 
@@ -1316,8 +1328,8 @@ class XIterable(Iterable[T]):
         key: str,
         __attr_keys1: str,
         *attr_keys: str,
-        init: Union[S, NOTHING],
         as_dict: Literal[True],
+        init: Union[S, NothingType],
     ) -> Dict[Tuple[str, ...], S]:
         ...
 
@@ -1327,8 +1339,8 @@ class XIterable(Iterable[T]):
         bin_op_func: Callable[[S, T], S],
         key: List[K],
         *,
-        init: Union[S, NOTHING],
         as_dict: Literal[False],
+        init: Union[S, NothingType],
     ) -> XIterable[Tuple[K, S]]:
         ...
 
@@ -1338,8 +1350,8 @@ class XIterable(Iterable[T]):
         bin_op_func: Callable[[S, T], S],
         key: List[K],
         *,
-        init: Union[S, NOTHING],
         as_dict: Literal[True],
+        init: Union[S, NothingType],
     ) -> Dict[K, S]:
         ...
 
@@ -1349,8 +1361,8 @@ class XIterable(Iterable[T]):
         bin_op_func: Callable[[S, T], S],
         key: Callable[[T], K],
         *,
-        init: Union[S, NOTHING],
         as_dict: Literal[False],
+        init: Union[S, NothingType],
     ) -> XIterable[Tuple[K, S]]:
         ...
 
@@ -1360,18 +1372,18 @@ class XIterable(Iterable[T]):
         bin_op_func: Callable[[S, T], S],
         key: Callable[[T], K],
         *,
-        init: Union[S, NOTHING],
         as_dict: Literal[True],
+        init: Union[S, NothingType],
     ) -> Dict[K, S]:
         ...
 
-    def reduceby(
+    def reduceby(  # type: ignore[misc] # signatures 2 and 4 are not satified due to inconsistencies with type variables
         self,
         bin_op_func: Callable[[S, T], S],
         key: Union[str, List[K], Callable[[T], K]],
         *attr_keys: str,
-        init: Union[S, NOTHING] = NOTHING,
         as_dict: bool = False,
+        init: Union[S, NothingType] = NOTHING,
     ) -> Union[
         XIterable[Tuple[str, S]],
         Dict[str, S],

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -236,13 +236,13 @@ def optional_lru_cache(
 
 
 @overload
-def optional_lru_cache(
+def optional_lru_cache(  # noqa: F811  # redefinition of unused function
     func: Callable[_P, _T], *, maxsize: Optional[int] = 128, typed: bool = False
 ) -> Callable[_P, _T]:
     ...
 
 
-def optional_lru_cache(
+def optional_lru_cache(  # noqa: F811  # redefinition of unused function
     func: Optional[Callable[_P, _T]] = None, *, maxsize: Optional[int] = 128, typed: bool = False
 ) -> Union[Callable[_P, _T], Callable[[Callable[_P, _T]], Callable[_P, _T]]]:
     """Wrap :func:`functools.lru_cache` to fall back to the original function if arguments are not hashable.

--- a/tests/eve_tests/unit_tests/test_extended_typing.py
+++ b/tests/eve_tests/unit_tests/test_extended_typing.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import collections.abc
-import sys
 import typing
 
 import pytest
@@ -52,7 +51,7 @@ def test_is_actual_valid_type(t):
         Tuple[int],
         Tuple[int, ...],
         Tuple[int, int],
-        Dict[str],
+        Dict[str, Any],
         Dict[str, float],
         Mapping[int, float],
     ),
@@ -288,11 +287,3 @@ def test_infer_type():
             Callable[[int, float], type(None)], xtyping.CallableKwargsInfo({"foo": Tuple[str, ...]})
         ]
     )
-
-
-# @pytest.mark.parametrize(["hint","changes","expected"], [(list, list(), (1, []), dict())])
-# def test_replace_types():
-#     hint = Dict[int, float]
-
-#     assert xtyping.replace_types(hint, {int: float}) == Dict[float, float]
-#     assert xtyping.replace_types(hint, {float: int}) == Dict[int, int]

--- a/tests/eve_tests/unit_tests/test_extended_typing.py
+++ b/tests/eve_tests/unit_tests/test_extended_typing.py
@@ -18,7 +18,9 @@
 from __future__ import annotations
 
 import collections.abc
+import types
 import typing
+import sys
 
 import pytest
 
@@ -58,6 +60,30 @@ def test_is_actual_valid_type(t):
 )
 def test_is_actual_wrong_type(t):
     assert not xtyping.is_actual_type(t)
+
+
+ACTUAL_TYPE_SAMPLES = [
+    (3, int),
+    (4.5, float),
+    ({}, dict),
+    (int, type),
+    (tuple, type),
+    (list, type),
+    (Tuple[int, float], type(Tuple[int, float])),
+    (List[int], type(List[int])),
+]
+if sys.version_info >= (3, 9):
+    ACTUAL_TYPE_SAMPLES.extend(
+        [
+            (tuple[int, float], types.GenericAlias),
+            (list[int], types.GenericAlias),
+        ]
+    )
+
+
+@pytest.mark.parametrize(["instance", "expected"], ACTUAL_TYPE_SAMPLES)
+def test_get_actual_type(instance, expected):
+    assert xtyping.get_actual_type(instance) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/eve_tests/unit_tests/test_extended_typing.py
+++ b/tests/eve_tests/unit_tests/test_extended_typing.py
@@ -18,9 +18,9 @@
 from __future__ import annotations
 
 import collections.abc
+import sys
 import types
 import typing
-import sys
 
 import pytest
 
@@ -75,7 +75,7 @@ ACTUAL_TYPE_SAMPLES = [
 if sys.version_info >= (3, 9):
     ACTUAL_TYPE_SAMPLES.extend(
         [
-            (tuple[int, float], types.GenericAlias),
+            (tuple[int, float], types.GenericAlias),  # type: ignore[misc]   # ignore false positive bug: https://github.com/python/mypy/issues/11098
             (list[int], types.GenericAlias),
         ]
     )

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -65,8 +65,6 @@ class SampleDataClass:
 # Each item should be a tuple like:
 #   ( annotation: Any, valid_values: Sequence, wrong_values: Sequence,
 #     globalns: Optional[Dict[str, Any]], localns: Optional[Dict[str, Any]] )
-
-
 SAMPLE_TYPE_DEFINITIONS: List[
     Tuple[Any, Sequence, Sequence, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]
 ] = [

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+#
+# Eve Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import sys
+import typing
+
+import pytest
+
+from eve import type_validation as type_val
+from eve.extended_typing import (
+    Any,
+    Callable,
+    Dict,
+    Final,
+    ForwardRef,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    SourceTypeAnnotation,
+    Tuple,
+    Union,
+)
+
+
+VALIDATORS: Final = [type_val.simple_type_validator]
+FACTORIES: Final = [type_val.simple_type_validator_factory]
+
+
+class SampleEnum(enum.Enum):
+    FOO = "foo"
+    BLA = "bla"
+
+
+class SampleEmptyClass:
+    pass
+
+
+@dataclasses.dataclass
+class SampleDataClass:
+    a: int
+
+
+# Each item should be a tuple like:
+#   class SampleDataCase(NamedTuple):
+#       annotation: Any
+#       valid_values: Sequence
+#       wrong_values: Sequence
+#       globalns: Optional[Dict[str, Any]]
+#       localns: Optional[Dict[str, Any]]
+
+
+SAMPLE_TYPE_DEFINITIONS: List[
+    Tuple[Any, Sequence, Sequence, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]
+] = [
+    (bool, [True, False], [1, "True"], None, None),
+    (int, [1, -1], [1.0, "1"], None, None),
+    (float, [1.0], [1, "1.0"], None, None),
+    (complex, [1.0j, 1 + 2j, 3j], [1, "1.0"], None, None),
+    (str, ["", "one"], [1, ("one",)], None, None),
+    (complex, [1j], [1, 1.0, "1j"], None, None),
+    (bytes, [b"bytes", b""], ["string", ["a"]], None, None),
+    (typing.Any, ["any"], tuple(), None, None),
+    (
+        typing.Literal[1, True],
+        [1, True],
+        [False],
+        None,
+        None,
+    ),  # float literals are not supported by PEP 586
+    (typing.Tuple[int, str], [(3, "three")], [(), (3, 3)], None, None),
+    (typing.Tuple[int, ...], [(1, 2, 3), ()], [3, (3, "three")], None, None),
+    (typing.List[int], ([1, 2, 3], []), (1, [1.0]), None, None),
+    (typing.Set[int], ({1, 2, 3}, set()), (1, [1], (1,), {1: None}), None, None),
+    (typing.Dict[int, str], ({}, {3: "three"}), ([(3, "three")], 3, "three", []), None, None),
+    (typing.Sequence[int], ([1, 2, 3], [], (1, 2, 3), tuple()), (1, [1.0], {1}), None, None),
+    (typing.MutableSequence[int], ([1, 2, 3], []), ((1, 2, 3), tuple(), 1, [1.0], {1}), None, None),
+    (typing.Set[int], ({1, 2, 3}, set()), (1, [1], (1,), {1: None}), None, None),
+    (typing.Union[int, float, str], [1, 3.0, "one"], [[1], [], 1j], None, None),
+    (typing.Optional[int], [1, None], [[1], [], 1j], None, None),
+    (
+        typing.Dict[Union[int, float, str], Union[Tuple[int, Optional[float]], Set[int]]],
+        [{1: (2, 3.0)}, {1.0: (2, None)}, {"1": {1, 2}}],
+        [{(1, 1.0, "1"): set()}, {1: [1]}, {"1": (1,)}],
+        None,
+        None,
+    ),
+    (SampleEnum, [SampleEnum.FOO, SampleEnum.BLA], [SampleEnum, "foo", "bla"], None, None),
+    (
+        SampleEmptyClass,
+        [SampleEmptyClass(), SampleEmptyClass()],
+        [object(), "", None, SampleDataClass(1), SampleEmptyClass],
+        None,
+        None,
+    ),
+    (
+        SampleDataClass,
+        [SampleDataClass(1), SampleDataClass(-42)],
+        [object(), int(1), "1", SampleDataClass],
+        None,
+        None,
+    ),
+    (
+        ForwardRef("SampleDataClass"),
+        [SampleDataClass(1), SampleDataClass(-42)],
+        [object(), int(1), "1", SampleDataClass],
+        {"SampleDataClass": SampleDataClass},
+        None,
+    ),
+    (
+        ForwardRef("SampleDataClass"),
+        [SampleDataClass(1), SampleDataClass(-42)],
+        [object(), int(1), "1", SampleDataClass],
+        None,
+        {"SampleDataClass": SampleDataClass},
+    ),
+    (
+        ForwardRef("typing.List[SampleEmptyClass]"),
+        ([], [SampleEmptyClass()], [SampleEmptyClass()] * 5),
+        (SampleEmptyClass(), [1], (SampleEmptyClass(),), {1: SampleEmptyClass()}),
+        globals(),
+        None,
+    ),
+]
+
+if sys.version_info >= (3, 10):
+
+    @dataclasses.dataclass(slots=True)
+    class SampleSlottedDataClass:
+        b: float
+
+    SAMPLE_TYPE_DEFINITIONS.append(
+        (
+            SampleSlottedDataClass,
+            [SampleSlottedDataClass(1.0), SampleSlottedDataClass(1)],
+            [object(), float(1.2), int(1), "1.2", SampleSlottedDataClass],
+            None,
+            None,
+        )
+    )
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+@pytest.mark.parametrize(
+    ["type_hint", "valid_values", "wrong_values", "globalns", "localns"], SAMPLE_TYPE_DEFINITIONS
+)
+def test_validators(
+    validator: type_val.TypeValidator,
+    type_hint: SourceTypeAnnotation,
+    valid_values: Sequence,
+    wrong_values: Sequence,
+    globalns: Optional[Dict[str, Any]],
+    localns: Optional[Dict[str, Any]],
+):
+    for value in valid_values:
+        validator(value, type_hint, "<value>", globalns=globalns, localns=localns)
+
+    for value in wrong_values:
+        with pytest.raises((TypeError), match="'<value>'"):
+            validator(value, type_hint, "<value>", globalns=globalns, localns=localns)
+
+
+@pytest.mark.parametrize("factory", FACTORIES)
+@pytest.mark.parametrize(
+    ["type_hint", "valid_values", "wrong_values", "globalns", "localns"], SAMPLE_TYPE_DEFINITIONS
+)
+def test_validator_factories(
+    factory: type_val.TypeValidatorFactory,
+    type_hint: SourceTypeAnnotation,
+    valid_values: Sequence,
+    wrong_values: Sequence,
+    globalns: Optional[Dict[str, Any]],
+    localns: Optional[Dict[str, Any]],
+):
+    validator = factory(type_hint, name="<value>", globalns=globalns, localns=localns)
+    for value in valid_values:
+        validator(value)
+
+    for value in wrong_values:
+        with pytest.raises((TypeError), match="'<value>'"):
+            validator(value)
+
+
+@pytest.mark.parametrize("factory", FACTORIES)
+@pytest.mark.parametrize("type_hint", [123, callable, True, "asdfasdf"])
+def test_validator_factories_with_invalid_hints(
+    factory: type_val.TypeValidatorFactory, type_hint: SourceTypeAnnotation
+):
+    with pytest.raises(ValueError, match="annotation is not supported"):
+        factory(type_hint, name="<value>")
+
+
+@pytest.mark.parametrize(
+    "type_hint",
+    [
+        int,
+        float,
+        SampleEmptyClass,
+        SampleDataClass,
+        SampleEnum,
+        List[int],
+        Dict[Tuple[int, ...], List[Set[complex]]],
+    ],
+)
+def test_simple_validation_cache(type_hint):
+    validator = type_val.simple_type_validator_factory(type_hint, "value")
+    assert type_val.simple_type_validator_factory(type_hint, "value") is validator
+
+    assert type_val.simple_type_validator_factory(type_hint, "value_2") is not validator
+    assert type_val.simple_type_validator_factory(Optional[float], "value") is not validator
+    assert type_val.simple_type_validator_factory(List[float], "value") is not validator
+
+    opt_validator = type_val.simple_type_validator_factory(type_hint, "value", required=False)
+    assert opt_validator not in (validator, None)
+
+
+def test_simple_validation_particularities():
+    # strict int
+    strict_validator = type_val.simple_type_validator_factory(int, "value", strict_int=True)
+    lenient_validator = type_val.simple_type_validator_factory(int, "value", strict_int=False)
+    strict_validator(3)
+    lenient_validator(3)
+
+    with pytest.raises(TypeError, match="'bool'>"):
+        strict_validator(True)
+    lenient_validator(True)
+
+    # not supported annotations
+    assert (
+        type_val.simple_type_validator_factory(Callable[[int], float], "value", required=False)
+        is None
+    )
+
+    with pytest.raises(ValueError, match="annotation is not supported"):
+        type_val.simple_type_validator_factory(Callable[[int], float], "value", required=True)
+
+    with pytest.raises(ValueError, match="annotation is not supported"):
+        type_val.simple_type_validator_factory(Callable[[int], float], "value")

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -59,12 +59,8 @@ class SampleDataClass:
 
 
 # Each item should be a tuple like:
-#   class SampleDataCase(NamedTuple):
-#       annotation: Any
-#       valid_values: Sequence
-#       wrong_values: Sequence
-#       globalns: Optional[Dict[str, Any]]
-#       localns: Optional[Dict[str, Any]]
+#   ( annotation: Any, valid_values: Sequence, wrong_values: Sequence,
+#     globalns: Optional[Dict[str, Any]], localns: Optional[Dict[str, Any]] )
 
 
 SAMPLE_TYPE_DEFINITIONS: List[

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -23,7 +23,11 @@ import typing
 
 import pytest
 
-from eve import type_validation as type_val
+from eve import (
+    extended_typing as xtyping,
+    type_definitions as type_def,
+    type_validation as type_val,
+)
 from eve.extended_typing import (
     Any,
     Callable,
@@ -83,9 +87,21 @@ SAMPLE_TYPE_DEFINITIONS: List[
     ),  # float literals are not supported by PEP 586
     (typing.Tuple[int, str], [(3, "three")], [(), (3, 3)], None, None),
     (typing.Tuple[int, ...], [(1, 2, 3), ()], [3, (3, "three")], None, None),
+    (xtyping.FrozenList[int], [(1, 2, 3), ()], [3, (3, "three")], None, None),
     (typing.List[int], ([1, 2, 3], []), (1, [1.0]), None, None),
     (typing.Set[int], ({1, 2, 3}, set()), (1, [1], (1,), {1: None}), None, None),
     (typing.Dict[int, str], ({}, {3: "three"}), ([(3, "three")], 3, "three", []), None, None),
+    (
+        xtyping.FrozenDict[int, str],
+        (
+            type_def.frozendict(),
+            type_def.frozendict({3: "three"}),
+            type_def.frozendict({3: "three", -1: ""}),
+        ),
+        ({}, {3: "three"}, [(3, "three")], 3, "three", []),
+        None,
+        None,
+    ),
     (typing.Sequence[int], ([1, 2, 3], [], (1, 2, 3), tuple()), (1, [1.0], {1}), None, None),
     (typing.MutableSequence[int], ([1, 2, 3], []), ((1, 2, 3), tuple(), 1, [1.0], {1}), None, None),
     (typing.Set[int], ({1, 2, 3}, set()), (1, [1], (1,), {1: None}), None, None),


### PR DESCRIPTION
Decouple type validation functionality from `datamodels` in `eve` and other enhacements.

Main changes:
- Added a new `type_validation` module for run-time type validation with a generic interface supporting different implementations
- Additions to `extended_typing`, including new functionality and new typing defintions
- Additions and improvements to `type_definitions`, including `frozenlist` (alias of tuple) and `frozendict` (3rd party) collections
- Minor improvements to typing annotations of `utils` subpackage
