### PR TITLE
Numpy upcast

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,6 +157,5 @@ repos:
       tests/test_unittest/test_gtc/test_common.py |
       tests/test_unittest/test_gtc/test_oir.py |
       tests/test_unittest/test_gtc/gtir_utils.py |
-      tests/test_unittest/test_gtc/test_gtir_upcaster.py |
       tests/test_unittest/test_gtc/test_gtir_to_oir.py |
       )$

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import enum
+import functools
 import typing
 from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 
@@ -869,6 +870,7 @@ def data_type_to_typestr(dtype: DataType) -> str:
     return np.dtype(table[dtype]).str
 
 
+@functools.lru_cache(maxsize=None, typed=True)  # typed since uniqueness is only guaranteed per enum
 def op_to_ufunc(
     op: Union[
         UnaryOperator, ArithmeticOperator, ComparisonOperator, LogicalOperator, NativeFunction
@@ -946,6 +948,7 @@ def op_to_ufunc(
     return table[op]
 
 
+@functools.lru_cache(maxsize=None)
 def typestr_to_data_type(typestr: str) -> DataType:
     if not isinstance(typestr, str) or len(typestr) < 3 or not typestr[2:].isnumeric():
         return DataType.INVALID  # type: ignore

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -20,6 +20,7 @@ from typing import Any, ClassVar, Dict, Generic, List, Optional, Tuple, Type, Ty
 
 import numpy as np
 import pydantic
+import scipy.special
 from pydantic import validator
 from pydantic.class_validators import root_validator
 
@@ -866,6 +867,66 @@ def data_type_to_typestr(dtype: DataType) -> str:
     if dtype not in table:
         raise ValueError("Can not convert INVALID, AUTO or DEFAULT to typestr.")
     return np.dtype(table[dtype]).str
+
+
+def op_to_ufunc(
+    op: Union[
+        UnaryOperator, ArithmeticOperator, ComparisonOperator, LogicalOperator, NativeFunction
+    ]
+) -> np.ufunc:
+    table = {
+        UnaryOperator.POS: np.positive,
+        UnaryOperator.NEG: np.negative,
+        UnaryOperator.NOT: np.logical_not,
+        ArithmeticOperator.ADD: np.add,
+        ArithmeticOperator.SUB: np.subtract,
+        ArithmeticOperator.MUL: np.multiply,
+        ArithmeticOperator.DIV: np.true_divide,
+        ComparisonOperator.GT: np.greater,
+        ComparisonOperator.LT: np.less,
+        ComparisonOperator.GE: np.greater_equal,
+        ComparisonOperator.LE: np.less_equal,
+        ComparisonOperator.EQ: np.equal,
+        ComparisonOperator.NE: np.not_equal,
+        LogicalOperator.AND: np.logical_and,
+        LogicalOperator.OR: np.logical_or,
+        NativeFunction.ABS: np.abs,
+        NativeFunction.MIN: np.minimum,
+        NativeFunction.MAX: np.maximum,
+        NativeFunction.MOD: np.remainder,
+        NativeFunction.SIN: np.sin,
+        NativeFunction.COS: np.cos,
+        NativeFunction.TAN: np.tan,
+        NativeFunction.ARCSIN: np.arcsin,
+        NativeFunction.ARCCOS: np.arccos,
+        NativeFunction.ARCTAN: np.arctan,
+        NativeFunction.SINH: np.sinh,
+        NativeFunction.COSH: np.cosh,
+        NativeFunction.TANH: np.tanh,
+        NativeFunction.ARCSINH: np.arcsinh,
+        NativeFunction.ARCCOSH: np.arccosh,
+        NativeFunction.ARCTANH: np.arctanh,
+        NativeFunction.SQRT: np.sqrt,
+        NativeFunction.POW: np.power,
+        NativeFunction.EXP: np.exp,
+        NativeFunction.LOG: np.log,
+        NativeFunction.GAMMA: scipy.special.gamma,
+        NativeFunction.CBRT: np.cbrt,
+        NativeFunction.ISFINITE: np.isfinite,
+        NativeFunction.ISINF: np.isinf,
+        NativeFunction.ISNAN: np.isnan,
+        NativeFunction.FLOOR: np.floor,
+        NativeFunction.CEIL: np.ceil,
+        NativeFunction.TRUNC: np.trunc,
+    }
+    if not isinstance(
+        op, (NativeFunction, ArithmeticOperator, ComparisonOperator, LogicalOperator, UnaryOperator)
+    ):
+        raise TypeError(
+            "Can only convert instances of GTC operators and supported native functions to typestr."
+        )
+
+    return table[op]
 
 
 def typestr_to_data_type(typestr: str) -> DataType:

--- a/src/gtc/common.py
+++ b/src/gtc/common.py
@@ -874,58 +874,75 @@ def op_to_ufunc(
         UnaryOperator, ArithmeticOperator, ComparisonOperator, LogicalOperator, NativeFunction
     ]
 ) -> np.ufunc:
-    table = {
-        UnaryOperator.POS: np.positive,
-        UnaryOperator.NEG: np.negative,
-        UnaryOperator.NOT: np.logical_not,
-        ArithmeticOperator.ADD: np.add,
-        ArithmeticOperator.SUB: np.subtract,
-        ArithmeticOperator.MUL: np.multiply,
-        ArithmeticOperator.DIV: np.true_divide,
-        ComparisonOperator.GT: np.greater,
-        ComparisonOperator.LT: np.less,
-        ComparisonOperator.GE: np.greater_equal,
-        ComparisonOperator.LE: np.less_equal,
-        ComparisonOperator.EQ: np.equal,
-        ComparisonOperator.NE: np.not_equal,
-        LogicalOperator.AND: np.logical_and,
-        LogicalOperator.OR: np.logical_or,
-        NativeFunction.ABS: np.abs,
-        NativeFunction.MIN: np.minimum,
-        NativeFunction.MAX: np.maximum,
-        NativeFunction.MOD: np.remainder,
-        NativeFunction.SIN: np.sin,
-        NativeFunction.COS: np.cos,
-        NativeFunction.TAN: np.tan,
-        NativeFunction.ARCSIN: np.arcsin,
-        NativeFunction.ARCCOS: np.arccos,
-        NativeFunction.ARCTAN: np.arctan,
-        NativeFunction.SINH: np.sinh,
-        NativeFunction.COSH: np.cosh,
-        NativeFunction.TANH: np.tanh,
-        NativeFunction.ARCSINH: np.arcsinh,
-        NativeFunction.ARCCOSH: np.arccosh,
-        NativeFunction.ARCTANH: np.arctanh,
-        NativeFunction.SQRT: np.sqrt,
-        NativeFunction.POW: np.power,
-        NativeFunction.EXP: np.exp,
-        NativeFunction.LOG: np.log,
-        NativeFunction.GAMMA: scipy.special.gamma,
-        NativeFunction.CBRT: np.cbrt,
-        NativeFunction.ISFINITE: np.isfinite,
-        NativeFunction.ISINF: np.isinf,
-        NativeFunction.ISNAN: np.isnan,
-        NativeFunction.FLOOR: np.floor,
-        NativeFunction.CEIL: np.ceil,
-        NativeFunction.TRUNC: np.trunc,
-    }
-    if not isinstance(
-        op, (NativeFunction, ArithmeticOperator, ComparisonOperator, LogicalOperator, UnaryOperator)
-    ):
+    Table: Dict[
+        Union[
+            UnaryOperator, ArithmeticOperator, ComparisonOperator, LogicalOperator, NativeFunction
+        ],
+        np.ufunc,
+    ]
+    # Can't put all in single table since UnaryOperator.POS == BinaryOperator.ADD
+    if isinstance(op, UnaryOperator):
+        table = {
+            UnaryOperator.POS: np.positive,
+            UnaryOperator.NEG: np.negative,
+            UnaryOperator.NOT: np.logical_not,
+        }
+    elif isinstance(op, ArithmeticOperator):
+        table = {
+            ArithmeticOperator.ADD: np.add,
+            ArithmeticOperator.SUB: np.subtract,
+            ArithmeticOperator.MUL: np.multiply,
+            ArithmeticOperator.DIV: np.true_divide,
+        }
+    elif isinstance(op, ComparisonOperator):
+        table = {
+            ComparisonOperator.GT: np.greater,
+            ComparisonOperator.LT: np.less,
+            ComparisonOperator.GE: np.greater_equal,
+            ComparisonOperator.LE: np.less_equal,
+            ComparisonOperator.EQ: np.equal,
+            ComparisonOperator.NE: np.not_equal,
+        }
+    elif isinstance(op, LogicalOperator):
+        table = {
+            LogicalOperator.AND: np.logical_and,
+            LogicalOperator.OR: np.logical_or,
+        }
+    elif isinstance(op, NativeFunction):
+        table = {
+            NativeFunction.ABS: np.abs,
+            NativeFunction.MIN: np.minimum,
+            NativeFunction.MAX: np.maximum,
+            NativeFunction.MOD: np.remainder,
+            NativeFunction.SIN: np.sin,
+            NativeFunction.COS: np.cos,
+            NativeFunction.TAN: np.tan,
+            NativeFunction.ARCSIN: np.arcsin,
+            NativeFunction.ARCCOS: np.arccos,
+            NativeFunction.ARCTAN: np.arctan,
+            NativeFunction.SINH: np.sinh,
+            NativeFunction.COSH: np.cosh,
+            NativeFunction.TANH: np.tanh,
+            NativeFunction.ARCSINH: np.arcsinh,
+            NativeFunction.ARCCOSH: np.arccosh,
+            NativeFunction.ARCTANH: np.arctanh,
+            NativeFunction.SQRT: np.sqrt,
+            NativeFunction.POW: np.power,
+            NativeFunction.EXP: np.exp,
+            NativeFunction.LOG: np.log,
+            NativeFunction.GAMMA: scipy.special.gamma,
+            NativeFunction.CBRT: np.cbrt,
+            NativeFunction.ISFINITE: np.isfinite,
+            NativeFunction.ISINF: np.isinf,
+            NativeFunction.ISNAN: np.isnan,
+            NativeFunction.FLOOR: np.floor,
+            NativeFunction.CEIL: np.ceil,
+            NativeFunction.TRUNC: np.trunc,
+        }
+    else:
         raise TypeError(
             "Can only convert instances of GTC operators and supported native functions to typestr."
         )
-
     return table[op]
 
 

--- a/src/gtc/passes/gtir_upcaster.py
+++ b/src/gtc/passes/gtir_upcaster.py
@@ -14,12 +14,15 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Any, Dict, Iterator, List
+import functools
+from typing import Any, Callable, Dict, Iterator, List
+
+import numpy as np
 
 from eve import Node, NodeTranslator
 from eve.concepts import TreeNode
 from gtc import gtir
-from gtc.common import ArithmeticOperator, DataType
+from gtc.common import DataType, data_type_to_typestr, op_to_ufunc, typestr_to_data_type
 from gtc.gtir import Expr
 
 
@@ -27,20 +30,44 @@ def _upcast_node(target_dtype: DataType, node: Expr) -> Expr:
     return node if node.dtype == target_dtype else gtir.Cast(dtype=target_dtype, expr=node)
 
 
-def _upcast_nodes(*exprs: Expr) -> Iterator[Expr]:
+def _upcast_nodes(*exprs: Expr, upcasting_rule: Callable) -> Iterator[Expr]:
     assert all(e.dtype for e in exprs)
     dtypes: List[DataType] = [e.dtype for e in exprs]  # type: ignore # guaranteed to be not None
-    target_dtype = max(dtypes)
-    return map(lambda e: _upcast_node(target_dtype, e), exprs)
+    target_dtypes = upcasting_rule(*dtypes)
+    return iter(_upcast_node(target_dtype, arg) for target_dtype, arg in zip(target_dtypes, exprs))
 
 
-def _update_node(node: Node, updated_children: Dict[str, TreeNode]) -> Expr:
+def _update_node(node: gtir.Expr, updated_children: Dict[str, TreeNode]) -> Node:
     # create new node only if children changed
     old_children = node.dict(include={*updated_children.keys()})
     if any([old_children[k] != updated_children[k] for k in updated_children.keys()]):
         return node.copy(update=updated_children)
     else:
         return node
+
+
+def _numpy_ufunc_upcasting_rule(*dtypes, ufunc: np.ufunc):
+    types = ufunc.types
+    for t in types:
+        inputs, output = t.split("->")
+        assert len(inputs) == len(dtypes)
+        if all(
+            np.can_cast(data_type_to_typestr(arg_dtype), cand_typestr)
+            for arg_dtype, cand_typestr in zip(dtypes, inputs)
+        ):
+            assert typestr_to_data_type(np.dtype(output).str) != DataType.INVALID
+            return [typestr_to_data_type(np.dtype(cand_typestr).str) for cand_typestr in inputs]
+    raise ValueError(f"No implementation found for dtypes {dtypes} and ufunc {ufunc}")
+
+
+def _numpy_common_upcasting_rule(*dtypes):
+    typestrs = [data_type_to_typestr(dtype) for dtype in dtypes if dtype != DataType.DEFAULT]
+    if not typestrs:
+        res_type = DataType.DEFAULT
+    else:
+        res_dtype: np.dtype = np.result_type(*typestrs)
+        res_type = typestr_to_data_type(res_dtype.str)
+    return [res_type] * len(dtypes)
 
 
 class _GTIRUpcasting(NodeTranslator):
@@ -52,31 +79,41 @@ class _GTIRUpcasting(NodeTranslator):
     """
 
     def visit_BinaryOp(self, node: gtir.BinaryOp, **kwargs: Any) -> gtir.BinaryOp:
-        left, right = _upcast_nodes(self.visit(node.left), self.visit(node.right))
-        # Python division is always floating-point, even with both left and right integers
-        # See https://github.com/GridTools/gt4py/issues/742 for more details
-        if node.op == ArithmeticOperator.DIV:
-            if left.dtype.isinteger():
-                left = _upcast_node(DataType.FLOAT32, self.visit(node.left))
-            if right.dtype.isinteger():
-                right = _upcast_node(DataType.FLOAT32, self.visit(node.right))
+        upcasting_rule = functools.partial(_numpy_ufunc_upcasting_rule, ufunc=op_to_ufunc(node.op))
+        left, right = _upcast_nodes(
+            self.visit(node.left), self.visit(node.right), upcasting_rule=upcasting_rule
+        )
         return _update_node(node, {"left": left, "right": right})
+
+    def visit_UnaryOp(self, node: gtir.UnaryOp, **kwargs: Any) -> gtir.UnaryOp:
+        upcasting_rule = functools.partial(_numpy_ufunc_upcasting_rule, ufunc=op_to_ufunc(node.op))
+        (expr,) = _upcast_nodes(self.visit(node.expr), upcasting_rule=upcasting_rule)
+        return _update_node(node, {"expr": expr})
 
     def visit_TernaryOp(self, node: gtir.TernaryOp, **kwargs: Any) -> gtir.TernaryOp:
         true_expr, false_expr = _upcast_nodes(
-            self.visit(node.true_expr), self.visit(node.false_expr)
+            self.visit(node.true_expr),
+            self.visit(node.false_expr),
+            upcasting_rule=_numpy_common_upcasting_rule,
         )
         return _update_node(
             node, {"true_expr": true_expr, "false_expr": false_expr, "cond": self.visit(node.cond)}
         )
 
     def visit_NativeFuncCall(self, node: gtir.NativeFuncCall, **kwargs: Any) -> gtir.NativeFuncCall:
-        args = [*_upcast_nodes(*self.visit(node.args))]
+        upcasting_rule = functools.partial(
+            _numpy_ufunc_upcasting_rule, ufunc=op_to_ufunc(node.func)
+        )
+        args = [*_upcast_nodes(*self.visit(node.args), upcasting_rule=upcasting_rule)]
         return _update_node(node, {"args": args})
 
     def visit_ParAssignStmt(self, node: gtir.ParAssignStmt, **kwargs: Any) -> gtir.ParAssignStmt:
         assert node.left.dtype
-        right = _upcast_node(node.left.dtype, self.visit(node.right))
+
+        def upcasting_rule(*dtypes):
+            return [node.left.dtype] * len(dtypes)
+
+        _, right = _upcast_nodes(node.left, self.visit(node.right), upcasting_rule=upcasting_rule)
         return _update_node(node, {"right": right})
 
 

--- a/src/gtc/passes/gtir_upcaster.py
+++ b/src/gtc/passes/gtir_upcaster.py
@@ -46,9 +46,9 @@ def _update_node(node: gtir.Expr, updated_children: Dict[str, TreeNode]) -> Node
         return node
 
 
+@functools.lru_cache
 def _numpy_ufunc_upcasting_rule(*dtypes, ufunc: np.ufunc):
-    types = ufunc.types
-    for t in types:
+    for t in ufunc.types:
         inputs, output = t.split("->")
         assert len(inputs) == len(dtypes)
         if all(
@@ -60,6 +60,7 @@ def _numpy_ufunc_upcasting_rule(*dtypes, ufunc: np.ufunc):
     raise ValueError(f"No implementation found for dtypes {dtypes} and ufunc {ufunc}")
 
 
+@functools.lru_cache
 def _numpy_common_upcasting_rule(*dtypes):
     typestrs = [data_type_to_typestr(dtype) for dtype in dtypes if dtype != DataType.DEFAULT]
     if not typestrs:

--- a/src/gtc/passes/gtir_upcaster.py
+++ b/src/gtc/passes/gtir_upcaster.py
@@ -48,6 +48,14 @@ def _update_node(node: gtir.Expr, updated_children: Dict[str, TreeNode]) -> Node
 
 @functools.lru_cache
 def _numpy_ufunc_upcasting_rule(*dtypes, ufunc: np.ufunc):
+    """
+    Look up upcasting behavior according to NumPy universal function casting convention.
+
+    NumPy specifies that it chooses ufunc implementations based on input types, where the inputs are suitably cast if
+    necessary. Mimicing this results in a behavior that can be reproduced in C++ backends but is also consistent with python in the
+    numpy backend to the extent possible. NumPy makes their casting rules available through a type promotion API.
+    See https://numpy.org/doc/stable/user/basics.ufuncs.html?highlight=index#type-casting-rules for details.
+    """
     for t in ufunc.types:
         inputs, output = t.split("->")
         assert len(inputs) == len(dtypes)
@@ -62,6 +70,13 @@ def _numpy_ufunc_upcasting_rule(*dtypes, ufunc: np.ufunc):
 
 @functools.lru_cache
 def _numpy_common_upcasting_rule(*dtypes):
+    """
+    Look up upcasting behavior according to C++ casting rules through NumPy API.
+
+    NumPy makes a simple casting rule lookup available through a type promotion API. In our case, this coincides with
+    C++ conventions. (We do not give precedence to field types over scalar types.)
+    See https://numpy.org/doc/stable/reference/generated/numpy.result_type.html for details.
+    """
     typestrs = [data_type_to_typestr(dtype) for dtype in dtypes if dtype != DataType.DEFAULT]
     if not typestrs:
         res_type = DataType.DEFAULT

--- a/tests/test_unittest/test_gtc/test_gtir_upcaster.py
+++ b/tests/test_unittest/test_gtc/test_gtir_upcaster.py
@@ -123,7 +123,20 @@ def test_upcast_integers_division():
     upcast_and_validate(
         testee,
         [
-            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
-            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
         ],
+    )
+
+
+def test_upcast_float64():
+    testee = BinaryOp(
+        op=ArithmeticOperator.DIV,
+        left=LiteralFactory(value="1", dtype=DataType.INT32),
+        right=LiteralFactory(value="2", dtype=DataType.FLOAT32),
+    )
+
+    upcast_and_validate(
+        testee,
+        [],
     )

--- a/tests/test_unittest/test_gtc/test_gtir_upcaster.py
+++ b/tests/test_unittest/test_gtc/test_gtir_upcaster.py
@@ -127,16 +127,3 @@ def test_upcast_integers_division():
             Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
         ],
     )
-
-
-def test_upcast_float64():
-    testee = BinaryOp(
-        op=ArithmeticOperator.DIV,
-        left=LiteralFactory(value="1", dtype=DataType.INT32),
-        right=LiteralFactory(value="2", dtype=DataType.FLOAT32),
-    )
-
-    upcast_and_validate(
-        testee,
-        [],
-    )

--- a/tests/test_unittest/test_gtc/test_gtir_upcaster.py
+++ b/tests/test_unittest/test_gtc/test_gtir_upcaster.py
@@ -111,3 +111,19 @@ def test_upcast_in_cond_of_TernaryOp():
         false_expr=AN_UNIMPORTANT_LITERAL,
     )
     upcast_and_validate(testee, [Cast(dtype=DataType.FLOAT64, expr=A_INT64_LITERAL)])
+
+
+def test_upcast_integers_division():
+    testee = BinaryOp(
+        op=ArithmeticOperator.DIV,
+        left=LiteralFactory(value="1", dtype=DataType.INT32),
+        right=LiteralFactory(value="2", dtype=DataType.INT32),
+    )
+
+    upcast_and_validate(
+        testee,
+        [
+            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
+        ],
+    )


### PR DESCRIPTION
## Description

An alternative to #776 for fixing #742. 

Instead of special casing the division, this uses numpy casting rules to determine input dtypes. This should lead to equivalent behavior for numpy and compiled backends.
