### PR TITLE
Allow "shift" on sparse field

### DIFF
--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -269,6 +269,18 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
 
         if isinstance(new_func.type, ct.FieldType):
             new_args = self.visit(node.args, **kwargs)
+            if len(new_args) == 1 and isinstance(new_args[0], foast.Constant):
+                if not new_func.type.dims[-1].local:
+                    raise FieldOperatorTypeDeductionError.from_foast_node(
+                        node, msg="Cannot slice a non-local dimension."
+                    )
+                return foast.Call(
+                    func=new_func,
+                    args=new_args,
+                    kwargs={},
+                    location=node.location,
+                    type=ct.FieldType(dims=new_func.type.dims[:-1], dtype=new_func.type.dtype),
+                )
             source_dim = new_args[0].type.source
             target_dims = new_args[0].type.target
             if new_func.type.dims and source_dim not in new_func.type.dims:

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -229,6 +229,8 @@ class FieldOperatorLowering(NodeTranslator):
                 return im.shift_(offset_name, offset_index)(self.visit(node.func, **kwargs))
             case foast.Name(id=offset_name):
                 return im.shift_(offset_name)(self.visit(node.func, **kwargs))
+            case foast.Constant(value=value):
+                return im.shift_(int(value))(self.visit(node.func, **kwargs))
         raise FieldOperatorLoweringError("Unexpected shift arguments!")
 
     def _visit_reduce(self, node: foast.Call, **kwargs) -> itir.FunCall:


### PR DESCRIPTION
Alternative to #821, less intrusive with 1 to 1 mapping to itir

Syntax
```python
@field_operator
def sparse_op(sparse: Field[[Edge, E2VDim], "float64"]) -> Field[[Edge], "float64"]:
    return sparse(0)
```