### PR TITLE
Functional: Enhanced field / scalar type promotion

### DIFF
--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -247,7 +247,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         if not is_compatible(new_operand.type):
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Incompatible type for unary operator `{node.op}`: {new_operand.type}!",
+                msg=f"Incompatible type for unary operator `{node.op}`: `{new_operand.type}`!",
             )
         return foast.UnaryOp(
             op=node.op, operand=new_operand, location=node.location, type=new_operand.type

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -185,8 +185,9 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
 
         self._check_operand_dtypes_match(node, left=left, right=right)
 
-        # check dimensions match and broadcast scalars to fields
         try:
+            # transform operands to have bool dtype and use regular promotion
+            #  mechanism to handle dimension promotion
             return type_info.promote(boolified_type(left.type), boolified_type(right.type))
         except GTTypeError as ex:
             raise FieldOperatorTypeDeductionError.from_foast_node(

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -192,7 +192,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Could not promote `{left.type}` and `{right.type}` to common type"
-                f" in call to {node.op}.",
+                f" in call to `{node.op}`.",
             ) from ex
 
     def _deduce_binop_type(
@@ -210,7 +210,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         for arg in (left, right):
             if not is_compatible(arg.type):
                 raise FieldOperatorTypeDeductionError.from_foast_node(
-                    arg, msg=f"Type {arg.type} can not be used in operator '{node.op}'!"
+                    arg, msg=f"Type {arg.type} can not be used in operator `{node.op}`!"
                 )
 
         left_type = cast(ct.FieldType | ct.ScalarType, left.type)
@@ -225,7 +225,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Could not promote `{left_type}` and `{right_type}` to common type"
-                f" in call to {node.op}.",
+                f" in call to `{node.op}`.",
             ) from ex
 
     def _check_operand_dtypes_match(
@@ -235,7 +235,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         if not type_info.extract_dtype(left.type) == type_info.extract_dtype(right.type):
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Incompatible datatypes in operator '{node.op}': {left.type} and {right.type}!",
+                msg=f"Incompatible datatypes in operator `{node.op}`: {left.type} and {right.type}!",
             )
 
     def visit_UnaryOp(self, node: foast.UnaryOp, **kwargs) -> foast.UnaryOp:
@@ -246,7 +246,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         if not is_compatible(new_operand.type):
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Incompatible type for unary operator '{node.op}': {new_operand.type}!",
+                msg=f"Incompatible type for unary operator `{node.op}`: {new_operand.type}!",
             )
         return foast.UnaryOp(
             op=node.op, operand=new_operand, location=node.location, type=new_operand.type
@@ -302,7 +302,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
 
         raise FieldOperatorTypeDeductionError.from_foast_node(
             node,
-            msg=f"Objects of type '{new_func.type}' are not callable.",
+            msg=f"Objects of type `{new_func.type}` are not callable.",
         )
 
     def _ensure_signature_valid(self, node: foast.Call, **kwargs) -> None:
@@ -315,7 +315,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         except GTTypeError as err:
             raise FieldOperatorTypeDeductionError.from_foast_node(
-                node, msg=f"Invalid argument types in call to '{node.func.id}'!"
+                node, msg=f"Invalid argument types in call to `{node.func.id}`!"
             ) from err
 
     def _visit_neighbor_sum(self, node: foast.Call, **kwargs) -> foast.Call:

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -214,7 +214,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 )
 
         left_type = cast(ct.FieldType | ct.ScalarType, left.type)
-        right_type = cast(ct.FieldType | ct.ScalarType, left.type)
+        right_type = cast(ct.FieldType | ct.ScalarType, right.type)
 
         if node.op == foast.BinaryOperator.POW:
             return left_type

--- a/src/functional/ffront/type_info.py
+++ b/src/functional/ffront/type_info.py
@@ -1,4 +1,5 @@
-from typing import Iterator, Type, TypeGuard
+from types import EllipsisType
+from typing import Iterator, Type, TypeGuard, cast
 
 from functional.common import Dimension, GTTypeError
 from functional.ffront import common_types as ct
@@ -165,31 +166,123 @@ def is_concretizable(symbol_type: ct.SymbolType, to_type: ct.SymbolType) -> bool
     return False
 
 
