### PR TITLE
Change packaging configuration to include typings and data files using modern settings.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include *.md
-include *.rst
-include *.toml
-include *.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ zip_safe = False
 packages = find:
 package_dir =
     =src
-include_package_data = True
 python_requires = >= 3.10
 install_requires =
     attrs>=20.3
@@ -59,6 +58,12 @@ install_requires =
     toolz>=0.11
     typing-extensions>=4.2
     xxhash>=1.4.4
+
+[options.package_data]
+# References:
+#  https://setuptools.pypa.io/en/latest/userguide/datafiles.html
+#  https://github.com/abravalheri/experiment-setuptools-package-data
+* = *.md, *.rst, *.toml, *.txt, py.typed
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
References for information about including data files in Python packages:
-  https://setuptools.pypa.io/en/latest/userguide/datafiles.html
-  https://github.com/abravalheri/experiment-setuptools-package-data