### PR TITLE
Functional: Add support for conditionals

### DIFF
--- a/src/functional/ffront/fbuiltins.py
+++ b/src/functional/ffront/fbuiltins.py
@@ -32,6 +32,7 @@ __all__ = [
     "int64",
     "neighbor_sum",
     "broadcast",
+    "where",
 ]
 
 
@@ -69,8 +70,20 @@ broadcast = BuiltInFunction(
     )
 )
 
+where = BuiltInFunction(
+    ct.FunctionType(
+        args=[
+            ct.DeferredSymbolType(constraint=ct.FieldType),
+            ct.DeferredSymbolType(constraint=ct.FieldType),
+            ct.DeferredSymbolType(constraint=ct.FieldType),
+        ],
+        kwargs={},
+        returns=ct.DeferredSymbolType(constraint=ct.FieldType),
+    )
+)
 
-FUN_BUILTIN_NAMES = ["neighbor_sum", "broadcast"]
+
+FUN_BUILTIN_NAMES = ["neighbor_sum", "broadcast", "where"]
 
 
 EXTERNALS_MODULE_NAME = "__externals__"

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -322,7 +322,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         except GTTypeError as err:
             raise FieldOperatorTypeDeductionError.from_foast_node(
-                node, msg=f"Invalid argument types in call to '{node.func.id}'!"
+                node, msg=f"Invalid argument types in call to `{node.func.id}`."
             ) from err
 
     def _visit_neighbor_sum(self, node: foast.Call, **kwargs) -> foast.Call:
@@ -332,8 +332,8 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             field_dims_str = ", ".join(str(dim) for dim in field_type.dims)
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Incompatible field argument in {node.func.id}. Expected "
-                f"a field with dimension {reduction_dim}, but got "
+                msg=f"Incompatible field argument in call to `{node.func.id}`. "
+                f"Expected a field with dimension {reduction_dim}, but got "
                 f"{field_dims_str}.",
             )
         return_type = ct.FieldType(
@@ -352,17 +352,17 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
     def _visit_where(self, node: foast.Call, **kwargs) -> foast.Call:
         mask_type = cast(ct.FieldType, node.args[0].type)
         left_type = cast(ct.FieldType, node.args[1].type)
-        right_type = cast(ct.FieldType, node.args[1].type)
+        right_type = cast(ct.FieldType, node.args[2].type)
         if not type_info.is_logical(mask_type):
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Incompatible argument to {node.func.id}. Expected "
-                f"a boolean as first argument.",
+                msg=f"Incompatible argument in call to `{node.func.id}`. Expected "
+                f"a field with dtype bool, but got `{mask_type}`.",
             )
         if left_type != right_type:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Incompatible argument to {node.func.id}. Expected arguments "
+                msg=f"Incompatible argument in call to `{node.func.id}`. Expected "
                 f"second and third argument to be of equal type.",
             )
         return foast.Call(

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -349,6 +349,30 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             type=return_type,
         )
 
+    def _visit_where(self, node: foast.Call, **kwargs) -> foast.Call:
+        mask_type = cast(ct.FieldType, node.args[0].type)
+        left_type = cast(ct.FieldType, node.args[1].type)
+        right_type = cast(ct.FieldType, node.args[1].type)
+        if not type_info.is_logical(mask_type):
+            raise FieldOperatorTypeDeductionError.from_foast_node(
+                node,
+                msg=f"Incompatible argument to {node.func.id}. Expected "
+                f"a boolean as first argument.",
+            )
+        if left_type != right_type:
+            raise FieldOperatorTypeDeductionError.from_foast_node(
+                node,
+                msg=f"Incompatible argument to {node.func.id}. Expected arguments "
+                f"second and third argument to be of equal type.",
+            )
+        return foast.Call(
+            func=node.func,
+            args=node.args,
+            kwargs=node.kwargs,
+            type=left_type,
+            location=node.location,
+        )
+
     def _visit_broadcast(self, node: foast.Call, **kwargs) -> foast.Call:
         field_type = cast(ct.FieldType, node.args[0].type)
         broadcast_dims_expr = cast(foast.TupleExpr, node.args[1]).elts

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -254,6 +254,11 @@ class FieldOperatorLowering(NodeTranslator):
             im.call_(self.visit(node.func, **kwargs))(*self.visit(node.args, **kwargs))
         )
 
