### PR TITLE
Implement {lazy_,}stencil option raise_if_not_cached

### DIFF
--- a/src/gt4py/definitions.py
+++ b/src/gt4py/definitions.py
@@ -101,6 +101,7 @@ class BuildOptions(AttributeClassLike):
     backend_opts = attribute(of=DictOf[str, Any], factory=dict)
     build_info = attribute(of=dict, optional=True)
     rebuild = attribute(of=bool, default=False)
+    raise_if_not_cached = attribute(of=bool, default=False)
     cache_settings = attribute(of=DictOf[str, Any], factory=dict)
     _impl_opts = attribute(of=DictOf[str, Any], factory=dict)
 

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -164,6 +164,7 @@ def stencil(
     name=None,
     rebuild=False,
     cache_settings=None,
+    raise_if_not_cached=False,
     **kwargs,
 ):
     """Generate an implementation of the stencil definition with the specified backend.
@@ -205,6 +206,10 @@ def stencil(
         rebuild : `bool`, optional
             Force rebuild of the :class:`gt4py.StencilObject` even if it is
             found in the cache. (`False` by default).
+
+        raise_if_not_cached: `bool`, optional
+            If this is True, the call will raise an exception if the stencil does not
+            exist in the cache, or if the cache is inconsistent. (`False` by default).
 
         cache_settings: `dict`, optional
             Dictionary to configure cache (directory) settings (see
@@ -248,6 +253,8 @@ def stencil(
         raise ValueError(f"Invalid 'name' string ('{name}')")
     if not isinstance(rebuild, bool):
         raise ValueError(f"Invalid 'rebuild' bool value ('{rebuild}')")
+    if not isinstance(raise_if_not_cached, bool):
+        raise ValueError(f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')")
     if cache_settings is not None and not isinstance(cache_settings, dict):
         raise ValueError(f"Invalid 'cache_settings' dictionary ('{cache_settings}')")
 
@@ -280,6 +287,7 @@ def stencil(
         module=module,
         format_source=format_source,
         rebuild=rebuild,
+        raise_if_not_cached=raise_if_not_cached,
         backend_opts=kwargs,
         build_info=build_info,
         cache_settings=cache_settings or {},
@@ -300,7 +308,7 @@ def stencil(
             build_options=build_options,
             externals=externals or {},
         )
-        setattr(definition_func, "__annotations__", original_annotations)
+        definition_func.__anntations__ = original_annotations
         return out
 
     if definition is None:
@@ -319,6 +327,7 @@ def lazy_stencil(
     format_source=True,
     name=None,
     rebuild=False,
+    raise_if_not_cached=False,
     eager=False,
     check_syntax=True,
     **kwargs,
@@ -356,6 +365,10 @@ def lazy_stencil(
             Force rebuild of the :class:`gt4py.StencilObject` even if it is
             found in the cache. (`False` by default).
 
+        raise_if_not_cached: `bool`, optional
+            If this is True, the call will raise an exception if the stencil does not
+            exist in the cache, or if the cache is inconsistent. (`False` by default).
+
         eager : `bool`, optional
             If true do not defer stencil building and instead return the fully built raw implementation object.
 
@@ -387,6 +400,8 @@ def lazy_stencil(
         raise ValueError(f"Invalid 'name' string ('{name}')")
     if not isinstance(rebuild, bool):
         raise ValueError(f"Invalid 'rebuild' bool value ('{rebuild}')")
+    if not isinstance(raise_if_not_cached, bool):
+        raise ValueError(f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')")
 
     module = None
     if name:
@@ -417,6 +432,7 @@ def lazy_stencil(
         module=module,
         format_source=format_source,
         rebuild=rebuild,
+        raise_if_not_cached=raise_if_not_cached,
         backend_opts=kwargs,
         build_info=build_info,
         impl_opts=_impl_opts,

--- a/src/gt4py/gtscript.py
+++ b/src/gt4py/gtscript.py
@@ -308,7 +308,7 @@ def stencil(
             build_options=build_options,
             externals=externals or {},
         )
-        definition_func.__anntations__ = original_annotations
+        definition_func.__annotations__ = original_annotations
         return out
 
     if definition is None:

--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -76,19 +76,15 @@ class StencilBuilder:
         self._build_data: Dict[str, Any] = {}
         self._externals: Dict[str, Any] = {}
 
-        if (
-            self.options.raise_if_not_cached
-            and not self.caching.is_cache_info_available_and_consistent(validate_hash=True)
-        ):
-            raise ValueError(
-                f"The stencil {self._definition.__name__} is not up to date in the cache"
-            )
-
     def build(self) -> Type["StencilObject"]:
         """Generate, compile and/or load everything necessary to provide a usable stencil class."""
         # load or generate
         stencil_class = None if self.options.rebuild else self.backend.load()
-        if stencil_class is None:
+        if stencil_class is None and self.options.raise_if_not_cached:
+            raise ValueError(
+                f"The stencil {self._definition.__name__} is not up to date in the cache"
+            )
+        elif stencil_class is None:
             stencil_class = self.backend.generate()
         return stencil_class
 

--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -80,11 +80,11 @@ class StencilBuilder:
         """Generate, compile and/or load everything necessary to provide a usable stencil class."""
         # load or generate
         stencil_class = None if self.options.rebuild else self.backend.load()
-        if stencil_class is None and self.options.raise_if_not_cached:
-            raise ValueError(
-                f"The stencil {self._definition.__name__} is not up to date in the cache"
-            )
-        elif stencil_class is None:
+        if stencil_class is None:
+            if self.options.raise_if_not_cached:
+                raise ValueError(
+                    f"The stencil {self._definition.__name__} is not up to date in the cache"
+                )
             stencil_class = self.backend.generate()
         return stencil_class
 

--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -76,6 +76,14 @@ class StencilBuilder:
         self._build_data: Dict[str, Any] = {}
         self._externals: Dict[str, Any] = {}
 
+        if (
+            self.options.raise_if_not_cached
+            and not self.caching.is_cache_info_available_and_consistent(validate_hash=True)
+        ):
+            raise ValueError(
+                f"The stencil {self._definition.__name__} is not up to date in the cache"
+            )
+
     def build(self) -> Type["StencilObject"]:
         """Generate, compile and/or load everything necessary to provide a usable stencil class."""
         # load or generate

--- a/tests/test_unittest/test_stencil_builder.py
+++ b/tests/test_unittest/test_stencil_builder.py
@@ -13,6 +13,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import numpy
+import pytest
 
 from gt4py.gtscript import PARALLEL, Field, computation, interval
 from gt4py.stencil_builder import StencilBuilder
@@ -119,3 +120,18 @@ def test_regression_run_gtir_pipeline_twice(tmp_path):
     # property caching should not reevaluate the analysis pipeline as a side effect.
     ir = builder.gtir_pipeline.full()
     assert ir is builder.gtir_pipeline.full()
+
+
+def test_raise_if_not_cached():
+    builder = (
+        StencilBuilder(assign_bool_float)
+        .with_backend("numpy")
+        .with_externals({"a": 1.0})
+        .with_options(name="simple_stencil", module="", rebuild=True, raise_if_not_cached=True)
+    )
+
+    with pytest.raises(ValueError, match="not up to date"):
+        builder.build()
+
+    builder.options.raise_if_not_cached = False
+    builder.build()


### PR DESCRIPTION
## Description

There are cases where users need to check whether stencils are already compiled, e.g. before a large-scale run.

This PR adds a keyword argument `raise_if_not_cached` that ensures the stencil is up to date in the cache, otherwise it raises an exception to the user.

Before this change, there was no way for users to get at this behavior without importing "Private" gt4py classes such as the `StencilBuilder`:

```python
import numpy as np
from gt4py.gtscript import function, Field, PARALLEL, computation, interval, stencil
from gt4py import storage as gt_storage
from gt4py.stencil_builder import StencilBuilder
from typing import Callable
from gt4py import StencilObject

BACKEND = "gtc:numpy"
DTYPE = np.float_

@function
def laplacian(field):
    return (
        -4.0 * field[0, 0, 0] + field[-1, 0, 0] + field[1, 0, 0] + field[0, -1, 0] + field[0, 1, 0]
    )


def laplap_stencil(in_field: Field[DTYPE], out_field: Field[DTYPE]):
    with computation(PARALLEL), interval(...):
        tmp = laplacian(in_field)
        out_field = laplacian(tmp)


def get_stencil_or_raise(backend: str, *, definition: Callable[..., None], **kwargs) -> StencilObject:
    externals = kwargs.get("externals", {})
    caching_strategy = kwargs.get("caching_strategy", "jit")
    builder = StencilBuilder(
        definition, backend=backend, options=kwargs.get("build_options", None)
    ).with_externals(externals).with_caching(caching_strategy)

    if not builder.caching.is_cache_info_available_and_consistent(validate_hash=True):
        raise ValueError("The stencil is not up to date in the cache")

    return builder.build()

laplap_obj = get_stencil_or_raise(BACKEND, definition=laplap_stencil)
```
