### PR TITLE
Functional: Grid deduction cleanup

### DIFF
--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -278,13 +278,10 @@ class Program:
             raise RuntimeError(f"Reference to undefined symbol(s) `{', '.join(undefined)}`.")
 
         referenced_gt_callables = self._gt_callables_from_captured_vars(capture_vars)
-        grid_type = self._deduce_grid_type(
-            self.grid_type, self._offsets_and_dimensions_from_gt_callables(referenced_gt_callables)
-        )
 
         lowered_funcs = self._lowered_funcs_from_gt_callables(referenced_gt_callables)
         return ProgramLowering.apply(
-            self.past_node, function_definitions=lowered_funcs, grid_type=grid_type
+            self.past_node, function_definitions=lowered_funcs, force_grid_type=self.grid_type
         )
 
     def _validate_args(self, *args, **kwargs) -> None:

--- a/tests/functional_tests/ffront_tests/test_domain_decution.py
+++ b/tests/functional_tests/ffront_tests/test_domain_decution.py
@@ -1,8 +1,9 @@
 import pytest
 
 from functional.common import Dimension, DimensionKind, GridType, GTTypeError
-from functional.ffront.decorator import Program
 from functional.ffront.fbuiltins import FieldOffset
+from functional.ffront.past_to_itir import _deduce_grid_type
+from functional.ffront.symbol_makers import make_symbol_type_from_value
 
 
 Dim = Dimension("Dim")
@@ -12,29 +13,15 @@ CartesianOffset = FieldOffset("CartesianOffset", source=Dim, target=(Dim,))
 UnstructuredOffset = FieldOffset("UnstructuredOffset", source=Dim, target=(Dim, LocalDim))
 
 
-def test_domain_deduction_cartesian():
-    assert Program._deduce_grid_type(None, {CartesianOffset}) == GridType.CARTESIAN
-    assert Program._deduce_grid_type(None, {Dim}) == GridType.CARTESIAN
-
-
-def test_domain_deduction_unstructured():
-    assert Program._deduce_grid_type(None, {UnstructuredOffset}) == GridType.UNSTRUCTURED
-    assert Program._deduce_grid_type(None, {LocalDim}) == GridType.UNSTRUCTURED
-
-
-def test_domain_complies_with_request_cartesian():
-    assert Program._deduce_grid_type(GridType.CARTESIAN, {CartesianOffset}) == GridType.CARTESIAN
-    with pytest.raises(GTTypeError, match="unstructured.*FieldOffset.*found"):
-        Program._deduce_grid_type(GridType.CARTESIAN, {UnstructuredOffset})
-        Program._deduce_grid_type(GridType.CARTESIAN, {LocalDim})
-
-
-def test_domain_complies_with_request_unstructured():
-    assert (
-        Program._deduce_grid_type(GridType.UNSTRUCTURED, {UnstructuredOffset})
-        == GridType.UNSTRUCTURED
-    )
-    # unstructured is ok, even if we don't have unstructured offsets
-    assert (
-        Program._deduce_grid_type(GridType.UNSTRUCTURED, {CartesianOffset}) == GridType.UNSTRUCTURED
-    )
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ({CartesianOffset}, GridType.CARTESIAN),
+        ({Dim}, GridType.CARTESIAN),
+        ({UnstructuredOffset}, GridType.UNSTRUCTURED),
+        ({LocalDim}, GridType.UNSTRUCTURED),
+    ],
+)
+def test_domain_deduction(input: set[Dimension | FieldOffset], expected: GridType):
+    inputs_as_type = {make_symbol_type_from_value(el) for el in input}
+    assert _deduce_grid_type(inputs_as_type) == expected


### PR DESCRIPTION
The grid type used to determine whether `unstructured_domain` or `cartesian_domain` is emitted in PAST lowering is currently deduced in the `Program` decorator. This deduction should be the responsibility of the lowering and is hence moved to be located in the PAST -> ITIR lowering.