### PR TITLE
Special Treatment of Regions in DaCe backends

### DIFF
--- a/src/gt4py/backend/dace_backend.py
+++ b/src/gt4py/backend/dace_backend.py
@@ -106,7 +106,7 @@ def _pre_expand_trafos(stencil_ir: gtir.Stencil, sdfg: dace.SDFG, layout_map):
     for node, _ in filter(
         lambda n: isinstance(n[0], StencilComputation), sdfg.all_nodes_recursive()
     ):
-        if node.has_splittable_regions():  # and "corner" in node.label:
+        if node.has_splittable_regions():
             expansion_priority = [
                 "Sections",
                 "Stages",
@@ -114,7 +114,6 @@ def _pre_expand_trafos(stencil_ir: gtir.Stencil, sdfg: dace.SDFG, layout_map):
                 "I",
                 "K",
             ]
-            print("Reordered schedule for", node.label)
         else:
             expansion_priority = ["TileJ", "TileI", "Sections"]
             if node.oir_node.loop_order == common.LoopOrder.PARALLEL:
@@ -256,7 +255,6 @@ class DaCeComputationCodegen:
         with dace.config.temporary_config():
             dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=-1)
             dace.config.Config.set("compiler", "cpu", "openmp_sections", value=False)
-            sdfg.view()
             code_objects = sdfg.generate_code()
         is_gpu = "CUDA" in {co.title for co in code_objects}
 

--- a/src/gtc/dace/expansion/daceir_builder.py
+++ b/src/gtc/dace/expansion/daceir_builder.py
@@ -110,7 +110,7 @@ def _all_stmts_same_region(scope_nodes, axis: dcir.Axis, interval):
         axis in dcir.Axis.dims_horizontal()
         and isinstance(interval, dcir.DomainInterval)
         and all(
-            isinstance(stmt, oir.MaskStmt) and isinstance(stmt.mask, common.HorizontalMask)
+            isinstance(stmt, dcir.HorizontalRestriction)
             for tasklet in iter_tree(scope_nodes).if_isinstance(dcir.Tasklet)
             for stmt in tasklet.stmts
         )

--- a/src/gtc/dace/expansion/expansion.py
+++ b/src/gtc/dace/expansion/expansion.py
@@ -27,7 +27,7 @@ from gtc.dace.expansion.daceir_builder import DaCeIRBuilder
 from gtc.dace.expansion.sdfg_builder import StencilComputationSDFGBuilder
 from gtc.dace.nodes import StencilComputation
 
-from .utils import split_horizontal_exeuctions_regions
+from .utils import split_horizontal_executions_regions
 
 
 @dace.library.register_expansion(StencilComputation, "default")
@@ -129,7 +129,7 @@ class StencilComputationExpansion(dace.library.ExpandTransformation):
         node: "StencilComputation", parent_state: dace.SDFGState, parent_sdfg: dace.SDFG
     ) -> dace.nodes.NestedSDFG:
         """Expand the coarse SDFG in parent_sdfg to a NestedSDFG with all the states."""
-        split_horizontal_exeuctions_regions(node)
+        split_horizontal_executions_regions(node)
         arrays = StencilComputationExpansion._get_parent_arrays(node, parent_state, parent_sdfg)
 
         daceir: dcir.NestedSDFG = DaCeIRBuilder().visit(

--- a/src/gtc/dace/expansion/expansion.py
+++ b/src/gtc/dace/expansion/expansion.py
@@ -26,7 +26,9 @@ from gtc import daceir as dcir
 from gtc.dace.expansion.daceir_builder import DaCeIRBuilder
 from gtc.dace.expansion.sdfg_builder import StencilComputationSDFGBuilder
 from gtc.dace.nodes import StencilComputation
+
 from .utils import split_horizontal_exeuctions_regions
+
 
 @dace.library.register_expansion(StencilComputation, "default")
 class StencilComputationExpansion(dace.library.ExpandTransformation):

--- a/src/gtc/dace/expansion/expansion.py
+++ b/src/gtc/dace/expansion/expansion.py
@@ -26,7 +26,7 @@ from gtc import daceir as dcir
 from gtc.dace.expansion.daceir_builder import DaCeIRBuilder
 from gtc.dace.expansion.sdfg_builder import StencilComputationSDFGBuilder
 from gtc.dace.nodes import StencilComputation
-
+from .utils import split_horizontal_exeuctions_regions
 
 @dace.library.register_expansion(StencilComputation, "default")
 class StencilComputationExpansion(dace.library.ExpandTransformation):
@@ -127,6 +127,7 @@ class StencilComputationExpansion(dace.library.ExpandTransformation):
         node: "StencilComputation", parent_state: dace.SDFGState, parent_sdfg: dace.SDFG
     ) -> dace.nodes.NestedSDFG:
         """Expand the coarse SDFG in parent_sdfg to a NestedSDFG with all the states."""
