### PR TITLE
Functional: Full Reduction Support & Fixes

### DIFF
--- a/src/functional/iterator/backends/gtfn/codegen.py
+++ b/src/functional/iterator/backends/gtfn/codegen.py
@@ -31,8 +31,6 @@ class GTFNCodegen(codegen.TemplatedGenerator):
         if node.type == "int":
             return node.value
         elif node.type == "float":
-            return f"{self.asfloat(node.value)}f"
-        elif node.type == "double":
             return self.asfloat(node.value)
         elif node.type == "bool":
             return node.value.lower()

--- a/src/functional/iterator/backends/gtfn/codegen.py
+++ b/src/functional/iterator/backends/gtfn/codegen.py
@@ -29,7 +29,7 @@ class GTFNCodegen(codegen.TemplatedGenerator):
 
     def visit_Literal(self, node: Literal, **kwargs: Any) -> str:
         if node.type == "int":
-            return node.value
+            return node.value + "_c"
         elif node.type == "float":
             return self.asfloat(node.value)
         elif node.type == "bool":
@@ -44,7 +44,6 @@ class GTFNCodegen(codegen.TemplatedGenerator):
         return node.value if isinstance(node.value, str) else f"{node.value}_c"
 
     FunCall = as_fmt("{fun}({','.join(args)})")
-    TemplatedFunCall = as_fmt("{fun}<{','.join(template_args)}>({','.join(args)})")
     Lambda = as_mako(
         "[=](${','.join('auto ' + p for p in params)}){return ${expr};}"
     )  # TODO capture

--- a/src/functional/iterator/backends/gtfn/gtfn_ir.py
+++ b/src/functional/iterator/backends/gtfn/gtfn_ir.py
@@ -61,12 +61,6 @@ class FunCall(Expr):
     args: List[Expr]
 
 
-class TemplatedFunCall(Expr):
-    fun: Expr  # VType[Callable]
-    template_args: List[Expr]
-    args: List[Expr]
-
-
 class FunctionDefinition(Node, SymbolTableTrait):
     id: SymbolName  # noqa: A003
     params: List[Sym]
@@ -97,8 +91,8 @@ class FencilDefinition(Node, SymbolTableTrait):
         for name in [
             "deref",
             "shift",
-            "tuple",
-            "get",
+            "make_tuple",
+            "tuple_get",
             "can_deref",
             "domain",  # TODO(havogt) decide if domain is part of IR
             "named_range",

--- a/src/functional/iterator/transforms/unroll_reduce.py
+++ b/src/functional/iterator/transforms/unroll_reduce.py
@@ -1,4 +1,5 @@
 from eve import NodeTranslator
+from eve.utils import UIDs
 from functional.iterator import ir
 
 
@@ -13,12 +14,16 @@ class UnrollReduce(NodeTranslator):
         return isinstance(node.fun, ir.FunCall) and node.fun.fun == ir.SymRef(id="reduce")
 
     @staticmethod
-    def _make_shift(offsets: list[ir.OffsetLiteral], iterator: ir.Expr):
+    def _make_shift(offsets: list[ir.Expr], iterator: ir.Expr):
         return ir.FunCall(fun=ir.FunCall(fun=ir.SymRef(id="shift"), args=offsets), args=[iterator])
 
     @staticmethod
     def _make_deref(iterator: ir.Expr):
         return ir.FunCall(fun=ir.SymRef(id="deref"), args=[iterator])
+
+    @staticmethod
+    def _make_can_deref(iterator: ir.Expr):
+        return ir.FunCall(fun=ir.SymRef(id="can_deref"), args=[iterator])
 
     @staticmethod
     def _make_if(cond: ir.Expr, true_expr: ir.Expr, false_expr: ir.Expr):
@@ -27,45 +32,34 @@ class UnrollReduce(NodeTranslator):
             args=[cond, true_expr, false_expr],
         )
 
-    @staticmethod
-    def _wrap_can_deref(prev: ir.Expr, current: ir.Expr, i: int, arg: ir.Expr):
-        can_deref = ir.FunCall(
-            fun=ir.SymRef(id="can_deref"),
-            args=[UnrollReduce._make_shift([ir.OffsetLiteral(value=i)], arg)],
-        )
-        return UnrollReduce._make_if(can_deref, current, prev)
-
-    @staticmethod
-    def _make_step(prev: ir.Expr, i: int, fun: ir.Expr, args: list[ir.Expr]):
-        return ir.FunCall(
-            fun=fun,
-            args=[
-                prev,
-                *map(
-                    lambda arg: UnrollReduce._make_deref(
-                        UnrollReduce._make_shift([ir.OffsetLiteral(value=i)], arg)
-                    ),
-                    args,
-                ),
-            ],
-        )
-
     def visit_FunCall(self, node: ir.FunCall, **kwargs):
         node = self.generic_visit(node, **kwargs)
         if not self._is_reduce(node):
             return node
 
         offset_provider = kwargs["offset_provider"]
+        assert offset_provider is not None
         last_offset = self._get_last_offset(node.args[0])
-        unroll_factor = offset_provider[last_offset.value].max_neighbors
+        max_neighbors = offset_provider[last_offset.value].max_neighbors
         has_skip_values = offset_provider[last_offset.value].has_skip_values
-        reduce_fun = node.fun.args[0]
-        reduce_init = node.fun.args[1]
 
