### PR TITLE
Functional: Fixes for PopupTmps-Transformation

### DIFF
--- a/tests/functional_tests/iterator_tests/test_popup_tmps.py
+++ b/tests/functional_tests/iterator_tests/test_popup_tmps.py
@@ -193,3 +193,112 @@ def test_capture(fresh_uid_sequence):
     )
     actual = PopupTmps().visit(testee)
     assert actual == testee
+
+
+def test_crossref():
+    testee = ir.FunCall(
+        fun=ir.Lambda(
+            params=[ir.Sym(id="x")],
+            expr=ir.FunCall(
+                fun=ir.Lambda(
+                    params=[ir.Sym(id="x1")],
+                    expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="x1")]),
+                ),
+                args=[
+                    ir.FunCall(
+                        fun=ir.FunCall(
+                            fun=ir.SymRef(id="lift"),
+                            args=[
+                                ir.Lambda(
+                                    params=[ir.Sym(id="x2")],
+                                    expr=ir.FunCall(
+                                        fun=ir.SymRef(id="deref"),
+                                        args=[ir.SymRef(id="x2")],
+                                    ),
+                                )
+                            ],
+                        ),
+                        args=[
+                            ir.FunCall(
+                                fun=ir.FunCall(
+                                    fun=ir.SymRef(id="lift"),
+                                    args=[
+                                        ir.Lambda(
+                                            params=[ir.Sym(id="x3")],
+                                            expr=ir.FunCall(
+                                                fun=ir.SymRef(id="deref"),
+                                                args=[ir.SymRef(id="x3")],
+                                            ),
+                                        )
+                                    ],
+                                ),
+                                args=[ir.SymRef(id="x")],
+                            )
+                        ],
+                    )
+                ],
+            ),
+        ),
+        args=[ir.SymRef(id="x")],
+    )
+    expected = ir.FunCall(
+        fun=ir.Lambda(
+            params=[
+                ir.Sym(id="x"),
+                ir.Sym(id="_lift_1"),
+                ir.Sym(id="_lift_2"),
+            ],
+            expr=ir.FunCall(
+                fun=ir.Lambda(
+                    params=[ir.Sym(id="x1")],
+                    expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="x1")]),
+                ),
+                args=[ir.SymRef(id="_lift_2")],
+            ),
+        ),
+        args=[
+            ir.SymRef(id="x"),
+            ir.FunCall(
+                fun=ir.FunCall(
+                    fun=ir.SymRef(id="lift"),
+                    args=[
+                        ir.Lambda(
+                            params=[ir.Sym(id="x3")],
+                            expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="x3")]),
+                        )
+                    ],
+                ),
+                args=[ir.SymRef(id="x")],
+            ),
+            ir.FunCall(
+                fun=ir.FunCall(
+                    fun=ir.SymRef(id="lift"),
+                    args=[
+                        ir.Lambda(
+                            params=[ir.Sym(id="x2")],
+                            expr=ir.FunCall(fun=ir.SymRef(id="deref"), args=[ir.SymRef(id="x2")]),
+                        )
+                    ],
+                ),
+                args=[
+                    ir.FunCall(
+                        fun=ir.FunCall(
+                            fun=ir.SymRef(id="lift"),
+                            args=[
+                                ir.Lambda(
+                                    params=[ir.Sym(id="x3")],
+                                    expr=ir.FunCall(
+                                        fun=ir.SymRef(id="deref"),
+                                        args=[ir.SymRef(id="x3")],
+                                    ),
+                                )
+                            ],
+                        ),
+                        args=[ir.SymRef(id="x")],
+                    )
+                ],
+            ),
+        ],
+    )
+    actual = PopupTmps().visit(testee)
+    assert actual == expected


### PR DESCRIPTION
## Description

Fixes incorrect replacement of argument values in lifted scans and popping up lifts with cross-references (one lift referencing another).

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


