### PR TITLE
Functional: Globally Define Scan Builtin in Embedded Backend

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -625,6 +625,41 @@ def as_tuple_field(field):
     return field
 
 
+_column_range = None
+
+
+@builtins.scan.register(
+    EMBEDDED
+)  # TODO this is a bit ugly, alternative: pass scan range via iterator
+def scan(scan_pass, is_forward, init):
+    def impl(*iters):
+        if _column_range is None:
+            raise RuntimeError("Column range is not defined, cannot scan.")
+
+        column_range = _column_range
+        if not is_forward:
+            column_range = reversed(column_range)
+
+        state = init
+        col = []
+        for i in column_range:
+            state = scan_pass(
+                state, *map(shifted_scan_arg(i), iters)
+            )  # more generic scan returns state and result as 2 different things
+            col.append(state)
+
+        if not is_forward:
+            col = np.flip(col)
+
+        if isinstance(col[0], tuple):
+            dtype = np.dtype([("", type(c)) for c in col[0]])
+            return np.asarray(col, dtype=dtype)
+
+        return np.asarray(col)
+
+    return impl
+
+
 def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
     if "offset_provider" not in kwargs:
         raise RuntimeError("offset_provider not provided")
@@ -634,42 +669,14 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
         if not (is_located_field(out) or can_be_tuple_field(out)):
             raise TypeError("Out needs to be a located field.")
 
+        global _column_range
         column = None
         if "column_axis" in kwargs:
-            _column_axis = kwargs["column_axis"]
-            column = Column(_column_axis, domain[_column_axis])
-            del domain[_column_axis]
+            column_axis = kwargs["column_axis"]
+            column = Column(column_axis, domain[column_axis])
+            del domain[column_axis]
 
-        @builtins.scan.register(
-            EMBEDDED
-        )  # TODO this is a bit ugly, alternative: pass scan range via iterator
-        def scan(scan_pass, is_forward, init):
-            def impl(*iters):
-                if column is None:
-                    raise RuntimeError("Column axis is not defined, cannot scan.")
-
-                _range = column.range
-                if not is_forward:
-                    _range = reversed(_range)
-
-                state = init
-                col = []
-                for i in _range:
-                    state = scan_pass(
-                        state, *map(shifted_scan_arg(i), iters)
-                    )  # more generic scan returns state and result as 2 different things
-                    col.append(state)
-
-                if not is_forward:
-                    col = np.flip(col)
-
-                if isinstance(col[0], tuple):
-                    dtype = ", ".join(np.dtype(type(c)).str for c in col[0])
-                    return np.asarray(col, dtype=dtype)
-
-                return np.asarray(col)
-
-            return impl
+            _column_range = column.range
 
         out = as_tuple_field(out) if can_be_tuple_field(out) else out
 
@@ -694,6 +701,8 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
                     colpos[column.axis] = k
                     ordered_indices = get_ordered_indices(out.axises, colpos)
                     out[ordered_indices] = res[k]
+
+        _column_range = None
 
     fun(*args)
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -625,12 +625,10 @@ def as_tuple_field(field):
     return field
 
 
-_column_range = None
+_column_range = None  # TODO this is a bit ugly, alternative: pass scan range via iterator
 
 
-@builtins.scan.register(
-    EMBEDDED
-)  # TODO this is a bit ugly, alternative: pass scan range via iterator
+@builtins.scan.register(EMBEDDED)
 def scan(scan_pass, is_forward, init):
     def impl(*iters):
         if _column_range is None:


### PR DESCRIPTION
## Description

The scan builtin was defined “lazily” before, leading to an error when it was used at the top level of a closure.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


