### PR TITLE
Force early binding of function symbols in loops.

### DIFF
--- a/src/gtc/cuir/kernel_fusion.py
+++ b/src/gtc/cuir/kernel_fusion.py
@@ -48,7 +48,9 @@ class FuseKernels(NodeTranslator):
                 kernel.iter_tree()
                 .if_isinstance(cuir.FieldAccess)
                 .filter(
-                    lambda x: any(off != 0 for off in x.offset.to_dict().values())
+                    lambda x, parallel=parallel: any(
+                        off != 0 for off in x.offset.to_dict().values()
+                    )
                     or (x.offset.to_dict()["k"] != 0 and parallel)
                 )
                 .getattr("name")

--- a/src/gtc/passes/oir_optimizations/temporaries.py
+++ b/src/gtc/passes/oir_optimizations/temporaries.py
@@ -150,7 +150,9 @@ class WriteBeforeReadTemporariesToScalars(TemporariesToScalarsBase):
             offsets = accesses.offsets()
             ordered_accesses = accesses.ordered_accesses()
 
-            def write_before_read(tmp: str) -> bool:
+            def write_before_read(
+                tmp: str, offsets=offsets, ordered_accesses=ordered_accesses
+            ) -> bool:
                 if tmp not in offsets:
                     return True
                 if offsets[tmp] != {(0, 0, 0)}:


### PR DESCRIPTION
Force binding of symbols in functions in loops by means of keyword arguments.
This fixes the  B023 errors that appeared in the Formatting & Compliance CI due to a recent mypy update.
