### PR TITLE
Functional: domain -> cartesian_domain | unstructured_domain in Iterator IR

### DIFF
--- a/src/functional/common.py
+++ b/src/functional/common.py
@@ -19,7 +19,7 @@ import dataclasses
 import enum
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
 
 from eve.type_definitions import StrEnum
 
@@ -82,6 +82,12 @@ class Backend:
     # TODO : proper definition and implementation
     def generate_operator(self, ir):
         return ir
+
+
+@runtime_checkable
+class Connectivity(Protocol):
+    max_neighbors: int
+    has_skip_values: bool
 
 
 @enum.unique

--- a/src/functional/common.py
+++ b/src/functional/common.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import abc
 import dataclasses
+import enum
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
+
+from eve.type_definitions import StrEnum
 
 
 DimT = TypeVar("DimT", bound="Dimension")
@@ -79,6 +82,12 @@ class Backend:
     # TODO : proper definition and implementation
     def generate_operator(self, ir):
         return ir
+
+
+@enum.unique
+class GridType(StrEnum):
+    CARTESIAN = "cartesian"
+    UNSTRUCTURED = "unstructured"
 
 
 class GTError:

--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -190,6 +190,12 @@ class Program:
         requested_grid_type: Optional[GridType],
         offsets_and_dimensions: set[FieldOffset | Dimension],
     ):
+        """
+        Derive grid type from actually occurring dimensions and check against optional user request.
+        
+        Unstructured grid type is consistent with any kind of offset, cartesian is easier to optimize for but only
+        allowed in the absence of unstructured dimensions and offsets.
+        """
         def is_cartesian_offset(o: FieldOffset):
             return len(o.target) == 1 and o.source == o.target[0]
 

--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -26,7 +26,7 @@ import functools
 import types
 import typing
 import warnings
-from typing import Callable
+from typing import Callable, Iterable
 
 from eve.extended_typing import Any, Optional, Protocol
 from eve.utils import UIDs
@@ -192,10 +192,11 @@ class Program:
     ):
         """
         Derive grid type from actually occurring dimensions and check against optional user request.
-        
+
         Unstructured grid type is consistent with any kind of offset, cartesian is easier to optimize for but only
         allowed in the absence of unstructured dimensions and offsets.
         """
+
         def is_cartesian_offset(o: FieldOffset):
             return len(o.target) == 1 and o.source == o.target[0]
 
@@ -215,31 +216,36 @@ class Program:
 
         return deduced_grid_type if requested_grid_type is None else requested_grid_type
 
-    def _lowered_funcs_from_captured_vars(
-        self, captured_vars: CapturedVars
-    ) -> tuple[list[itir.FunctionDefinition], set[FieldOffset | Dimension]]:
-        lowered_funcs = []
-        offsets_and_dimensions = set[FieldOffset | Dimension]()
-
+    def _gt_callables_from_captured_vars(self, captured_vars: CapturedVars) -> list[GTCallable]:
         all_captured_vars = collections.ChainMap(captured_vars.globals, captured_vars.nonlocals)
 
+        gt_callables = []
         for name, value in all_captured_vars.items():
             if isinstance(value, GTCallable):
-                itir_node = value.__gt_itir__()
-                if itir_node.id != name:
+                if value.__gt_itir__().id != name:
                     raise RuntimeError(
                         "Name of the closure reference and the function it holds do not match."
                     )
-                lowered_funcs.append(itir_node)
+                gt_callables.append(value)
+        return gt_callables
 
-                if (captured := value.__gt_captured_vars__()) is not None:
-                    for c in (captured.globals | captured.nonlocals).values():
-                        if isinstance(c, FieldOffset):
-                            offsets_and_dimensions.add(c)
-                        if isinstance(c, Dimension):
-                            offsets_and_dimensions.add(c)
+    def _offsets_and_dimensions_from_gt_callables(
+        self, gt_callables: Iterable[GTCallable]
+    ) -> set[FieldOffset | Dimension]:
+        offsets_and_dimensions: set[FieldOffset | Dimension] = set()
+        for gt_callable in gt_callables:
+            if (captured := gt_callable.__gt_captured_vars__()) is not None:
+                for c in (captured.globals | captured.nonlocals).values():
+                    if isinstance(c, FieldOffset):
+                        offsets_and_dimensions.add(c)
+                    if isinstance(c, Dimension):
+                        offsets_and_dimensions.add(c)
+        return offsets_and_dimensions
 
-        return lowered_funcs, offsets_and_dimensions
+    def _lowered_funcs_from_gt_callables(
+        self, gt_callables: Iterable[GTCallable]
+    ) -> list[itir.FunctionDefinition]:
+        return [gt_callable.__gt_itir__() for gt_callable in gt_callables]
 
     @functools.cached_property
     def itir(self) -> itir.FencilDefinition:
@@ -258,12 +264,12 @@ class Program:
         if undefined := referenced_var_names - defined_var_names:
             raise RuntimeError(f"Reference to undefined symbol(s) `{', '.join(undefined)}`.")
 
-        lowered_funcs, offsets_and_dimensions = self._lowered_funcs_from_captured_vars(capture_vars)
-
+        referenced_gt_callables = self._gt_callables_from_captured_vars(capture_vars)
         grid_type = self._deduce_grid_type(
-            self.grid_type,
-            offsets_and_dimensions,
+            self.grid_type, self._offsets_and_dimensions_from_gt_callables(referenced_gt_callables)
         )
+
+        lowered_funcs = self._lowered_funcs_from_gt_callables(referenced_gt_callables)
         return ProgramLowering.apply(
             self.past_node, function_definitions=lowered_funcs, grid_type=grid_type
         )

--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -30,14 +30,14 @@ from typing import Callable
 
 from eve.extended_typing import Any, Optional, Protocol
 from eve.utils import UIDs
-from functional.common import GTTypeError
+from functional.common import GridType, GTTypeError
 from functional.ffront import (
     common_types as ct,
     field_operator_ast as foast,
     program_ast as past,
     symbol_makers,
 )
-from functional.ffront.fbuiltins import BUILTINS, Dimension
+from functional.ffront.fbuiltins import BUILTINS, Dimension, FieldOffset
 from functional.ffront.foast_to_itir import FieldOperatorLowering
 from functional.ffront.func_to_foast import FieldOperatorParser
 from functional.ffront.func_to_past import ProgramParser