-def _is_sublist(small_list, big_list):
-    if len(small_list) > len(big_list):
-        return False
-    elif all(i in big_list for i in small_list):
-        start = big_list.index(small_list[0])
-        end = big_list.index(small_list[-1]) + 1
-        return small_list == big_list[start:end]
-    return False
-
-
-def is_dimensionally_promotable(symbol_type: ct.SymbolType, to_type: ct.SymbolType) -> bool:
+def promote(*types: ct.FieldType | ct.ScalarType) -> ct.FieldType | ct.SymbolType:
     """
-    Check if `symbol_type` has no fixed dimensionality and can be dimensionally promoted.
+    Promote a set of field or scalar types to a common type.
 
-    This is not to be mistaken for broadcasting, a more general concept, which allows interactions
-    between differing sets of dimensions.
+    The resulting type is defined on all dimensions of the arguments, respecting
+    the individual order of the dimensions of each argument (see
+    :func:`promote_dims` for more details).
+
+    >>> dtype = ct.ScalarType(kind=ct.ScalarKind.INT64)
+    >>> I, J, K = (Dimension(value=dim) for dim in ["I", "J", "K"])
+    >>> promoted: ct.FieldType = promote(
+    ...     ct.FieldType(dims=[I, J], dtype=dtype),
+    ...     ct.FieldType(dims=[I, J, K], dtype=dtype),
+    ...     dtype
+    ... )
+    >>> promoted.dims == [I, J, K] and promoted.dtype == dtype
+    True
+
+    >>> promote(
+    ...     ct.FieldType(dims=[I, J], dtype=dtype),
+    ...     ct.FieldType(dims=[K], dtype=dtype)
+    ... ) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+     ...
+    functional.common.GTTypeError: Dimensions can not be promoted. Could not determine order of the following dimensions: J, K.
     """
