### PR TITLE
Enable `run_gtfn` by default in iterator_tests

### DIFF
--- a/tests/functional_tests/iterator_tests/conftest.py
+++ b/tests/functional_tests/iterator_tests/conftest.py
@@ -27,17 +27,24 @@ def pretty_format_and_check(root: itir.FencilDefinition, *args, **kwargs) -> str
     return pretty
 
 
+_common_processors = [
+    # (processor, do_validate)
+    (None, True),
+    (lisp.format_lisp, False),
+    (pretty_format_and_check, False),
+    (roundtrip.executor, True),
+    (type_check.check, False),
+    (double_roundtrip.executor, True),
+]
+_processors = [*_common_processors, (gtfn_cpu.run_gtfn, True)]
+_processors_no_gtfn_exec = [
+    *_common_processors,
+    (functional.fencil_processors.formatters.gtfn.format_sourcecode, False),
+]
+
+
 @pytest.fixture(
-    params=[
-        # (processor, do_validate)
-        (None, True),
-        (lisp.format_lisp, False),
-        (gtfn_cpu.run_gtfn, True),
-        (pretty_format_and_check, False),
-        (roundtrip.executor, True),
-        (type_check.check, False),
-        (double_roundtrip.executor, True),
-    ],
+    params=_processors,
     ids=lambda p: f"backend={p[0].__module__.split('.')[-1] + '.' + p[0].__name__ if p[0] else p[0]}",
 )
 def fencil_processor(request):
@@ -45,16 +52,7 @@ def fencil_processor(request):
 
 
 @pytest.fixture(
-    params=[
-        # (processor, do_validate)
-        (None, True),
-        (lisp.format_lisp, False),
-        (functional.fencil_processors.formatters.gtfn.format_sourcecode, False),
-        (pretty_format_and_check, False),
-        (roundtrip.executor, True),
-        (type_check.check, False),
-        (double_roundtrip.executor, True),
-    ],
+    params=_processors_no_gtfn_exec,
     ids=lambda p: f"backend={p[0].__module__.split('.')[-1] + '.' + p[0].__name__ if p[0] else p[0]}",
 )
 def fencil_processor_no_gtfn_exec(request):

--- a/tests/functional_tests/iterator_tests/conftest.py
+++ b/tests/functional_tests/iterator_tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import functional.fencil_processors.formatters.gtfn
 from functional.fencil_processors import type_check
 from functional.fencil_processors.formatters import lisp
-from functional.fencil_processors.runners import double_roundtrip, roundtrip
+from functional.fencil_processors.runners import double_roundtrip, gtfn_cpu, roundtrip
 from functional.iterator import ir as itir
 from functional.iterator.pretty_parser import pparse
 from functional.iterator.pretty_printer import pformat
@@ -32,7 +32,7 @@ def pretty_format_and_check(root: itir.FencilDefinition, *args, **kwargs) -> str
         # (processor, do_validate)
         (None, True),
         (lisp.format_lisp, False),
-        (functional.fencil_processors.formatters.gtfn.format_sourcecode, False),
+        (gtfn_cpu.run_gtfn, True),
         (pretty_format_and_check, False),
         (roundtrip.executor, True),
         (type_check.check, False),
@@ -41,6 +41,23 @@ def pretty_format_and_check(root: itir.FencilDefinition, *args, **kwargs) -> str
     ids=lambda p: f"backend={p[0].__module__.split('.')[-1] + '.' + p[0].__name__ if p[0] else p[0]}",
 )
 def fencil_processor(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        # (processor, do_validate)
+        (None, True),
+        (lisp.format_lisp, False),
+        (functional.fencil_processors.formatters.gtfn.format_sourcecode, False),
+        (pretty_format_and_check, False),
+        (roundtrip.executor, True),
+        (type_check.check, False),
+        (double_roundtrip.executor, True),
+    ],
+    ids=lambda p: f"backend={p[0].__module__.split('.')[-1] + '.' + p[0].__name__ if p[0] else p[0]}",
+)
+def fencil_processor_no_gtfn_exec(request):
     return request.param
 
 

--- a/tests/functional_tests/iterator_tests/test_anton_toy.py
+++ b/tests/functional_tests/iterator_tests/test_anton_toy.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pytest
 
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import cartesian_domain, deref, lift, named_range, shift
 from functional.iterator.embedded import np_as_located_field
 from functional.iterator.runtime import CartesianAxis, closure, fendef, fundef, offset
@@ -60,6 +62,10 @@ def naive_lap(inp):
 
 def test_anton_toy(fencil_processor, use_tmps):
     fencil_processor, validate = fencil_processor