@@ -124,7 +124,7 @@ class GTCallable(Protocol):
         ...
 
     # TODO(tehrengruber): For embedded execution a `__call__` method and for
-    #  "truely" embedded execution arguably also a `from_function` method is
+    #  "truly" embedded execution arguably also a `from_function` method is
     #  required. Since field operators currently have a `__gt_type__` with a
     #  Field return value, but it's `__call__` method being void (result via
     #  out arg) there is no good / consistent definition on what signature a
@@ -155,6 +155,7 @@ class Program:
     externals: dict[str, Any]
     backend: Optional[str]
     definition: Optional[types.FunctionType] = None
+    grid_type: Optional[GridType] = None
 
     @classmethod
     def from_function(
@@ -162,6 +163,7 @@ class Program:
         definition: types.FunctionType,
         externals: Optional[dict] = None,
         backend: Optional[str] = None,
+        grid_type: Optional[GridType] = None,
     ) -> "Program":
         captured_vars = _collect_capture_vars(CapturedVars.from_function(definition))
         past_node = ProgramParser.apply_to_function(definition)
@@ -171,6 +173,7 @@ class Program:
             externals={} if externals is None else externals,
             backend=backend,
             definition=definition,
+            grid_type=grid_type,
         )
 
     def with_backend(self, backend: str) -> "Program":
@@ -182,23 +185,47 @@ class Program:
             definition=self.definition,  # type: ignore[arg-type]  # mypy wrongly deduces definition as method here
         )
 
+    @staticmethod
+    def _deduce_grid_type(requested_grid_type: Optional[GridType], offsets: set[FieldOffset]):
+        def is_cartesian_offset(o: FieldOffset):
+            return o.source == o.target
+
+        deduced_grid_type = GridType.CARTESIAN
+        for o in offsets:
+            if not is_cartesian_offset(o):
+                deduced_grid_type = GridType.UNSTRUCTURED
+                break
+
+        if requested_grid_type == GridType.CARTESIAN and deduced_grid_type == GridType.UNSTRUCTURED:
+            raise GTTypeError(
+                "grid_type == GridType.CARTESIAN was requested, but unstructured `FieldOffset` was found."
+            )
+
+        return deduced_grid_type if requested_grid_type is None else requested_grid_type
+
     def _lowered_funcs_from_captured_vars(
         self, captured_vars: CapturedVars
-    ) -> list[itir.FunctionDefinition]:
+    ) -> tuple[list[itir.FunctionDefinition], set[FieldOffset]]:
         lowered_funcs = []
+        offsets = set[FieldOffset]()
 
         all_captured_vars = collections.ChainMap(captured_vars.globals, captured_vars.nonlocals)
 
         for name, value in all_captured_vars.items():
-            if not isinstance(value, GTCallable):
-                continue
-            itir_node = value.__gt_itir__()
-            if itir_node.id != name:
-                raise RuntimeError(
-                    "Name of the closure reference and the function it holds do not match."
-                )
-            lowered_funcs.append(itir_node)
-        return lowered_funcs
+            if isinstance(value, GTCallable):
+                itir_node = value.__gt_itir__()
+                if itir_node.id != name:
+                    raise RuntimeError(
+                        "Name of the closure reference and the function it holds do not match."
+                    )
+                lowered_funcs.append(itir_node)
+
+                if (captured := value.__gt_captured_vars__()) is not None:
+                    for c in captured.globals:
+                        if isinstance(c, FieldOffset):
+                            offsets.add(c)
+
+        return lowered_funcs, offsets
 
     @functools.cached_property
     def itir(self) -> itir.FencilDefinition:
@@ -217,9 +244,12 @@ class Program:
         if undefined := referenced_var_names - defined_var_names:
             raise RuntimeError(f"Reference to undefined symbol(s) `{', '.join(undefined)}`.")
 
-        lowered_funcs = self._lowered_funcs_from_captured_vars(capture_vars)
+        lowered_funcs, offsets = self._lowered_funcs_from_captured_vars(capture_vars)
 
-        return ProgramLowering.apply(self.past_node, function_definitions=lowered_funcs)
+        grid_type = self._deduce_grid_type(self.grid_type, offsets)
+        return ProgramLowering.apply(
+            self.past_node, function_definitions=lowered_funcs, grid_type=grid_type
+        )
 
     def _validate_args(self, *args, **kwargs) -> None:
         # TODO(tehrengruber): better error messages, check argument types
@@ -285,6 +315,7 @@ def program(
     *,
     externals=None,
     backend=None,
+    grid_type=None,
 ) -> Program | Callable[[types.FunctionType], Program]:
     """
     Generate an implementation of a program from a Python function object.
@@ -305,7 +336,7 @@ def program(
     """
 
     def program_inner(definition: types.FunctionType) -> Program:
-        return Program.from_function(definition, externals, backend)
+        return Program.from_function(definition, externals, backend, grid_type)
 
     return program_inner if definition is None else program_inner(definition)
 

--- a/src/functional/ffront/fbuiltins.py
+++ b/src/functional/ffront/fbuiltins.py
@@ -14,7 +14,6 @@
 
 from builtins import bool, float, int
 from dataclasses import dataclass
-from typing import Optional
 
 from numpy import float32, float64, int32, int64
 
@@ -102,8 +101,8 @@ BUILTINS = {name: globals()[name] for name in __all__ + ["bool", "int", "float"]
 #  guidelines for decision.
 @dataclass(frozen=True)
 class FieldOffset(runtime.Offset):
-    source: Optional[Dimension] = None
-    target: Optional[tuple[Dimension, ...]] = None
+    source: Dimension
+    target: tuple[Dimension, ...]
 
     def __gt_type__(self):
         return ct.OffsetType(source=self.source, target=self.target)

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -11,10 +11,8 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from typing import Union
-
 from eve import NodeTranslator, traits
-from functional.common import GTTypeError
+from functional.common import GridType, GTTypeError
 from functional.ffront import common_types, program_ast as past
 from functional.iterator import ir as itir
 
@@ -60,9 +58,15 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
 
     @classmethod
     def apply(
-        cls, node: past.Program, function_definitions: list[itir.FunctionDefinition]
+        cls,
+        node: past.Program,
+        function_definitions: list[itir.FunctionDefinition],
+        grid_type: GridType,
     ) -> itir.FencilDefinition:
-        return cls().visit(node, function_definitions=function_definitions)
+        return cls(grid_type=grid_type).visit(node, function_definitions=function_definitions)
+
+    def __init__(self, grid_type):
+        self.grid_type = grid_type
 
     def _gen_size_params_from_program(self, node: past.Program):
         """Generate symbols for each field param and dimension."""
@@ -192,11 +196,14 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
                 "Unexpected `out` argument. Must be a `past.Subscript` or `past.Name` node."
             )
 