+    def _visit_where(self, node: foast.Call, **kwargs) -> itir.FunCall:
+        mask = to_value(node.args[0])(self.visit(node.args[0], **kwargs))
+        left, right = (self.visit(arg, **kwargs) for arg in node.args[1:])
+        return im.call_("if_")(mask, left, right)
+
     def _visit_broadcast(self, node: foast.Call, **kwargs) -> itir.FunCall:
         # just lower broadcasted field as iterator IR does not care about broadcasting
         broadcasted_field = node.args[0]

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -257,7 +257,10 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_where(self, node: foast.Call, **kwargs) -> itir.FunCall:
         mask = to_value(node.args[0])(self.visit(node.args[0], **kwargs))
         left, right = (self.visit(arg, **kwargs) for arg in node.args[1:])
-        return im.call_("if_")(mask, left, right)
+        # since the if_ builtin expects a value for the condition we need to
+        #  use a lifted-lambda here such that the mask is also shifted on a
+        #  subsequent shift.
+        return self._lift_lambda(node)(im.call_("deref")(im.call_("if_")(mask, left, right)))
 
     def _visit_broadcast(self, node: foast.Call, **kwargs) -> itir.FunCall:
         # just lower broadcasted field as iterator IR does not care about broadcasting

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -255,12 +255,11 @@ class FieldOperatorLowering(NodeTranslator):
         )
 
     def _visit_where(self, node: foast.Call, **kwargs) -> itir.FunCall:
-        mask = to_value(node.args[0])(self.visit(node.args[0], **kwargs))
-        left, right = (self.visit(arg, **kwargs) for arg in node.args[1:])
+        mask, left, right = (to_value(arg)(self.visit(arg, **kwargs)) for arg in node.args)
         # since the if_ builtin expects a value for the condition we need to
         #  use a lifted-lambda here such that the mask is also shifted on a
         #  subsequent shift.
-        return self._lift_lambda(node)(im.call_("deref")(im.call_("if_")(mask, left, right)))
+        return self._lift_lambda(node)(im.call_("if_")(mask, left, right))
 
     def _visit_broadcast(self, node: foast.Call, **kwargs) -> itir.FunCall:
         # just lower broadcasted field as iterator IR does not care about broadcasting

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -496,7 +496,7 @@ def test_conditional_shifted():
         mask: Field[[IDim], bool],
         a: Field[[IDim], float64],
         b: Field[[IDim], float64],
-        out: Field[[IDim], float64]
+        out: Field[[IDim], float64],
     ):
         conditional(mask, a, b, out=out[:-1])
 

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -464,11 +464,11 @@ def test_conditional():
     out = np_as_located_field(IDim)(np.zeros((size,)))
 
     @field_operator(backend="roundtrip")
-    def simple_conditional(
+    def conditional(
         mask: Field[[IDim], bool], a: Field[[IDim], float64], b: Field[[IDim], float64]
     ) -> Field[[IDim], float64]:
         return where(mask, a, b)
 
-    simple_conditional(mask, a, b, out=out, offset_provider={})
+    conditional(mask, a, b, out=out, offset_provider={})
 
     assert np.allclose(np.where(mask, a, b), out)

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -472,3 +472,34 @@ def test_conditional():
     conditional(mask, a, b, out=out, offset_provider={})
 
     assert np.allclose(np.where(mask, a, b), out)
+
+
+def test_conditional_shifted():
+    Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+
+    size = 10
+    mask = np_as_located_field(IDim)(np.zeros((size,), dtype=bool))
+    mask.array()[size // 2] = True
+    a = np_as_located_field(IDim)(np.arange(0, size, 1))
+    b = np_as_located_field(IDim)(np.zeros((size,)))
+    out = np_as_located_field(IDim)(np.zeros((size,)))
+
+    @field_operator(backend="roundtrip")
+    def conditional(
+        mask: Field[[IDim], bool], a: Field[[IDim], float64], b: Field[[IDim], float64]
+    ) -> Field[[IDim], float64]:
+        tmp = where(mask, a, b)
+        return tmp(Ioff[1])
+
+    @program
+    def conditional_program(
+        mask: Field[[IDim], bool],
+        a: Field[[IDim], float64],
+        b: Field[[IDim], float64],
+        out: Field[[IDim], float64]
+    ):
+        conditional(mask, a, b, out=out[:-1])
+
+    conditional_program(mask, a, b, out, offset_provider={"Ioff": IDim})
+
+    assert np.allclose(np.where(mask, a, b)[1:], out.array()[:-1])


### PR DESCRIPTION
This PR adds support for conditionals alla `np.where` in the frontend.

```python
@field_operator(backend="roundtrip")
def simple_conditional(
    mask: Field[[IDim], bool], a: Field[[IDim], float64], b: Field[[IDim], float64]
) -> Field[[IDim], float64]:
    return where(mask, a, b)
```

~~Still a draft, some more testing required.~~