### PR TITLE
Use default cuda stream in dace orchestration (Possibly fix #793)

### DIFF
--- a/tests/test_integration/test_dace_parsing.py
+++ b/tests/test_integration/test_dace_parsing.py
@@ -39,6 +39,8 @@ def dace_env():
         / "dacecache"
     )
     with dace.config.temporary_config():
+        dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=-1)
+        dace.config.Config.set("compiler", "cpu", "openmp_sections", value=False)
         dace.config.Config.set("compiler", "cpu", "args", value="")
         dace.config.Config.set("compiler", "allow_view_arguments", value=True)
         dace.config.Config.set("default_build_folder", value=str(gt_cache_path))

--- a/tests/test_integration/test_dace_parsing.py
+++ b/tests/test_integration/test_dace_parsing.py
@@ -39,6 +39,7 @@ def dace_env():
         / "dacecache"
     )
     with dace.config.temporary_config():
+        # Setting max_concurrent_streams to -1 configures dace to only use the default stream.
         dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=-1)
         dace.config.Config.set("compiler", "cpu", "openmp_sections", value=False)
         dace.config.Config.set("compiler", "cpu", "args", value="")


### PR DESCRIPTION
The recently observed CI failure (see issue #793) may be caused by cupy not causing a device synchronization when copying host-to-device. With this PR this possible cause should be excluded. Either way, in our expiericence with using dace orchestration it is good practice to set those options. 
