### PR TITLE
Embedded backend performance improvements

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -20,7 +20,6 @@ from typing import (
     TypeAlias,
     TypeGuard,
     Union,
-    cast,
     runtime_checkable,
 )
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -668,7 +668,7 @@ def get_ordered_indices(
             if isinstance(elem, list):
                 pos = copy.copy(pos)  # copy such that we can modify
                 # we consume a sparse entry, this smells...
-                elem, *pos[axis.value] = cast(SparsePositionEntry, elem)  # type: ignore[index]
+                elem = pos[axis.value].pop(0)
             assert isinstance(elem, (int, slice))
             res.append(elem)
     return tuple(res)

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -673,8 +673,8 @@ def get_ordered_indices(
             elem = pos[axis.value]
             if _is_sparse_position_entry(elem):
                 sparse_position_tracker.setdefault(axis.value, 0)
-                sparse_position_tracker[axis.value] += 1
                 res.append(elem[sparse_position_tracker[axis.value]])
+                sparse_position_tracker[axis.value] += 1
             else:
                 assert isinstance(elem, (int, slice))
                 res.append(elem)


### PR DESCRIPTION
- Ignore expensive _tupsum calls if no offsets are given to LocatedField
- Use tuple instead of list for sparse shifts
- Avoid unnecessary copy of position in execute_shift