### PR TITLE
Functional: allow explicit domain in field view

### DIFF
--- a/src/functional/common.py
+++ b/src/functional/common.py
@@ -20,9 +20,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
+from eve.extended_typing import TypeVarTuple, Unpack
+
 
 DimT = TypeVar("DimT", bound="Dimension")
 DimsT = TypeVar("DimsT", bound=Sequence["Dimension"])
+DimsTTup = TypeVarTuple("DimsTTup")
 DT = TypeVar("DT", bound="DType")
 
 
@@ -55,6 +58,10 @@ class DType:
 
 
 class Field(Generic[DimsT, DT]):
+    ...
+
+
+class Domain(Generic[Unpack[DimsTTup]]):  # type: ignore[misc] # mypy doesn't like Unpack
     ...
 
 

--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -103,6 +103,15 @@ class FieldType(DataType):
 
 
 @dataclass(frozen=True)
+class DomainType(DataType):
+    dims: Union[list[func_common.Dimension], Literal[Ellipsis]]  # type: ignore[valid-type,misc]
+
+    def __str__(self):
+        dims = "..." if self.dims is Ellipsis else f"[{', '.join(dim.value for dim in self.dims)}]"
+        return f"Domain[{dims}]"
+
+
+@dataclass(frozen=True)
 class FunctionType(SymbolType):
     args: list[Union[DataType, DeferredSymbolType]]
     kwargs: dict[str, Union[DataType, DeferredSymbolType]]

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -189,6 +189,7 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                     )
 
         elif isinstance(node, past.Name):