+
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: this test does not validate")
+
     shape = [5, 7, 9]
     rng = np.random.default_rng()
     inp = np_as_located_field(IDim, JDim, KDim, origin={IDim: 1, JDim: 1, KDim: 0})(

--- a/tests/functional_tests/iterator_tests/test_builtins.py
+++ b/tests/functional_tests/iterator_tests/test_builtins.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from functional.fencil_processors import type_check
+from functional.fencil_processors.formatters.gtfn import format_sourcecode as gtfn_format_sourcecode
 from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import (
     and_,
@@ -136,7 +137,7 @@ def test_math_function_builtins(fencil_processor, builtin_name, inputs, as_colum
 
     fencil_processor, validate = fencil_processor
 
-    if fencil_processor == run_gtfn:
+    if fencil_processor == run_gtfn or fencil_processor == gtfn_format_sourcecode:
         pytest.xfail("Support for math builtins comes in separate PR.")
     if fencil_processor == type_check.check:
         pytest.xfail("type inference does not yet support math builtins")

--- a/tests/functional_tests/iterator_tests/test_builtins.py
+++ b/tests/functional_tests/iterator_tests/test_builtins.py
@@ -5,11 +5,11 @@ import numpy as np
 import pytest
 
 from functional.fencil_processors import type_check
-from functional.fencil_processors.formatters.gtfn import format_sourcecode as gtfn_format_sourcecode
-from functional.fencil_processors.runners import gtfn_cpu
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import (
     and_,
     can_deref,
+    cartesian_domain,
     deref,
     divides,
     eq,
@@ -19,16 +19,13 @@ from functional.iterator.builtins import (
     lift,
     minus,
     multiplies,
+    named_range,
     not_,
     or_,
     plus,
     shift,
 )
-from functional.iterator.embedded import (
-    NeighborTableOffsetProvider,
-    index_field,
-    np_as_located_field,
-)
+from functional.iterator.embedded import NeighborTableOffsetProvider, np_as_located_field
 from functional.iterator.runtime import CartesianAxis, closure, fendef, fundef, offset
 
 from .conftest import run_processor
@@ -64,8 +61,8 @@ def fencil(builtin, out, *inps, processor, as_column=False):
             return builtin(deref(arg0))
 
         @fendef(offset_provider={}, column_axis=column_axis)
-        def fenimpl(dom, arg0, out):
-            closure(dom, sten, out, [arg0])
+        def fenimpl(size, arg0, out):
+            closure(cartesian_domain(named_range(IDim, 0, size)), sten, out, [arg0])
 
     elif len(inps) == 2:
 
@@ -74,8 +71,8 @@ def fencil(builtin, out, *inps, processor, as_column=False):
             return builtin(deref(arg0), deref(arg1))
 
         @fendef(offset_provider={}, column_axis=column_axis)
-        def fenimpl(dom, arg0, arg1, out):
-            closure(dom, sten, out, [arg0, arg1])
+        def fenimpl(size, arg0, arg1, out):
+            closure(cartesian_domain(named_range(IDim, 0, size)), sten, out, [arg0, arg1])
 
     elif len(inps) == 3:
 
@@ -84,13 +81,13 @@ def fencil(builtin, out, *inps, processor, as_column=False):
             return builtin(deref(arg0), deref(arg1), deref(arg2))
 
         @fendef(offset_provider={}, column_axis=column_axis)
-        def fenimpl(dom, arg0, arg1, arg2, out):
-            closure(dom, sten, out, [arg0, arg1, arg2])
+        def fenimpl(size, arg0, arg1, arg2, out):
+            closure(cartesian_domain(named_range(IDim, 0, size)), sten, out, [arg0, arg1, arg2])
 
     else:
         raise AssertionError("Add overload")
 
-    return run_processor(fenimpl, processor, {IDim: range(out.shape[0])}, *inps, out)
+    return run_processor(fenimpl, processor, out.shape[0], *inps, out)
 
 
 @pytest.mark.parametrize("as_column", [False, True])
@@ -139,8 +136,8 @@ def test_math_function_builtins(fencil_processor, builtin_name, inputs, as_colum
 
     fencil_processor, validate = fencil_processor
 
-    if fencil_processor == gtfn_format_sourcecode:
-        pytest.xfail("gtfn does not yet support math builtins")
+    if fencil_processor == run_gtfn:
+        pytest.xfail("Support for math builtins comes in separate PR.")
     if fencil_processor == type_check.check:
         pytest.xfail("type inference does not yet support math builtins")
 
@@ -188,6 +185,9 @@ def _can_deref_lifted(inp):
 @pytest.mark.parametrize("stencil", [_can_deref, _can_deref_lifted])
 def test_can_deref(fencil_processor, stencil):
     fencil_processor, validate = fencil_processor
+
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: gtfn bindings don't support unstructured")
 
     Node = CartesianAxis("Node")
 

--- a/tests/functional_tests/iterator_tests/test_column_stencil.py
+++ b/tests/functional_tests/iterator_tests/test_column_stencil.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
 
-import functional.fencil_processors.formatters.gtfn
 from functional.common import Dimension
-from functional.fencil_processors.formatters import gtfn
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import *
 from functional.iterator.embedded import np_as_located_field
 from functional.iterator.runtime import closure, fendef, fundef, offset
@@ -61,6 +60,9 @@ def test_column_stencil(fencil_processor, use_tmps):
 
 def test_column_stencil_with_k_origin(fencil_processor, use_tmps):
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("origin not yet supported in gtfn")
+
     shape = [5, 7]
     raw_inp = np.fromfunction(lambda i, k: i * 10 + k, [shape[0] + 1, shape[1] + 2])
     inp = np_as_located_field(IDim, KDim, origin={IDim: 0, KDim: 1})(raw_inp)
@@ -107,7 +109,7 @@ def test_ksum_scan(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == functional.fencil_processors.formatters.gtfn.format_sourcecode:
+    if fencil_processor == run_gtfn:
         pytest.xfail("gtfn does not yet support scans")
     shape = [1, 7]
     inp = np_as_located_field(IDim, KDim)(np.asarray([list(range(7))]))
@@ -149,7 +151,7 @@ def test_ksum_back_scan(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == functional.fencil_processors.formatters.gtfn.format_sourcecode:
+    if fencil_processor == run_gtfn:
         pytest.xfail("gtfn does not yet support scans")
     shape = [1, 7]
     inp = np_as_located_field(IDim, KDim)(np.asarray([list(range(7))]))
@@ -196,7 +198,7 @@ def test_kdoublesum_scan(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == gtfn.format_sourcecode:
+    if fencil_processor == run_gtfn:
         pytest.xfail("gtfn does not yet support scans")
     shape = [1, 7]
     inp0 = np_as_located_field(IDim, KDim)(np.asarray([list(range(7))], dtype=np.float64))

--- a/tests/functional_tests/iterator_tests/test_column_stencil.py
+++ b/tests/functional_tests/iterator_tests/test_column_stencil.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from functional.common import Dimension
+from functional.fencil_processors.formatters.gtfn import format_sourcecode as gtfn_format_sourcecode
 from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import *
 from functional.iterator.embedded import np_as_located_field
@@ -109,7 +110,7 @@ def test_ksum_scan(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == run_gtfn:
+    if fencil_processor == run_gtfn or fencil_processor == gtfn_format_sourcecode:
         pytest.xfail("gtfn does not yet support scans")
     shape = [1, 7]
     inp = np_as_located_field(IDim, KDim)(np.asarray([list(range(7))]))
@@ -151,7 +152,7 @@ def test_ksum_back_scan(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == run_gtfn:
+    if fencil_processor == run_gtfn or fencil_processor == gtfn_format_sourcecode:
         pytest.xfail("gtfn does not yet support scans")
     shape = [1, 7]
     inp = np_as_located_field(IDim, KDim)(np.asarray([list(range(7))]))
@@ -198,7 +199,7 @@ def test_kdoublesum_scan(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == run_gtfn:
+    if fencil_processor == run_gtfn or fencil_processor == gtfn_format_sourcecode:
         pytest.xfail("gtfn does not yet support scans")
     shape = [1, 7]
     inp0 = np_as_located_field(IDim, KDim)(np.asarray([list(range(7))], dtype=np.float64))

--- a/tests/functional_tests/iterator_tests/test_fvm_nabla.py
+++ b/tests/functional_tests/iterator_tests/test_fvm_nabla.py
@@ -20,6 +20,7 @@ from .conftest import run_processor
 pytest.importorskip("atlas4py")
 
 from functional.common import Dimension
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator import library
 from functional.iterator.atlas_utils import AtlasTable
 from functional.iterator.builtins import *
@@ -126,6 +127,8 @@ def test_compute_zavgS(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently only supported for cartesian")
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: gtfn bindings don't support unstructured")
     setup = nabla_setup()
 
     pp = np_as_located_field(Vertex)(setup.input_field)
@@ -184,6 +187,8 @@ def test_compute_zavgS2(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently only supported for cartesian")
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: gtfn bindings don't support unstructured")
     setup = nabla_setup()
 
     pp = np_as_located_field(Vertex)(setup.input_field)
@@ -222,6 +227,8 @@ def test_nabla(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently only supported for cartesian")
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: gtfn bindings don't support unstructured")
     setup = nabla_setup()
 
     sign = np_as_located_field(Vertex, V2E)(setup.sign_field)
@@ -276,6 +283,8 @@ def nabla2(
 def test_nabla2(fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently only supported for cartesian")
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: gtfn bindings don't support unstructured")
     fencil_processor, validate = fencil_processor
     setup = nabla_setup()
 
@@ -359,6 +368,8 @@ def test_nabla_sign(fencil_processor, use_tmps):
         pytest.xfail("use_tmps currently only supported for cartesian")
 
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("TODO: gtfn bindings don't support unstructured")
     setup = nabla_setup()
 
     # sign = np_as_located_field(Vertex, V2E)(setup.sign_field)

--- a/tests/functional_tests/iterator_tests/test_hdiff.py
+++ b/tests/functional_tests/iterator_tests/test_hdiff.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 from functional.common import Dimension
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import *
 from functional.iterator.embedded import np_as_located_field
 from functional.iterator.runtime import closure, fendef, fundef, offset
@@ -58,6 +60,9 @@ def hdiff(inp, coeff, out, x, y):
 
 def test_hdiff(hdiff_reference, fencil_processor, use_tmps):
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("origin not yet supported in gtfn")
+
     inp, coeff, out = hdiff_reference
     shape = (out.shape[0], out.shape[1])
 

--- a/tests/functional_tests/iterator_tests/test_toy_connectivity.py
+++ b/tests/functional_tests/iterator_tests/test_toy_connectivity.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from functional.common import Dimension
-from functional.fencil_processor_no_gtfn_execs.formatters import gtfn
+from functional.fencil_processors.formatters import gtfn
 from functional.iterator.builtins import deref, lift, reduce, shift
 from functional.iterator.embedded import (
     NeighborTableOffsetProvider,

--- a/tests/functional_tests/iterator_tests/test_toy_connectivity.py
+++ b/tests/functional_tests/iterator_tests/test_toy_connectivity.py
@@ -111,14 +111,14 @@ def sum_edges_to_vertices(in_edges):
 
 
 def test_sum_edges_to_vertices(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Edge)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
     run_processor(
         sum_edges_to_vertices[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
@@ -133,14 +133,14 @@ def sum_edges_to_vertices_reduce(in_edges):
 
 
 def test_sum_edges_to_vertices_reduce(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Edge)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
     run_processor(
         sum_edges_to_vertices_reduce[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
@@ -155,14 +155,14 @@ def first_vertex_neigh_of_first_edge_neigh_of_cells(in_vertices):
 
 
 def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Vertex)
     out = np_as_located_field(Cell)(np.zeros([9]))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
     run_processor(
         first_vertex_neigh_of_first_edge_neigh_of_cells[{Cell: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={
@@ -180,7 +180,7 @@ def sparse_stencil(non_sparse, inp):
 
 
 def test_sparse_input_field(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     non_sparse = np_as_located_field(Edge)(np.zeros(18))
     inp = np_as_located_field(Vertex, V2E)(np.asarray([[1, 2, 3, 4]] * 9))
     out = np_as_located_field(Vertex)(np.zeros([9]))
@@ -189,7 +189,7 @@ def test_sparse_input_field(fencil_processor_no_gtfn_exec):
 
     run_processor(
         sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         non_sparse,
         inp,
         out=out,
@@ -204,7 +204,7 @@ V2V = offset("V2V")
 
 
 def test_sparse_input_field_v2v(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     non_sparse = np_as_located_field(Edge)(np.zeros(9))
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
@@ -213,7 +213,7 @@ def test_sparse_input_field_v2v(fencil_processor_no_gtfn_exec):
 
     run_processor(
         sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         non_sparse,
         inp,
         out=out,
@@ -233,7 +233,7 @@ def slice_sparse_stencil(sparse):
 
 
 def test_slice_sparse(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
@@ -241,7 +241,7 @@ def test_slice_sparse(fencil_processor_no_gtfn_exec):
 
     run_processor(
         slice_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={
@@ -259,14 +259,14 @@ def slice_twice_sparse_stencil(sparse):
 
 
 def test_slice_twice_sparse(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V, V2V)(v2v_arr[v2v_arr])
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
     ref = v2v_arr[v2v_arr][:, 2, 1]
     run_processor(
         slice_twice_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={
@@ -284,7 +284,7 @@ def shift_sliced_sparse_stencil(sparse):
 
 
 def test_shift_sliced_sparse(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
@@ -292,7 +292,7 @@ def test_shift_sliced_sparse(fencil_processor_no_gtfn_exec):
 
     run_processor(
         shift_sliced_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={
@@ -310,7 +310,7 @@ def slice_shifted_sparse_stencil(sparse):
 
 
 def test_slice_shifted_sparse(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
@@ -318,7 +318,7 @@ def test_slice_shifted_sparse(fencil_processor_no_gtfn_exec):
 
     run_processor(
         slice_shifted_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={
@@ -341,14 +341,14 @@ def lift_stencil(inp):
 
 
 def test_lift(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Vertex)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 
     run_processor(
         lift_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
@@ -363,14 +363,14 @@ def sparse_shifted_stencil(inp):
 
 
 def test_shift_sparse_input_field(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 
     run_processor(
         sparse_shifted_stencil[{Vertex: range(0, 9)}],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
@@ -391,7 +391,7 @@ def shift_sparse_stencil2(inp):
 
 
 def test_shift_sparse_input_field2(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Vertex)
     inp_sparse = np_as_located_field(Edge, E2V)(e2v_arr)
     out1 = np_as_located_field(Vertex)(np.zeros([9]))
@@ -405,14 +405,14 @@ def test_shift_sparse_input_field2(fencil_processor_no_gtfn_exec):
     domain = {Vertex: range(0, 9)}
     run_processor(
         shift_shift_stencil2[domain],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out1,
         offset_provider=offset_provider,
     )
     run_processor(
         shift_sparse_stencil2[domain],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp_sparse,
         out=out2,
         offset_provider=offset_provider,
@@ -432,8 +432,8 @@ def sparse_shifted_stencil_reduce(inp):
 
 
 def test_sparse_shifted_stencil_reduce(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
-    if fencil_processor_no_gtfn_exec == gtfn.format_sourcecode:
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
+    if fencil_processor == gtfn.format_sourcecode:
         pytest.xfail("We cannot unroll a reduction on a sparse field only.")
         # With our current understanding, this iterator IR program is illegal, however we might want to fix it and therefore keep the test for now.
 
@@ -452,7 +452,7 @@ def test_sparse_shifted_stencil_reduce(fencil_processor_no_gtfn_exec):
     domain = {Vertex: range(0, 9)}
     run_processor(
         sparse_shifted_stencil_reduce[domain],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},

--- a/tests/functional_tests/iterator_tests/test_toy_connectivity.py
+++ b/tests/functional_tests/iterator_tests/test_toy_connectivity.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from functional.common import Dimension
-from functional.fencil_processors.formatters import gtfn
+from functional.fencil_processor_no_gtfn_execs.formatters import gtfn
 from functional.iterator.builtins import deref, lift, reduce, shift
 from functional.iterator.embedded import (
     NeighborTableOffsetProvider,
@@ -110,15 +110,15 @@ def sum_edges_to_vertices(in_edges):
     )
 
 
-def test_sum_edges_to_vertices(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_sum_edges_to_vertices(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Edge)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
     run_processor(
         sum_edges_to_vertices[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
@@ -132,15 +132,15 @@ def sum_edges_to_vertices_reduce(in_edges):
     return reduce(lambda a, b: a + b, 0)(shift(V2E)(in_edges))
 
 
-def test_sum_edges_to_vertices_reduce(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_sum_edges_to_vertices_reduce(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Edge)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
     run_processor(
         sum_edges_to_vertices_reduce[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={"V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4)},
@@ -154,15 +154,15 @@ def first_vertex_neigh_of_first_edge_neigh_of_cells(in_vertices):
     return deref(shift(E2V, 0)(shift(C2E, 0)(in_vertices)))
 
 
-def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Vertex)
     out = np_as_located_field(Cell)(np.zeros([9]))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
     run_processor(
         first_vertex_neigh_of_first_edge_neigh_of_cells[{Cell: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={
@@ -179,8 +179,8 @@ def sparse_stencil(non_sparse, inp):
     return reduce(lambda a, b, c: a + c, 0)(shift(V2E)(non_sparse), inp)
 
 
-def test_sparse_input_field(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_sparse_input_field(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     non_sparse = np_as_located_field(Edge)(np.zeros(18))
     inp = np_as_located_field(Vertex, V2E)(np.asarray([[1, 2, 3, 4]] * 9))
     out = np_as_located_field(Vertex)(np.zeros([9]))
@@ -189,7 +189,7 @@ def test_sparse_input_field(fencil_processor):
 
     run_processor(
         sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         non_sparse,
         inp,
         out=out,
@@ -203,8 +203,8 @@ def test_sparse_input_field(fencil_processor):
 V2V = offset("V2V")
 
 
-def test_sparse_input_field_v2v(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_sparse_input_field_v2v(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     non_sparse = np_as_located_field(Edge)(np.zeros(9))
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
@@ -213,7 +213,7 @@ def test_sparse_input_field_v2v(fencil_processor):
 
     run_processor(
         sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         non_sparse,
         inp,
         out=out,
@@ -232,8 +232,8 @@ def slice_sparse_stencil(sparse):
     return deref(shift(1)(sparse))
 
 
-def test_slice_sparse(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_slice_sparse(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
@@ -241,7 +241,7 @@ def test_slice_sparse(fencil_processor):
 
     run_processor(
         slice_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={
@@ -258,15 +258,15 @@ def slice_twice_sparse_stencil(sparse):
     return deref(shift(2)(shift(1)(sparse)))
 
 
-def test_slice_twice_sparse(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_slice_twice_sparse(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V, V2V)(v2v_arr[v2v_arr])
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
     ref = v2v_arr[v2v_arr][:, 2, 1]
     run_processor(
         slice_twice_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={
@@ -283,8 +283,8 @@ def shift_sliced_sparse_stencil(sparse):
     return deref(shift(V2V, 0)(shift(1)(sparse)))
 
 
-def test_shift_sliced_sparse(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_shift_sliced_sparse(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
@@ -292,7 +292,7 @@ def test_shift_sliced_sparse(fencil_processor):
 
     run_processor(
         shift_sliced_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={
@@ -309,8 +309,8 @@ def slice_shifted_sparse_stencil(sparse):
     return deref(shift(1)(shift(V2V, 0)(sparse)))
 
 
-def test_slice_shifted_sparse(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_slice_shifted_sparse(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
 
@@ -318,7 +318,7 @@ def test_slice_shifted_sparse(fencil_processor):
 
     run_processor(
         slice_shifted_sparse_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={
@@ -340,15 +340,15 @@ def lift_stencil(inp):
     return deref(shift(V2V, 2)(lift(deref_stencil)(inp)))
 
 
-def test_lift(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_lift(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Vertex)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 
     run_processor(
         lift_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
@@ -362,15 +362,15 @@ def sparse_shifted_stencil(inp):
     return deref(shift(0, 2)(shift(V2V)(inp)))
 
 
-def test_shift_sparse_input_field(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_shift_sparse_input_field(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 
     run_processor(
         sparse_shifted_stencil[{Vertex: range(0, 9)}],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},
@@ -390,8 +390,8 @@ def shift_sparse_stencil2(inp):
     return deref(shift(3, 1)(shift(V2E)(inp)))
 
 
-def test_shift_sparse_input_field2(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_shift_sparse_input_field2(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
     inp = index_field(Vertex)
     inp_sparse = np_as_located_field(Edge, E2V)(e2v_arr)
     out1 = np_as_located_field(Vertex)(np.zeros([9]))
@@ -405,14 +405,14 @@ def test_shift_sparse_input_field2(fencil_processor):
     domain = {Vertex: range(0, 9)}
     run_processor(
         shift_shift_stencil2[domain],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out1,
         offset_provider=offset_provider,
     )
     run_processor(
         shift_sparse_stencil2[domain],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp_sparse,
         out=out2,
         offset_provider=offset_provider,
@@ -431,9 +431,9 @@ def sparse_shifted_stencil_reduce(inp):
     return reduce(sum_, 0)(shift(V2V)(lift(reduce(sum_, 0))(inp)))
 
 
-def test_sparse_shifted_stencil_reduce(fencil_processor):
-    fencil_processor, validate = fencil_processor
-    if fencil_processor == gtfn.format_sourcecode:
+def test_sparse_shifted_stencil_reduce(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    if fencil_processor_no_gtfn_exec == gtfn.format_sourcecode:
         pytest.xfail("We cannot unroll a reduction on a sparse field only.")
         # With our current understanding, this iterator IR program is illegal, however we might want to fix it and therefore keep the test for now.
 
@@ -452,7 +452,7 @@ def test_sparse_shifted_stencil_reduce(fencil_processor):
     domain = {Vertex: range(0, 9)}
     run_processor(
         sparse_shifted_stencil_reduce[domain],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={"V2V": NeighborTableOffsetProvider(v2v_arr, Vertex, Vertex, 4)},

--- a/tests/functional_tests/iterator_tests/test_trivial.py
+++ b/tests/functional_tests/iterator_tests/test_trivial.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 from functional.common import Dimension
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import *
 from functional.iterator.embedded import np_as_located_field
 from functional.iterator.runtime import closure, fendef, fundef, offset
@@ -32,6 +34,10 @@ def baz(baz_inp):
 
 def test_trivial(fencil_processor, use_tmps):
     fencil_processor, validate = fencil_processor
+
+    if fencil_processor == run_gtfn:
+        pytest.xfail("origin not yet supported in gtfn")
+
     rng = np.random.default_rng()
     inp = rng.uniform(size=(5, 7, 9))
     out = np.copy(inp)
@@ -68,6 +74,9 @@ def fen_direct_deref(i_size, j_size, out, inp):
 
 def test_direct_deref(fencil_processor, use_tmps):
     fencil_processor, validate = fencil_processor
+    if fencil_processor == run_gtfn:
+        pytest.xfail("extract_fundefs_from_closures() doesn't work for builtins in gtfn")
+
     rng = np.random.default_rng()
     inp = rng.uniform(size=(5, 7))
     out = np.copy(inp)

--- a/tests/functional_tests/iterator_tests/test_tuple.py
+++ b/tests/functional_tests/iterator_tests/test_tuple.py
@@ -36,7 +36,7 @@ def tuple_output2(inp1, inp2):
     [tuple_output1, tuple_output2],
 )
 def test_tuple_output(fencil_processor_no_gtfn_exec, stencil):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -57,16 +57,14 @@ def test_tuple_output(fencil_processor_no_gtfn_exec, stencil):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(
-        stencil[dom], fencil_processor_no_gtfn_exec, inp1, inp2, out=out, offset_provider={}
-    )
+    run_processor(stencil[dom], fencil_processor, inp1, inp2, out=out, offset_provider={})
     if validate:
         assert np.allclose(inp1, out[0])
         assert np.allclose(inp2, out[1])
 
 
 def test_tuple_of_field_of_tuple_output(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     @fundef
     def stencil(inp1, inp2, inp3, inp4):
@@ -100,7 +98,7 @@ def test_tuple_of_field_of_tuple_output(fencil_processor_no_gtfn_exec):
     }
     run_processor(
         stencil[dom],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp1,
         inp2,
         inp3,
@@ -116,7 +114,7 @@ def test_tuple_of_field_of_tuple_output(fencil_processor_no_gtfn_exec):
 
 
 def test_tuple_of_tuple_of_field_output(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     @fundef
     def stencil(inp1, inp2, inp3, inp4):
@@ -155,7 +153,7 @@ def test_tuple_of_tuple_of_field_output(fencil_processor_no_gtfn_exec):
     }
     run_processor(
         stencil[dom],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp1,
         inp2,
         inp3,
@@ -175,7 +173,7 @@ def test_tuple_of_tuple_of_field_output(fencil_processor_no_gtfn_exec):
     [tuple_output1, tuple_output2],
 )
 def test_field_of_tuple_output(fencil_processor_no_gtfn_exec, stencil):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -194,9 +192,7 @@ def test_field_of_tuple_output(fencil_processor_no_gtfn_exec, stencil):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(
-        stencil[dom], fencil_processor_no_gtfn_exec, inp1, inp2, out=out, offset_provider={}
-    )
+    run_processor(stencil[dom], fencil_processor, inp1, inp2, out=out, offset_provider={})
     if validate:
         assert np.allclose(inp1, out_np[:]["f0"])
         assert np.allclose(inp2, out_np[:]["f1"])
@@ -207,7 +203,7 @@ def test_field_of_tuple_output(fencil_processor_no_gtfn_exec, stencil):
     [tuple_output1, tuple_output2],
 )
 def test_field_of_extra_dim_output(fencil_processor_no_gtfn_exec, stencil):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -226,9 +222,7 @@ def test_field_of_extra_dim_output(fencil_processor_no_gtfn_exec, stencil):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(
-        stencil[dom], fencil_processor_no_gtfn_exec, inp1, inp2, out=out, offset_provider={}
-    )
+    run_processor(stencil[dom], fencil_processor, inp1, inp2, out=out, offset_provider={})
     if validate:
         assert np.allclose(inp1, out_np[:, :, :, 0])
         assert np.allclose(inp2, out_np[:, :, :, 1])
@@ -241,7 +235,7 @@ def tuple_input(inp):
 
 
 def test_tuple_field_input(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -259,15 +253,13 @@ def test_tuple_field_input(fencil_processor_no_gtfn_exec):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(
-        tuple_input[dom], fencil_processor_no_gtfn_exec, (inp1, inp2), out=out, offset_provider={}
-    )
+    run_processor(tuple_input[dom], fencil_processor, (inp1, inp2), out=out, offset_provider={})
     if validate:
         assert np.allclose(np.asarray(inp1) + np.asarray(inp2), out)
 
 
 def test_field_of_tuple_input(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -288,13 +280,13 @@ def test_field_of_tuple_input(fencil_processor_no_gtfn_exec):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(tuple_input[dom], fencil_processor_no_gtfn_exec, inp, out=out, offset_provider={})
+    run_processor(tuple_input[dom], fencil_processor, inp, out=out, offset_provider={})
     if validate:
         assert np.allclose(np.asarray(inp1) + np.asarray(inp2), out)
 
 
 def test_field_of_extra_dim_input(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -311,7 +303,7 @@ def test_field_of_extra_dim_input(fencil_processor_no_gtfn_exec):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(tuple_input[dom], fencil_processor_no_gtfn_exec, inp, out=out, offset_provider={})
+    run_processor(tuple_input[dom], fencil_processor, inp, out=out, offset_provider={})
     if validate:
         assert np.allclose(np.asarray(inp1) + np.asarray(inp2), out)
 
@@ -328,7 +320,7 @@ def tuple_tuple_input(inp):
 
 
 def test_tuple_of_field_of_tuple_input(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -351,7 +343,7 @@ def test_tuple_of_field_of_tuple_input(fencil_processor_no_gtfn_exec):
     }
     run_processor(
         tuple_tuple_input[dom],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         (inp, inp),
         out=out,
         offset_provider={},
@@ -361,7 +353,7 @@ def test_tuple_of_field_of_tuple_input(fencil_processor_no_gtfn_exec):
 
 
 def test_tuple_of_tuple_of_field_input(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -380,7 +372,7 @@ def test_tuple_of_tuple_of_field_input(fencil_processor_no_gtfn_exec):
     }
     run_processor(
         tuple_tuple_input[dom],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         ((inp1, inp2), (inp3, inp4)),
         out=out,
         offset_provider={},
@@ -392,7 +384,7 @@ def test_tuple_of_tuple_of_field_input(fencil_processor_no_gtfn_exec):
 
 
 def test_field_of_2_extra_dim_input(fencil_processor_no_gtfn_exec):
-    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
+    fencil_processor, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -410,7 +402,7 @@ def test_field_of_2_extra_dim_input(fencil_processor_no_gtfn_exec):
     }
     run_processor(
         tuple_tuple_input[dom],
-        fencil_processor_no_gtfn_exec,
+        fencil_processor,
         inp,
         out=out,
         offset_provider={},

--- a/tests/functional_tests/iterator_tests/test_tuple.py
+++ b/tests/functional_tests/iterator_tests/test_tuple.py
@@ -35,8 +35,8 @@ def tuple_output2(inp1, inp2):
     "stencil",
     [tuple_output1, tuple_output2],
 )
-def test_tuple_output(fencil_processor, stencil):
-    fencil_processor, validate = fencil_processor
+def test_tuple_output(fencil_processor_no_gtfn_exec, stencil):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -57,14 +57,16 @@ def test_tuple_output(fencil_processor, stencil):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(stencil[dom], fencil_processor, inp1, inp2, out=out, offset_provider={})
+    run_processor(
+        stencil[dom], fencil_processor_no_gtfn_exec, inp1, inp2, out=out, offset_provider={}
+    )
     if validate:
         assert np.allclose(inp1, out[0])
         assert np.allclose(inp2, out[1])
 
 
-def test_tuple_of_field_of_tuple_output(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_tuple_of_field_of_tuple_output(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     @fundef
     def stencil(inp1, inp2, inp3, inp4):
@@ -97,7 +99,14 @@ def test_tuple_of_field_of_tuple_output(fencil_processor):
         KDim: range(0, shape[2]),
     }
     run_processor(
-        stencil[dom], fencil_processor, inp1, inp2, inp3, inp4, out=out, offset_provider={}
+        stencil[dom],
+        fencil_processor_no_gtfn_exec,
+        inp1,
+        inp2,
+        inp3,
+        inp4,
+        out=out,
+        offset_provider={},
     )
     if validate:
         assert np.allclose(inp1, out_np1[:]["f0"])
@@ -106,8 +115,8 @@ def test_tuple_of_field_of_tuple_output(fencil_processor):
         assert np.allclose(inp4, out_np2[:]["f1"])
 
 
-def test_tuple_of_tuple_of_field_output(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_tuple_of_tuple_of_field_output(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     @fundef
     def stencil(inp1, inp2, inp3, inp4):
@@ -145,7 +154,14 @@ def test_tuple_of_tuple_of_field_output(fencil_processor):
         KDim: range(0, shape[2]),
     }
     run_processor(
-        stencil[dom], fencil_processor, inp1, inp2, inp3, inp4, out=out, offset_provider={}
+        stencil[dom],
+        fencil_processor_no_gtfn_exec,
+        inp1,
+        inp2,
+        inp3,
+        inp4,
+        out=out,
+        offset_provider={},
     )
     if validate:
         assert np.allclose(inp1, out[0][0])
@@ -158,8 +174,8 @@ def test_tuple_of_tuple_of_field_output(fencil_processor):
     "stencil",
     [tuple_output1, tuple_output2],
 )
-def test_field_of_tuple_output(fencil_processor, stencil):
-    fencil_processor, validate = fencil_processor
+def test_field_of_tuple_output(fencil_processor_no_gtfn_exec, stencil):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -178,7 +194,9 @@ def test_field_of_tuple_output(fencil_processor, stencil):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(stencil[dom], fencil_processor, inp1, inp2, out=out, offset_provider={})
+    run_processor(
+        stencil[dom], fencil_processor_no_gtfn_exec, inp1, inp2, out=out, offset_provider={}
+    )
     if validate:
         assert np.allclose(inp1, out_np[:]["f0"])
         assert np.allclose(inp2, out_np[:]["f1"])
@@ -188,8 +206,8 @@ def test_field_of_tuple_output(fencil_processor, stencil):
     "stencil",
     [tuple_output1, tuple_output2],
 )
-def test_field_of_extra_dim_output(fencil_processor, stencil):
-    fencil_processor, validate = fencil_processor
+def test_field_of_extra_dim_output(fencil_processor_no_gtfn_exec, stencil):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -208,7 +226,9 @@ def test_field_of_extra_dim_output(fencil_processor, stencil):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(stencil[dom], fencil_processor, inp1, inp2, out=out, offset_provider={})
+    run_processor(
+        stencil[dom], fencil_processor_no_gtfn_exec, inp1, inp2, out=out, offset_provider={}
+    )
     if validate:
         assert np.allclose(inp1, out_np[:, :, :, 0])
         assert np.allclose(inp2, out_np[:, :, :, 1])
@@ -220,8 +240,8 @@ def tuple_input(inp):
     return tuple_get(0, inp_deref) + tuple_get(1, inp_deref)
 
 
-def test_tuple_field_input(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_tuple_field_input(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -239,13 +259,15 @@ def test_tuple_field_input(fencil_processor):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(tuple_input[dom], fencil_processor, (inp1, inp2), out=out, offset_provider={})
+    run_processor(
+        tuple_input[dom], fencil_processor_no_gtfn_exec, (inp1, inp2), out=out, offset_provider={}
+    )
     if validate:
         assert np.allclose(np.asarray(inp1) + np.asarray(inp2), out)
 
 
-def test_field_of_tuple_input(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_field_of_tuple_input(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -266,13 +288,13 @@ def test_field_of_tuple_input(fencil_processor):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(tuple_input[dom], fencil_processor, inp, out=out, offset_provider={})
+    run_processor(tuple_input[dom], fencil_processor_no_gtfn_exec, inp, out=out, offset_provider={})
     if validate:
         assert np.allclose(np.asarray(inp1) + np.asarray(inp2), out)
 
 
-def test_field_of_extra_dim_input(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_field_of_extra_dim_input(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -289,7 +311,7 @@ def test_field_of_extra_dim_input(fencil_processor):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(tuple_input[dom], fencil_processor, inp, out=out, offset_provider={})
+    run_processor(tuple_input[dom], fencil_processor_no_gtfn_exec, inp, out=out, offset_provider={})
     if validate:
         assert np.allclose(np.asarray(inp1) + np.asarray(inp2), out)
 
@@ -305,8 +327,8 @@ def tuple_tuple_input(inp):
     )
 
 
-def test_tuple_of_field_of_tuple_input(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_tuple_of_field_of_tuple_input(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -327,13 +349,19 @@ def test_tuple_of_field_of_tuple_input(fencil_processor):
         JDim: range(0, shape[1]),
         KDim: range(0, shape[2]),
     }
-    run_processor(tuple_tuple_input[dom], fencil_processor, (inp, inp), out=out, offset_provider={})
+    run_processor(
+        tuple_tuple_input[dom],
+        fencil_processor_no_gtfn_exec,
+        (inp, inp),
+        out=out,
+        offset_provider={},
+    )
     if validate:
         assert np.allclose(2.0 * (np.asarray(inp1) + np.asarray(inp2)), out)
 
 
-def test_tuple_of_tuple_of_field_input(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_tuple_of_tuple_of_field_input(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -352,7 +380,7 @@ def test_tuple_of_tuple_of_field_input(fencil_processor):
     }
     run_processor(
         tuple_tuple_input[dom],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         ((inp1, inp2), (inp3, inp4)),
         out=out,
         offset_provider={},
@@ -363,8 +391,8 @@ def test_tuple_of_tuple_of_field_input(fencil_processor):
         )
 
 
-def test_field_of_2_extra_dim_input(fencil_processor):
-    fencil_processor, validate = fencil_processor
+def test_field_of_2_extra_dim_input(fencil_processor_no_gtfn_exec):
+    fencil_processor_no_gtfn_exec, validate = fencil_processor_no_gtfn_exec
 
     shape = [5, 7, 9]
     rng = np.random.default_rng()
@@ -382,7 +410,7 @@ def test_field_of_2_extra_dim_input(fencil_processor):
     }
     run_processor(
         tuple_tuple_input[dom],
-        fencil_processor,
+        fencil_processor_no_gtfn_exec,
         inp,
         out=out,
         offset_provider={},

--- a/tests/functional_tests/iterator_tests/test_vertical_advection.py
+++ b/tests/functional_tests/iterator_tests/test_vertical_advection.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
 
-import functional.fencil_processors.formatters.gtfn
 from functional.common import Dimension
-from functional.fencil_processors.codegens import gtfn
+from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import *
 from functional.iterator.embedded import np_as_located_field
 from functional.iterator.runtime import closure, fendef, fundef
@@ -74,7 +73,7 @@ def test_tridiag(tridiag_reference, fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == functional.fencil_processors.formatters.gtfn.format_sourcecode:
+    if fencil_processor == run_gtfn:
         pytest.xfail("gtfn does not yet support scans")
     a, b, c, d, x = tridiag_reference
     shape = a.shape

--- a/tests/functional_tests/iterator_tests/test_vertical_advection.py
+++ b/tests/functional_tests/iterator_tests/test_vertical_advection.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from functional.common import Dimension
+from functional.fencil_processors.formatters.gtfn import format_sourcecode as gtfn_format_sourcecode
 from functional.fencil_processors.runners.gtfn_cpu import run_gtfn
 from functional.iterator.builtins import *
 from functional.iterator.embedded import np_as_located_field
@@ -73,7 +74,7 @@ def test_tridiag(tridiag_reference, fencil_processor, use_tmps):
     if use_tmps:
         pytest.xfail("use_tmps currently not supported for scans")
     fencil_processor, validate = fencil_processor
-    if fencil_processor == run_gtfn:
+    if fencil_processor == run_gtfn or fencil_processor == gtfn_format_sourcecode:
         pytest.xfail("gtfn does not yet support scans")
     a, b, c, d, x = tridiag_reference
     shape = a.shape


### PR DESCRIPTION
Disables tests that are not supported yet:
- scan
- using `origin` attribute in field
- tuples in interface
- ...