### PR TITLE
Cartesian: Add infrastructure to support gt4py versioning in future commits

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,16 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
+[bumpversion:file:src/eve/version.py]
+parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"
+serialize = "{major}.{minor}.{patch}"
+
+[bumpversion:file:src/gtc/version.py]
+parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"
+serialize = "{major}.{minor}.{patch}"
+
+[bumpversion:file:src/gt4py/version.py]
+parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"
+serialize = "{major}.{minor}.{patch}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -9,6 +9,8 @@ serialize =
 values = 0
 
 [bumpversion:part:major]
+# gt4py.cartesian currently maps to 0.1.x
+# TODO: remove when merging cartesian and functional in the same repo
 values = 1
 
 [bumpversion:file:src/eve/version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
-commit = True
-tag = True
+current_version = 0.0.1
 
 [bumpversion:file:src/eve/version.py]
 parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,14 +1,30 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.1.0
+parse = (?P<zero>\d+)\.(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
+serialize = 
+    {zero}.{major}.{minor}.{patch}
+    {zero}.{major}.{minor}
+
+[bumpversion:part:zero]
+values = 0
+
+[bumpversion:part:major]
+values = 1
 
 [bumpversion:file:src/eve/version.py]
-parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"
-serialize = "{major}.{minor}.{patch}"
+parse = \"(?P<zero>\d+)\.(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?"
+serialize = 
+    "{zero}.{major}.{minor}.{patch}"
+    "{zero}.{major}.{minor}"
 
 [bumpversion:file:src/gtc/version.py]
-parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"
-serialize = "{major}.{minor}.{patch}"
+parse = \"(?P<zero>\d+)\.(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?"
+serialize = 
+    "{zero}.{major}.{minor}.{patch}"
+    "{zero}.{major}.{minor}"
 
 [bumpversion:file:src/gt4py/version.py]
-parse = \"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\"
-serialize = "{major}.{minor}.{patch}"
+parse = \"(?P<zero>\d+)\.(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?"
+serialize = 
+    "{zero}.{major}.{minor}.{patch}"
+    "{zero}.{major}.{minor}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# GT4Py Changelog
+
+Notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+
+## [Unreleased]
+
+## [0.1.x.x] - 2022-XX-XX
+### Added
+- New ...
+
+### Changed
+- Changed ...
+
+### Removed
+- Section ...

--- a/docs/eve/conf.py
+++ b/docs/eve/conf.py
@@ -50,7 +50,7 @@ description = "Eve framework to develop DSL toolchains."
 # built documents.
 
 # The short X.Y.Z version.
-version = eve.__versioninfo__.base_version
+version = eve.__version_info__.base_version
 
 # The full version, including alpha/beta/rc tags
 release = eve.__version__

--- a/docs/gt4py/conf.py
+++ b/docs/gt4py/conf.py
@@ -49,7 +49,7 @@ description = "Python API of the GridTools framework to develop performance port
 # built documents.
 
 # The short X.Y.Z version.
-version = gt4py.__versioninfo__.base_version
+version = gt4py.__version_info__.base_version
 
 # The full version, including alpha/beta/rc tags
 release = gt4py.__version__

--- a/docs/gtc/conf.py
+++ b/docs/gtc/conf.py
@@ -50,7 +50,7 @@ description = "Eve framework to develop DSL toolchains."
 # built documents.
 
 # The short X.Y.Z version.
-version = gtc.__versioninfo__.base_version
+version = gtc.__version_info__.base_version
 
 # The full version, including alpha/beta/rc tags
 release = gtc.__version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cython"]
+requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=40.8.0", "wheel", "cython"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+bump2version>=1.0.1
 check-manifest>=0.40
 coverage>=5.0
 darglint>=1.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,9 @@
 
 [metadata]
 name = gt4py
+version = attr: gt4py.version.VERSION
 author = ETH Zurich
-author_email = enriqueg@cscs.ch
+author_email = gridtools@cscs.ch
 description = Python API to develop performance portable applications for weather and climate
 license = gpl3
 license_files = LICENSE.txt
@@ -106,7 +107,7 @@ console_scripts =
     gtpyc = gt4py.cli:gtpyc
 
 
-#---- Development tools ----
+#---- Other tools ----
 
 #-- coverage --
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@
 
 [metadata]
 name = gt4py
-version = attr: gt4py.version.VERSION
+version = attr: gt4py.version.__version__
 author = ETH Zurich
 author_email = gridtools@cscs.ch
 description = Python API to develop performance portable applications for weather and climate

--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -28,7 +28,7 @@ on some of the previous ones):
 
 from __future__ import annotations  # isort:skip
 
-from .version import __version__, __versioninfo__  # isort:skip
+from .version import VERSION as __version__, VERSION_INFO as __versioninfo__  # isort:skip
 
 from .concepts import (
     FieldKind,

--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -28,7 +28,7 @@ on some of the previous ones):
 
 from __future__ import annotations  # isort:skip
 
-from .version import VERSION as __version__, VERSION_INFO as __versioninfo__  # isort:skip
+from .version import __version__, __version_info__  # isort:skip
 
 from .concepts import (
     FieldKind,
@@ -66,7 +66,7 @@ from .visitors import NodeMutator, NodeTranslator, NodeVisitor
 
 __all__ = [
     "__version__",
-    "__versioninfo__",
+    "__version_info__",
     "Bool",
     "Enum",
     "Float",

--- a/src/eve/version.py
+++ b/src/eve/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.1"
+VERSION: typing.Final = "0.0.2"
 VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/eve/version.py
+++ b/src/eve/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-__version__: typing.Final = "0.0.1"
+__version__: typing.Final = "0.1.0"
 __version_info__: typing.Final = pkg_version.parse(__version__)

--- a/src/eve/version.py
+++ b/src/eve/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.1"
-VERSION_INFO: typing.Final = pkg_version.parse(VERSION)
+__version__: typing.Final = "0.0.1"
+__version_info__: typing.Final = pkg_version.parse(__version__)

--- a/src/eve/version.py
+++ b/src/eve/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.2"
+VERSION: typing.Final = "0.0.1"
 VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/gt4py/__init__.py
+++ b/src/gt4py/__init__.py
@@ -14,23 +14,14 @@
 
 """Python API to develop performance portable applications for weather and climate."""
 
-from typing import Optional, Union
-
-from packaging.version import LegacyVersion, Version, parse
-from pkg_resources import DistributionNotFound, get_distribution
+import typing
 
 
-__copyright__ = "Copyright (c) 2014-2021 ETH Zurich"
-__license__ = "GPLv3+"
+__copyright__: typing.Final = "Copyright (c) 2014-2022 ETH Zurich"
+__license__: typing.Final = "GPLv3+"
 
-try:
-    __version__: str = get_distribution(__name__).version
-except DistributionNotFound as e:
-    __version__ = "X.X.X.unknown"
+from .version import VERSION as __version__, VERSION_INFO as __versioninfo__  # isort:skip
 
-__versioninfo__: Optional[Union[LegacyVersion, Version]] = parse(__version__)
-
-del DistributionNotFound, LegacyVersion, Version, get_distribution, parse
 
 from . import config, gtscript, storage
 from .stencil_object import StencilObject

--- a/src/gt4py/__init__.py
+++ b/src/gt4py/__init__.py
@@ -20,7 +20,7 @@ import typing
 __copyright__: typing.Final = "Copyright (c) 2014-2022 ETH Zurich"
 __license__: typing.Final = "GPLv3+"
 
-from .version import VERSION as __version__, VERSION_INFO as __versioninfo__  # isort:skip
+from .version import __version__, __version_info__  # isort:skip
 
 
 from . import config, gtscript, storage

--- a/src/gt4py/version.py
+++ b/src/gt4py/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.1"
+VERSION: typing.Final = "0.0.2"
 VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/gt4py/version.py
+++ b/src/gt4py/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-__version__: typing.Final = "0.0.1"
+__version__: typing.Final = "0.1.0"
 __version_info__: typing.Final = pkg_version.parse(__version__)

--- a/src/gt4py/version.py
+++ b/src/gt4py/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.1"
-VERSION_INFO: typing.Final = pkg_version.parse(VERSION)
+__version__: typing.Final = "0.0.1"
+__version_info__: typing.Final = pkg_version.parse(__version__)

--- a/src/gt4py/version.py
+++ b/src/gt4py/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.2"
+VERSION: typing.Final = "0.0.1"
 VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/gt4py/version.py
+++ b/src/gt4py/version.py
@@ -12,9 +12,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Version specification."""
 
-import setuptools
+import typing
+
+from packaging import version as pkg_version
 
 
-if __name__ == "__main__":
-    setuptools.setup()
+VERSION: typing.Final = "0.0.1"
+VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/gtc/__init__.py
+++ b/src/gtc/__init__.py
@@ -18,6 +18,6 @@ import typing
 __copyright__: typing.Final = "Copyright (c) 2014-2022 ETH Zurich"
 __license__: typing.Final = "GPLv3+"
 
-from .version import VERSION as __version__, VERSION_INFO as __versioninfo__  # isort:skip
+from .version import __version__, __version_info__  # isort:skip
 
-__all__ = ["__copyright__", "__license__", "__version__", "__versioninfo__"]
+__all__ = ["__copyright__", "__license__", "__version__", "__version_info__"]

--- a/src/gtc/__init__.py
+++ b/src/gtc/__init__.py
@@ -12,20 +12,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Optional, Union
-
-from packaging.version import LegacyVersion, Version, parse
-from pkg_resources import DistributionNotFound, get_distribution
+import typing
 
 
-__copyright__ = "Copyright (c) 2014-2021 ETH Zurich"
-__license__ = "GPLv3+"
+__copyright__: typing.Final = "Copyright (c) 2014-2022 ETH Zurich"
+__license__: typing.Final = "GPLv3+"
 
-try:
-    __version__: str = get_distribution("gt4py").version
-except DistributionNotFound:
-    __version__ = "X.X.X.unknown"
+from .version import VERSION as __version__, VERSION_INFO as __versioninfo__  # isort:skip
 
-__versioninfo__: Optional[Union[LegacyVersion, Version]] = parse(__version__)
-
-del DistributionNotFound, LegacyVersion, Version, get_distribution, parse
+__all__ = ["__copyright__", "__license__", "__version__", "__versioninfo__"]

--- a/src/gtc/version.py
+++ b/src/gtc/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.1"
+VERSION: typing.Final = "0.0.2"
 VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/gtc/version.py
+++ b/src/gtc/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-__version__: typing.Final = "0.0.1"
+__version__: typing.Final = "0.1.0"
 __version_info__: typing.Final = pkg_version.parse(__version__)

--- a/src/gtc/version.py
+++ b/src/gtc/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.1"
-VERSION_INFO: typing.Final = pkg_version.parse(VERSION)
+__version__: typing.Final = "0.0.1"
+__version_info__: typing.Final = pkg_version.parse(__version__)

--- a/src/gtc/version.py
+++ b/src/gtc/version.py
@@ -19,5 +19,5 @@ import typing
 from packaging import version as pkg_version
 
 
-VERSION: typing.Final = "0.0.2"
+VERSION: typing.Final = "0.0.1"
 VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/src/gtc/version.py
+++ b/src/gtc/version.py
@@ -12,9 +12,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""Version specification."""
 
-import setuptools
+import typing
+
+from packaging import version as pkg_version
 
 
-if __name__ == "__main__":
-    setuptools.setup()
+VERSION: typing.Final = "0.0.1"
+VERSION_INFO: typing.Final = pkg_version.parse(VERSION)

--- a/tests/eve_tests/unit_tests/test_version.py
+++ b/tests/eve_tests/unit_tests/test_version.py
@@ -20,7 +20,7 @@ import eve
 
 def test_version():
     assert isinstance(eve.version.__version__, str)
-    assert all(len(p) for p in eve.version.__version__.split("."))
+    assert len(eve.version.__version__) and all(len(p) for p in eve.version.__version__.split("."))
     assert eve.version.__version__ == eve.__version__
 
 
@@ -28,5 +28,8 @@ def test_version_info():
     from packaging.version import Version
 
     assert isinstance(eve.version.__version_info__, Version)
-    assert (0, 0) <= eve.version.__version_info__.release < (0, 1)
+    assert eve.version.__version_info__.release == tuple(
+        int(p) for p in eve.version.__version__.split(".")
+    )
+    assert (0, 1) <= eve.version.__version_info__.release < (0, 2)
     assert eve.version.__version_info__ == eve.__version_info__

--- a/tests/eve_tests/unit_tests/test_version.py
+++ b/tests/eve_tests/unit_tests/test_version.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+#
 # Eve Toolchain - GT4Py Project - GridTools Framework
 #
-# Copyright (c) 2014-2022, ETH Zurich
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
 # All rights reserved.
 #
 # This file is part of the GT4Py project and the GridTools framework.
@@ -12,12 +14,19 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Version specification."""
 
-import typing
-
-from packaging import version as pkg_version
+import eve
 
 
-VERSION: typing.Final = "0.0.1"
-VERSION_INFO: typing.Final = pkg_version.parse(VERSION)
+def test_version():
+    assert isinstance(eve.version.VERSION, str)
+    assert all(len(p) for p in eve.version.VERSION.split("."))
+    assert eve.version.VERSION == eve.__version__
+
+
+def test_version_info():
+    from packaging.version import Version
+
+    assert isinstance(eve.version.VERSION_INFO, Version)
+    assert (0, 0) <= eve.version.VERSION_INFO.release < (0, 1)
+    assert eve.version.VERSION_INFO == eve.__versioninfo__

--- a/tests/eve_tests/unit_tests/test_version.py
+++ b/tests/eve_tests/unit_tests/test_version.py
@@ -19,14 +19,14 @@ import eve
 
 
 def test_version():
-    assert isinstance(eve.version.VERSION, str)
-    assert all(len(p) for p in eve.version.VERSION.split("."))
-    assert eve.version.VERSION == eve.__version__
+    assert isinstance(eve.version.__version__, str)
+    assert all(len(p) for p in eve.version.__version__.split("."))
+    assert eve.version.__version__ == eve.__version__
 
 
 def test_version_info():
     from packaging.version import Version
 
-    assert isinstance(eve.version.VERSION_INFO, Version)
-    assert (0, 0) <= eve.version.VERSION_INFO.release < (0, 1)
-    assert eve.version.VERSION_INFO == eve.__versioninfo__
+    assert isinstance(eve.version.__version_info__, Version)
+    assert (0, 0) <= eve.version.__version_info__.release < (0, 1)
+    assert eve.version.__version_info__ == eve.__version_info__

--- a/tests/test_unittest/test_version.py
+++ b/tests/test_unittest/test_version.py
@@ -20,7 +20,9 @@ import gt4py
 
 def test_version():
     assert isinstance(gt4py.version.__version__, str)
-    assert all(len(p) for p in gt4py.version.__version__.split("."))
+    assert len(gt4py.version.__version__) and all(
+        len(p) for p in gt4py.version.__version__.split(".")
+    )
     assert gt4py.version.__version__ == gt4py.__version__
 
 
@@ -28,5 +30,17 @@ def test_version_info():
     from packaging.version import Version
 
     assert isinstance(gt4py.version.__version_info__, Version)
-    assert (0, 0) <= gt4py.version.__version_info__.release < (0, 1)
+    assert gt4py.version.__version_info__.release == tuple(
+        int(p) for p in gt4py.version.__version__.split(".")
+    )
+    assert (0, 1) <= gt4py.version.__version_info__.release < (0, 2)
     assert gt4py.version.__version_info__ == gt4py.__version_info__
+
+
+# TODO(egparedes): remove this test when changing the structure of the repo
+def test_subprojects_version_sync():
+    import eve
+    import gtc
+
+    assert gt4py.version.__version__ == eve.version.__version__
+    assert gt4py.version.__version__ == gtc.version.__version__

--- a/tests/test_unittest/test_version.py
+++ b/tests/test_unittest/test_version.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+#
 # Eve Toolchain - GT4Py Project - GridTools Framework
 #
-# Copyright (c) 2014-2022, ETH Zurich
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
 # All rights reserved.
 #
 # This file is part of the GT4Py project and the GridTools framework.
@@ -12,12 +14,19 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Version specification."""
 
-import typing
-
-from packaging import version as pkg_version
+import gt4py
 
 
-VERSION: typing.Final = "0.0.1"
-VERSION_INFO: typing.Final = pkg_version.parse(VERSION)
+def test_version():
+    assert isinstance(gt4py.version.VERSION, str)
+    assert all(len(p) for p in gt4py.version.VERSION.split("."))
+    assert gt4py.version.VERSION == gt4py.__version__
+
+
+def test_version_info():
+    from packaging.version import Version
+
+    assert isinstance(gt4py.version.VERSION_INFO, Version)
+    assert (0, 0) <= gt4py.version.VERSION_INFO.release < (0, 1)
+    assert gt4py.version.VERSION_INFO == gt4py.__versioninfo__

--- a/tests/test_unittest/test_version.py
+++ b/tests/test_unittest/test_version.py
@@ -19,14 +19,14 @@ import gt4py
 
 
 def test_version():
-    assert isinstance(gt4py.version.VERSION, str)
-    assert all(len(p) for p in gt4py.version.VERSION.split("."))
-    assert gt4py.version.VERSION == gt4py.__version__
+    assert isinstance(gt4py.version.__version__, str)
+    assert all(len(p) for p in gt4py.version.__version__.split("."))
+    assert gt4py.version.__version__ == gt4py.__version__
 
 
 def test_version_info():
     from packaging.version import Version
 
-    assert isinstance(gt4py.version.VERSION_INFO, Version)
-    assert (0, 0) <= gt4py.version.VERSION_INFO.release < (0, 1)
-    assert gt4py.version.VERSION_INFO == gt4py.__versioninfo__
+    assert isinstance(gt4py.version.__version_info__, Version)
+    assert (0, 0) <= gt4py.version.__version_info__.release < (0, 1)
+    assert gt4py.version.__version_info__ == gt4py.__version_info__


### PR DESCRIPTION
Add infrastructure to support gt4py versioning in future commits.

Changes:
- Add version configuration in .bumpversion.cfg
- Add `version.py` submodules with `__version__` and `__version_info__` attributes to all components
- Change setup.cfg and config files in docs to use the proper version value
- Add `CHANGELOG.md` template
- Add basic unit tests