+            self.uses_size_arguments = True
             out_field_name = node
             domain_args = [
                 itir.FunCall(

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -58,9 +58,9 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
     [Sym(id=SymbolName('inp')), Sym(id=SymbolName('out')), Sym(id=SymbolName('__inp_size_0')), Sym(id=SymbolName('__out_size_0'))]
     """
 
-    def __init__(self) -> None:
-        self.uses_size_arguments = False  # TODO refactor this error-prone state
-        super().__init__()
+    # def __init__(self) -> None:
+    #     self.uses_size_arguments = False  # TODO refactor this error-prone state
+    #     super().__init__()
 
     @classmethod
     def apply(
@@ -98,8 +98,8 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                 )
 
         params = [itir.Sym(id=inp.id) for inp in node.params]
-        if self.uses_size_arguments:
-            params += size_params
+        # if self.uses_size_arguments:
+        params += size_params
 
         return itir.FencilDefinition(
             id=node.id,
@@ -154,7 +154,7 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                     id=node.slice_.id
                 )
             else:
-                self.uses_size_arguments = True
+                # self.uses_size_arguments = True
                 if isinstance(node.slice_, past.TupleExpr) and all(
                     isinstance(el, past.Slice) for el in node.slice_.elts
                 ):
@@ -189,7 +189,7 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                     )
 
         elif isinstance(node, past.Name):
-            self.uses_size_arguments = True
+            # self.uses_size_arguments = True
             out_field_name = node
             domain_args = [
                 itir.FunCall(

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -93,13 +93,10 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                     "Only calls to functions returning a Field supported currently."
                 )
 
-        params = [itir.Sym(id=inp.id) for inp in node.params]
-        params += size_params
-
         return itir.FencilDefinition(
             id=node.id,
             function_definitions=function_definitions,
-            params=params,
+            params=[itir.Sym(id=inp.id) for inp in node.params] + size_params,
             closures=closures,
         )
 

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -58,10 +58,6 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
     [Sym(id=SymbolName('inp')), Sym(id=SymbolName('out')), Sym(id=SymbolName('__inp_size_0')), Sym(id=SymbolName('__out_size_0'))]
     """
 
-    # def __init__(self) -> None:
-    #     self.uses_size_arguments = False  # TODO refactor this error-prone state
-    #     super().__init__()
-
     @classmethod
     def apply(
         cls, node: past.Program, function_definitions: list[itir.FunctionDefinition]
@@ -98,7 +94,6 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                 )
 
         params = [itir.Sym(id=inp.id) for inp in node.params]
-        # if self.uses_size_arguments:
         params += size_params
 
         return itir.FencilDefinition(
@@ -154,7 +149,6 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                     id=node.slice_.id
                 )
             else:
-                # self.uses_size_arguments = True
                 if isinstance(node.slice_, past.TupleExpr) and all(
                     isinstance(el, past.Slice) for el in node.slice_.elts
                 ):
@@ -189,7 +183,6 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                     )
 
         elif isinstance(node, past.Name):
-            # self.uses_size_arguments = True
             out_field_name = node
             domain_args = [
                 itir.FunCall(

--- a/tests/functional_tests/cpp_backend_tests/CMakeLists.txt
+++ b/tests/functional_tests/cpp_backend_tests/CMakeLists.txt
@@ -69,6 +69,7 @@ if(BUILD_TESTING)
     fetch_googletest()
     
     add_fn_codegen_test(NAME copy_stencil SRC_FILE copy_stencil.py DRIVER_FILE copy_stencil_driver.cpp)
+    add_fn_codegen_test(NAME copy_stencil_field_view SRC_FILE copy_stencil_field_view.py DRIVER_FILE copy_stencil_driver.cpp)
     add_fn_codegen_test(NAME anton_lap SRC_FILE anton_lap.py DRIVER_FILE anton_lap_driver.cpp)
     add_fn_codegen_test(NAME fvm_nabla SRC_FILE fvm_nabla.py DRIVER_FILE fvm_nabla_driver.cpp)
 endif()

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil.py
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil.py
@@ -16,7 +16,7 @@ def copy_stencil(inp):
     return deref(inp)
 
 
-def copy_fencil(dom, inp, out):
+def copy(dom, inp, out):
     closure(
         dom,
         copy_stencil,
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         raise RuntimeError(f"Usage: {sys.argv[0]} <output_file>")
     output_file = sys.argv[1]
 
-    prog = trace(copy_fencil, [None] * 3)
+    prog = trace(copy, [None] * 3)
     generated_code = generate(prog, grid_type="Cartesian")
 
     with open(output_file, "w+") as output:

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_driver.cpp
@@ -16,9 +16,8 @@ GT_REGRESSION_TEST(fn_cartesian_copy, test_environment<>, fn_backend_t) {
   auto out = TypeParam::make_storage();
 
   auto comp = [&, in = TypeParam::make_const_storage(in)] {
-    generated::copy_fencil(fn_backend_t{},
-                           cartesian_domain(TypeParam::fn_cartesian_sizes()),
-                           in, out);
+    generated::copy(fn_backend_t{},
+                    cartesian_domain(TypeParam::fn_cartesian_sizes()), in, out);
   };
   comp();
 

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
@@ -20,7 +20,7 @@ def copy_stencil(inp: Field[[IDim, JDim, KDim], float64]) -> Field[[IDim, JDim, 
 
 @program
 def copy(
-    dom: Field[[], float64],
+    dom: Field[[], float64],  # TODO should be Domain[IDim, JDim, KDim]
     inp: Field[[IDim, JDim, KDim], float64],
     out: Field[[IDim, JDim, KDim], float64],
 ):

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
@@ -33,6 +33,9 @@ if __name__ == "__main__":
     output_file = sys.argv[1]
 
     prog = copy.itir
+    prog.params = list(
+        filter(lambda p: not p.id.startswith("__"), prog.params)
+    )  # hack to remove all field sizes which are not used if domain is explicit/absolute
     generated_code = generate(prog, grid_type="Cartesian")
 
     with open(output_file, "w+") as output:

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
@@ -2,7 +2,7 @@ import sys
 
 from numpy import float64
 
-from functional.common import Field
+from functional.common import Domain, Field
 from functional.ffront.decorator import field_operator, program
 from functional.iterator.backends.gtfn.gtfn_backend import generate
 from functional.iterator.runtime import CartesianAxis
@@ -20,7 +20,7 @@ def copy_stencil(inp: Field[[IDim, JDim, KDim], float64]) -> Field[[IDim, JDim, 
 
 @program
 def copy(
-    dom: Field[[], float64],  # TODO should be Domain[IDim, JDim, KDim]
+    dom: Domain[IDim, JDim, KDim],
     inp: Field[[IDim, JDim, KDim], float64],
     out: Field[[IDim, JDim, KDim], float64],
 ):

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view.py
@@ -1,0 +1,39 @@
+import sys
+
+from numpy import float64
+
+from functional.common import Field
+from functional.ffront.decorator import field_operator, program
+from functional.iterator.backends.gtfn.gtfn_backend import generate
+from functional.iterator.runtime import CartesianAxis
+
+
+IDim = CartesianAxis("IDim")
+JDim = CartesianAxis("JDim")
+KDim = CartesianAxis("KDim")
+
+
+@field_operator
+def copy_stencil(inp: Field[[IDim, JDim, KDim], float64]) -> Field[[IDim, JDim, KDim], float64]:
+    return inp
+
+
+@program
+def copy(
+    dom: Field[[], float64],
+    inp: Field[[IDim, JDim, KDim], float64],
+    out: Field[[IDim, JDim, KDim], float64],
+):
+    copy_stencil(inp, out=out[dom])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise RuntimeError(f"Usage: {sys.argv[0]} <output_file>")
+    output_file = sys.argv[1]
+
+    prog = copy.itir
+    generated_code = generate(prog, grid_type="Cartesian")
+
+    with open(output_file, "w+") as output:
+        output.write(generated_code)


### PR DESCRIPTION
Adds the possibility to pass domain as argument in field view program, instead of relative to the output field. If all domains are explicit, the itir fencil will not get the extra size arguments. This needs cleanup and checks...

```python
@program
def copy(
    dom: Domain[IDim, JDim, KDim],
    inp: Field[[IDim, JDim, KDim], float64],
    out: Field[[IDim, JDim, KDim], float64],
):
    copy_stencil(inp, out=out[dom])
```
