### PR TITLE
Functional: Illustrate slice sparse

### DIFF
--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -150,6 +150,12 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                         msg="Source and target must be equal for offsets with a single target.",
                     )
                 new_type = new_value.type
+            case ct.FieldType(dims=dims, dtype=dtype):
+                if not dims[-1].local:
+                    raise FieldOperatorTypeDeductionError.from_foast_node(
+                        new_value, msg="Can only slice a local dimension."
+                    )
+                new_type = ct.FieldType(dims=dims[:-1], dtype=dtype)
             case _:
                 raise FieldOperatorTypeDeductionError.from_foast_node(
                     new_value, msg="Could not deduce type of subscript expression!"

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -99,6 +99,8 @@ def to_value(node: foast.LocatedNode) -> Callable[[itir.Expr], itir.Expr]:
     """
     assert can_be_value_or_iterator(node.type)
     if resulting_type_kind(node.type) is TypeKind.FIELD:
+        if isinstance(node, foast.Subscript):
+            return lambda x: x
         return im.deref_
     return lambda x: x
 
@@ -183,7 +185,7 @@ class FieldOperatorLowering(NodeTranslator):
         return self.lifted_lambda(*param_names)
 
     def visit_Subscript(self, node: foast.Subscript, **kwargs) -> itir.FunCall:
-        return im.tuple_get_(node.index, self.visit(node.value, **kwargs))
+        return im.tuple_get_(node.index, im.deref_(self.visit(node.value, **kwargs)))
 
     def visit_TupleExpr(self, node: foast.TupleExpr, **kwargs) -> itir.FunCall:
         return im.make_tuple_(*self.visit(node.elts, **kwargs))

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -451,6 +451,9 @@ def _tupsum(a, b):
             first = s.start
             assert s.step is None
             assert s.stop is None
+        elif s is None:
+            is_slice = True
+            first = 0
         else:
             assert isinstance(s, numbers.Integral)
             first = s
@@ -459,6 +462,9 @@ def _tupsum(a, b):
             second = t.start
             assert t.step is None
             assert t.stop is None
+        elif t is None:
+            is_slice = True
+            second = 0
         else:
             assert isinstance(t, numbers.Integral)
             second = t

--- a/tests/functional_tests/cpp_backend_tests/CMakeLists.txt
+++ b/tests/functional_tests/cpp_backend_tests/CMakeLists.txt
@@ -71,6 +71,7 @@ if(BUILD_TESTING)
     add_fn_codegen_test(NAME copy_stencil SRC_FILE copy_stencil.py DRIVER_FILE copy_stencil_driver.cpp)
     add_fn_codegen_test(NAME anton_lap SRC_FILE anton_lap.py DRIVER_FILE anton_lap_driver.cpp)
     add_fn_codegen_test(NAME fvm_nabla SRC_FILE fvm_nabla.py DRIVER_FILE fvm_nabla_driver.cpp)
+    add_fn_codegen_test(NAME slice_sparse SRC_FILE slice_sparse.py DRIVER_FILE slice_sparse_driver.cpp)
 endif()
     
     

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil.py
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil.py
@@ -12,11 +12,11 @@ KDim = CartesianAxis("KDim")
 
 
 @fundef
-def slice_sparse(inp):
-    return tuple_get(0, deref(inp))
+def copy_stencil(inp):
+    return deref(inp)
 
 
-def slice_sparse_fencil(dom, inp, out):
+def copy_fencil(dom, inp, out):
     closure(
         dom,
         copy_stencil,

--- a/tests/functional_tests/cpp_backend_tests/slice_sparse.py
+++ b/tests/functional_tests/cpp_backend_tests/slice_sparse.py
@@ -19,7 +19,7 @@ def slice_sparse(inp):
 def slice_sparse_fencil(dom, inp, out):
     closure(
         dom,
-        copy_stencil,
+        slice_sparse,
         out,
         [inp],
     )
@@ -30,8 +30,8 @@ if __name__ == "__main__":
         raise RuntimeError(f"Usage: {sys.argv[0]} <output_file>")
     output_file = sys.argv[1]
 
-    prog = trace(copy_fencil, [None] * 3)
-    generated_code = generate(prog, grid_type="Cartesian")
+    prog = trace(slice_sparse_fencil, [None] * 3)
+    generated_code = generate(prog, grid_type="unstructured")
 
     with open(output_file, "w+") as output:
         output.write(generated_code)

--- a/tests/functional_tests/cpp_backend_tests/slice_sparse_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/slice_sparse_driver.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include GENERATED_FILE
+
+#include <fn_select.hpp>
+#include <test_environment.hpp>
+
+namespace {
+using namespace gridtools;
+using namespace fn;
+using namespace literals;
+
+constexpr inline auto in_elem = [](int node, int level, int elem = 0) {
+  return node + level % (10 + elem);
+};
+constexpr inline auto in_ = [](int node, int level) {
+  return tuple(in_elem(node, level, 0), in_elem(node, level, 1));
+};
+
+GT_REGRESSION_TEST(slice_sparse, test_environment<>, fn_backend_t) {
+
+  using float_t = typename TypeParam::float_t;
+  auto mesh = TypeParam::fn_unstructured_mesh();
+
+  int nodes = mesh.nvertices();
+  int levels = mesh.nlevels();
+
+  auto actual = mesh.template make_storage<float_t>(nodes, levels);
+  auto in = mesh.template make_const_storage<tuple<float_t, float_t>>(
+      in_, nodes, levels);
+  auto comp = [&] {
+    generated::slice_sparse_fencil(
+        fn_backend_t{}, unstructured_domain({nodes, levels}, {}), in, actual);
+  };
+  comp();
+
+  TypeParam::verify(in_elem, actual);
+}
+} // namespace


### PR DESCRIPTION
Just for discussion. This enables slicing a sparse field in the neighbor dimension (which is required if we want to use a sparse field outside of reductions).

The syntax here is
```python
@field_operator
def sparse_op(sparse: Field[[Edge, E2VDim], "float64"]) -> Field[[Edge], "float64"]:
    return sparse[0]
```
which slices the last dimension (if it is a local dimension).

We should discuss what we need and if the dimension needs to be named, e.g. 
```python
    return sparse[E2VDim[0]]
```