### PR TITLE
Functional: Fix Initializer Literals in Iterator Function Library

### DIFF
--- a/src/functional/iterator/library.py
+++ b/src/functional/iterator/library.py
@@ -3,10 +3,10 @@ from functional.iterator.builtins import reduce
 
 def sum_(fun=None):
     if fun is None:
-        return reduce(lambda a, b: a + b, 0)
+        return reduce(lambda a, b: a + b, 0.0)
     else:
-        return reduce(lambda first, a, b: first + fun(a, b), 0)  # TODO tracing for *args
+        return reduce(lambda first, a, b: first + fun(a, b), 0.0)  # TODO tracing for *args
 
 
 def dot(a, b):
-    return reduce(lambda acc, a_n, c_n: acc + a_n * c_n, 0)(a, b)
+    return reduce(lambda acc, a_n, c_n: acc + a_n * c_n, 0.0)(a, b)


### PR DESCRIPTION
## Description

Literal types were integral, but always used with floating point values. As there is no implicit casting defined for the IR, this is wrong.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


