### PR TITLE
Hide generated code in unnamed namespace

### DIFF
--- a/src/functional/fencil_processors/codegens/gtfn/codegen.py
+++ b/src/functional/fencil_processors/codegens/gtfn/codegen.py
@@ -170,6 +170,7 @@ class GTFNCodegen(codegen.TemplatedGenerator):
     #include <gridtools/fn/${grid_type_str}.hpp>
 
     namespace generated{
+    namespace{
     using namespace gridtools;
     using namespace fn;
     using namespace literals;
@@ -182,6 +183,7 @@ class GTFNCodegen(codegen.TemplatedGenerator):
             ${'\\n'.join(executions)}
         };
     };
+    }
     }
     """
     )


### PR DESCRIPTION
Put all generated code into an unnamed namespace to avoid name conflicts between compilation units.
In our case a compilation unit is a fencil.

This could still lead to conflicts if we decide to include multiple fencils (multiple generated .hpp files in our current approach) into the same compilation unit. Therefore it would probably be better longer term to replace the `generated` namespace by the name of the fencil. I would like to merge this fix first to unblock the scan-canonicalization.