### PR TITLE
Enhance broadcasting and where

### DIFF
--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -35,7 +35,7 @@ class SymbolType:
 class DeferredSymbolType(SymbolType):
     """Dummy used to represent a type not yet inferred."""
 
-    constraint: typing.Optional[typing.Type[SymbolType]]
+    constraint: typing.Optional[typing.Type[SymbolType] | tuple[typing.Type[SymbolType]]]
 
 
 @dataclass(frozen=True)

--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal, Optional, Union
+from typing import Literal, Optional
 
 import numpy as np
 

--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -1,4 +1,3 @@
-import typing
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
 
@@ -35,13 +34,13 @@ class SymbolType:
 class DeferredSymbolType(SymbolType):
     """Dummy used to represent a type not yet inferred."""
 
-    constraint: typing.Optional[typing.Type[SymbolType] | tuple[typing.Type[SymbolType], ...]]
+    constraint: Optional[type[SymbolType] | tuple[type[SymbolType], ...]]
 
 
 @dataclass(frozen=True)
 class SymbolTypeVariable(SymbolType):
     id: str  # noqa A003
-    bound: typing.Type[SymbolType]
+    bound: type[SymbolType]
 
 
 @dataclass(frozen=True)
@@ -94,7 +93,7 @@ class TupleType(DataType):
 
 @dataclass(frozen=True)
 class FieldType(DataType):
-    dims: Union[list[func_common.Dimension], Literal[Ellipsis]]  # type: ignore[valid-type,misc]
+    dims: list[func_common.Dimension] | Literal[Ellipsis]  # type: ignore[valid-type,misc]
     dtype: ScalarType
 
     def __str__(self):
@@ -104,9 +103,9 @@ class FieldType(DataType):
 
 @dataclass(frozen=True)
 class FunctionType(SymbolType):
-    args: list[Union[DataType, DeferredSymbolType]]
-    kwargs: dict[str, Union[DataType, DeferredSymbolType]]
-    returns: Union[DataType, DeferredSymbolType, VoidType]
+    args: list[DataType | DeferredSymbolType]
+    kwargs: dict[str, DataType | DeferredSymbolType]
+    returns: DataType | DeferredSymbolType | VoidType
 
     def __str__(self):
         arg_strs = [str(arg) for arg in self.args]

--- a/src/functional/ffront/common_types.py
+++ b/src/functional/ffront/common_types.py
@@ -35,7 +35,7 @@ class SymbolType:
 class DeferredSymbolType(SymbolType):
     """Dummy used to represent a type not yet inferred."""
 
-    constraint: typing.Optional[typing.Type[SymbolType] | tuple[typing.Type[SymbolType]]]
+    constraint: typing.Optional[typing.Type[SymbolType] | tuple[typing.Type[SymbolType], ...]]
 
 
 @dataclass(frozen=True)