+        domain_builtin = (
+            "cartesian_domain" if self.grid_type == GridType.CARTESIAN else "unstructured_domain"
+        )
         return itir.SymRef(id=self.visit(out_field_name, **kwargs).id), itir.FunCall(
-            fun=itir.SymRef(id="domain"), args=domain_args
+            fun=itir.SymRef(id=domain_builtin), args=domain_args  # TODO
         )
 
-    def visit_Constant(self, node: past.Constant, **kwargs) -> Union[itir.Literal]:
+    def visit_Constant(self, node: past.Constant, **kwargs) -> itir.Literal:
         if isinstance(node.type, common_types.ScalarType) and node.type.shape is None:
             match node.type.kind:
                 case common_types.ScalarKind.STRING:

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -200,7 +200,7 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
             "cartesian_domain" if self.grid_type == GridType.CARTESIAN else "unstructured_domain"
         )
         return itir.SymRef(id=self.visit(out_field_name, **kwargs).id), itir.FunCall(
-            fun=itir.SymRef(id=domain_builtin), args=domain_args  # TODO
+            fun=itir.SymRef(id=domain_builtin), args=domain_args
         )
 
     def visit_Constant(self, node: past.Constant, **kwargs) -> itir.Literal:

--- a/src/functional/ffront/past_to_itir.py
+++ b/src/functional/ffront/past_to_itir.py
@@ -47,7 +47,7 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
     ...     params=[ir.Sym(id="inp")],
     ...     expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="inp")])
     ... )
-    >>> lowered = ProgramLowering.apply(parsed, [fieldop_def])
+    >>> lowered = ProgramLowering.apply(parsed, [fieldop_def], grid_type=GridType.CARTESIAN)
     >>> type(lowered)
     <class 'functional.iterator.ir.FencilDefinition'>
     >>> lowered.id

--- a/src/functional/iterator/backends/gtfn/gtfn_ir.py
+++ b/src/functional/iterator/backends/gtfn/gtfn_ir.py
@@ -89,7 +89,8 @@ BUILTINS = {
     "make_tuple",
     "tuple_get",
     "can_deref",
-    "domain",  # TODO(havogt) decide if domain is part of IR
+    "cartesian_domain",
+    "unstructured_domain",
     "named_range",
 }
 

--- a/src/functional/iterator/builtins.py
+++ b/src/functional/iterator/builtins.py
@@ -21,7 +21,8 @@ __all__ = [
     "and_",
     "or_",
     "scan",
-    "domain",
+    "cartesian_domain",
+    "unstructured_domain",
     "named_range",
 ]
 
@@ -64,7 +65,12 @@ def scan(*args):
 
 
 @builtin_dispatch
-def domain(*args):
+def cartesian_domain(*args):
+    raise BackendNotSelectedError()
+
+
+@builtin_dispatch
+def unstructured_domain(*args):
     raise BackendNotSelectedError()
 
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -206,8 +206,13 @@ def reduce(fun, init):
     return sten
 
 
-@builtins.domain.register(EMBEDDED)
-def domain(*args):
+@builtins.cartesian_domain.register(EMBEDDED)
+def cartesian_domain(*args):
+    return dict(args)  # TODO wrap into a special type to allow checking in offset_provider
+
+
+@builtins.unstructured_domain.register(EMBEDDED)
+def unstructured_domain(*args):
     return dict(args)
 
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -248,9 +248,7 @@ def unstructured_domain(*args: NamedRange) -> UnstructuredDomain:
     return UnstructuredDomain(args)
 
 
-Domain = (
-    CartesianDomain | UnstructuredDomain | dict[str | Dimension, range]
-)  # TODO consider removing Dimension
+Domain = CartesianDomain | UnstructuredDomain | dict[str | Dimension, range]
 
 
 @builtins.named_range.register(EMBEDDED)

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -24,9 +24,9 @@ import numpy as np
 import numpy.typing as npt
 
 from functional import iterator
-from functional.common import Dimension
+from functional.common import Connectivity, Dimension
 from functional.iterator import builtins
-from functional.iterator.runtime import Offset
+from functional.iterator.runtime import CartesianDomain, Offset, UnstructuredDomain
 from functional.iterator.utils import tupelize
 
 
@@ -62,7 +62,6 @@ Axis: TypeAlias = Dimension
 # Offsets
 AnyOffset: TypeAlias = Tag | IntIndex
 CompleteOffset: TypeAlias = tuple[Tag, IntIndex]
-Connectivity: TypeAlias = NeighborTableOffsetProvider
 OffsetProviderElem: TypeAlias = Dimension | Connectivity
 OffsetProvider: TypeAlias = dict[Tag, OffsetProviderElem]
 
@@ -236,18 +235,26 @@ def reduce(fun, init):
     return sten
 
 
+NamedRange: TypeAlias = tuple[Tag | Dimension, range]
+
+
 @builtins.cartesian_domain.register(EMBEDDED)
-def cartesian_domain(*args):
-    return dict(args)  # TODO wrap into a special type to allow checking in offset_provider
+def cartesian_domain(*args: NamedRange) -> CartesianDomain:
+    return CartesianDomain(args)
 
 
 @builtins.unstructured_domain.register(EMBEDDED)
-def unstructured_domain(*args):
-    return dict(args)
+def unstructured_domain(*args: NamedRange) -> UnstructuredDomain:
+    return UnstructuredDomain(args)
+
+
+Domain = (
+    CartesianDomain | UnstructuredDomain | dict[str | Dimension, range]
+)  # TODO consider removing Dimension
 
 
 @builtins.named_range.register(EMBEDDED)
-def named_range(tag, start, end):
+def named_range(tag: Tag | Dimension, start: int, end: int) -> NamedRange:
     return (tag, range(start, end))
 
 
@@ -840,20 +847,31 @@ def scan(scan_pass, is_forward: bool, init):
     return impl
 
 