+        split_horizontal_exeuctions_regions(node)
         arrays = StencilComputationExpansion._get_parent_arrays(node, parent_state, parent_sdfg)
 
         daceir: dcir.NestedSDFG = DaCeIRBuilder().visit(

--- a/src/gtc/dace/expansion/utils.py
+++ b/src/gtc/dace/expansion/utils.py
@@ -68,9 +68,9 @@ class HorizontalMaskRemover(eve.NodeMutator):
                 res_body.append(newstmt)
         return dcir.Tasklet(
             stmts=res_body,
-            name_map=node.name_map,
-            read_accesses=node.read_accesses,
-            write_accesses=node.write_accesses,
+            decls=node.decls,
+            read_memlets=node.read_memlets,
+            write_memlets=node.write_memlets,
         )
 
     def visit_MaskStmt(self, node: oir.MaskStmt):
@@ -155,7 +155,7 @@ class HorizontalExecutionSplitter(eve.NodeTranslator):
         return oir.VerticalLoopSection(interval=node.interval, horizontal_executions=res_hes)
 
 
-def split_horizontal_exeuctions_regions(node: "StencilComputation"):
+def split_horizontal_executions_regions(node: "StencilComputation"):
 
     extents: List[Extent] = []
 

--- a/src/gtc/dace/expansion/utils.py
+++ b/src/gtc/dace/expansion/utils.py
@@ -17,7 +17,10 @@ import dace.data
 import dace.library
 import dace.subsets
 
+import eve
+from eve.iterators import iter_tree
 from gtc import common
+from gtc import oir
 
 
 def get_dace_debuginfo(node: common.LocNode):
@@ -32,3 +35,126 @@ def get_dace_debuginfo(node: common.LocNode):
         )
     else:
         return dace.dtypes.DebugInfo(0)
+
+
+class HorizontalIntervalRemover(eve.NodeMutator):
+    def visit_HorizontalMask(self, node: common.HorizontalMask, *, axis: "dcir.Axis"):
+        mask_attrs = dict(i=node.i, j=node.j)
+        mask_attrs[axis.lower()] = self.visit(getattr(node, axis.lower()))
+        return common.HorizontalMask(**mask_attrs)
+
+    def visit_HorizontalInterval(self, node: common.HorizontalInterval):
+        return common.HorizontalInterval(start=None, end=None)
+
+
+class HorizontalMaskRemover(eve.NodeMutator):
+    def visit_Tasklet(self, node: "dcir.Tasklet"):
+        from gtc import daceir as dcir
+
+        res_body = []
+        for stmt in node.stmts:
+            newstmt = self.visit(stmt)
+            if isinstance(newstmt, list):
+                res_body.extend(newstmt)
+            else:
+                res_body.append(newstmt)
+        return dcir.Tasklet(
+            stmts=res_body,
+            name_map=node.name_map,
+            read_accesses=node.read_accesses,
+            write_accesses=node.write_accesses,
+        )
+
+    def visit_MaskStmt(self, node: oir.MaskStmt):
+        if isinstance(node.mask, common.HorizontalMask):
+            if (
+                node.mask.i.start is None
+                and node.mask.j.start is None
+                and node.mask.i.end is None
+                and node.mask.j.end is None
+            ):
+                return self.generic_visit(node.body)
+        return self.generic_visit(node)
+
+
+def remove_horizontal_region(node, axis):
+    intervals_removed = HorizontalIntervalRemover().visit(node, axis=axis)
+    return HorizontalMaskRemover().visit(intervals_removed)
+
+
+def mask_includes_inner_domain(mask: common.HorizontalMask):
+    for interval in mask.intervals:
+        if interval.start is None and interval.end is None:
+            return True
+        elif interval.start is None and interval.end.level == common.LevelMarker.END:
+            return True
+        elif interval.end is None and interval.start.level == common.LevelMarker.START:
+            return True
+        elif (
+            interval.start is not None
+            and interval.end is not None
+            and interval.start.level != interval.end.level
+        ):
+            return True
+    return False
+
+
+class HorizontalExecutionSplitter(eve.NodeTranslator):
+    def visit_HorizontalExecution(self, node: oir.HorizontalExecution, *, extents, library_node):
+        if any(node.iter_tree().if_isinstance(oir.LocalScalar)):
+            extents.append(library_node.get_extents(node))
+            return node
+
+        last_stmts = []
+        res_he_stmts = [last_stmts]
+        for stmt in node.body:
+            if last_stmts and (
+                (
+                    isinstance(stmt, oir.HorizontalRestriction)
+                    and not mask_includes_inner_domain(stmt.mask)
+                )
+                or (
+                    (
+                        isinstance(last_stmts[0], oir.HorizontalRestriction)
+                        and not mask_includes_inner_domain(last_stmts[0].mask)
+                    )
+                )
+            ):
+                last_stmts = [stmt]
+                res_he_stmts.append(last_stmts)
+            else:
+                last_stmts.append(stmt)
+
+        res_hes = []
+        for stmts in res_he_stmts:
+            accessed_scalars = set(
+                acc.name for acc in iter_tree(stmts).if_isinstance(oir.ScalarAccess)
+            )
+            declarations = [decl for decl in node.declarations if decl.name in accessed_scalars]
+            res_he = oir.HorizontalExecution(declarations=declarations, body=stmts)
+            res_hes.append(res_he)
+            extents.append(library_node.get_extents(node))
+        return res_hes
+
+    def visit_VerticalLoopSection(self, node: oir.VerticalLoopSection, **kwargs):
+        res_hes = []
+        for he in node.horizontal_executions:
+            new_he = self.visit(he, **kwargs)
+            if isinstance(new_he, list):
+                res_hes.extend(new_he)
+            else:
+                res_hes.append(new_he)
+        return oir.VerticalLoopSection(interval=node.interval, horizontal_executions=res_hes)
+
+def split_horizontal_exeuctions_regions(node: "StencilComputation"):
+
+    extents = []
+
+    node.oir_node = HorizontalExecutionSplitter().visit(
+        node.oir_node, library_node=node, extents=extents
+    )
+    ctr = 0
+    for i, section in enumerate(node.oir_node.sections):
+        for j, he in enumerate(section.horizontal_executions):
+            node.extents[j * len(node.oir_node.sections) + i] = extents[ctr]
+            ctr += 1

