### PR TITLE
Functional: Allow returning multiple fields from a field operator

### DIFF
--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -227,8 +227,8 @@ class FieldOperatorLowering(NodeTranslator):
         if iterator_type_kind(node.value.type) is ITIRTypeKind.ITERATOR:
             return self._lift_lambda(node)(im.tuple_get_(node.index, im.deref_(value)))
         elif iterator_type_kind(node.value.type) in (
-                ITIRTypeKind.VALUE,
-                ITIRTypeKind.ENCAPSULATED_ITERATOR,
+            ITIRTypeKind.VALUE,
+            ITIRTypeKind.ENCAPSULATED_ITERATOR,
         ):
             return im.tuple_get_(node.index, value)
         raise AssertionError("Unexpected `IteratorTypeKind`.")
@@ -242,8 +242,8 @@ class FieldOperatorLowering(NodeTranslator):
             elts = tuple(to_value(el)(self.visit(el, **kwargs)) for el in node.elts)
             return self._lift_lambda(node)(im.make_tuple_(*elts))
         elif iterator_type_kind(node.type) in (
-                ITIRTypeKind.VALUE,
-                ITIRTypeKind.ENCAPSULATED_ITERATOR,
+            ITIRTypeKind.VALUE,
+            ITIRTypeKind.ENCAPSULATED_ITERATOR,
         ):
             elts = tuple(self.visit(el, **kwargs) for el in node.elts)
             return im.make_tuple_(*elts)

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -210,7 +210,7 @@ class FieldOperatorLowering(NodeTranslator):
             .filter(is_expr_with_iterator_type_kind(IteratorTypeKind.ENCAPSULATED_ITERATOR))
         ):
             raise NotImplementedError(
-                "Using a composite type containing a local field is not supported."
+                "Using composite types (e.g. tuples) containing local fields not supported."
             )
         param_names = (
             node.pre_walk_values()

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -49,19 +49,19 @@ def iterator_type_kind(
     symbol_type: ct.ScalarType | ct.FieldType | ct.TupleType,
 ) -> IteratorTypeKind:
     """
-    Return the kind of type on iterator level an foast expr of given type corresponds to.
+    Return the corresponding type kind (on iterator level) to a FOAST expression of the given symbol type.
 
     This function is used both to decide on how to lower an foast expression
     of the given type and how to handle such expressions in other expressions.
 
-    - VALUE: The expression is a value, e.g. a scalar.
-    - ITERATOR: The expression can be derefed returning a value or composite
-        object of values (e.g. tuple).
-    - ENCAPSULATED_ITERATOR: The expression is a composite object (e.g. tuple)
-        that contains at least one iterator.
+    - VALUE: The lowered expression is a value, e.g. a scalar.
+    - ITERATOR: The lowered expression is an iterator that can be dereferenced,
+        returning a value or composite object of values (e.g. tuple).
+    - ENCAPSULATED_ITERATOR: The lowered expression is a composite object
+        (e.g. tuple) that contains at least one iterator.
 
     +------------------------------------+------------------------+
-    | Expr                               | Iterator Type Kind     |
+    | FOAST Expr                         | Iterator Type Kind     |
     +====================================+========================+
     | 1                                  | VALUE                  |
     | regular_field                      | ITERATOR               |

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -39,7 +39,7 @@ def is_local_kind(symbol_type: ct.FieldType) -> bool:
     return any(dim.kind == DimensionKind.LOCAL for dim in symbol_type.dims)
 
 
-class IteratorTypeKind(enum.Enum):
+class ITIRTypeKind(enum.Enum):
     VALUE = 0
     ITERATOR = 1
     ENCAPSULATED_ITERATOR = 2
@@ -47,7 +47,7 @@ class IteratorTypeKind(enum.Enum):
 
 def iterator_type_kind(
     symbol_type: ct.ScalarType | ct.FieldType | ct.TupleType,
-) -> IteratorTypeKind:
+) -> ITIRTypeKind:
     """
     Return the corresponding type kind (on iterator level) to a FOAST expression of the given symbol type.
 
@@ -76,7 +76,7 @@ def iterator_type_kind(
     +------------------------------------+------------------------+
     """
     if isinstance(symbol_type, ct.FieldType):
-        return IteratorTypeKind.ITERATOR
+        return ITIRTypeKind.ITERATOR
     elif any(type_info.primitive_constituents(symbol_type).if_isinstance(ct.FieldType)):
         # if we encounter any field type that is defined on a local dimension
         #  the resulting type on iterator ir level is not an iterator, but contains
@@ -86,13 +86,13 @@ def iterator_type_kind(
             .if_isinstance(ct.FieldType)
             .filter(is_local_kind)
         ):
-            return IteratorTypeKind.ENCAPSULATED_ITERATOR
+            return ITIRTypeKind.ENCAPSULATED_ITERATOR
         # otherwise we get an iterator, e.g. an iterator of values or tuples
-        return IteratorTypeKind.ITERATOR
-    return IteratorTypeKind.VALUE
+        return ITIRTypeKind.ITERATOR
+    return ITIRTypeKind.VALUE
 
 
-def is_expr_with_iterator_type_kind(it_type_kind: IteratorTypeKind) -> Callable[[foast.Expr], bool]:
+def is_expr_with_iterator_type_kind(it_type_kind: ITIRTypeKind) -> Callable[[foast.Expr], bool]:
     def predicate(node: foast.Expr):
         return iterator_type_kind(node.type) is it_type_kind
 
@@ -123,11 +123,11 @@ def to_value(node: foast.LocatedNode) -> Callable[[itir.Expr], itir.Expr]:
     >>> to_value(scalar_b)(im.ref("a"))
     SymRef(id=SymbolRef('a'))
     """
-    if iterator_type_kind(node.type) is IteratorTypeKind.ITERATOR:
+    if iterator_type_kind(node.type) is ITIRTypeKind.ITERATOR:
         # just to ensure we don't accidentally deref a local field
         assert not (isinstance(node.type, ct.FieldType) and is_local_kind(node.type))
         return im.deref_
-    elif iterator_type_kind(node.type) is IteratorTypeKind.VALUE:
+    elif iterator_type_kind(node.type) is ITIRTypeKind.VALUE:
         return lambda x: x
 
     raise AssertionError(f"Type {node.type} can not be turned into a value.")
@@ -207,7 +207,7 @@ class FieldOperatorLowering(NodeTranslator):
         if any(
             node.pre_walk_values()
             .if_isinstance(foast.Name)
-            .filter(is_expr_with_iterator_type_kind(IteratorTypeKind.ENCAPSULATED_ITERATOR))
+            .filter(is_expr_with_iterator_type_kind(ITIRTypeKind.ENCAPSULATED_ITERATOR))
         ):
             raise NotImplementedError(
                 "Using composite types (e.g. tuples) containing local fields not supported."
@@ -215,7 +215,7 @@ class FieldOperatorLowering(NodeTranslator):
         param_names = (
             node.pre_walk_values()
             .if_isinstance(foast.Name)
-            .filter(is_expr_with_iterator_type_kind(IteratorTypeKind.ITERATOR))
+            .filter(is_expr_with_iterator_type_kind(ITIRTypeKind.ITERATOR))
             .getattr("id")
             .unique()
             .to_list()
@@ -224,11 +224,11 @@ class FieldOperatorLowering(NodeTranslator):
 
     def visit_Subscript(self, node: foast.Subscript, **kwargs) -> itir.FunCall:
         value = self.visit(node.value, **kwargs)
-        if iterator_type_kind(node.value.type) is IteratorTypeKind.ITERATOR:
+        if iterator_type_kind(node.value.type) is ITIRTypeKind.ITERATOR:
             return self._lift_lambda(node)(im.tuple_get_(node.index, im.deref_(value)))
         elif iterator_type_kind(node.value.type) in (
-            IteratorTypeKind.VALUE,
-            IteratorTypeKind.ENCAPSULATED_ITERATOR,
+                ITIRTypeKind.VALUE,
+                ITIRTypeKind.ENCAPSULATED_ITERATOR,
         ):
             return im.tuple_get_(node.index, value)
         raise AssertionError("Unexpected `IteratorTypeKind`.")
@@ -238,21 +238,21 @@ class FieldOperatorLowering(NodeTranslator):
         #  want to have a value. As soon as we have one local field in the
         #  expression we choose a tuple of iterators layout (which other
         #  parts of the lowering rely on).
-        if iterator_type_kind(node.type) is IteratorTypeKind.ITERATOR:
+        if iterator_type_kind(node.type) is ITIRTypeKind.ITERATOR:
             elts = tuple(to_value(el)(self.visit(el, **kwargs)) for el in node.elts)
             return self._lift_lambda(node)(im.make_tuple_(*elts))
         elif iterator_type_kind(node.type) in (
-            IteratorTypeKind.VALUE,
-            IteratorTypeKind.ENCAPSULATED_ITERATOR,
+                ITIRTypeKind.VALUE,
+                ITIRTypeKind.ENCAPSULATED_ITERATOR,
         ):
             elts = tuple(self.visit(el, **kwargs) for el in node.elts)
             return im.make_tuple_(*elts)
         raise AssertionError("Unexpected `IteratorTypeKind`.")
 
     def _lift_if_field(self, node: foast.LocatedNode) -> Callable[[itir.Expr], itir.Expr]:
-        if iterator_type_kind(node.type) is IteratorTypeKind.VALUE:
+        if iterator_type_kind(node.type) is ITIRTypeKind.VALUE:
             return lambda x: x
-        elif iterator_type_kind(node.type) is IteratorTypeKind.ITERATOR:
+        elif iterator_type_kind(node.type) is ITIRTypeKind.ITERATOR:
             return self._lift_lambda(node)
         raise AssertionError("Unexpected `IteratorTypeKind`.")
 
@@ -398,7 +398,7 @@ class InsideReductionLowering(FieldOperatorLowering):
 
     def visit_Name(self, node: foast.Name, **kwargs) -> itir.SymRef:
         uid = f"{node.id}__{self._sequential_id()}"
-        if iterator_type_kind(node.type) is IteratorTypeKind.ENCAPSULATED_ITERATOR:
+        if iterator_type_kind(node.type) is ITIRTypeKind.ENCAPSULATED_ITERATOR:
             raise NotImplementedError(
                 "Using composite types (e.g. tuples) containing local fields not supported."
             )

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -209,7 +209,9 @@ class FieldOperatorLowering(NodeTranslator):
             .if_isinstance(foast.Name)
             .filter(is_expr_with_iterator_type_kind(IteratorTypeKind.ENCAPSULATED_ITERATOR))
         ):
-            raise NotImplementedError()
+            raise NotImplementedError(
+                "Using a composite type containing a local field is not supported."
+            )
         param_names = (
             node.pre_walk_values()
             .if_isinstance(foast.Name)

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -32,68 +32,80 @@ from functional.ffront.fbuiltins import FUN_BUILTIN_NAMES, TYPE_BUILTIN_NAMES
 from functional.iterator import ir as itir
 
 
-class TypeKind(enum.Enum):
-    FIELD = 0
-    SCALAR = 1
-    UNKNOWN = 2
-
-
-def resulting_type_kind(symbol_type: ct.SymbolType) -> TypeKind:
-    """
-    Determine whether the resulting type kind of ``symbol_type`` is scalar, field or unknown.
-
-    Useful for determining whether an expression of ``symbol_type`` should be treated as a
-    value or iterator expression during lowering.
-
-    Examples:
-    ---------
-    >>> resulting_type_kind(ct.DeferredSymbolType(constraint=None)).name
-    'UNKNOWN'
-
-    >>> resulting_type_kind(ct.ScalarType(kind=ct.ScalarKind.BOOL)).name
-    'SCALAR'
-
-    >>> resulting_type_kind(ct.TupleType(types=[ct.ScalarType(kind=ct.ScalarKind.FLOAT64)])).name
-    'SCALAR'
-    """
-    match symbol_type:
-        case ct.DeferredSymbolType(constraint=None):
-            return TypeKind.UNKNOWN
-        case ct.TupleType(types=subtypes):
-            if subtypes:
-                return resulting_type_kind(subtypes[0])
-
-    match type_info.type_class(symbol_type):
-        case ct.FieldType:
-            return TypeKind.FIELD
-        case ct.ScalarType:
-            return TypeKind.SCALAR
-
-    return TypeKind.UNKNOWN
-
-
-def can_be_value_or_iterator(symbol_type: ct.SymbolType):
-    return resulting_type_kind(symbol_type) is not TypeKind.UNKNOWN
-
-
-def is_field(expr: foast.Expr) -> bool:
-    return resulting_type_kind(expr.type) is TypeKind.FIELD
-    #return type_info.type_class(expr.type) is ct.FieldType
-
-
-def is_local_kind(symbol_type: ct.SymbolType) -> TypeKind:
-    if isinstance(symbol_type, ct.TupleType):
-        return any(is_local_kind(el) for el in symbol_type.types)
+def is_local_kind(symbol_type: ct.FieldType) -> bool:
+    assert isinstance(symbol_type, ct.FieldType)
+    if symbol_type.dims == ...:
+        return False
     return any(dim.kind == DimensionKind.LOCAL for dim in symbol_type.dims)
+
+
+class IteratorTypeKind(enum.Enum):
+    VALUE = 0
+    ITERATOR = 1
+    ENCAPSULATED_ITERATOR = 2
+
+
+def iterator_type_kind(
+    symbol_type: ct.ScalarType | ct.FieldType | ct.TupleType,
+) -> IteratorTypeKind:
+    """
+    Return the kind of type on iterator level an foast expr of given type corresponds to.
+
+    This function is used both to decide on how to lower an foast expression
+    of the given type and how to handle such expressions in other expressions.
+
+    - VALUE: The expression is a value, e.g. a scalar.
+    - ITERATOR: The expression can be derefed returning a value or composite
+        object of values (e.g. tuple).
+    - ENCAPSULATED_ITERATOR: The expression is a composite object (e.g. tuple)
+        that contains at least one iterator.
+
+    +------------------------------------+------------------------+
+    | Expr                               | Iterator Type Kind     |
+    +====================================+========================+
+    | 1                                  | VALUE                  |
+    | regular_field                      | ITERATOR               |
+    | local_field                        | ITERATOR               |
+    | (1, 1)                             | VALUE                  |
+    | (1, regular_field)                 | ITERATOR               |
+    | (1, local_field)                   | ENCAPSULATED_ITERATOR  |
+    | (regular_field, local_field)       | ENCAPSULATED_ITERATOR  |
+    | (1, (1, regular_field))            | ITERATOR               |
+    | (1, (1, local_field))              | ENCAPSULATED_ITERATOR  |
+    | (1, (local_field, regular_field))  | ENCAPSULATED_ITERATOR  |
+    +------------------------------------+------------------------+
+    """
+    if isinstance(symbol_type, ct.FieldType):
+        return IteratorTypeKind.ITERATOR
+    elif any(type_info.primitive_constituents(symbol_type).if_isinstance(ct.FieldType)):
+        # if we encounter any field type that is defined on a local dimension
+        #  the resulting type on iterator ir level is not an iterator, but contains
+        #  one, e.g. a tuple of iterators.
+        if any(
+            type_info.primitive_constituents(symbol_type)
+            .if_isinstance(ct.FieldType)
+            .filter(is_local_kind)
+        ):
+            return IteratorTypeKind.ENCAPSULATED_ITERATOR
+        # otherwise we get an iterator, e.g. an iterator of values or tuples
+        return IteratorTypeKind.ITERATOR
+    return IteratorTypeKind.VALUE
+
+
+def is_expr_with_iterator_type_kind(it_type_kind: IteratorTypeKind) -> Callable[[foast.Expr], bool]:
+    def predicate(node: foast.Expr):
+        return iterator_type_kind(node.type) is it_type_kind
+
+    return predicate
 
 
 def to_value(node: foast.LocatedNode) -> Callable[[itir.Expr], itir.Expr]:
     """
     Either ``deref_`` or noop callable depending on the input node.
 
-    Input node must have a scalar or field type.
-    If the lowered input node will represent an iterator expression, return ``deref_``.
-    Otherwise return a noop callable.
+    Input node must have a scalar, non-local field, or tuple of non-local fields
+    type. If the lowered input node will represent an iterator expression,
+    return ``deref_``. Otherwise return a noop callable.
 
     Examples:
     ---------
@@ -111,11 +123,14 @@ def to_value(node: foast.LocatedNode) -> Callable[[itir.Expr], itir.Expr]:
     >>> to_value(scalar_b)(im.ref("a"))
     SymRef(id=SymbolRef('a'))
     """
-    from functional.common import DimensionKind
-    assert can_be_value_or_iterator(node.type)
-    if resulting_type_kind(node.type) is TypeKind.FIELD and not is_local_kind(node.type):
+    if iterator_type_kind(node.type) is IteratorTypeKind.ITERATOR:
+        # just to ensure we don't accidentally deref a local field
+        assert not (isinstance(node.type, ct.FieldType) and is_local_kind(node.type))
         return im.deref_
-    return lambda x: x
+    elif iterator_type_kind(node.type) is IteratorTypeKind.VALUE:
+        return lambda x: x
+
+    raise AssertionError(f"Type {node.type} can not be turned into a value.")
 
 
 class FieldOperatorLowering(NodeTranslator):
@@ -188,29 +203,56 @@ class FieldOperatorLowering(NodeTranslator):
     def visit_Name(self, node: foast.Name, **kwargs) -> itir.SymRef:
         return im.ref(node.id)
 
-    def _lift_lambda(self, node):
-        param_names = list(
-            node.pre_walk_values().if_isinstance(foast.Name).filter(is_field).getattr("id").unique()
+    def _lift_lambda(self, node: foast.LocatedNode):
+        if any(
+            node.pre_walk_values()
+            .if_isinstance(foast.Name)
+            .filter(is_expr_with_iterator_type_kind(IteratorTypeKind.ENCAPSULATED_ITERATOR))
+        ):
+            raise NotImplementedError()
+        param_names = (
+            node.pre_walk_values()
+            .if_isinstance(foast.Name)
+            .filter(is_expr_with_iterator_type_kind(IteratorTypeKind.ITERATOR))
+            .getattr("id")
+            .unique()
+            .to_list()
         )
         return self.lifted_lambda(*param_names)
 
     def visit_Subscript(self, node: foast.Subscript, **kwargs) -> itir.FunCall:
-        value = to_value(node.value)(self.visit(node.value, **kwargs))
-        return self._lift_if_field(node)(im.tuple_get_(node.index, value))
+        value = self.visit(node.value, **kwargs)
+        if iterator_type_kind(node.value.type) is IteratorTypeKind.ITERATOR:
+            return self._lift_lambda(node)(im.tuple_get_(node.index, im.deref_(value)))
+        elif iterator_type_kind(node.value.type) in (
+            IteratorTypeKind.VALUE,
+            IteratorTypeKind.ENCAPSULATED_ITERATOR,
+        ):
+            return im.tuple_get_(node.index, value)
+        raise AssertionError("Unexpected `IteratorTypeKind`.")
 
     def visit_TupleExpr(self, node: foast.TupleExpr, **kwargs) -> itir.FunCall:
-        # it is important to use `node` here instead of el to decide if we
+        # it is important to use `node` here instead of `el` to decide if we
         #  want to have a value. As soon as we have one local field in the
         #  expression we choose a tuple of iterators layout (which other
         #  parts of the lowering rely on).
-        elts = tuple(to_value(node)(self.visit(el, **kwargs)) for el in node.elts)
-        return self._lift_if_field(node)(im.make_tuple_(*elts))
+        if iterator_type_kind(node.type) is IteratorTypeKind.ITERATOR:
+            elts = tuple(to_value(el)(self.visit(el, **kwargs)) for el in node.elts)
+            return self._lift_lambda(node)(im.make_tuple_(*elts))
+        elif iterator_type_kind(node.type) in (
+            IteratorTypeKind.VALUE,
+            IteratorTypeKind.ENCAPSULATED_ITERATOR,
+        ):
+            elts = tuple(self.visit(el, **kwargs) for el in node.elts)
+            return im.make_tuple_(*elts)
+        raise AssertionError("Unexpected `IteratorTypeKind`.")
 
     def _lift_if_field(self, node: foast.LocatedNode) -> Callable[[itir.Expr], itir.Expr]:
-        assert can_be_value_or_iterator(node.type)
-        if resulting_type_kind(node.type) is TypeKind.SCALAR or is_local_kind(node.type):
+        if iterator_type_kind(node.type) is IteratorTypeKind.VALUE:
             return lambda x: x
-        return self._lift_lambda(node)
+        elif iterator_type_kind(node.type) is IteratorTypeKind.ITERATOR:
+            return self._lift_lambda(node)
+        raise AssertionError("Unexpected `IteratorTypeKind`.")
 
     def visit_UnaryOp(self, node: foast.UnaryOp, **kwargs) -> itir.FunCall:
         # TODO(tehrengruber): extend iterator ir to support unary operators
@@ -311,7 +353,15 @@ class FieldOperatorLowering(NodeTranslator):
         #  type is a field. As such the lowering expects an iterator and tries
         #  to deref it.
         if isinstance(broadcasted_field.type, ct.ScalarType):
-            assert len(list(node.pre_walk_values().if_isinstance(foast.Name).filter(is_field))) == 0
+            assert (
+                len(
+                    node.pre_walk_values()
+                    .if_isinstance(foast.Name)
+                    .filter(lambda expr: isinstance(expr.type, ct.FieldType))
+                    .to_list()
+                )
+                == 0
+            )
             lowered_arg = im.lift_(im.lambda__()(lowered_arg))()
 
         return lowered_arg
@@ -346,6 +396,10 @@ class InsideReductionLowering(FieldOperatorLowering):
 
     def visit_Name(self, node: foast.Name, **kwargs) -> itir.SymRef:
         uid = f"{node.id}__{self._sequential_id()}"
+        if iterator_type_kind(node.type) is IteratorTypeKind.ENCAPSULATED_ITERATOR:
+            raise NotImplementedError(
+                "Using composite types (e.g. tuples) containing local fields not supported."
+            )
         self.lambda_params[uid] = super().visit_Name(node, **kwargs)
         return im.ref(uid)
 

--- a/src/functional/ffront/type_info.py
+++ b/src/functional/ffront/type_info.py
@@ -1,6 +1,7 @@
 from types import EllipsisType
 from typing import Iterator, Type, TypeGuard, cast
 
+from eve.utils import XIterable, xiter
 from functional.common import Dimension, GTTypeError
 from functional.ffront import common_types as ct
 
@@ -42,6 +43,36 @@ def type_class(symbol_type: ct.SymbolType) -> Type[ct.SymbolType]:
     raise GTTypeError(
         f"Invalid type for TypeInfo: requires {ct.SymbolType}, got {type(symbol_type)}!"
     )
+
+
+def primitive_constituents(
+    symbol_type: ct.ScalarType | ct.FieldType | ct.TupleType,
+) -> XIterable[ct.ScalarType | ct.FieldType]:
+    """
+    Return the primitive types contained in a composite type.
+
+    >>> from functional.common import Dimension
+    >>> I = Dimension(value="I")
+    >>> int_type = ct.ScalarType(kind=ct.ScalarKind.INT)
+    >>> field_type = ct.FieldType(dims=[I], dtype=int_type)
+
+    >>> tuple_type = ct.TupleType(types=[int_type, field_type])
+    >>> primitive_constituents(tuple_type).to_list()  # doctest: +ELLIPSIS
+    [ScalarType(...), FieldType(...)]
+
+    >>> nested_tuple = ct.TupleType(types=[field_type, tuple_type])
+    >>> primitive_constituents(nested_tuple).to_list()  # doctest: +ELLIPSIS
+    [FieldType(...), ScalarType(...), FieldType(...)]
+    """
+
+    def constituents_yielder(symbol_type: ct.SymbolType):
+        if isinstance(symbol_type, ct.TupleType):
+            for el_type in symbol_type.types:
+                yield from constituents_yielder(el_type)
+        else:
+            yield symbol_type
+
+    return xiter(constituents_yielder(symbol_type))
 
 
 def extract_dtype(symbol_type: ct.SymbolType) -> ct.ScalarType:

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -271,6 +271,7 @@ def reduction_setup():
     edge = Dimension("Edge")
     vertex = Dimension("Vertex")
     v2edim = Dimension("V2E", kind=DimensionKind.LOCAL)
+    e2vdim = Dimension("E2V", kind=DimensionKind.LOCAL)
 
     v2e_arr = np.array(
         [
@@ -285,20 +286,35 @@ def reduction_setup():
             [8, 14, 7, 17],
         ]
     )
+    num_edges = np.max(v2e_arr)+1
+    e2v_arr = [[] for _ in range(0, num_edges)]
+    for v in range(0, v2e_arr.shape[0]):
+        for e in v2e_arr[v]:
+            e2v_arr[e].append(v)
+    assert all(len(row) == 2 for row in e2v_arr)
+    e2v_arr = np.asarray(e2v_arr)
 
     yield namedtuple(
         "ReductionSetup",
-        ["size", "Edge", "Vertex", "V2EDim", "V2E", "inp", "out", "v2e_table", "offset_provider"],
+        ["size", "num_vertices", "num_edges", "Edge", "Vertex", "V2EDim", "E2VDim", "V2E", "E2V", "inp", "out", "offset_provider", "v2e_table", "e2v_table"],
     )(
-        size=9,
+        size=v2e_arr.shape[0],
+        num_vertices=v2e_arr.shape[0],
+        num_edges=e2v_arr.shape[0],
         Edge=edge,
         Vertex=vertex,
         V2EDim=v2edim,
+        E2VDim=e2vdim,
         V2E=FieldOffset("V2E", source=edge, target=(vertex, v2edim)),
+        E2V=FieldOffset("E2V", source=vertex, target=(edge, e2vdim)),
         inp=index_field(edge),
         out=np_as_located_field(vertex)(np.zeros([size])),
-        offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, vertex, edge, 4)},
+        offset_provider={
+            "V2E": NeighborTableOffsetProvider(v2e_arr, vertex, edge, 4),
+            "E2V": NeighborTableOffsetProvider(e2v_arr, edge, vertex, 2, has_skip_values=False)
+        },
         v2e_table=v2e_arr,
+        e2v_table=e2v_arr,
     )  # type: ignore
 
 
@@ -400,6 +416,7 @@ def test_reduction_expression(reduction_setup):
         tmp_nbh_tup = edge_f(V2E), edge_f(V2E)
         tmp_nbh = tmp_nbh_tup[0]
         return 3.0 * neighbor_sum(-edge_f(V2E) * tmp_nbh * 2.0, axis=V2EDim)
+
 
     @program(backend=fieldview_backend)
     def fencil(edge_f: Field[[Edge], float64], out: Field[[Vertex], float64]) -> None:
@@ -583,3 +600,95 @@ def test_conditional_shifted():
     conditional_program(mask, a, b, out, offset_provider={"Ioff": IDim})
 
     assert np.allclose(np.where(mask, a, b)[1:], out.array()[:-1])
+
+
+def test_tuple_return():
+    size = 10
+    a = np_as_located_field(IDim)(np.ones((size,)))
+    b = np_as_located_field(IDim)(2 * np.ones((size,)))
+    out = np_as_located_field(IDim)(np.zeros((size,)))
+
+    @field_operator
+    def foo(
+        a: Field[[IDim], float64], b: Field[[IDim], float64]
+    ) -> tuple[Field[[IDim], float64], Field[[IDim], float64]]:
+        return a, b
+
+    @field_operator
+    def combine(a: Field[[IDim], float64], b: Field[[IDim], float64]) -> Field[[IDim], float64]:
+        something = foo(a, b)
+        return something[0] + something[1]
+
+    combine(a, b, out=out, offset_provider={})
+
+    assert np.allclose(a.array() + b.array(), out)
+
+
+def test_tuple_with_local_field_in_reduction_shifted(reduction_setup):
+    rs = reduction_setup
+    Edge = rs.Edge
+    Vertex = rs.Vertex
+    V2EDim = rs.V2EDim
+    V2E = rs.V2E
+    E2V = rs.E2V
+
+    num_vertices = rs.num_vertices
+    num_edges = rs.num_edges
+
+    size = 10
+    # TODO(tehrengruber): use different values per location
+    a = np_as_located_field(Edge)(np.ones((num_vertices,)))
+    b = np_as_located_field(Vertex)(2*np.ones((num_edges,)))
+    out = np_as_located_field(Edge)(np.zeros((num_edges,)))
+
+    @field_operator
+    def foo(
+        edge_field: Field[[Edge], float64],
+        vertex_field: Field[[Vertex], float64]
+    ) -> Field[[Edge], float64]:
+        tup = edge_field(V2E), vertex_field
+        # the shift inside the reduction fails as tup is a tuple of iterators
+        #  (as it contains a local field) which can not be shifted
+        red = neighbor_sum(tup[0]+vertex_field, axis=V2EDim)
+        # even if the above is fixed we need to be careful with a subsequent
+        #  shift as the lifted lambda will contain tup as an argument which -
+        #  again - can not be shifted.
+        return red(E2V[0])
+
+    #foo(a, b, out=out, offset_provider=rs.offset_provider)
+
+    # conn table used is inverted here on purpose
+    red = np.sum(np.asarray(a)[rs.e2v_table] + np.asarray(b)[:, np.newaxis],
+                 axis=1)
+    expected = red[rs.v2e_table][:, 0]
+
+    assert np.allclose(expected, out)
+
+
+def test_tuple_return_2(reduction_setup):
+    rs = reduction_setup
+    Edge = rs.Edge
+    Vertex = rs.Vertex
+    V2EDim = rs.V2EDim
+    V2E = rs.V2E
+
+    @field_operator
+    def reduction_tuple(
+        a: Field[[Edge], float], b: Field[[Edge], float]#, c: float
+    ) -> tuple[Field[[Vertex], float], Field[[Vertex], float], float]:
+        a = neighbor_sum(a(V2E), axis=V2EDim)
+        b = neighbor_sum(b(V2E), axis=V2EDim)
+        #c = c * 1.0
+        return a, b#, c
+
+    @field_operator
+    def fencil_tuple(
+        a: Field[[Edge], float], b: Field[[Edge], float]#, c: float
+    ) -> Field[[Vertex], float]:
+        tp_red = reduction_tuple(a, b)
+        return (tp_red[0] + tp_red[1])# * c
+
+    fencil_tuple(rs.inp, rs.inp, out=rs.out, offset_provider=rs.offset_provider)
+
+    ref = np.sum(rs.v2e_table, axis=1) * 2
+    assert np.allclose(ref, rs.out)

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -616,28 +616,6 @@ def test_conditional_shifted():
     assert np.allclose(np.where(mask, a, b)[1:], out.array()[:-1])
 
 
-def test_tuple_return():
-    size = 10
-    a = np_as_located_field(IDim)(np.ones((size,)))
-    b = np_as_located_field(IDim)(2 * np.ones((size,)))
-    out = np_as_located_field(IDim)(np.zeros((size,)))
-
-    @field_operator
-    def foo(
-        a: Field[[IDim], float64], b: Field[[IDim], float64]
-    ) -> tuple[Field[[IDim], float64], Field[[IDim], float64]]:
-        return a, b
-
-    @field_operator
-    def combine(a: Field[[IDim], float64], b: Field[[IDim], float64]) -> Field[[IDim], float64]:
-        something = foo(a, b)
-        return something[0] + something[1]
-
-    combine(a, b, out=out, offset_provider={})
-
-    assert np.allclose(a.array() + b.array(), out)
-
-
 def test_nested_tuple_return():
     size = 10
     a = np_as_located_field(IDim)(np.ones((size,)))

--- a/tests/functional_tests/ffront_tests/test_lowering.py
+++ b/tests/functional_tests/ffront_tests/test_lowering.py
@@ -80,8 +80,11 @@ def test_multicopy():
     parsed = FieldOperatorParser.apply_to_function(multicopy)
     lowered = FieldOperatorLowering.apply(parsed)
 
-    # TODO(ricoh): reevaluate after tuple of fields is allowed in iterator model
-    reference = im.deref_(im.make_tuple_("inp1", "inp2"))
+    reference = im.deref_(
+        im.lift_(im.lambda__("inp1", "inp2")(im.make_tuple_(im.deref_("inp1"), im.deref_("inp2"))))(
+            "inp1", "inp2"
+        )
+    )
 
     assert lowered.expr == reference
 
@@ -181,14 +184,21 @@ def test_unpacking():
     parsed = FieldOperatorParser.apply_to_function(unpacking)
     lowered = FieldOperatorLowering.apply(parsed)
 
+    tuple_expr = im.lift_(
+        im.lambda__("inp1", "inp2")(im.make_tuple_(im.deref_("inp1"), im.deref_("inp2")))
+    )("inp1", "inp2")
+    tuple_access_0 = im.lift_(
+        im.lambda__("__tuple_tmp_0")(im.tuple_get_(0, im.deref_("__tuple_tmp_0")))
+    )("__tuple_tmp_0")
+    tuple_access_1 = im.lift_(
+        im.lambda__("__tuple_tmp_0")(im.tuple_get_(1, im.deref_("__tuple_tmp_0")))
+    )("__tuple_tmp_0")
+
     reference = im.deref_(
-        im.let("__tuple_tmp_0", im.make_tuple_("inp1", "inp2"))(
-            im.let("tmp1__0", im.tuple_get_(0, "__tuple_tmp_0"))(
-                im.let("tmp2__0", im.tuple_get_(1, "__tuple_tmp_0"))("tmp1__0")
-            )
+        im.let("__tuple_tmp_0", tuple_expr)(
+            im.let("tmp1__0", tuple_access_0)(im.let("tmp2__0", tuple_access_1)("tmp1__0"))
         )
     )
-
     assert lowered.expr == reference
 
 
@@ -230,8 +240,10 @@ def test_temp_tuple():
     parsed = FieldOperatorParser.apply_to_function(temp_tuple)
     lowered = FieldOperatorLowering.apply(parsed)
 
-    # TODO(ricoh): reevaluate after tuple of fields is allowed in iterator model
-    reference = im.deref_(im.let("tmp__0", im.make_tuple_("a", "b"))("tmp__0"))
+    tuple_expr = im.lift_(im.lambda__("a", "b")(im.make_tuple_(im.deref_("a"), im.deref_("b"))))(
+        "a", "b"
+    )
+    reference = im.deref_(im.let("tmp__0", tuple_expr)("tmp__0"))
 
     assert lowered.expr == reference
 


### PR DESCRIPTION
This PR fixes some problems and improves support for field operators returning tuples of fields.

```python
@field_operator
def foo(
    a: Field[[IDim], float64], b: Field[[IDim], float64]
) -> tuple[Field[[IDim], float64], Field[[IDim], float64]]:
    return a, b

@field_operator
def combine(a: Field[[IDim], float64], b: Field[[IDim], float64]) -> Field[[IDim], float64]:
    something = foo(a, b)
    return something[0] + something[1]

combine(a, b, out=out, offset_provider={})
```

Note that this does not include programs returning multiple fields.