### PR TITLE
Functional: Temporary workaround pydantic update

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     numpy>=1.21
     packaging>=20.0
     pybind11>=2.5
-    pydantic>=1.5
+    pydantic>=1.5, <=1.9.0
     toolz>=0.11
     typing-extensions>=4.2
     xxhash>=1.4.4

--- a/src/functional/iterator/backends/gtfn/itir_to_gtfn_ir.py
+++ b/src/functional/iterator/backends/gtfn/itir_to_gtfn_ir.py
@@ -119,6 +119,10 @@ class GTFN_lowering(NodeTranslator):
 
     def visit_StencilClosure(self, node: itir.StencilClosure, **kwargs: Any) -> StencilExecution:
         backend = Backend(domain=self.visit(node.domain))
+
+        if not isinstance(node.stencil, SymRef):
+            raise RuntimeError(f"Stencil must be a SymRef to FunctionDefinition.")
+
         return StencilExecution(
             stencil=self.visit(node.stencil),
             output=self.visit(node.output),

--- a/src/functional/iterator/backends/gtfn/itir_to_gtfn_ir.py
+++ b/src/functional/iterator/backends/gtfn/itir_to_gtfn_ir.py
@@ -120,8 +120,8 @@ class GTFN_lowering(NodeTranslator):
     def visit_StencilClosure(self, node: itir.StencilClosure, **kwargs: Any) -> StencilExecution:
         backend = Backend(domain=self.visit(node.domain))
 
-        if not isinstance(node.stencil, SymRef):
-            raise RuntimeError(f"Stencil must be a SymRef to FunctionDefinition.")
+        if not isinstance(node.stencil, itir.SymRef):
+            raise RuntimeError("Stencil must be a SymRef to FunctionDefinition.")
 
         return StencilExecution(
             stencil=self.visit(node.stencil),


### PR DESCRIPTION
The real fix needs to go in `gtfn_backend.extract_fundefs_from_closures()` where `id(stencil)` is not stable with pydantic 1.9.1. (A new node is allocated (probably in `add_fundefs`)).