--- a/src/gtc/dace/expansion/utils.py
+++ b/src/gtc/dace/expansion/utils.py
@@ -21,13 +21,13 @@ import dace.subsets
 
 import eve
 from eve.iterators import iter_tree
-from gtc import common, oir
+from gtc import common
+from gtc import daceir as dcir
+from gtc import oir
 from gtc.definitions import Extent
 
 
 if TYPE_CHECKING:
-    import daceir as dcir
-
     from gtc.dace.nodes import StencilComputation
 
 
@@ -57,7 +57,6 @@ class HorizontalIntervalRemover(eve.NodeMutator):
 
 class HorizontalMaskRemover(eve.NodeMutator):
     def visit_Tasklet(self, node: "dcir.Tasklet"):
-        from gtc import daceir as dcir
 
         res_body = []
         for stmt in node.stmts:

--- a/src/gtc/dace/nodes.py
+++ b/src/gtc/dace/nodes.py
@@ -177,8 +177,7 @@ class StencilComputation(library.LibraryNode):
     def has_splittable_regions(self):
         for he in self.oir_node.iter_tree().if_isinstance(oir.HorizontalExecution):
             if not he.declarations and any(
-                isinstance(stmt, oir.MaskStmt)
-                and isinstance(stmt.mask, common.HorizontalMask)
+                isinstance(stmt, oir.HorizontalRestriction)
                 and not mask_includes_inner_domain(stmt.mask)
                 for stmt in he.body
             ):

--- a/tests/test_integration/test_suites.py
+++ b/tests/test_integration/test_suites.py
@@ -883,6 +883,40 @@ class TestHorizontalRegions(gt_testing.StencilTestSuite):
         field_out[:, -1, :] = field_in[:, -1, :] - 1.0
 
 
+class TestHorizontalRegionsCorners(gt_testing.StencilTestSuite):
+    dtypes = {
+        "field_in": np.float32,
+        "field_out": np.float32,
+    }
+    domain_range = [(4, 4), (4, 4), (2, 2)]
+    backends = ALL_BACKENDS
+    symbols = {
+        "field_in": gt_testing.field(
+            in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]
+        ),
+        "field_out": gt_testing.field(
+            in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]
+        ),
+    }
+
+    def definition(field_in, field_out):
+        with computation(PARALLEL), interval(...):
+            with horizontal(region[I[0] : I[2], J[0] : J[2]], region[I[-3] : I[-1], J[-3] : J[-1]]):
+                field_out = (  # noqa: F841  # local variable 'field_out' is assigned to but never used
+                    field_in + 1.0
+                )
+            with horizontal(region[I[0] : I[2], J[-3] : J[-1]], region[I[-3] : I[-1], J[0] : J[2]]):
+                field_out = (  # noqa: F841  # local variable 'field_out' is assigned to but never used
+                    field_in - 1.0
+                )
+
+    def validation(field_in, field_out, *, domain, origin):
+        field_out[0:2, 0:2, :] = field_in[0:2, 0:2, :] + 1.0
+        field_out[-3:-1, -3:-1, :] = field_in[-3:-1, -3:-1, :] + 1.0
+        field_out[0:2, -3:-1, :] = field_in[0:2, -3:-1, :] - 1.0
+        field_out[-3:-1, 0:2, :] = field_in[-3:-1, 0:2, :] - 1.0
+
+
 class TestTypedTemporary(gt_testing.StencilTestSuite):
     dtypes = {"field_in": np.float32, "field_out": np.float32}
     domain_range = [(2, 2), (2, 2), (2, 8)]


### PR DESCRIPTION
This PR implements a expansion configuration where
* for HorizontalExecutions with a single region, the regions are implemented by restriting the map ranges instead of guarding statements with a predicate.
* HorizontalExecutions where each statement is only applied to a corner of a domain are broken up into multiple HorizontalExecutions (making them amenable to the much more efficient implementation of the first bullet point.)