### PR TITLE
Embedded: Allow operations between scalars and columns

### DIFF
--- a/src/eve/trees.py
+++ b/src/eve/trees.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     TreeLike = Any
 else:
 
-    class TreeLike(abc.ABC):
+    class TreeLike(abc.ABC):  # noqa: B024
         ...
 
 

--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -198,8 +198,8 @@ class Column(np.lib.mixins.NDArrayOperatorsMixin):
         # - we allow scalars to silently pass through and be handled correctly by numpy
         # - we let numpy do the checking of compatible shapes
         assert method == "__call__"
-        if not all(inp.kstart == self.kstart for inp in inputs if isinstance(inp, Column)):
-            raise ValueError("Incompatible Column.kstart")
+        if (wrong_kstarts := (set(inp.kstart for inp in inputs if isinstance(inp, Column)) - {self.kstart})):
+            raise ValueError("Incompatible Column.kstart: it should be '{self.kstart}' but found other values: {wrong_kstarts}")
         return self.__class__(
             self.kstart,
             ufunc(*(inp.data if isinstance(inp, Column) else inp for inp in inputs), **kwargs),

--- a/tests/eve_tests/unit_tests/test_utils.py
+++ b/tests/eve_tests/unit_tests/test_utils.py
@@ -73,7 +73,7 @@ def test_register_subclasses():
         pass
 
     @eve.utils.register_subclasses(MyVirtualSubclassA, MyVirtualSubclassB)
-    class MyBaseClass(abc.ABC):
+    class MyBaseClass(abc.ABC):  # noqa: B024
         pass
 
     assert issubclass(MyVirtualSubclassA, MyBaseClass) and issubclass(

--- a/tests/functional_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/functional_tests/iterator_tests/test_embedded_internals.py
@@ -14,6 +14,14 @@ def test_column_ufunc():
     assert res.kstart == 1
 
 
+def test_column_ufunc_with_scalar():
+    a = Column(1, np.asarray(range(0, 3)))
+    res = 1.0 + a
+    assert isinstance(res, Column)
+    assert np.array_equal(res.data, a.data + 1.0)
+    assert res.kstart == 1
+
+
 def test_column_ufunc_wrong_kstart():
     a = Column(1, np.asarray(range(0, 3)))
     wrong_kstart = Column(2, np.asarray(range(3, 6)))
@@ -33,6 +41,19 @@ def test_column_ufunc_wrong_shape():
 def test_column_array_function():
     cond = Column(1, np.asarray([True, False]))
     a = Column(1, np.asarray([1, 1]))
+    b = Column(1, np.asarray([2, 2]))
+
+    res = np.where(cond, a, b)
+    ref = np.asarray([1, 2])
+
+    assert isinstance(res, Column)
+    assert np.array_equal(res.data, ref)
+    assert res.kstart == 1
+
+
+def test_column_array_function_with_scalar():
+    cond = Column(1, np.asarray([True, False]))
+    a = 1
     b = Column(1, np.asarray([2, 2]))
 
     res = np.where(cond, a, b)

--- a/tests/functional_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/functional_tests/iterator_tests/test_embedded_internals.py
@@ -18,7 +18,7 @@ def test_column_ufunc_wrong_kstart():
     a = Column(1, np.asarray(range(0, 3)))
     wrong_kstart = Column(2, np.asarray(range(3, 6)))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         a + wrong_kstart
 
 
@@ -26,7 +26,7 @@ def test_column_ufunc_wrong_shape():
     a = Column(1, np.asarray(range(0, 3)))
     wrong_shape = Column(1, np.asarray([1, 2]))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         a + wrong_shape
 
 
@@ -48,7 +48,7 @@ def test_column_array_function_wrong_kstart():
     wrong_kstart = Column(2, np.asarray([1, 1]))
     b = Column(1, np.asarray([2, 2]))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         np.where(cond, wrong_kstart, b)
 
 
@@ -57,5 +57,5 @@ def test_column_array_function_wrong_shape():
     wrong_shape = Column(2, np.asarray([1, 1, 1]))
     b = Column(1, np.asarray([2, 2]))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         np.where(cond, wrong_shape, b)


### PR DESCRIPTION
In #905 the checks were too strict in cases where the user combines scalars with iterators.