### PR TITLE
Functional: Add Transform to Prune Unused Closure Inputs

### DIFF
--- a/src/functional/iterator/transforms/prune_closure_inputs.py
+++ b/src/functional/iterator/transforms/prune_closure_inputs.py
@@ -3,12 +3,14 @@ from functional.iterator import ir
 
 
 class PruneClosureInputs(NodeTranslator):
-    def visit_StencilClosure(self, node):
+    """Removes all unused input arguments from a stencil closure."""
+
+    def visit_StencilClosure(self, node: ir.StencilClosure) -> ir.StencilClosure:
         if not isinstance(node.stencil, ir.Lambda):
             return node
 
-        unused = {p.id for p in node.stencil.params}
-        expr = self.visit(node.stencil.expr, unused=unused, shadowed=set())
+        unused: set[str] = {p.id for p in node.stencil.params}
+        expr = self.visit(node.stencil.expr, unused=unused, shadowed=set[str]())
         params = []
         inputs = []
         for param, inp in zip(node.stencil.params, node.inputs):
@@ -23,12 +25,12 @@ class PruneClosureInputs(NodeTranslator):
             inputs=inputs,
         )
 
-    def visit_SymRef(self, node, *, unused, shadowed):
+    def visit_SymRef(self, node: ir.SymRef, *, unused: set[str], shadowed: set[str]) -> ir.SymRef:
         if node.id not in shadowed:
             unused.discard(node.id)
         return node
 
-    def visit_Lambda(self, node, *, unused, shadowed):
+    def visit_Lambda(self, node: ir.Lambda, *, unused: set[str], shadowed: set[str]) -> ir.Lambda:
         return self.generic_visit(
             node, unused=unused, shadowed=shadowed | {p.id for p in node.params}
         )

--- a/src/functional/iterator/transforms/prune_closure_inputs.py
+++ b/src/functional/iterator/transforms/prune_closure_inputs.py
@@ -1,0 +1,34 @@
+from eve import NodeTranslator
+from functional.iterator import ir
+
+
+class PruneClosureInputs(NodeTranslator):
+    def visit_StencilClosure(self, node):
+        if not isinstance(node.stencil, ir.Lambda):
+            return node
+
+        unused = {p.id for p in node.stencil.params}
+        expr = self.visit(node.stencil.expr, unused=unused, shadowed=set())
+        params = []
+        inputs = []
+        for param, inp in zip(node.stencil.params, node.inputs):
+            if param.id not in unused:
+                params.append(param)
+                inputs.append(inp)
+
+        return ir.StencilClosure(
+            domain=node.domain,
+            stencil=ir.Lambda(params=params, expr=expr),
+            output=node.output,
+            inputs=inputs,
+        )
+
+    def visit_SymRef(self, node, *, unused, shadowed):
+        if node.id not in shadowed:
+            unused.discard(node.id)
+        return node
+
+    def visit_Lambda(self, node, *, unused, shadowed):
+        return self.generic_visit(
+            node, unused=unused, shadowed=shadowed | {p.id for p in node.params}
+        )

--- a/tests/functional_tests/iterator_tests/test_prune_closure_inputs.py
+++ b/tests/functional_tests/iterator_tests/test_prune_closure_inputs.py
@@ -1,0 +1,60 @@
+from functional.iterator import ir
+from functional.iterator.transforms.prune_closure_inputs import PruneClosureInputs
+
+
+def test_simple():
+    testee = ir.StencilClosure(
+        domain=ir.SymRef(id="d"),
+        stencil=ir.Lambda(
+            params=[ir.Sym(id="x"), ir.Sym(id="y"), ir.Sym(id="z")],
+            expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="y")]),
+        ),
+        output=ir.SymRef(id="out"),
+        inputs=[ir.SymRef(id="foo"), ir.SymRef(id="bar"), ir.SymRef(id="baz")],
+    )
+    expected = ir.StencilClosure(
+        domain=ir.SymRef(id="d"),
+        stencil=ir.Lambda(
+            params=[ir.Sym(id="y")],
+            expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="y")]),
+        ),
+        output=ir.SymRef(id="out"),
+        inputs=[ir.SymRef(id="bar")],
+    )
+    actual = PruneClosureInputs().visit(testee)
+    assert actual == expected
+
+
+def test_shadowing():
+    testee = ir.StencilClosure(
+        domain=ir.SymRef(id="d"),
+        stencil=ir.Lambda(
+            params=[ir.Sym(id="x"), ir.Sym(id="y"), ir.Sym(id="z")],
+            expr=ir.FunCall(
+                fun=ir.Lambda(
+                    params=[ir.SymRef(id="z")],
+                    expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="z")]),
+                ),
+                args=[ir.SymRef(id="y")],
+            ),
+        ),
+        output=ir.SymRef(id="out"),
+        inputs=[ir.SymRef(id="foo"), ir.SymRef(id="bar"), ir.SymRef(id="baz")],
+    )
+    expected = ir.StencilClosure(
+        domain=ir.SymRef(id="d"),
+        stencil=ir.Lambda(
+            params=[ir.Sym(id="y")],
+            expr=ir.FunCall(
+                fun=ir.Lambda(
+                    params=[ir.SymRef(id="z")],
+                    expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="z")]),
+                ),
+                args=[ir.SymRef(id="y")],
+            ),
+        ),
+        output=ir.SymRef(id="out"),
+        inputs=[ir.SymRef(id="bar")],
+    )
+    actual = PruneClosureInputs().visit(testee)
+    assert actual == expected


### PR DESCRIPTION
## Description

Adds a iterator IR transformation to prune unused closure input arguments. Required by the upcoming scan canonicalization.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


