### PR TITLE
Fix backend names in examples

### DIFF
--- a/docs/gt4py/quickstart.rst
+++ b/docs/gt4py/quickstart.rst
@@ -160,7 +160,7 @@ regular function call receiving the definition function:
 
     stencil_example_numpy = gtscript.stencil(backend="numpy", definition=stencil_example)
 
-    another_example_gtmc = gtscript.stencil(backend="gtmc", definition=stencil_example)
+    another_example_gtmc = gtscript.stencil(backend="gt:cpu_ifirst", definition=stencil_example)
 
 The generated code is written to and compiled in a local '.gt_cache' folder. Subsequent
 invocations will check whether a recent version of the stencil already exists in the cache.

--- a/examples/demo_burgers.ipynb
+++ b/examples/demo_burgers.ipynb
@@ -234,7 +234,7 @@
    ],
    "source": [
     "# gridtools4py settings\n",
-    "backend = \"numpy\"  # \"debug\", \"numpy\", \"gtx86\", \"gtmc\", \"gtcuda\" (not working)\n",
+    "backend = \"numpy\"  # \"numpy\", \"gt:cpu_ifirst\", \"gt:cpu_kfirst\", \"gt:gpu\" (not working)\n",
     "backend_opts = {'verbose': True} if backend.startswith('gt') else {}\n",
     "dtype = np.float64\n",
     "origin = (3, 3, 0)\n",

--- a/examples/demo_horizontal_diffusion.ipynb
+++ b/examples/demo_horizontal_diffusion.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "backend=\"gtcuda\" # \"debug\", \"numpy\", \"gtx86\", \"gtcuda\"\n",
+    "backend=\"gtcuda\" # \"numpy\", \"gt:cpu_ifirst\", \"gt:gpu\"\n",
     "dtype = np.float64"
    ]
   },

--- a/examples/demo_isentropic_diagnostics.ipynb
+++ b/examples/demo_isentropic_diagnostics.ipynb
@@ -128,7 +128,7 @@
    ],
    "source": [
     "# gridtools4py settings\n",
-    "backend = \"numpy\"  # \"debug\", \"numpy\", \"gtx86\", \"gtmc\", \"gtcuda\" (not working)\n",
+    "backend = \"numpy\"  # \"numpy\", \"gt:cpu_ifirst\", \"gt:cpu_kfirst\", \"gt:gpu\" (not working)\n",
     "backend_opts = {'verbose': True} if backend.startswith('gt') else {}\n",
     "dtype = np.float64\n",
     "origin = (3, 3, 0)\n",


### PR DESCRIPTION
## Description

Fixes a few backend names in ipython notebooks and the quickstart. Resolves #799.