### PR TITLE
Functional: Faster Eve Visitors & ReusingNodeTranslator

### DIFF
--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -74,7 +74,7 @@ from .trees import (
     walk_values,
 )
 from .type_definitions import NOTHING, ConstrainedStr, Enum, IntEnum, NothingType, StrEnum
-from .visitors import NodeTranslator, NodeVisitor
+from .visitors import NodeTranslator, NodeVisitor, ReusingNodeTranslator
 
 
 __all__ = [
@@ -136,4 +136,5 @@ __all__ = [
     # visitors
     "NodeTranslator",
     "NodeVisitor",
+    "ReusingNodeTranslator",
 ]

--- a/src/eve/visitors.py
+++ b/src/eve/visitors.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import collections.abc
 import copy
 
 from . import concepts, trees
@@ -106,7 +105,8 @@ class NodeVisitor:
 
         if hasattr(self, method_name):
             visitor = getattr(self, method_name)
-        elif isinstance(node, concepts.Node):
+        # Note: avoiding expensive `isinstance(node, concepts.Node)`
+        elif concepts.Node in node.__class__.__mro__:
             for node_class in node.__class__.__mro__[1:]:
                 class_name = node_class.__name__
                 if "__" in class_name:
@@ -157,20 +157,19 @@ class NodeTranslator(NodeVisitor):
 
         memo = kwargs.get("__memo__", None)
 
-        if isinstance(node, concepts.Node):
+        # Note: avoiding expensive `isinstance(node, concepts.Node)`
+        if concepts.Node in node.__class__.__mro__:
             new_node = node.__class__(  # type: ignore
                 **{
                     name: new_child
-                    for name, child in node.iter_children_items()
+                    for name, child in node.iter_children_items()  # type: ignore
                     if (new_child := self.visit(child, **kwargs)) is not NOTHING
                 },
             )
-            new_node.annex.reset(copy.deepcopy(node.annex.__dict__, memo=memo))
+            new_node.annex.reset(copy.deepcopy(node.annex.__dict__, memo=memo))  # type: ignore
             return new_node
 
-        if isinstance(node, (list, tuple, set, collections.abc.Set)) or (
-            isinstance(node, collections.abc.Sequence) and not isinstance(node, (str, bytes))
-        ):
+        if isinstance(node, (list, tuple, set)):
             # Sequence or set: create a new container instance with the new values
             return node.__class__(  # type: ignore
                 new_child
@@ -178,7 +177,7 @@ class NodeTranslator(NodeVisitor):
                 if (new_child := self.visit(child, **kwargs)) is not NOTHING
             )
 
-        if isinstance(node, (dict, collections.abc.Mapping)):
+        if isinstance(node, dict):
             # Mapping: create a new mapping instance with the new values
             return node.__class__(  # type: ignore[call-arg]
                 {
@@ -189,3 +188,57 @@ class NodeTranslator(NodeVisitor):
             )
 
         return copy.deepcopy(node, memo=memo)
+
+
+class ReusingNodeTranslator(NodeVisitor):
+    def generic_visit(self, node: concepts.RootNode, **kwargs: Any) -> Any:  # noqa: C901
+        # Note: avoiding expensive `isinstance(node, concepts.Node)`
+        if concepts.Node in node.__class__.__mro__:
+            new_values_dict = dict()
+            changed = False
+            for name, child in node.iter_children_items():  # type: ignore
+                new_child = self.visit(child, **kwargs)
+                if new_child is not NOTHING:
+                    if new_child is not child:
+                        new_values_dict[name] = new_child
+                        changed = True
+                    else:
+                        new_values_dict[name] = child
+            if not changed:
+                return node
+            new_node = node.__class__(**new_values_dict)
+            new_node.annex.reset(node.annex.__dict__)  # type: ignore
+            return new_node
+
+        if isinstance(node, (list, tuple, set)):
+            # Sequence or set: create a new container instance with the new values
+            new_values_list = []
+            changed = False
+            for child in trees.iter_children_values(node):
+                new_child = self.visit(child, **kwargs)
+                if new_child is not NOTHING:
+                    if new_child is not child:
+                        new_values_list.append(new_child)
+                        changed = True
+                    else:
+                        new_values_list.append(child)
+            if not changed:
+                return node
+            return node.__class__(new_values_list)
+
+        if isinstance(node, dict):
+            # Mapping: create a new mapping instance with the new values
+            new_values_dict = dict()
+            changed = False
+            for name, child in trees.iter_children_items(node):
+                new_child = self.visit(child, **kwargs)
+                if new_child is not NOTHING:
+                    if new_child is not child:
+                        new_values_dict[name] = new_child
+                        changed = True
+                    else:
+                        new_values_dict[name] = child
+            if not changed:
+                return node
+            return node.__class__(new_values_dict)
+        return node

--- a/src/eve/visitors.py
+++ b/src/eve/visitors.py
@@ -198,7 +198,9 @@ class ReusingNodeTranslator(NodeVisitor):
             changed = False
             for name, child in node.iter_children_items():  # type: ignore
                 new_child = self.visit(child, **kwargs)
-                if new_child is not NOTHING:
+                if new_child is NOTHING:
+                    changed = True
+                else:
                     if new_child is not child:
                         new_values_dict[name] = new_child
                         changed = True
@@ -216,7 +218,9 @@ class ReusingNodeTranslator(NodeVisitor):
             changed = False
             for child in trees.iter_children_values(node):
                 new_child = self.visit(child, **kwargs)
-                if new_child is not NOTHING:
+                if new_child is NOTHING:
+                    changed = True
+                else:
                     if new_child is not child:
                         new_values_list.append(new_child)
                         changed = True
@@ -232,7 +236,9 @@ class ReusingNodeTranslator(NodeVisitor):
             changed = False
             for name, child in trees.iter_children_items(node):
                 new_child = self.visit(child, **kwargs)
-                if new_child is not NOTHING:
+                if new_child is NOTHING:
+                    changed = True
+                else:
                     if new_child is not child:
                         new_values_dict[name] = new_child
                         changed = True

--- a/src/functional/iterator/transforms/common.py
+++ b/src/functional/iterator/transforms/common.py
@@ -14,7 +14,7 @@ def add_fundefs(
 
 
 def replace_nodes(root: eve.concepts.RootNode, idmap: dict[int, eve.Node]) -> eve.concepts.RootNode:
-    class ReplaceNode(eve.NodeTranslator):
+    class ReplaceNode(eve.ReusingNodeTranslator):
         def visit_Node(self, node: eve.Node) -> eve.Node:
             if id(node) in idmap:
                 return idmap[id(node)]

--- a/src/functional/iterator/transforms/eta_reduction.py
+++ b/src/functional/iterator/transforms/eta_reduction.py
@@ -1,8 +1,8 @@
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 
 
-class EtaReduction(NodeTranslator):
+class EtaReduction(ReusingNodeTranslator):
     """Eta reduction: simplifies `λ(args...) → f(args...)` to `f`."""
 
     def visit_Lambda(self, node: ir.Lambda) -> ir.Node:

--- a/src/functional/iterator/transforms/global_tmps.py
+++ b/src/functional/iterator/transforms/global_tmps.py
@@ -1,13 +1,13 @@
 from typing import Dict, List
 
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 from functional.iterator.runtime import CartesianAxis
 from functional.iterator.transforms.collect_shifts import CollectShifts
 from functional.iterator.transforms.popup_tmps import PopupTmps
 
 
-class CreateGlobalTmps(NodeTranslator):
+class CreateGlobalTmps(ReusingNodeTranslator):
     @staticmethod
     def _extend_domain(domain: ir.FunCall, offset_provider, shifts):
         assert isinstance(domain.fun, ir.SymRef) and domain.fun.id == "domain"

--- a/src/functional/iterator/transforms/inline_fundefs.py
+++ b/src/functional/iterator/transforms/inline_fundefs.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Set
 
-from eve import NOTHING, NodeTranslator
+from eve import NOTHING, ReusingNodeTranslator
 from functional.iterator import ir
 
 
-class InlineFundefs(NodeTranslator):
+class InlineFundefs(ReusingNodeTranslator):
     def visit_SymRef(self, node: ir.SymRef, *, symtable: Dict[str, Any]):
         if node.id in symtable and isinstance((symbol := symtable[node.id]), ir.FunctionDefinition):
             return ir.Lambda(
@@ -17,7 +17,7 @@ class InlineFundefs(NodeTranslator):
         return self.generic_visit(node, symtable=node.annex.symtable)
 
 
-class PruneUnreferencedFundefs(NodeTranslator):
+class PruneUnreferencedFundefs(ReusingNodeTranslator):
     def visit_FunctionDefinition(
         self, node: ir.FunctionDefinition, *, referenced: Set[str], second_pass: bool
     ):

--- a/src/functional/iterator/transforms/inline_lambdas.py
+++ b/src/functional/iterator/transforms/inline_lambdas.py
@@ -1,9 +1,9 @@
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 from functional.iterator.transforms.remap_symbols import RemapSymbolRefs, RenameSymbols
 
 
-class InlineLambdas(NodeTranslator):
+class InlineLambdas(ReusingNodeTranslator):
     def visit_FunCall(self, node: ir.FunCall):
         node = self.generic_visit(node)
         if isinstance(node.fun, ir.Lambda):

--- a/src/functional/iterator/transforms/inline_lifts.py
+++ b/src/functional/iterator/transforms/inline_lifts.py
@@ -1,8 +1,8 @@
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 
 
-class InlineLifts(NodeTranslator):
+class InlineLifts(ReusingNodeTranslator):
     @staticmethod
     def _is_lift(node: ir.Node):
         return (

--- a/src/functional/iterator/transforms/normalize_shifts.py
+++ b/src/functional/iterator/transforms/normalize_shifts.py
@@ -1,8 +1,8 @@
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 
 
-class NormalizeShifts(NodeTranslator):
+class NormalizeShifts(ReusingNodeTranslator):
     def visit_FunCall(self, node: ir.FunCall):
         node = self.generic_visit(node)
         if (

--- a/src/functional/iterator/transforms/popup_tmps.py
+++ b/src/functional/iterator/transforms/popup_tmps.py
@@ -1,11 +1,11 @@
 from typing import Dict, Optional
 
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 from functional.iterator.transforms.remap_symbols import RemapSymbolRefs
 
 
-class PopupTmps(NodeTranslator):
+class PopupTmps(ReusingNodeTranslator):
     _counter = 0
 
     def visit_FunCall(self, node: ir.FunCall, *, lifts: Optional[Dict[str, ir.Node]] = None):

--- a/src/functional/iterator/transforms/prune_closure_inputs.py
+++ b/src/functional/iterator/transforms/prune_closure_inputs.py
@@ -1,8 +1,8 @@
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 
 
-class PruneClosureInputs(NodeTranslator):
+class PruneClosureInputs(ReusingNodeTranslator):
     """Removes all unused input arguments from a stencil closure."""
 
     def visit_StencilClosure(self, node: ir.StencilClosure) -> ir.StencilClosure:

--- a/src/functional/iterator/transforms/remap_symbols.py
+++ b/src/functional/iterator/transforms/remap_symbols.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Optional, Set
 
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from functional.iterator import ir
 
 
-class RemapSymbolRefs(NodeTranslator):
+class RemapSymbolRefs(ReusingNodeTranslator):
     def visit_SymRef(self, node: ir.SymRef, *, symbol_map: Dict[str, ir.Node]):
         return symbol_map.get(node.id, node)
 
@@ -23,7 +23,7 @@ class RemapSymbolRefs(NodeTranslator):
         return super().generic_visit(node, **kwargs)
 
 
-class RenameSymbols(NodeTranslator):
+class RenameSymbols(ReusingNodeTranslator):
     def visit_Sym(
         self, node: ir.Sym, *, name_map: Dict[str, str], active: Optional[Set[str]] = None
     ):

--- a/src/functional/iterator/transforms/unroll_reduce.py
+++ b/src/functional/iterator/transforms/unroll_reduce.py
@@ -1,9 +1,9 @@
-from eve import NodeTranslator
+from eve import ReusingNodeTranslator
 from eve.utils import UIDs
 from functional.iterator import ir
 
 
-class UnrollReduce(NodeTranslator):
+class UnrollReduce(ReusingNodeTranslator):
     @staticmethod
     def _get_last_offset(node: ir.Expr):
         assert isinstance(node, ir.FunCall)


### PR DESCRIPTION
## Description

Three changes for much improved node visitor and node translator performance (just `time pytest` gives ~15% improvement, even though most expensive tests are not at all dominated by the visitors’ performance):
- Replaces `isinstance` checks in Eve visitors by (less elegant but much faster) traversal through `node.__class__.__mro__`. The main reason for the bad performance of the `isinstance` checks is `typing._ProtocolMeta.__instancecheck__`, which is now skipped.
- Further, this PR removes support for currently unused abstract `collections.abc.Set` and `collections.abc.Mapping` in visitors, which also feature slow `isinstance` checks.
- Last but not least, a new `ReusingNodeTranslator` is introduced that returns the unmodified original node whenever possible and never creates deep copies of nodes.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