-        expr = reduce_init
-        for i in range(unroll_factor):
-            prev = expr
-            expr = self._make_step(expr, i, reduce_fun, node.args)
-            if has_skip_values:
-                expr = self._wrap_can_deref(prev, expr, i, node.args[0])
+        acc = ir.SymRef(id=UIDs.sequential_id(prefix="_acc"))
+        offset = ir.SymRef(id=UIDs.sequential_id(prefix="_i"))
+        step = ir.SymRef(id=UIDs.sequential_id(prefix="_step"))
+
+        fun, init = node.fun.args
+
+        derefed_shifted_args = [
+            self._make_deref(self._make_shift([offset], arg)) for arg in node.args
+        ]
+        step_fun = ir.FunCall(fun=fun, args=[acc] + derefed_shifted_args)
+        if has_skip_values:
+            can_deref = self._make_can_deref(self._make_shift([offset], node.args[0]))
+            step_fun = self._make_if(can_deref, step_fun, acc)
+        step_fun = ir.Lambda(params=[ir.Sym(id=acc.id), ir.Sym(id=offset.id)], expr=step_fun)
+        expr = init
+        for i in range(max_neighbors):
+            expr = ir.FunCall(fun=step, args=[expr, ir.OffsetLiteral(value=i)])
+        expr = ir.FunCall(fun=ir.Lambda(params=[ir.Sym(id=step.id)], expr=expr), args=[step_fun])
+
         return expr

--- a/tests/functional_tests/iterator_tests/test_unroll_reduce.py
+++ b/tests/functional_tests/iterator_tests/test_unroll_reduce.py
@@ -2,12 +2,14 @@ from types import SimpleNamespace
 
 import pytest
 
+from eve.utils import UIDs
 from functional.iterator import ir
 from functional.iterator.transforms.unroll_reduce import UnrollReduce
 
 
 @pytest.fixture
 def basic_reduction():
+    UIDs.reset_sequence()
     return ir.FunCall(
         fun=ir.FunCall(
             fun=ir.SymRef(id="reduce"),
@@ -22,44 +24,58 @@ def basic_reduction():
     )
 
 
-def _shift_apply(args, offset, fun="deref"):
-    return [
+def _expected(red, dim, max_neighbors, has_skip_values):
+    acc = ir.SymRef(id="_acc_1")
+    offset = ir.SymRef(id="_i_2")
+    step = ir.SymRef(id="_step_3")
+
+    red_fun, red_init = red.fun.args
+
+    shifted_args = [
         ir.FunCall(
-            fun=ir.SymRef(id=fun),
+            fun=ir.SymRef(id="deref"),
             args=[
                 ir.FunCall(
-                    fun=ir.FunCall(
-                        fun=ir.SymRef(id="shift"), args=[ir.OffsetLiteral(value=offset)]
-                    ),
+                    fun=ir.FunCall(fun=ir.SymRef(id="shift"), args=[offset]),
                     args=[arg],
                 )
             ],
         )
-        for arg in args
+        for arg in red.args
     ]
+
+    step_expr = ir.FunCall(fun=red_fun, args=[acc] + shifted_args)
+    if has_skip_values:
+        can_deref = ir.FunCall(
+            fun=ir.SymRef(id="can_deref"),
+            args=[
+                ir.FunCall(
+                    fun=ir.FunCall(fun=ir.SymRef(id="shift"), args=[offset]),
+                    args=[red.args[0]],
+                )
+            ],
+        )
+        step_expr = ir.FunCall(fun=ir.SymRef(id="if_"), args=[can_deref, step_expr, acc])
+    step_fun = ir.Lambda(params=[ir.Sym(id=acc.id), ir.Sym(id=offset.id)], expr=step_expr)
+
+    step_app = red_init
+    for i in range(max_neighbors):
+        step_app = ir.FunCall(fun=step, args=[step_app, ir.OffsetLiteral(value=i)])
+
+    return ir.FunCall(fun=ir.Lambda(params=[ir.Sym(id=step.id)], expr=step_app), args=[step_fun])
 
 
 def test_no_skip_values(basic_reduction):
+    expected = _expected(basic_reduction, "dim", 3, False)
+
     offset_provider = {"dim": SimpleNamespace(max_neighbors=3, has_skip_values=False)}
-    acc = basic_reduction.fun.args[1]
-    for offset in range(offset_provider["dim"].max_neighbors):
-        acc = ir.FunCall(
-            fun=basic_reduction.fun.args[0], args=[acc] + _shift_apply(basic_reduction.args, offset)
-        )
-    expected = acc
     actual = UnrollReduce().visit(basic_reduction, offset_provider=offset_provider)
     assert actual == expected
 
 
 def test_skip_values(basic_reduction):
+    expected = _expected(basic_reduction, "dim", 3, True)
+
     offset_provider = {"dim": SimpleNamespace(max_neighbors=3, has_skip_values=True)}
-    acc = basic_reduction.fun.args[1]
-    for offset in range(offset_provider["dim"].max_neighbors):
-        cond = _shift_apply(basic_reduction.args[:1], offset, fun="can_deref")[0]
-        val = ir.FunCall(
-            fun=basic_reduction.fun.args[0], args=[acc] + _shift_apply(basic_reduction.args, offset)
-        )
-        acc = ir.FunCall(fun=ir.SymRef(id="if_"), args=[cond, val, acc])
-    expected = acc
     actual = UnrollReduce().visit(basic_reduction, offset_provider=offset_provider)
     assert actual == expected


### PR DESCRIPTION
## Description

Introduces a new reduction unrolling strategy, leading to directly inlinable lifts and least possible code size thanks to elimination of common subexpressions appearing in the previous implementation. The FVM nabla examples are now fully supported by the gtfn backend.

## Requirements

Before submitting this PR, please make sure:

- [ ] You have run the code checks, tests and documentation build successfully
- [ ] All fixes and all new functionality are tested and documentation is up to date
- [ ] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [ ] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [ ] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


