### PR TITLE
allow broadcasting of [K] and [Edge, K] fields

### DIFF
--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -24,8 +24,10 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
     """
     Check if ``left`` and ``right`` types are compatible after optional broadcasting.
 
-    A binary field operation between two arguments can proceed and the result is a field.
-    on top of the dimensions, also the dtypes must match.
+    If both are fields and do not have the same list of dimensions, then the smaller
+    dimension list must be fully contained in the bigger one (ordered subset).
+
+    Dtypes must also match in any case.
 
     Examples:
     ---------
@@ -37,17 +39,37 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
     >>> are_broadcast_compatible(int_field_t, int_scalar_t)
     True
 
+    >>> from functional.iterator.runtime import CartesianAxis
+    >>> Edge = CartesianAxis("Edge")
+    >>> K = CartesianAxis("K")
+    >>> are_broadcast_compatible(
+    ...     TypeInfo(ct.FieldType(dtype=ct.ScalarType(kind=ct.ScalarKind.INT64), dims=[K])),
+    ...     TypeInfo(ct.FieldType(dtype=ct.ScalarType(kind=ct.ScalarKind.INT64), dims=[Edge, K])),
+    ... )
+    True
+
+    >>> are_broadcast_compatible(
+    ...     TypeInfo(ct.FieldType(dtype=ct.ScalarType(kind=ct.ScalarKind.INT64), dims=[Edge])),
+    ...     TypeInfo(ct.FieldType(dtype=ct.ScalarType(kind=ct.ScalarKind.INT64), dims=[Edge, K])),
+    ... )
+    True
     """
     both_dims_given = bool(left.dims and right.dims)
     both_dims_given &= not isinstance(left.dims, GenericDimensions)
     both_dims_given &= not isinstance(right.dims, GenericDimensions)
-    if both_dims_given and any(
-        ldim != rdim
-        for ldim, rdim in zip(
-            left.dims, right.dims  # type: ignore[arg-type]  # we know they are lists here
+    if (
+        both_dims_given and isinstance(left.dims, list) and isinstance(right.dims, list)
+    ):  # isinstance calls are for mypy
+        smaller_dims, bigger_dims = (
+            (left.dims, right.dims)
+            if len(left.dims) <= len(right.dims)
+            else (right.dims, left.dims)
         )
-    ):
-        return False
+        if smaller_dims[0] in bigger_dims and smaller_dims[-1] in bigger_dims:
+            start_index = bigger_dims.index(smaller_dims[0])
+            end_index = bigger_dims.index(smaller_dims[-1])
+            if smaller_dims != bigger_dims[start_index : end_index + 1]:
+                return True
     return left.dtype == right.dtype
 
 

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -69,7 +69,9 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
             start_index = bigger_dims.index(smaller_dims[0])
             end_index = bigger_dims.index(smaller_dims[-1])
             if smaller_dims != bigger_dims[start_index : end_index + 1]:
-                return True
+                return False
+        else:
+            return False
     return left.dtype == right.dtype
 
 

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -57,9 +57,9 @@ def are_broadcast_compatible(left: TypeInfo, right: TypeInfo) -> bool:
     both_dims_given = bool(left.dims and right.dims)
     both_dims_given &= not isinstance(left.dims, GenericDimensions)
     both_dims_given &= not isinstance(right.dims, GenericDimensions)
-    if (
-        both_dims_given and isinstance(left.dims, list) and isinstance(right.dims, list)
-    ):  # isinstance calls are for mypy
+    if both_dims_given:
+        assert isinstance(left.dims, list)  # to reassure mypy
+        assert isinstance(right.dims, list)  # to reassure mypy
         smaller_dims, bigger_dims = (
             (left.dims, right.dims)
             if len(left.dims) <= len(right.dims)

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -198,6 +198,27 @@ def test_tuples():
     assert np.allclose((a.array() * 1.3 + b.array() * 5.0) * 3.4, c)
 
 
+def test_broadcasting():
+    Edge = CartesianAxis("Edge")
+    K = CartesianAxis("K")
+
+    size = 10
+    ksize = 5
+    a = np_as_located_field(Edge, K)(np.ones((size, ksize)))
+    b = np_as_located_field(K)(np.ones((ksize)) * 2)
+    c = np_as_located_field(Edge, K)(np.zeros((size, ksize)))
+
+    @field_operator(backend="roundtrip")
+    def broadcast(
+        inp1: Field[[Edge, K], float64], inp2: Field[[K], float64]
+    ) -> Field[[Edge, K], float64]:
+        return inp1 / inp2
+
+    broadcast(a, b, out=c, offset_provider={})
+
+    assert np.allclose((a.array() / b.array()), c)
+
+
 @pytest.fixture
 def reduction_setup():
 


### PR DESCRIPTION
## Description

Relax implicit field broadcasting to: the smaller list of dimensions must be fully contained within the bigger one.

Example:

```
Field[[Edge, K], ...] + Field[[Edge], ...] # worked before, keeps working
Field[[K], ...] + Field[[Edge, K], ...] # works too now
```

The tradeoff is that less potential run time errors are caught, but this can only be solved by a less simplistic approach.

## Requirements

Before submitting this PR, please make sure:

- [X] You have run the code checks, tests and documentation build successfully
- [X] All fixes and all new functionality are tested and documentation is up to date
- [X] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [X] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [X] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


