### PR TITLE
Functional: Fix exception chaining tests

### DIFF
--- a/tests/functional_tests/ffront_tests/test_foast_parsing.py
+++ b/tests/functional_tests/ffront_tests/test_foast_parsing.py
@@ -235,7 +235,7 @@ def test_conditional_wrong_arg_type():
     with pytest.raises(FieldOperatorTypeDeductionError) as exc_info:
         _ = FieldOperatorParser.apply_to_function(conditional_wrong_arg_type)
 
-    assert re.search(msg, exc_info.value.__context__.args[0]) is not None
+    assert re.search(msg, exc_info.value.__cause__.args[0]) is not None
 
 
 # --- External symbols ---

--- a/tests/functional_tests/ffront_tests/test_past_lowering.py
+++ b/tests/functional_tests/ffront_tests/test_past_lowering.py
@@ -159,13 +159,11 @@ def test_invalid_call_sig_program(invalid_call_sig_program_def):
     #  immediately after missing `out` argument
     # assert (
     #    re.search(
-    #        "Function takes 1 arguments, but 2 were given.", exc_info.value.__context__.args[0]
+    #        "Function takes 1 arguments, but 2 were given.", exc_info.value.__cause__.args[0]
     #    )
     #    is not None
     # )
     assert (
-        re.search(
-            "Missing required keyword argument\(s\) `out`", exc_info.value.__context__.args[0]
-        )
+        re.search("Missing required keyword argument\(s\) `out`", exc_info.value.__cause__.args[0])
         is not None
     )

--- a/tests/functional_tests/ffront_tests/test_program.py
+++ b/tests/functional_tests/ffront_tests/test_program.py
@@ -225,4 +225,4 @@ def test_wrong_argument_type(fieldview_backend, copy_program_def):
         " but got Field\[\[JDim\], dtype=float64\].",
     ]
     for msg in msgs:
-        assert re.search(msg, exc_info.value.__context__.args[0]) is not None
+        assert re.search(msg, exc_info.value.__cause__.args[0]) is not None


### PR DESCRIPTION
We frequently use exception chaining in the frontend to enhance exceptions with additional information only available in "outer" stack frames. In the tests we used `__context__` to access the inner most exceptions, but since we explicitly chain we should actually use `__cause__`. This PR fixes that.