### PR TITLE
Functional: embedded execution position/offset based on str not obj

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -31,9 +31,8 @@ EMBEDDED = "embedded"
 
 
 Position = dict[str, Union[tuple[Optional[int], ...], Optional[int]]]
-MaybePosition = Optional[
-    Position
-]  # if a neighbor-table lookup results in not-a-neighbor, we set the position to None
+#: A ``None`` position flags invalid not-a-neighbor results in neighbor-table lookups
+MaybePosition: TypeAlias = Optional[Position]  
 AnyOffset = str | int
 OffsetProvider = dict[str, Any]
 
@@ -266,8 +265,7 @@ def execute_shift(
 ) -> MaybePosition:
     assert pos is not None
     if tag in pos and pos[tag] is None:  # sparse field with offset as neighbor dimension
-        new_pos = pos.copy()
-        new_pos[tag] = index
+        new_pos = pos | {tag: index}    
         return new_pos
     assert tag in offset_provider
     offset_implementation = offset_provider[tag]
@@ -281,7 +279,7 @@ def execute_shift(
     elif isinstance(offset_implementation, NeighborTableOffsetProvider):
         assert offset_implementation.origin_axis.value in pos
         new_pos = pos.copy()
-        del new_pos[offset_implementation.origin_axis.value]
+        new_pos.pop(offset_implementation.origin_axis.value)
         if offset_implementation.tbl[pos[offset_implementation.origin_axis.value], index] is None:
             return None
         else:

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -8,7 +8,6 @@ from typing import (
     Iterable,
     Optional,
     Protocol,
-    Tuple,
     TypeVar,
     Union,
     runtime_checkable,
@@ -27,7 +26,7 @@ from functional.iterator.utils import tupelize
 EMBEDDED = "embedded"
 
 
-PosT = dict[str, Union[Tuple[Optional[int], ...], Optional[int]]]
+PosT = dict[str, Union[tuple[Optional[int], ...], Optional[int]]]
 MaybePosT = Optional[PosT]
 OffsetT = Union[str, int]
 OffsetProviderT = dict[str, Any]

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -19,7 +19,7 @@ import numpy.typing
 from functional import iterator
 from functional.common import Dimension
 from functional.iterator import builtins
-from functional.iterator.runtime import CartesianAxis, Offset
+from functional.iterator.runtime import Offset
 from functional.iterator.utils import tupelize
 
 
@@ -258,7 +258,7 @@ def execute_shift(
         return new_pos
     assert tag in offset_provider
     offset_implementation = offset_provider[tag]
-    if isinstance(offset_implementation, CartesianAxis):
+    if isinstance(offset_implementation, Dimension):
         assert offset_implementation.value in pos
         new_pos = pos.copy()
         val = new_pos[offset_implementation.value]
@@ -450,7 +450,7 @@ def make_in_iterator(
         if isinstance(axis, Offset):
             assert isinstance(axis.value, str)
             sparse_dimensions.append(axis.value)
-        elif isinstance(axis, CartesianAxis) and axis.local:
+        elif isinstance(axis, Dimension) and axis.local:
             # we just use the name of the axis to match the offset literal for now
             sparse_dimensions.append(axis.value)
 
@@ -587,7 +587,7 @@ def shift(*offsets: Union[Offset, int]):
 
 @dataclass
 class Column:
-    axis: CartesianAxis
+    axis: str
     range: range  # noqa: A003
 
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -237,7 +237,7 @@ def less(first, second):
     return first < second
 
 
-def named_range_(axis: str, range_: range) -> Generator[tuple[str, int], None, None]:
+def named_range_(axis: str, range_: Iterable[int]) -> Iterable[tuple[str, int]]:
     return ((axis, i) for i in range_)
 
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -714,8 +714,8 @@ _column_range = None  # TODO this is a bit ugly, alternative: pass scan range vi
 
 
 @builtins.scan.register(EMBEDDED)
-def scan(scan_pass, is_forward, init):
-    def impl(*iters):
+def scan(scan_pass, is_forward: bool, init):
+    def impl(*iters: ItIterator):
         if _column_range is None:
             raise RuntimeError("Column range is not defined, cannot scan.")
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import itertools
 import numbers
 from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
-    Generator,
     Iterable,
     Optional,
     Protocol,
+    Sequence,
+    TypeGuard,
     TypeVar,
     Union,
+    cast,
     runtime_checkable,
 )
 
@@ -26,15 +30,17 @@ from functional.iterator.utils import tupelize
 EMBEDDED = "embedded"
 
 
-PosT = dict[str, Union[tuple[Optional[int], ...], Optional[int]]]
-MaybePosT = Optional[PosT]
-OffsetT = Union[str, int]
-OffsetProviderT = dict[str, Any]
+Position = dict[str, Union[tuple[Optional[int], ...], Optional[int]]]
+MaybePosition = Optional[
+    Position
+]  # if a neighbor-table lookup results in not-a-neighbor, we set the position to None
+AnyOffset = str | int
+OffsetProvider = dict[str, Any]
 
 
 @runtime_checkable
 class ItIterator(Protocol):
-    def shift(self, *offsets: OffsetT) -> None:
+    def shift(self, *offsets: AnyOffset) -> ItIterator:
         ...
 
     def max_neighbors(self) -> int:
@@ -49,23 +55,27 @@ class ItIterator(Protocol):
 
 @runtime_checkable
 class LocatedField(Protocol):
+    """A field with named dimensions providing read access."""
+
     @property
     def axes(self) -> tuple[Dimension, ...]:
         ...
 
-    def __getitem__(self, indices) -> Any:
+    def __getitem__(self, indices: Union[int, tuple[int, ...]]) -> Any:
         ...
 
 
 class AssignableLocatedField(LocatedField):
-    def __setitem__(self, indices, value) -> None:
+    """A LocatedField with write access."""
+
+    def __setitem__(self, indices: Union[int, tuple[int, ...]], value: Any) -> None:
         ...
 
 
 class NeighborTableOffsetProvider:
     def __init__(
         self,
-        tbl,
+        tbl: np.ndarray,  # TODO(havogt): define neighbor table concept
         origin_axis: Dimension,
         neighbor_axis: Dimension,
         max_neighbors: int,
@@ -241,16 +251,19 @@ def named_range_(axis: str, range_: Iterable[int]) -> Iterable[tuple[str, int]]:
     return ((axis, i) for i in range_)
 
 
-def domain_iterator(domain: dict[str, range]):
-    return (
-        dict(elem)
-        for elem in itertools.product(*(named_range_(tup[0], tup[1]) for tup in domain.items()))
+def domain_iterator(domain: dict[str, range]) -> Sequence[Position]:
+    return cast(
+        Sequence[Position],
+        (
+            dict(elem)
+            for elem in itertools.product(*(named_range_(tup[0], tup[1]) for tup in domain.items()))
+        ),
     )
 
 
 def execute_shift(
-    pos: MaybePosT, tag: str, index: int, *, offset_provider: OffsetProviderT
-) -> MaybePosT:
+    pos: MaybePosition, tag: str, index: int, *, offset_provider: OffsetProvider
+) -> MaybePosition:
     assert pos is not None
     if tag in pos and pos[tag] is None:  # sparse field with offset as neighbor dimension
         new_pos = pos.copy()
@@ -261,9 +274,9 @@ def execute_shift(
     if isinstance(offset_implementation, Dimension):
         assert offset_implementation.value in pos
         new_pos = pos.copy()
-        val = new_pos[offset_implementation.value]
-        assert isinstance(val, int)  # make mypy happy
-        new_pos[offset_implementation.value] = val + index
+        _extracted_val_for_mypy_check = new_pos[offset_implementation.value]
+        assert isinstance(_extracted_val_for_mypy_check, int)
+        new_pos[offset_implementation.value] = _extracted_val_for_mypy_check + index
         return new_pos
     elif isinstance(offset_implementation, NeighborTableOffsetProvider):
         assert offset_implementation.origin_axis.value in pos
@@ -272,9 +285,9 @@ def execute_shift(
         if offset_implementation.tbl[pos[offset_implementation.origin_axis.value], index] is None:
             return None
         else:
-            new_pos[offset_implementation.neighbor_axis.value] = offset_implementation.tbl[
-                pos[offset_implementation.origin_axis.value], index
-            ]
+            new_pos[offset_implementation.neighbor_axis.value] = int(
+                offset_implementation.tbl[pos[offset_implementation.origin_axis.value], index]
+            )
         return new_pos
 
     raise AssertionError()
@@ -291,7 +304,7 @@ def execute_shift(
 # = shift(c2e,e2v,2,0)(cell_field) <-- v2c,e2c twice incomplete shift
 # = shift(2,0)(shift(c2e,e2v)(cell_field))
 # for implementations it means everytime we have an index, we can "execute" a concrete shift
-def group_offsets(*offsets: OffsetT) -> tuple[list[tuple[str, int]], list[str]]:
+def group_offsets(*offsets: AnyOffset) -> tuple[list[tuple[str, int]], list[str]]:
     tag_stack = []
     complete_offsets = []
     for offset in offsets:
@@ -305,11 +318,11 @@ def group_offsets(*offsets: OffsetT) -> tuple[list[tuple[str, int]], list[str]]:
 
 
 def shift_position(
-    pos: MaybePosT, *complete_offsets: tuple[str, int], offset_provider: OffsetProviderT
-) -> MaybePosT:
+    pos: MaybePosition, *complete_offsets: tuple[str, int], offset_provider: OffsetProvider
+) -> MaybePosition:
     if pos is None:
         return None
-    new_pos: MaybePosT = pos.copy()
+    new_pos: MaybePosition = pos.copy()  # becomes MaybePos later
     for tag, index in complete_offsets:
         new_pos = execute_shift(new_pos, tag, index, offset_provider=offset_provider)
         if new_pos is None:
@@ -317,7 +330,7 @@ def shift_position(
     return new_pos
 
 
-def get_open_offsets(*offsets: OffsetT) -> list[str]:
+def get_open_offsets(*offsets: AnyOffset) -> list[str]:
     return group_offsets(*offsets)[1]
 
 
@@ -370,15 +383,19 @@ Undefined._setup_math_operations()
 _UNDEFINED = Undefined()
 
 
+def _is_position_fully_defined(pos: Position) -> TypeGuard[dict[str, int]]:
+    return all(isinstance(v, int) for v in pos.values())
+
+
 class MDIterator:
     def __init__(
         self,
         field: LocatedField,
-        pos: MaybePosT,
+        pos: MaybePosition,
         *,
-        incomplete_offsets=None,
-        offset_provider,
-        column_axis=None,
+        incomplete_offsets: Sequence[str] = None,
+        offset_provider: OffsetProvider,
+        column_axis: str = None,
     ) -> None:
         self.field = field
         self.pos = pos
@@ -386,7 +403,7 @@ class MDIterator:
         self.offset_provider = offset_provider
         self.column_axis = column_axis
 
-    def shift(self, *offsets: OffsetT):
+    def shift(self, *offsets: AnyOffset) -> MDIterator:
         complete_offsets, open_offsets = group_offsets(*self.incomplete_offsets, *offsets)
         return MDIterator(
             self.field,
@@ -396,22 +413,23 @@ class MDIterator:
             column_axis=self.column_axis,
         )
 
-    def max_neighbors(self):
+    def max_neighbors(self) -> int:
         assert self.incomplete_offsets
         assert isinstance(
             self.offset_provider[self.incomplete_offsets[0]], NeighborTableOffsetProvider
         )
         return self.offset_provider[self.incomplete_offsets[0]].max_neighbors
 
-    def can_deref(self):
+    def can_deref(self) -> bool:
         return self.pos is not None
 
-    def deref(self):
+    def deref(self) -> Any:
         if not self.can_deref():
             # this can legally happen in cases like `if_(can_deref(inp), deref(inp), 42.)`
             # because both branches will be eagerly executed
             return _UNDEFINED
 
+        assert self.pos is not None
         shifted_pos = self.pos.copy()
         # TODO(havogt): support nested tuples
         axes = self.field[0].axes if isinstance(self.field, tuple) else self.field.axes
@@ -422,6 +440,8 @@ class MDIterator:
         if self.column_axis is not None:
             slice_column[self.column_axis] = slice(shifted_pos[self.column_axis], None)
             del shifted_pos[self.column_axis]
+
+        assert _is_position_fully_defined(shifted_pos)
         ordered_indices = get_ordered_indices(
             axes,
             shifted_pos,
@@ -436,12 +456,15 @@ class MDIterator:
             return _UNDEFINED
 
 
+assert issubclass(MDIterator, ItIterator)
+
+
 def make_in_iterator(
-    inp,
-    pos: PosT,
+    inp: LocatedField,
+    pos: Position,
     offset_provider: dict[str, Any],
     *,
-    column_axis,
+    column_axis: Optional[str],
 ) -> MDIterator:
     # TODO(havogt): support nested tuples
     axes = inp[0].axes if isinstance(inp, tuple) else inp.axes
@@ -456,8 +479,8 @@ def make_in_iterator(
 
     assert len(sparse_dimensions) <= 1  # TODO multiple is not a current use case
     new_pos = pos.copy()
-    for axis in sparse_dimensions:
-        new_pos[axis] = None
+    for sparse_dim in sparse_dimensions:
+        new_pos[sparse_dim] = None
     if column_axis is not None:
         # if we deal with column stencil the column position is just an offset by which the whole column needs to be shifted
         new_pos[column_axis] = 0
@@ -483,26 +506,34 @@ class LocatedFieldImpl:
     """
 
     @property
-    def axes(self):
+    def axes(self) -> tuple[Dimension, ...]:
         return self._axes
 
-    def __init__(self, getter, axes: tuple[Dimension, ...], dtype, *, setter=None, array=None):
+    def __init__(
+        self,
+        getter: Callable[[Union[int, tuple[int, ...]]], Any],
+        axes: tuple[Dimension, ...],
+        dtype,
+        *,
+        setter: Optional[Callable[[Union[int, tuple[int, ...]], Any], None]] = None,
+        array: Optional[Callable[[], np.ndarray]] = None,
+    ):
         self.getter = getter
         self._axes = axes
         self.setter = setter
         self.array = array
         self.dtype = dtype
 
-    def __getitem__(self, indices):
+    def __getitem__(self, indices: Union[int, tuple[int, ...]]) -> Any:
         indices = tupelize(indices)
         return self.getter(indices)
 
-    def __setitem__(self, indices, value):
+    def __setitem__(self, indices: Union[int, tuple[int, ...]], value: Any):
         if self.setter is None:
             raise TypeError("__setitem__ not supported for this field")
         self.setter(indices, value)
 
-    def __array__(self):
+    def __array__(self) -> np.ndarray:
         if self.array is None:
             raise TypeError("__array__ not supported for this field")
         return self.array()
@@ -547,8 +578,10 @@ def _tupsum(a, b):
     return tuple(combine_slice(*i) for i in zip(a, b))
 
 
-def np_as_located_field(*axes: Dimension, origin=None):
-    def _maker(a: np.ndarray):
+def np_as_located_field(
+    *axes: Dimension, origin: Optional[dict[Dimension, int]] = None
+) -> Callable[[np.ndarray], LocatedFieldImpl]:
+    def _maker(a: np.ndarray) -> LocatedFieldImpl:
         if a.ndim != len(axes):
             raise TypeError("ndarray.ndim incompatible with number of given axes")
 
@@ -570,7 +603,9 @@ def np_as_located_field(*axes: Dimension, origin=None):
 
 
 def index_field(axis: Dimension, dtype=float) -> LocatedField:
-    return LocatedFieldImpl(lambda index: index[0], (axis,), dtype)
+    return LocatedFieldImpl(
+        lambda index: index[0] if isinstance(index, tuple) else index, (axis,), dtype
+    )  # TODO for typing this looks like an AssignableLocatedField
 
 
 def constant_field(value: Any, dtype: type) -> LocatedField:
@@ -578,8 +613,8 @@ def constant_field(value: Any, dtype: type) -> LocatedField:
 
 
 @builtins.shift.register(EMBEDDED)
-def shift(*offsets: Union[Offset, int]):
-    def impl(it):
+def shift(*offsets: Union[Offset, int]) -> Callable[[ItIterator], ItIterator]:
+    def impl(it: ItIterator) -> ItIterator:
         return it.shift(*list(o.value if isinstance(o, Offset) else o for o in offsets))
 
     return impl
@@ -588,24 +623,26 @@ def shift(*offsets: Union[Offset, int]):
 @dataclass
 class Column:
     axis: str
-    range: range  # noqa: A003
+    range: range  # TODO(havogt) introduce range type that doesn't have step # noqa: A003
 
 
 class ScanArgIterator:
-    def __init__(self, wrapped_iter: ItIterator, k_pos: int, *, offsets=None) -> None:
+    def __init__(
+        self, wrapped_iter: ItIterator, k_pos: int, *, offsets: Sequence[AnyOffset] = None
+    ) -> None:
         self.wrapped_iter = wrapped_iter
         self.offsets = offsets or []
         self.k_pos = k_pos
 
-    def deref(self):
+    def deref(self) -> Any:
         if not self.can_deref():
             return _UNDEFINED
         return self.wrapped_iter.deref()[self.k_pos]
 
-    def can_deref(self):
+    def can_deref(self) -> bool:
         return self.wrapped_iter.can_deref()
 
-    def shift(self, *offsets: OffsetT) -> "ScanArgIterator":
+    def shift(self, *offsets: AnyOffset) -> ScanArgIterator:
         return ScanArgIterator(self.wrapped_iter, self.k_pos, offsets=[*offsets, *self.offsets])
 
 
@@ -617,7 +654,7 @@ def shifted_scan_arg(k_pos: int) -> Callable[[ItIterator], ScanArgIterator]:
 
 
 def is_located_field(field: Any) -> bool:
-    return isinstance(field, LocatedField)
+    return isinstance(field, LocatedField)  # TODO(havogt): avoid isinstance on Protocol
 
 
 def has_uniform_tuple_element(field) -> bool:
@@ -750,10 +787,10 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
     @iterator.runtime.closure.register(EMBEDDED)
     def closure(
         domain_: dict[Union[str, Dimension], range],
-        sten,
+        sten: Callable[..., Any],
         out: AssignableLocatedField,
         ins: list[LocatedField],
-    ):  # domain is Dict[axis, range]
+    ) -> None:  # domain is Dict[axis, range]
         domain: dict[str, range] = {
             k.value if isinstance(k, Dimension) else k: v for k, v in domain_.items()
         }
@@ -784,12 +821,14 @@ def fendef_embedded(fun, *args, **kwargs):  # noqa: 536
             res = sten(*ins_iters)
 
             if column is None:
+                assert _is_position_fully_defined(pos)
                 ordered_indices = get_ordered_indices(out.axes, pos)
                 out[ordered_indices] = res
             else:
                 colpos = pos.copy()
                 for k in column.range:
                     colpos[column.axis] = k
+                    assert _is_position_fully_defined(colpos)
                     ordered_indices = get_ordered_indices(out.axes, colpos)
                     out[ordered_indices] = res[k]
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -138,9 +138,8 @@ def make_tuple(*args):
 def lift(stencil):
     def impl(*args):
         class wrap_iterator:
-            def __init__(self, *, offsets=None, elem=None) -> None:
-                if offsets:
-                    assert all(isinstance(o, (int, str)) for o in offsets)
+            def __init__(self, *, offsets=(), elem=None) -> None:
+                assert all(isinstance(o, (int, str)) for o in offsets)
                 self.offsets = offsets or []
                 self.elem = elem
 

--- a/src/functional/iterator/runtime.py
+++ b/src/functional/iterator/runtime.py
@@ -11,7 +11,7 @@ __all__ = ["offset", "fundef", "fendef", "closure", "CartesianAxis"]
 
 @dataclass(frozen=True)
 class Offset:
-    value: Optional[Union[int, str]] = None
+    value: Union[int, str]
 
 
 def offset(value):

--- a/tests/functional_tests/iterator_tests/test_field.py
+++ b/tests/functional_tests/iterator_tests/test_field.py
@@ -13,7 +13,7 @@ def test_located_field_1d():
 
     foo[0] = 42
 
-    assert foo.axises[0] == "foo"
+    assert foo.axes[0] == "foo"
     assert foo[0] == 42
 
 
@@ -22,7 +22,7 @@ def test_located_field_2d():
 
     foo[0, 0] = 42
 
-    assert foo.axises[0] == "foo"
+    assert foo.axes[0] == "foo"
     assert foo[0, 0] == 42
     assert foo.dtype == np.float64
 


### PR DESCRIPTION
Iterator position in embedded execution is now a `dict[str, int]`. Offsets are translated directly from `Offset` object to `str`.
This avoids that embedded execution accidentally uses extra information from `Offset` or `Dimension`. This information needs to be provided via `offset_provider`.

Additionally:
- adds type hints