### PR TITLE
Remove mention of deprecated backends

### DIFF
--- a/docs/gt4py/commandline.rst
+++ b/docs/gt4py/commandline.rst
@@ -69,9 +69,9 @@ Then
 
 .. code-block:: bash
 
-   $ gtpyc gen my_stencils.gt.py --backend=gtx86 --output-path=./my-stencils-out
+   $ gtpyc gen my_stencils.gt.py --backend=gt:cpu_ifirst --output-path=./my-stencils-out
 
-Will generate the C++ stencil code files using the "gtx86" backend for each
+Will generate the C++ stencil code files using the "gt:cpu_ifirst" backend for each
 stencil in the global namespace of ``gstencils.gt.py`` (also ones imported from
 other modules) and output them inside ``my-stencils-out/``. The code files for
 each stencil are put in a subfolder named after the stencil:
@@ -87,7 +87,7 @@ each stencil are put in a subfolder named after the stencil:
        ├── computation.cpp
        └── computation.hpp
 
-The line 
+The line
 
 .. code-block:: python
    :caption: my_stencils.gt.py

--- a/src/gt4py/backend/numpy_backend.py
+++ b/src/gt4py/backend/numpy_backend.py
@@ -93,7 +93,6 @@ class NumpyBackend(BaseBackend, CLIBackendMixin):
     }
     languages = {"computation": "python", "bindings": ["python"]}
     MODULE_GENERATOR_CLASS = ModuleGenerator
-    GTIR_KEY = "gtc:gtir"
 
     def generate_computation(self) -> Dict[str, Union[str, Dict]]:
         computation_name = (

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -131,7 +131,7 @@ class Storage(np.ndarray):
             supported are the floating point and integer dtypes of numpy
 
         backend: string, backend identifier
-            Currently possible: debug, numpy, gtx86, gtmc, gtcuda
+            Currently possible: numpy, gt:cpu_ifirst, gt:cpu_kfirst, gt:gpu
 
         default_origin: tuple of ints
             determines the point to which the storage memory address is aligned.

--- a/tests/test_unittest/test_backend_api.py
+++ b/tests/test_unittest/test_backend_api.py
@@ -58,7 +58,7 @@ def test_generate_computation(backend, tmp_path):
         and ("computation.cpp" in result["init_1_src"] or "computation.cu" in result["init_1_src"])
         and "bindings.cpp" not in result["init_1_src"]
     )
-    # TODO(havogt) remove once gtc:gt produces a cpp-file for computation
+    # TODO(havogt) remove once gt: produces a cpp-file for computation
     gtc_result = (
         (backend.languages["computation"] in ["c++", "cuda"])
         and "computation.hpp" in result["init_1_src"]


### PR DESCRIPTION
## Description

A user recently mentioned that they were confused by some deprecated (removed)
backends mentioned in the source code. This removes those.

Resolves #917.
