### PR TITLE
Fix Version of typing-extensions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     pybind11>=2.5
     pydantic>=1.5
     toolz>=0.11
-    typing-extensions>=3.7
+    typing-extensions>=4.2
     xxhash>=1.4.4
 
 [options.packages.find]


### PR DESCRIPTION
## Description

Typing-extensions version 4.2 is required for the use of `field_specifiers` in `dataclass_transform` (see https://github.com/python/typing/pull/1120).

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


