### PR TITLE
Functional: Support Mixed-Type Tuples and Nested Tuples in Embedded Scan

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -887,18 +887,11 @@ _column_range: Optional[
 ] = None  # TODO this is a bit ugly, alternative: pass scan range via iterator
 
 
-def _ensure_dtype_matches(val: numbers.Number | tuple[numbers.Number, ...], expected_dtype: type):
-    if isinstance(val, tuple):
-        assert all(isinstance(el, expected_dtype) for el in val)
-    else:
-        assert isinstance(val, expected_dtype)
-
-
-def _column_dtype_and_shape(levels: int, elem: Any) -> tuple[type, int | tuple[int, int]]:
+def _column_dtype(elem: Any) -> np.dtype:
     if isinstance(elem, tuple):
-        return type(elem[0]), (levels, len(elem))
+        return np.dtype([(f"f{i}", _column_dtype(e)) for i, e in enumerate(elem)])
     else:
-        return type(elem), levels
+        return np.dtype(type(elem))
 
 
 @builtins.scan.register(EMBEDDED)
@@ -906,21 +899,16 @@ def scan(scan_pass, is_forward: bool, init):
     def impl(*iters: ItIterator):
         if _column_range is None:
             raise RuntimeError("Column range is not defined, cannot scan.")
-        if isinstance(init, tuple):
-            if any(isinstance(el, tuple) for el in init):
-                raise NotImplementedError("Nested tuples not supported.")
 
         levels = len(_column_range)
         column_range = _column_range if is_forward else reversed(_column_range)
 
-        dtype, shape = _column_dtype_and_shape(levels, init)
+        dtype = _column_dtype(init)
 
         state = init
-        col = np.zeros(shape, dtype=dtype)
+        col = np.zeros(levels, dtype=dtype)
         for i in column_range:
             state = scan_pass(state, *map(shifted_scan_arg(i), iters))
-            if __debug__:
-                _ensure_dtype_matches(state, dtype)
             col[i] = state
 
         return col


### PR DESCRIPTION
## Description

Adds support for tuples with various element types and nested tuples in the embedded backend’s scan implementation.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