+def _dimension_to_tag(domain: Domain) -> dict[Tag, range]:
+    return {k.value if isinstance(k, Dimension) else k: v for k, v in domain.items()}
+
+
+def _validate_domain(domain: Domain, offset_provider: OffsetProvider) -> None:
+    if isinstance(domain, CartesianDomain):
+        if any(isinstance(o, Connectivity) for o in offset_provider.values()):
+            raise RuntimeError(
+                "Got a `CartesianDomain`, but found a `Connectivity` in `offset_provider`, expected `UnstructuredDomain`."
+            )
+
+
 def fendef_embedded(fun: Callable[..., None], *args: Any, **kwargs: Any):
     if "offset_provider" not in kwargs:
         raise RuntimeError("offset_provider not provided")
 
     @iterator.runtime.closure.register(EMBEDDED)
     def closure(
-        domain_: dict[Union[str, Dimension], range],
+        domain_: Domain,
         sten: Callable[..., Any],
         out: MutableLocatedField,
         ins: list[LocatedField],
     ) -> None:
-        domain: dict[str, range] = {
-            k.value if isinstance(k, Dimension) else k: v for k, v in domain_.items()
-        }
+        _validate_domain(domain_, kwargs["offset_provider"])
+        domain: dict[Tag, range] = _dimension_to_tag(domain_)
         if not (is_located_field(out) or can_be_tuple_field(out)):
             raise TypeError("Out needs to be a located field.")
 