--- a/src/functional/ffront/fbuiltins.py
+++ b/src/functional/ffront/fbuiltins.py
@@ -65,7 +65,7 @@ max_over = _reduction_like
 broadcast = BuiltInFunction(
     ct.FunctionType(
         args=[
-            ct.DeferredSymbolType(constraint=ct.FieldType),
+            ct.DeferredSymbolType(constraint=(ct.FieldType, ct.ScalarType)),
             ct.DeferredSymbolType(constraint=ct.TupleType),
         ],
         kwargs={},
@@ -77,8 +77,8 @@ where = BuiltInFunction(
     ct.FunctionType(
         args=[
             ct.DeferredSymbolType(constraint=ct.FieldType),
-            ct.DeferredSymbolType(constraint=ct.FieldType),
-            ct.DeferredSymbolType(constraint=ct.FieldType),
+            ct.DeferredSymbolType(constraint=(ct.FieldType, ct.ScalarType)),
+            ct.DeferredSymbolType(constraint=(ct.FieldType, ct.ScalarType)),
         ],
         kwargs={},
         returns=ct.DeferredSymbolType(constraint=ct.FieldType),

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -359,22 +359,17 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 msg=f"Incompatible argument in call to `{node.func.id}`. Expected "
                 f"a field with dtype bool, but got `{mask_type}`.",
             )
-        if left_type != right_type:
-            raise FieldOperatorTypeDeductionError.from_foast_node(
-                node,
-                msg=f"Incompatible argument in call to `{node.func.id}`. Expected "
-                f"second and third argument to be of equal type.",
-            )
+        return_type = type_info.promote(left_type, right_type)
         return foast.Call(
             func=node.func,
             args=node.args,
             kwargs=node.kwargs,
-            type=left_type,
+            type=return_type,
             location=node.location,
         )
 
     def _visit_broadcast(self, node: foast.Call, **kwargs) -> foast.Call:
-        field_type = cast(ct.FieldType, node.args[0].type)
+        arg_type = cast(ct.FieldType | ct.ScalarType, node.args[0].type)
         broadcast_dims_expr = cast(foast.TupleExpr, node.args[1]).elts
 
         if any([not (isinstance(elt.type, ct.DimensionType)) for elt in broadcast_dims_expr]):
@@ -386,16 +381,16 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
 
         broadcast_dims = [cast(ct.DimensionType, elt.type).dim for elt in broadcast_dims_expr]
 
-        if not set(field_type.dims).issubset(set(broadcast_dims)):
+        if not set((arg_dims := type_info.extract_dims(arg_type))).issubset(set(broadcast_dims)):
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Incompatible broadcast dimensions in {node.func.id}. Expected "
-                f"broadcast dimension is missing {set(field_type.dims).difference(set(broadcast_dims))}",
+                f"broadcast dimension is missing {set(arg_dims).difference(set(broadcast_dims))}",
             )
 
         return_type = ct.FieldType(
             dims=broadcast_dims,
-            dtype=field_type.dtype,
+            dtype=type_info.extract_dtype(arg_type),
         )
 
         return foast.Call(

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -359,7 +359,15 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 msg=f"Incompatible argument in call to `{node.func.id}`. Expected "
                 f"a field with dtype bool, but got `{mask_type}`.",
             )
-        return_type = type_info.promote(left_type, right_type)
+
+        try:
+            return_type = type_info.promote(left_type, right_type)
+        except GTTypeError as ex:
+            raise FieldOperatorTypeDeductionError.from_foast_node(
+                node,
+                msg=f"Incompatible argument in call to `{node.func.id}`.",
+            ) from ex
+
         return foast.Call(
             func=node.func,
             args=node.args,

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -221,7 +221,7 @@ class FieldOperatorLowering(NodeTranslator):
         return self._lift_if_field(node)(
             im.call_(node.op.value)(
                 to_value(node.left)(self.visit(node.left, **kwargs)),
-                to_value(node.left)(self.visit(node.right, **kwargs)),
+                to_value(node.right)(self.visit(node.right, **kwargs)),
             )
         )
 
@@ -285,7 +285,10 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_broadcast(self, node: foast.Call, **kwargs) -> itir.FunCall:
         # just lower broadcasted field as iterator IR does not care about broadcasting
         broadcasted_field = node.args[0]
-        return self.visit(broadcasted_field, **kwargs)
+        lowered_arg = self.visit(broadcasted_field, **kwargs)
+        if isinstance(broadcasted_field.type, ct.ScalarType):
+            lowered_arg = im.lift_(im.lambda__()(lowered_arg))()
+        return lowered_arg
 
     def _visit_neighbor_sum(self, node: foast.Call, **kwargs) -> itir.FunCall:
         return self._visit_reduce(node, **kwargs)

--- a/src/functional/ffront/type_info.py
+++ b/src/functional/ffront/type_info.py
@@ -15,7 +15,7 @@ def is_concrete(symbol_type: ct.SymbolType) -> TypeGuard[ct.SymbolType]:
     return False
 
 
-def type_class(symbol_type: ct.SymbolType) -> Type[ct.SymbolType] | tuple[Type[ct.SymbolType]]:
+def type_class(symbol_type: ct.SymbolType) -> Type[ct.SymbolType]:
     """
     Determine which class should be used to create a compatible concrete type.
 

--- a/src/functional/ffront/type_info.py
+++ b/src/functional/ffront/type_info.py
@@ -15,7 +15,7 @@ def is_concrete(symbol_type: ct.SymbolType) -> TypeGuard[ct.SymbolType]:
     return False
 
 
-def type_class(symbol_type: ct.SymbolType) -> Type[ct.SymbolType]:
+def type_class(symbol_type: ct.SymbolType) -> Type[ct.SymbolType] | tuple[Type[ct.SymbolType]]:
     """
     Determine which class should be used to create a compatible concrete type.
 
@@ -34,6 +34,8 @@ def type_class(symbol_type: ct.SymbolType) -> Type[ct.SymbolType]:
         case ct.DeferredSymbolType(constraint):
             if constraint is None:
                 raise GTTypeError(f"No type information available for {symbol_type}!")
+            elif isinstance(constraint, tuple):
+                raise GTTypeError(f"Not sufficient type information available for {symbol_type}!")
             return constraint
         case ct.SymbolType() as concrete_type:
             return concrete_type.__class__
@@ -158,7 +160,7 @@ def is_concretizable(symbol_type: ct.SymbolType, to_type: ct.SymbolType) -> bool
 
     """
     if isinstance(symbol_type, ct.DeferredSymbolType) and (
-        symbol_type.constraint is None or issubclass(type_class(to_type), symbol_type.constraint)
+        symbol_type.constraint is None or issubclass(type_class(to_type), symbol_type.constraint)  # type: ignore[arg-type]
     ):
         return True
     elif is_concrete(symbol_type):

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -467,8 +467,8 @@ def test_broadcast_scalar():
     out = np_as_located_field(IDim)(np.zeros((size)))
 
     @field_operator(backend="roundtrip")
-    def scalar_broadcast() -> Field[[IDim,], float64]:
-        return broadcast(float(1.), (IDim,))
+    def scalar_broadcast() -> Field[[IDim], float64]:
+        return broadcast(float(1.0), (IDim,))
 
     scalar_broadcast(out=out, offset_provider={})
 

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -239,7 +239,7 @@ def test_tuples():
     assert np.allclose((a.array() * 1.3 + b.array() * 5.0) * 3.4, c)
 
 
-def test_broadcasting():
+def test_promotion():
     Edge = Dimension("Edge")
     K = Dimension("K")
 
@@ -250,12 +250,12 @@ def test_broadcasting():
     c = np_as_located_field(Edge, K)(np.zeros((size, ksize)))
 
     @field_operator(backend="roundtrip")
-    def broadcast(
+    def promotion(
         inp1: Field[[Edge, K], float64], inp2: Field[[K], float64]
     ) -> Field[[Edge, K], float64]:
         return inp1 / inp2
 
-    broadcast(a, b, out=c, offset_provider={})
+    promotion(a, b, out=c, offset_provider={})
 
     assert np.allclose((a.array() / b.array()), c)
 
@@ -462,6 +462,19 @@ def test_broadcast_simple():
     assert np.allclose(a.array()[:, np.newaxis], out)
 
 
+def test_broadcast_scalar():
+    size = 10
+    out = np_as_located_field(IDim)(np.zeros((size)))
+
+    @field_operator(backend="roundtrip")
+    def scalar_broadcast() -> Field[[IDim,], float64]:
+        return broadcast(float(1.), (IDim,))
+
+    scalar_broadcast(out=out, offset_provider={})
+
+    assert np.allclose(1, out)
+
+
 def test_broadcast_two_fields():
     size = 10
     a = np_as_located_field(IDim)(np.arange(0, size, 1, dtype=int))
@@ -518,6 +531,24 @@ def test_conditional():
     conditional(mask, a, b, out=out, offset_provider={})
 
     assert np.allclose(np.where(mask, a, b), out)
+
+
+def test_conditional_promotion():
+    size = 10
+    mask = np_as_located_field(IDim)(np.zeros((size,), dtype=bool))
+    mask.array()[0 : (size // 2)] = True
+    a = np_as_located_field(IDim)(np.ones((size,)))
+    out = np_as_located_field(IDim)(np.zeros((size,)))
+
+    @field_operator(backend="roundtrip")
+    def conditional(
+        mask: Field[[IDim], bool], a: Field[[IDim], float64]
+    ) -> Field[[IDim], float64]:
+        return where(mask, a, 10.)
+
+    conditional(mask, a, out=out, offset_provider={})
+
+    assert np.allclose(np.where(mask, a, 10), out)
 
 
 def test_conditional_shifted():

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -541,10 +541,8 @@ def test_conditional_promotion():
     out = np_as_located_field(IDim)(np.zeros((size,)))
 
     @field_operator(backend="roundtrip")
-    def conditional(
-        mask: Field[[IDim], bool], a: Field[[IDim], float64]
-    ) -> Field[[IDim], float64]:
-        return where(mask, a, 10.)
+    def conditional(mask: Field[[IDim], bool], a: Field[[IDim], float64]) -> Field[[IDim], float64]:
+        return where(mask, a, 10.0)
 
     conditional(mask, a, out=out, offset_provider={})
 

--- a/tests/functional_tests/ffront_tests/test_interface.py
+++ b/tests/functional_tests/ffront_tests/test_interface.py
@@ -21,6 +21,8 @@ Basic Interface Tests
             arctan(), sqrt(), exp(), log(), isfinite(), isinf(), isnan(), floor(), ceil(), trunc()
     - evaluation test cases
 """
+import re
+
 import pytest
 
 from functional.common import Field
@@ -229,9 +231,11 @@ def test_conditional_wrong_arg_type():
     ) -> Field[..., float64]:
         return where(mask, a, b)
 
-    msg = r"Expected second and third argument to be of equal type."
-    with pytest.raises(FieldOperatorTypeDeductionError, match=msg):
+    msg = r"Could not promote scalars of different dtype \(not implemented\)."
+    with pytest.raises(FieldOperatorTypeDeductionError) as exc_info:
         _ = FieldOperatorParser.apply_to_function(conditional_wrong_arg_type)
+
+    assert re.search(msg, exc_info.value.__context__.args[0]) is not None
 
 
 # --- External symbols ---


### PR DESCRIPTION
Enhances the broadcasting and where builtins to accept scalar / literal arguments.

```python
broadcast(1., (IDim,))
where(mask, a, 10)
```