### PR TITLE
Loop over node.params instead of api_signature for internal bindings

### DIFF
--- a/src/gt4py/backend/gtc_common.py
+++ b/src/gt4py/backend/gtc_common.py
@@ -195,13 +195,11 @@ class PyExtModuleGenerator(BaseModuleGenerator):
         ir = self.builder.gtir
         sources = gt_utils.text.TextBlock(indent_size=BaseModuleGenerator.TEMPLATE_INDENT_SIZE)
 
-        params_decls = {decl.name: decl for decl in ir.params}
         args: List[str] = []
-        for arg in ir.api_signature:
-            if arg.name not in self.args_data.unreferenced:
-                args.append(arg.name)
-                if isinstance(params_decls.get(arg.name, None), gtir.FieldDecl):
-                    args.append("list(_origin_['{}'])".format(arg.name))
+        for decl in ir.params:
+            args.append(decl.name)
+            if isinstance(decl, gtir.FieldDecl):
+                args.append("list(_origin_['{}'])".format(decl.name))
 
         # only generate implementation if any multi_stages are present. e.g. if no statement in the
         # stencil has any effect on the API fields, this may not be the case since they could be

--- a/src/gt4py/stencil_object.py
+++ b/src/gt4py/stencil_object.py
@@ -434,29 +434,28 @@ class StencilObject(abc.ABC):
 
         # Set an appropriate origin for all fields
         for name, field_info in self.field_info.items():
-            if field_info.access != AccessKind.NONE:
-                assert name in field_args, f"Missing value for '{name}' field."
-                field_origin = origin.get(name, None)
+            assert name in field_args, f"Missing value for '{name}' field."
+            field_origin = origin.get(name, None)
 
-                if field_origin is not None:
-                    field_origin_ndim = len(field_origin)
-                    if field_origin_ndim != field_info.ndim:
-                        assert (
-                            field_origin_ndim == field_info.domain_ndim
-                        ), f"Invalid origin specification ({field_origin}) for '{name}' field."
-                        origin[name] = (*field_origin, *((0,) * len(field_info.data_dims)))
+            if field_origin is not None:
+                field_origin_ndim = len(field_origin)
+                if field_origin_ndim != field_info.ndim:
+                    assert (
+                        field_origin_ndim == field_info.domain_ndim
+                    ), f"Invalid origin specification ({field_origin}) for '{name}' field."
+                    origin[name] = (*field_origin, *((0,) * len(field_info.data_dims)))
 
-                elif all_origin is not None:
-                    origin[name] = (
-                        *gtc_utils.filter_mask(all_origin, field_info.domain_mask),
-                        *((0,) * len(field_info.data_dims)),
-                    )
+            elif all_origin is not None:
+                origin[name] = (
+                    *gtc_utils.filter_mask(all_origin, field_info.domain_mask),
+                    *((0,) * len(field_info.data_dims)),
+                )
 
-                elif isinstance(field_arg := field_args.get(name), gt_storage.storage.Storage):
-                    origin[name] = field_arg.default_origin
+            elif isinstance(field_arg := field_args.get(name), gt_storage.storage.Storage):
+                origin[name] = field_arg.default_origin
 
-                else:
-                    origin[name] = (0,) * field_info.ndim
+            else:
+                origin[name] = (0,) * field_info.ndim
 
         return origin
 

--- a/tests/test_integration/test_code_generation.py
+++ b/tests/test_integration/test_code_generation.py
@@ -17,7 +17,19 @@ import pytest
 
 from gt4py import gtscript
 from gt4py import storage as gt_storage
-from gt4py.gtscript import __INLINED, BACKWARD, FORWARD, PARALLEL, Field, computation, interval
+from gt4py.gtscript import (
+    __INLINED,
+    BACKWARD,
+    FORWARD,
+    PARALLEL,
+    Field,
+    I,
+    J,
+    computation,
+    horizontal,
+    interval,
+    region,
+)
 
 from ..definitions import ALL_BACKENDS, CPU_BACKENDS
 from .stencil_definitions import EXTERNALS_REGISTRY as externals_registry
@@ -539,3 +551,17 @@ def test_origin_k_fields(backend):
     )
     np.testing.assert_allclose(0.0, np.asarray(outp)[:, :, 0])
     np.testing.assert_allclose(0.0, np.asarray(outp)[:, :, -1])
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_pruned_args_match(backend):
+    @gtscript.stencil(backend=backend)
+    def test(out: Field[np.float64], inp: Field[np.float64]):
+        with computation(PARALLEL), interval(...):
+            out = 0.0
+            with horizontal(region[I[0] - 1, J[0] - 1]):
+                out = inp
+
+    inp = gt_storage.zeros(backend, default_origin=(0, 0, 0), shape=(2, 2, 2), dtype=np.float64)
+    out = gt_storage.empty(backend, default_origin=(0, 0, 0), shape=(2, 2, 2), dtype=np.float64)
+    test(out, inp)


### PR DESCRIPTION
## Description

Params was not updated after pruning arguments, which left fields that were only referenced in eliminated horizontal regions still in the signature in the stencil module, but not in the pybind11 generated run method and caused a mismatch. This adds a test and fixes the issue.

It turns out that the easy fix is to not prune parameters at all, but to loop over the node.params instead of the api_signature when creating the internal bindings.