--- a/src/functional/iterator/ir.py
+++ b/src/functional/iterator/ir.py
@@ -76,7 +76,8 @@ class StencilClosure(Node):
 
 
 BUILTINS = {
-    "domain",
+    "cartesian_domain",
+    "unstructured_domain",
     "named_range",
     "lift",
     "make_tuple",

--- a/src/functional/iterator/pretty_parser.py
+++ b/src/functional/iterator/pretty_parser.py
@@ -55,7 +55,8 @@ GRAMMAR = """
         | prec8 "(" ( prec0 "," )* prec0? ")" -> call
         | "{" ( prec0 "," )* prec0? "}" -> make_tuple
         | "⟪" ( prec0 "," )* prec0? "⟫" -> shift
-        | "⟨" ( prec0 "," )* prec0? "⟩" -> domain
+        | "u⟨" ( prec0 "," )* prec0? "⟩" -> unstructured_domain
+        | "c⟨" ( prec0 "," )* prec0? "⟩" -> cartesian_domain
 
     ?prec9: _literal
         | SYM_REF
@@ -154,8 +155,11 @@ class ToIrTransformer(lark.Transformer):
     def named_range(self, name: ir.AxisLiteral, start: ir.Expr, end: ir.Expr) -> ir.FunCall:
         return ir.FunCall(fun=ir.SymRef(id="named_range"), args=[name, start, end])
 
-    def domain(self, *ranges: ir.Expr) -> ir.FunCall:
-        return ir.FunCall(fun=ir.SymRef(id="domain"), args=list(ranges))
+    def cartesian_domain(self, *ranges: ir.Expr) -> ir.FunCall:
+        return ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=list(ranges))
+
+    def unstructured_domain(self, *ranges: ir.Expr) -> ir.FunCall:
+        return ir.FunCall(fun=ir.SymRef(id="unstructured_domain"), args=list(ranges))
 
     def ifthenelse(self, condition: ir.Expr, then: ir.Expr, otherwise: ir.Expr) -> ir.FunCall:
         return ir.FunCall(fun=ir.SymRef(id="if_"), args=[condition, then, otherwise])

--- a/src/functional/iterator/pretty_printer.py
+++ b/src/functional/iterator/pretty_printer.py
@@ -168,13 +168,11 @@ class PrettyPrinter(NodeTranslator):
                 res = self._hmerge(dim, [": ["], start, [", "], end, [")"])
                 return self._prec_parens(res, prec, PRECEDENCE["__call__"])
             if fun_name == "cartesian_domain" and len(node.args) >= 1:
-                # cartesian_domain(x, y, ...) → { x × y × ... }
+                # cartesian_domain(x, y, ...) → c{ x × y × ... }
                 args = self.visit(node.args, prec=PRECEDENCE["__call__"])
                 return self._hmerge(["c⟨ "], *self._hinterleave(args, ", "), [" ⟩"])
-            if (
-                fun_name == "unstructured_domain" and len(node.args) >= 1
-            ):  # TODO distinguish domains
-                # unstructured_domain(x, y, ...) → { x × y × ... }
+            if fun_name == "unstructured_domain" and len(node.args) >= 1:
+                # unstructured_domain(x, y, ...) → u{ x × y × ... }
                 args = self.visit(node.args, prec=PRECEDENCE["__call__"])
                 return self._hmerge(["u⟨ "], *self._hinterleave(args, ", "), [" ⟩"])
             if fun_name == "if_" and len(node.args) == 3:

--- a/src/functional/iterator/pretty_printer.py
+++ b/src/functional/iterator/pretty_printer.py
@@ -167,10 +167,16 @@ class PrettyPrinter(NodeTranslator):
                 dim, start, end = self.visit(node.args, prec=0)
                 res = self._hmerge(dim, [": ["], start, [", "], end, [")"])
                 return self._prec_parens(res, prec, PRECEDENCE["__call__"])
-            if fun_name == "domain" and len(node.args) >= 1:
-                # domain(x, y, ...) → { x × y × ... }
+            if fun_name == "cartesian_domain" and len(node.args) >= 1:
+                # cartesian_domain(x, y, ...) → { x × y × ... }
                 args = self.visit(node.args, prec=PRECEDENCE["__call__"])
-                return self._hmerge(["⟨ "], *self._hinterleave(args, ", "), [" ⟩"])
+                return self._hmerge(["c⟨ "], *self._hinterleave(args, ", "), [" ⟩"])
+            if (
+                fun_name == "unstructured_domain" and len(node.args) >= 1
+            ):  # TODO distinguish domains
+                # unstructured_domain(x, y, ...) → { x × y × ... }
+                args = self.visit(node.args, prec=PRECEDENCE["__call__"])
+                return self._hmerge(["u⟨ "], *self._hinterleave(args, ", "), [" ⟩"])
             if fun_name == "if_" and len(node.args) == 3:
                 # if_(x, y, z) → if x then y else z
                 ifb, thenb, elseb = self.visit(node.args, prec=PRECEDENCE["if_"])

--- a/src/functional/iterator/runtime.py
+++ b/src/functional/iterator/runtime.py
@@ -79,7 +79,8 @@ class FundefDispatcher:
                     dom = dom()
                 if isinstance(dom, dict):
                     # if passed as a dict, we need to convert back to builtins for interpretation by the backends
-                    dom = builtins.domain(
+                    assert "offset_provider" in kwargs
+                    dom = builtins.cartesian_domain(  # TODO dispatch
                         *tuple(
                             map(
                                 lambda x: builtins.named_range(x[0], x[1].start, x[1].stop),

--- a/src/functional/iterator/tracing.py
+++ b/src/functional/iterator/tracing.py
@@ -135,9 +135,14 @@ def tuple_get(*args):
     return _f("tuple_get", *args)
 
 
-@iterator.builtins.domain.register(TRACING)
-def domain(*args):
-    return _f("domain", *args)
+@iterator.builtins.cartesian_domain.register(TRACING)
+def cartesian_domain(*args):
+    return _f("cartesian_domain", *args)
+
+
+@iterator.builtins.unstructured_domain.register(TRACING)
+def unstructured_domain(*args):
+    return _f("unstructured_domain", *args)
 
 
 @iterator.builtins.named_range.register(TRACING)

--- a/src/functional/iterator/transforms/global_tmps.py
+++ b/src/functional/iterator/transforms/global_tmps.py
@@ -10,7 +10,9 @@ from functional.iterator.transforms.popup_tmps import PopupTmps
 class CreateGlobalTmps(NodeTranslator):
     @staticmethod
     def _extend_domain(domain: ir.FunCall, offset_provider, shifts):
-        assert isinstance(domain.fun, ir.SymRef) and domain.fun.id == "domain"
+        assert isinstance(domain.fun, ir.SymRef) and (
+            domain.fun.id == "cartesian_domain" or domain.fun.id == "unstructured_domain"
+        )
         assert all(isinstance(o, CartesianAxis) for o in offset_provider.values())
 
         offset_limits = {k: (0, 0) for k in offset_provider.keys()}

--- a/tests/functional_tests/ffront_tests/test_domain_decution.py
+++ b/tests/functional_tests/ffront_tests/test_domain_decution.py
@@ -1,0 +1,33 @@
+import pytest
+
+from functional.common import Dimension, GridType, GTTypeError
+from functional.ffront.decorator import Program
+from functional.ffront.fbuiltins import FieldOffset
+
+
+Dim = Dimension("Dim")
+LocalDim = Dimension("LocalDim", local=True)
+
+CartesianOffset = FieldOffset("CartesianOffset", source=Dim, target=(Dim,))
+UnstructuredOffset = FieldOffset("UnstructuredOffset", source=Dim, target=(Dim, LocalDim))
+
+
+def test_domain_deduction():
+    assert Program._deduce_grid_type(GridType.CARTESIAN, {CartesianOffset}) == GridType.CARTESIAN
+    assert (
+        Program._deduce_grid_type(GridType.UNSTRUCTURED, {UnstructuredOffset})
+        == GridType.UNSTRUCTURED
+    )
+    assert Program._deduce_grid_type(None, {CartesianOffset}) == GridType.CARTESIAN
+    assert Program._deduce_grid_type(None, {Dim}) == GridType.CARTESIAN
+    assert Program._deduce_grid_type(None, {UnstructuredOffset}) == GridType.UNSTRUCTURED
+    assert Program._deduce_grid_type(None, {LocalDim}) == GridType.UNSTRUCTURED
+
+    # unstructured is ok, even if we don't have unstructured offsets
+    assert (
+        Program._deduce_grid_type(GridType.UNSTRUCTURED, {CartesianOffset}) == GridType.UNSTRUCTURED
+    )
+
+    with pytest.raises(GTTypeError, match="unstructured.*FieldOffset.*found"):
+        Program._deduce_grid_type(GridType.CARTESIAN, {UnstructuredOffset})
+        Program._deduce_grid_type(GridType.CARTESIAN, {LocalDim})

--- a/tests/functional_tests/ffront_tests/test_domain_decution.py
+++ b/tests/functional_tests/ffront_tests/test_domain_decution.py
@@ -12,22 +12,29 @@ CartesianOffset = FieldOffset("CartesianOffset", source=Dim, target=(Dim,))
 UnstructuredOffset = FieldOffset("UnstructuredOffset", source=Dim, target=(Dim, LocalDim))
 
 
-def test_domain_deduction():
+def test_domain_deduction_cartesian():
+    assert Program._deduce_grid_type(None, {CartesianOffset}) == GridType.CARTESIAN
+    assert Program._deduce_grid_type(None, {Dim}) == GridType.CARTESIAN
+
+
+def test_domain_deduction_unstructured():
+    assert Program._deduce_grid_type(None, {UnstructuredOffset}) == GridType.UNSTRUCTURED
+    assert Program._deduce_grid_type(None, {LocalDim}) == GridType.UNSTRUCTURED
+
+
+def test_domain_complies_with_request_cartesian():
     assert Program._deduce_grid_type(GridType.CARTESIAN, {CartesianOffset}) == GridType.CARTESIAN
+    with pytest.raises(GTTypeError, match="unstructured.*FieldOffset.*found"):
+        Program._deduce_grid_type(GridType.CARTESIAN, {UnstructuredOffset})
+        Program._deduce_grid_type(GridType.CARTESIAN, {LocalDim})
+
+
+def test_domain_complies_with_request_unstructured():
     assert (
         Program._deduce_grid_type(GridType.UNSTRUCTURED, {UnstructuredOffset})
         == GridType.UNSTRUCTURED
     )
-    assert Program._deduce_grid_type(None, {CartesianOffset}) == GridType.CARTESIAN
-    assert Program._deduce_grid_type(None, {Dim}) == GridType.CARTESIAN
-    assert Program._deduce_grid_type(None, {UnstructuredOffset}) == GridType.UNSTRUCTURED
-    assert Program._deduce_grid_type(None, {LocalDim}) == GridType.UNSTRUCTURED
-
     # unstructured is ok, even if we don't have unstructured offsets
     assert (
         Program._deduce_grid_type(GridType.UNSTRUCTURED, {CartesianOffset}) == GridType.UNSTRUCTURED
     )
-
-    with pytest.raises(GTTypeError, match="unstructured.*FieldOffset.*found"):
-        Program._deduce_grid_type(GridType.CARTESIAN, {UnstructuredOffset})
-        Program._deduce_grid_type(GridType.CARTESIAN, {LocalDim})

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -171,7 +171,7 @@ def test_unary_neg():
 
 def test_shift():
     size = 10
-    Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+    Ioff = FieldOffset("Ioff", source=IDim, target=(IDim,))
     a = np_as_located_field(IDim)(np.arange(size + 1))
     b = np_as_located_field(IDim)(np.zeros((size)))
 
@@ -191,7 +191,7 @@ def test_shift():
 def test_fold_shifts():
     """Shifting the result of an addition should work."""
     size = 10
-    Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+    Ioff = FieldOffset("Ioff", source=IDim, target=(IDim,))
     a = np_as_located_field(IDim)(np.arange(size + 1))
     b = np_as_located_field(IDim)(np.ones((size + 2)) * 2)
     c = np_as_located_field(IDim)(np.zeros((size)))
@@ -425,7 +425,7 @@ def test_scalar_arg():
 
 def test_scalar_arg_with_field():
     Edge = Dimension("Edge")
-    EdgeOffset = FieldOffset("EdgeOffset", source=Edge, target=[Edge])
+    EdgeOffset = FieldOffset("EdgeOffset", source=Edge, target=(Edge,))
     size = 5
     inp = index_field(Edge)
     factor = 3
@@ -498,7 +498,7 @@ def test_broadcast_two_fields():
 
 
 def test_broadcast_shifted():
-    Joff = FieldOffset("Joff", source=JDim, target=[JDim])
+    Joff = FieldOffset("Joff", source=JDim, target=(JDim,))
 
     size = 10
     a = np_as_located_field(IDim)(np.arange(0, size, 1, dtype=int))
@@ -550,7 +550,7 @@ def test_conditional_promotion():
 
 
 def test_conditional_shifted():
-    Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+    Ioff = FieldOffset("Ioff", source=IDim, target=(IDim,))
 
     size = 10
     mask = np_as_located_field(IDim)(np.zeros((size,), dtype=bool))

--- a/tests/functional_tests/ffront_tests/test_lowering.py
+++ b/tests/functional_tests/ffront_tests/test_lowering.py
@@ -104,7 +104,7 @@ def test_arithmetic():
 
 
 def test_shift():
-    Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+    Ioff = FieldOffset("Ioff", source=IDim, target=(IDim,))
 
     def shift_by_one(inp: Field[[IDim], float64]):
         return inp(Ioff[1])
@@ -119,7 +119,7 @@ def test_shift():
 
 
 def test_negative_shift():
-    Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+    Ioff = FieldOffset("Ioff", source=IDim, target=(IDim,))
 
     def shift_by_one(inp: Field[[IDim], float64]):
         return inp(Ioff[-1])

--- a/tests/functional_tests/ffront_tests/test_program.py
+++ b/tests/functional_tests/ffront_tests/test_program.py
@@ -34,7 +34,7 @@ from functional.iterator.embedded import np_as_located_field
 
 float64 = float
 IDim = Dimension("IDim")
-Ioff = FieldOffset("Ioff", source=IDim, target=[IDim])
+Ioff = FieldOffset("Ioff", source=IDim, target=(IDim,))
 
 
 # TODO(tehrengruber): Improve test structure. Identity needs to be decorated

--- a/tests/functional_tests/ffront_tests/test_program.py
+++ b/tests/functional_tests/ffront_tests/test_program.py
@@ -21,7 +21,7 @@ import pytest
 
 import eve
 from eve.pattern_matching import ObjectPattern as P
-from functional.common import Field, GTTypeError
+from functional.common import Field, GridType, GTTypeError
 from functional.ffront import common_types, program_ast as past
 from functional.ffront.decorator import field_operator, program
 from functional.ffront.fbuiltins import Dimension, FieldOffset
@@ -279,12 +279,14 @@ def test_copy_restrict_parsing(copy_restrict_program_def):
 
 def test_copy_lowering(copy_program_def, itir_identity_fundef):
     past_node = ProgramParser.apply_to_function(copy_program_def)
-    itir_node = ProgramLowering.apply(past_node, function_definitions=[itir_identity_fundef])
+    itir_node = ProgramLowering.apply(
+        past_node, function_definitions=[itir_identity_fundef], grid_type=GridType.CARTESIAN
+    )
     closure_pattern = P(
         itir.StencilClosure,
         domain=P(
             itir.FunCall,
-            fun=P(itir.SymRef, id=eve.SymbolRef("domain")),
+            fun=P(itir.SymRef, id=eve.SymbolRef("cartesian_domain")),
             args=[
                 P(
                     itir.FunCall,
@@ -318,12 +320,14 @@ def test_copy_lowering(copy_program_def, itir_identity_fundef):
 
 def test_copy_restrict_lowering(copy_restrict_program_def, itir_identity_fundef):
     past_node = ProgramParser.apply_to_function(copy_restrict_program_def)
-    itir_node = ProgramLowering.apply(past_node, function_definitions=[itir_identity_fundef])
+    itir_node = ProgramLowering.apply(
+        past_node, function_definitions=[itir_identity_fundef], grid_type=GridType.CARTESIAN
+    )
     closure_pattern = P(
         itir.StencilClosure,
         domain=P(
             itir.FunCall,
-            fun=P(itir.SymRef, id=eve.SymbolRef("domain")),
+            fun=P(itir.SymRef, id=eve.SymbolRef("cartesian_domain")),
             args=[
                 P(
                     itir.FunCall,

--- a/tests/functional_tests/iterator_tests/test_anton_toy.py
+++ b/tests/functional_tests/iterator_tests/test_anton_toy.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from functional.iterator.builtins import deref, domain, lift, named_range, shift
+from functional.iterator.builtins import cartesian_domain, deref, lift, named_range, shift
 from functional.iterator.embedded import np_as_located_field
 from functional.iterator.runtime import CartesianAxis, closure, fendef, fundef, offset
 
@@ -37,7 +37,7 @@ KDim = CartesianAxis("KDim")
 @fendef(offset_provider={"i": IDim, "j": JDim})
 def fencil(x, y, z, out, inp):
     closure(
-        domain(named_range(IDim, 0, x), named_range(JDim, 0, y), named_range(KDim, 0, z)),
+        cartesian_domain(named_range(IDim, 0, x), named_range(JDim, 0, y), named_range(KDim, 0, z)),
         lap,
         out,
         [inp],

--- a/tests/functional_tests/iterator_tests/test_cartesian_offset_provider.py
+++ b/tests/functional_tests/iterator_tests/test_cartesian_offset_provider.py
@@ -19,7 +19,7 @@ def foo(inp):
 @fendef(offset_provider={"I": I_loc, "J": J_loc})
 def fencil(output, input):
     closure(
-        domain(named_range(I_loc, 0, 1), named_range(J_loc, 0, 1)),
+        cartesian_domain(named_range(I_loc, 0, 1), named_range(J_loc, 0, 1)),
         foo,
         output,
         [input],
@@ -29,7 +29,7 @@ def fencil(output, input):
 @fendef(offset_provider={"I": J_loc, "J": I_loc})
 def fencil_swapped(output, input):
     closure(
-        domain(named_range(I_loc, 0, 1), named_range(J_loc, 0, 1)),
+        cartesian_domain(named_range(I_loc, 0, 1), named_range(J_loc, 0, 1)),
         foo,
         output,
         [input],
@@ -61,7 +61,7 @@ def delay_complete_shift(inp):
 @fendef(offset_provider={"I": J_loc, "J": I_loc})
 def delay_complete_shift_fencil(output, input):
     closure(
-        domain(named_range(I_loc, 0, 1), named_range(J_loc, 0, 1)),
+        cartesian_domain(named_range(I_loc, 0, 1), named_range(J_loc, 0, 1)),
         delay_complete_shift,
         output,
         [input],

--- a/tests/functional_tests/iterator_tests/test_column_stencil.py
+++ b/tests/functional_tests/iterator_tests/test_column_stencil.py
@@ -22,7 +22,7 @@ IDim = CartesianAxis("IDim")
 @fendef(column_axis=KDim)
 def fencil(i_size, k_size, inp, out):
     closure(
-        domain(named_range(IDim, 0, i_size), named_range(KDim, 0, k_size)),
+        cartesian_domain(named_range(IDim, 0, i_size), named_range(KDim, 0, k_size)),
         multiply_stencil,
         out,
         [inp],
@@ -89,7 +89,7 @@ def ksum(inp):
 @fendef(column_axis=KDim)
 def ksum_fencil(i_size, k_size, inp, out):
     closure(
-        domain(named_range(IDim, 0, i_size), named_range(KDim, 0, k_size)),
+        cartesian_domain(named_range(IDim, 0, i_size), named_range(KDim, 0, k_size)),
         ksum,
         out,
         [inp],
@@ -130,7 +130,7 @@ def ksum_back(inp):
 @fendef(column_axis=KDim)
 def ksum_back_fencil(i_size, k_size, inp, out):
     closure(
-        domain(named_range(IDim, 0, i_size), named_range(KDim, 0, k_size)),
+        cartesian_domain(named_range(IDim, 0, i_size), named_range(KDim, 0, k_size)),
         ksum_back,
         out,
         [inp],

--- a/tests/functional_tests/iterator_tests/test_domain.py
+++ b/tests/functional_tests/iterator_tests/test_domain.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from functional.common import Dimension
+from functional.iterator.builtins import deref
+from functional.iterator.embedded import np_as_located_field
+from functional.iterator.runtime import CartesianDomain, UnstructuredDomain, _deduce_domain, fundef
+
+
+@fundef
+def foo(inp):
+    return deref(inp)
+
+
+connectivity = SimpleNamespace(max_neighbors=0, has_skip_values=True)
+
+
+def test_deduce_domain():
+    assert isinstance(_deduce_domain({}, {}), CartesianDomain)
+    assert isinstance(_deduce_domain(UnstructuredDomain(), {}), UnstructuredDomain)
+    assert isinstance(
+        _deduce_domain({}, {"foo": connectivity}),
+        UnstructuredDomain,
+    )
+    assert isinstance(
+        _deduce_domain(CartesianDomain([("I", range(1))]), {"foo": connectivity}),
+        CartesianDomain,
+    )
+
+
+I = Dimension("I")
+
+
+def test_embedded_error_on_wrong_domain():
+    dom = CartesianDomain([("I", range(1))])
+
+    out = np_as_located_field(I)(
+        np.zeros(
+            1,
+        )
+    )
+    with pytest.raises(RuntimeError, match="expected `UnstructuredDomain`"):
+        foo[dom](
+            np_as_located_field(I)(np.zeros((1,))), out=out, offset_provider={"bar": connectivity}
+        )

--- a/tests/functional_tests/iterator_tests/test_fvm_nabla.py
+++ b/tests/functional_tests/iterator_tests/test_fvm_nabla.py
@@ -53,7 +53,7 @@ def compute_zavgS_fencil(
     S_M,
 ):
     closure(
-        domain(named_range(Edge, 0, n_edges)),
+        unstructured_domain(named_range(Edge, 0, n_edges)),
         compute_zavgS,
         out,
         [pp, S_M],
@@ -112,7 +112,7 @@ def nabla(
     vol,
 ):
     closure(
-        domain(named_range(Vertex, 0, n_nodes)),
+        unstructured_domain(named_range(Vertex, 0, n_nodes)),
         pnabla,
         out,
         [pp, S_MXX, S_MYY, sign, vol],
@@ -168,7 +168,7 @@ def compute_zavgS2_fencil(
     S_M,
 ):
     closure(
-        domain(named_range(Edge, 0, n_edges)),
+        unstructured_domain(named_range(Edge, 0, n_edges)),
         compute_zavgS2,
         out,
         [pp, S_M],
@@ -259,7 +259,7 @@ def nabla2(
     vol,
 ):
     closure(
-        domain(named_range(Vertex, 0, n_nodes)),
+        unstructured_domain(named_range(Vertex, 0, n_nodes)),
         compute_pnabla2,
         out,
         [pp, S, sign, vol],
@@ -334,13 +334,13 @@ def compute_pnabla_sign(pp, S_M, vol, node_index, is_pole_edge):
 def nabla_sign(n_nodes, out_MXX, out_MYY, pp, S_MXX, S_MYY, vol, node_index, is_pole_edge):
     # TODO replace by single stencil which returns tuple
     closure(
-        domain(named_range(Vertex, 0, n_nodes)),
+        unstructured_domain(named_range(Vertex, 0, n_nodes)),
         compute_pnabla_sign,
         out_MXX,
         [pp, S_MXX, vol, node_index, is_pole_edge],
     )
     closure(
-        domain(named_range(Vertex, 0, n_nodes)),
+        unstructured_domain(named_range(Vertex, 0, n_nodes)),
         compute_pnabla_sign,
         out_MYY,
         [pp, S_MYY, vol, node_index, is_pole_edge],

--- a/tests/functional_tests/iterator_tests/test_hdiff.py
+++ b/tests/functional_tests/iterator_tests/test_hdiff.py
@@ -47,7 +47,7 @@ def hdiff_sten(inp, coeff):
 @fendef(offset_provider={"I": IDim, "J": JDim})
 def hdiff(inp, coeff, out, x, y):
     closure(
-        domain(named_range(IDim, 0, x), named_range(JDim, 0, y)),
+        cartesian_domain(named_range(IDim, 0, x), named_range(JDim, 0, y)),
         hdiff_sten,
         out,
         [inp, coeff],

--- a/tests/functional_tests/iterator_tests/test_horizontal_indirection.py
+++ b/tests/functional_tests/iterator_tests/test_horizontal_indirection.py
@@ -45,6 +45,8 @@ def test_simple_indirection():
     for i in range(shape[0]):
         ref[i] = inp[i - 1] if cond[i] < 0 else inp[i + 1]
 
-    foo[domain(named_range(IDim, 0, shape[0]))](inp, cond, out=out, offset_provider={"I": IDim})
+    foo[cartesian_domain(named_range(IDim, 0, shape[0]))](
+        inp, cond, out=out, offset_provider={"I": IDim}
+    )
 
     assert allclose(ref, out)

--- a/tests/functional_tests/iterator_tests/test_implicit_fencil.py
+++ b/tests/functional_tests/iterator_tests/test_implicit_fencil.py
@@ -62,7 +62,7 @@ def test_lambda_domain(backend):
     inp = a_field()
     out = out_field()
 
-    dom = lambda: domain(named_range(I, 0, 10))
+    dom = lambda: cartesian_domain(named_range(I, 0, 10))
     copy_stencil[dom](inp, out=out, offset_provider={}, backend=backend)
 
     if validate:

--- a/tests/functional_tests/iterator_tests/test_pretty_parser.py
+++ b/tests/functional_tests/iterator_tests/test_pretty_parser.py
@@ -116,10 +116,20 @@ def test_named_range():
     assert actual == expected
 
 
-def test_domain():
-    testee = "⟨ x, y ⟩"
+def test_cartesian_domain():
+    testee = "c⟨ x, y ⟩"
     expected = ir.FunCall(
-        fun=ir.SymRef(id="domain"),
+        fun=ir.SymRef(id="cartesian_domain"),
+        args=[ir.SymRef(id="x"), ir.SymRef(id="y")],
+    )
+    actual = pparse(testee)
+    assert actual == expected
+
+
+def test_unstructured_domain():
+    testee = "u⟨ x, y ⟩"
+    expected = ir.FunCall(
+        fun=ir.SymRef(id="unstructured_domain"),
         args=[ir.SymRef(id="x"), ir.SymRef(id="y")],
     )
     actual = pparse(testee)

--- a/tests/functional_tests/iterator_tests/test_pretty_printer.py
+++ b/tests/functional_tests/iterator_tests/test_pretty_printer.py
@@ -220,12 +220,22 @@ def test_named_range():
     assert actual == expected
 
 
-def test_domain():
+def test_cartesian_domain():
     testee = ir.FunCall(
-        fun=ir.SymRef(id="domain"),
+        fun=ir.SymRef(id="cartesian_domain"),
         args=[ir.SymRef(id="x"), ir.SymRef(id="y")],
     )
-    expected = "⟨ x, y ⟩"
+    expected = "c⟨ x, y ⟩"
+    actual = pformat(testee)
+    assert actual == expected
+
+
+def test_unstructured_domain():
+    testee = ir.FunCall(
+        fun=ir.SymRef(id="unstructured_domain"),
+        args=[ir.SymRef(id="x"), ir.SymRef(id="y")],
+    )
+    expected = "u⟨ x, y ⟩"
     actual = pformat(testee)
     assert actual == expected
 

--- a/tests/functional_tests/iterator_tests/test_trivial.py
+++ b/tests/functional_tests/iterator_tests/test_trivial.py
@@ -37,7 +37,7 @@ def test_trivial(backend, use_tmps):
     inp_s = np_as_located_field(IDim, JDim, origin={IDim: 0, JDim: 0})(inp[:, :, 0])
     out_s = np_as_located_field(IDim, JDim)(np.zeros_like(inp[:, :, 0]))
 
-    baz[domain(named_range(IDim, 0, shape[0]), named_range(JDim, 0, shape[1]))](
+    baz[cartesian_domain(named_range(IDim, 0, shape[0]), named_range(JDim, 0, shape[1]))](
         inp_s, out=out_s, backend=backend, use_tmps=use_tmps, offset_provider={"I": IDim, "J": JDim}
     )
 
@@ -48,7 +48,7 @@ def test_trivial(backend, use_tmps):
 @fendef
 def fen_direct_deref(i_size, j_size, out, inp):
     closure(
-        domain(
+        cartesian_domain(
             named_range(IDim, 0, i_size),
             named_range(JDim, 0, j_size),
         ),

--- a/tests/functional_tests/iterator_tests/test_vertical_advection.py
+++ b/tests/functional_tests/iterator_tests/test_vertical_advection.py
@@ -54,7 +54,7 @@ KDim = CartesianAxis("KDim")
 @fendef
 def fen_solve_tridiag(i_size, j_size, k_size, a, b, c, d, x):
     closure(
-        domain(
+        cartesian_domain(
             named_range(IDim, 0, i_size),
             named_range(JDim, 0, j_size),
             named_range(KDim, 0, k_size),


### PR DESCRIPTION
Introduces `cartesian_domain` and `unstructured_domain` in Iterator IR. The semantics of `unstructured_domain` arguments is `unstructured_domain(horizontal_named_range, vertical_named_range)`. Currently this is not checked. It requires to encode this information in the `Dimension` which will come with the backend integration.