### PR TITLE
Functional: Fix Shifting of Invalid Iterator in Embedded Backend

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -247,6 +247,8 @@ def group_offsets(*offsets):
 
 
 def shift_position(pos, *complete_offsets, offset_provider):
+    if pos is None:
+        return None
     new_pos = pos.copy()
     for tag, index in complete_offsets:
         new_pos = execute_shift(new_pos, tag, index, offset_provider=offset_provider)


### PR DESCRIPTION
## Description

Fixes a bug where shifting of an invalid (non-derefable) iterator raises an error in the embedded backend.

## Requirements

Before submitting this PR, please make sure:

- [ ] You have run the code checks, tests and documentation build successfully
- [ ] All fixes and all new functionality are tested and documentation is up to date
- [ ] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


