### PR TITLE
Upcast integers to floats for division

### DIFF
--- a/src/gtc/passes/gtir_upcaster.py
+++ b/src/gtc/passes/gtir_upcaster.py
@@ -57,9 +57,9 @@ class _GTIRUpcasting(NodeTranslator):
         # See https://github.com/GridTools/gt4py/issues/742 for more details
         if node.op == ArithmeticOperator.DIV:
             if left.dtype.isinteger():
-                left = _upcast_node(DataType.FLOAT32, self.visit(node.left))
+                left = _upcast_node(DataType.FLOAT64, self.visit(node.left))
             if right.dtype.isinteger():
-                right = _upcast_node(DataType.FLOAT32, self.visit(node.right))
+                right = _upcast_node(DataType.FLOAT64, self.visit(node.right))
         return _update_node(node, {"left": left, "right": right})
 
     def visit_TernaryOp(self, node: gtir.TernaryOp, **kwargs: Any) -> gtir.TernaryOp:

--- a/tests/test_unittest/test_gtc/test_gtir_upcaster.py
+++ b/tests/test_unittest/test_gtc/test_gtir_upcaster.py
@@ -123,7 +123,7 @@ def test_upcast_integers_division():
     upcast_and_validate(
         testee,
         [
-            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
-            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
         ],
     )

--- a/tests/test_unittest/test_gtc/test_gtir_upcaster.py
+++ b/tests/test_unittest/test_gtc/test_gtir_upcaster.py
@@ -111,3 +111,19 @@ def test_upcast_in_cond_of_TernaryOp():
         false_expr=AN_UNIMPORTANT_LITERAL,
     )
     upcast_and_validate(testee, [Cast(dtype=DataType.FLOAT64, expr=A_INT64_LITERAL)])
+
+
+def test_upcast_integers_division():
+    testee = BinaryOp(
+        op=ArithmeticOperator.DIV,
+        left=LiteralFactory(value="1", dtype=DataType.INT32),
+        right=LiteralFactory(value="2", dtype=DataType.INT32),
+    )
+
+    upcast_and_validate(
+        testee,
+        [
+            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
+        ],
+    )


### PR DESCRIPTION
## Description

Make a special case for integer division in the gtir_upcaster rules in order to follow the Python convention that dividing integers results in a floating point number.

Resolves https://github.com/GridTools/gt4py/issues/742.

I chose this route over a more general approach because I think it's a unique situation that's unlikely to show up in other rules. The others should follow the approach that the resulting dtype is determinable by the types involved, without a special case.