-    # scalars can always be broadcasted
-    if type_class(symbol_type) is ct.ScalarType:
-        return True
-    # symbol_type must be either zero- or any dimensional or have same dimensionality as to_type
-    elif type_class(to_type) is ct.FieldType:
-        dims = extract_dims(symbol_type)
-        return dims in [[], Ellipsis] or _is_sublist(dims, extract_dims(to_type))
-    return False
+    if all(isinstance(type_, ct.ScalarType) for type_ in types):
+        if not all(type_ == types[0] for type_ in types):
+            raise GTTypeError("Could not promote scalars of different dtype not implemented.")
+        if not all(type_.shape is None for type_ in types):  # type: ignore[union-attr]
+            raise NotImplementedError("Shape promotion not implemented.")
+        return types[0]
+    elif all(isinstance(type_, (ct.ScalarType, ct.FieldType)) for type_ in types):
+        dims = promote_dims(*(extract_dims(type_) for type_ in types))
+        dtype = cast(ct.ScalarType, promote(*(extract_dtype(type_) for type_ in types)))
+
+        return ct.FieldType(dims=dims, dtype=dtype)
+    raise TypeError("Expected a FieldType or ScalarType.")
+
+
+def promote_dims(
+    *dims_list: list[Dimension] | EllipsisType,
+) -> list[Dimension] | EllipsisType:
+    """
+    Find a unique ordering of multiple (individually ordered) lists of dimensions.
+
+    The resulting list of dimensions contains all dimensions of the arguments
+    in the order they originally appear. If no unique order exists or a
+    contradicting order is found an exception is raised.
+
+    A modified version (ensuring uniqueness of the order) of
+    `Kahn's algirithm <https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm>`_
+    is used to topologically sort the arguments.
+
+    >>> I, J, K = (Dimension(value=dim) for dim in ["I", "J", "K"])
+    >>> promote_dims([I, J], [I, J, K]) == [I, J, K]
+    True
+    >>> promote_dims([I, J], [K]) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+     ...
+    functional.common.GTTypeError: Dimensions can not be promoted. Could not determine order of the following dimensions: J, K.
+    >>> promote_dims([I, J], [J, I]) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+     ...
+    functional.common.GTTypeError: Dimensions can not be promoted. The following dimensions appear in contradicting order: I, J.
+    """
+    # build a graph with the vertices being dimensions and edges representing
+    #  the order between two dimensions
+    graph: dict[Dimension, set[Dimension]] = {}
+    for dims in dims_list:
+        if dims == Ellipsis:
+            return Ellipsis
+        dims = cast(list[Dimension], dims)
+        if len(dims) == 0:
+            continue
+        # create a vertex for each dimension
+        for dim in dims:
+            if dim not in graph:
+                graph[dim] = set()
+        # add edges
+        previous_dim = dims[0]
+        for dim in dims[1:]:
+            graph[dim].add(previous_dim)
+            previous_dim = dim
+
+    # modified version of Kahn's algorithm
+    topologically_sorted_list: list[Dimension] = []
+
+    # compute in-degree for each vertex
+    in_degree = {v: 0 for v in graph.keys()}
+    for v1 in graph:
+        for v2 in graph[v1]:
+            in_degree[v2] += 1
+
+    # process vertices with in-degree == 0
+    # TODO(tehrengruber): avoid recomputation of zero_in_degree_vertex_list
+    while zero_in_degree_vertex_list := [v for v, d in in_degree.items() if d == 0]:
+        if len(zero_in_degree_vertex_list) != 1:
+            raise GTTypeError(
+                f"Dimensions can not be promoted. Could not determine "
+                f"order of the following dimensions: "
+                f"{', '.join((dim.value for dim in zero_in_degree_vertex_list))}."
+            )
+        v = zero_in_degree_vertex_list[0]
+        del in_degree[v]
+        topologically_sorted_list.insert(0, v)
+        # update in-degree
+        for neighbour in graph[v]:
+            in_degree[neighbour] -= 1
+
+    if len(in_degree.items()) > 0:
+        raise GTTypeError(
+            f"Dimensions can not be promoted. The following dimensions "
+            f"appear in contradicting order: {', '.join((dim.value for dim in in_degree.keys()))}."
+        )
+
+    return topologically_sorted_list
 
 
 def function_signature_incompatibilities(

--- a/tests/functional_tests/ffront_tests/test_type_deduction.py
+++ b/tests/functional_tests/ffront_tests/test_type_deduction.py
@@ -240,7 +240,7 @@ def test_adding_bool():
 
     with pytest.raises(
         FieldOperatorTypeDeductionError,
-        match=(r"Type Field\[\.\.\., dtype=bool\] can not be used in operator '\+'!"),
+        match=(r"Type Field\[\.\.\., dtype=bool\] can not be used in operator `\+`!"),
     ):
         _ = FieldOperatorParser.apply_to_function(add_bools)
 
@@ -268,7 +268,7 @@ def test_bitopping_float():
 
     with pytest.raises(
         FieldOperatorTypeDeductionError,
-        match=(r"Type Field\[\.\.\., dtype=float64\] can not be used in operator '\&'! "),
+        match=(r"Type Field\[\.\.\., dtype=float64\] can not be used in operator `\&`! "),
     ):
         _ = FieldOperatorParser.apply_to_function(float_bitop)
 
@@ -279,7 +279,7 @@ def test_signing_bool():
 
     with pytest.raises(
         FieldOperatorTypeDeductionError,
-        match=r"Incompatible type for unary operator '\-': Field\[\.\.\., dtype=bool\]!",
+        match=r"Incompatible type for unary operator `\-`: `Field\[\.\.\., dtype=bool\]`!",
     ):
         _ = FieldOperatorParser.apply_to_function(sign_bool)
 
@@ -290,7 +290,7 @@ def test_notting_int():
 
     with pytest.raises(
         FieldOperatorTypeDeductionError,
-        match=r"Incompatible type for unary operator 'not': Field\[\.\.\., dtype=int64\]!",
+        match=r"Incompatible type for unary operator `not`: `Field\[\.\.\., dtype=int64\]`!",
     ):
         _ = FieldOperatorParser.apply_to_function(not_int)
 

--- a/tests/functional_tests/ffront_tests/test_type_deduction.py
+++ b/tests/functional_tests/ffront_tests/test_type_deduction.py
@@ -11,7 +11,7 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from typing import Optional
+from typing import Optional, Pattern
 
 import pytest
 
@@ -166,7 +166,9 @@ def test_unpack_assign():
     )
 
 
-def dimension_promotion_cases():
+def dimension_promotion_cases() -> list[
+    tuple[list[list[Dimension]], list[Dimension] | None, None | Pattern]
+]:
     raw_list = [
         # list of list of dimensions, expected result, expected error message
         ([["I", "J"], ["I"]], ["I", "J"], None),


### PR DESCRIPTION
This PR replaces the previous type promotion mechanisms in the frontend by an enhanced version. The newly introduced `type_info.promote` function uses topologically sorting to determine a new `FieldType` from an arbitrary number of `FieldType`s. The motivation for this PR came from the need of a promotion mechanism that works for more than two field types while implementing the scan operator.

See the following snippet or the (doc)tests for an example:

```python
dtype = ct.ScalarType(kind=ct.ScalarKind.INT64)
I, J, K = (Dimension(value=dim) for dim in ["I", "J", "K"])
promoted: ct.FieldType = promote(
  ct.FieldType(dims=[I, J], dtype=dtype),
  ct.FieldType(dims=[I, J, K], dtype=dtype),
  dtype
)
assert promoted.dims == [I, J, K] and promoted.dtype == dtype
```