### PR TITLE
Fix nested call with scalar arguments

### DIFF
--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -386,7 +386,7 @@ class FieldOperatorLowering(NodeTranslator):
             for arg in node.args:
                 lowered_arg = self.visit(arg, **kwargs)
                 if iterator_type_kind(arg.type) == ITIRTypeKind.VALUE:
-                    lowered_arg = im.call_(im.lift_(im.lambda__()(lowered_arg)))()
+                    lowered_arg = im.lift_(im.lambda__()(lowered_arg))()
                 lowered_args.append(lowered_arg)
 
             return self._lift_if_field(node)(im.call_(lowered_func)(*lowered_args))

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -480,7 +480,6 @@ def test_scalar_arg(fieldview_backend):
 
 
 def test_nested_scalar_arg(fieldview_backend):
-    """Test scalar argument being turned into 0-dim field."""
     if fieldview_backend == gtfn_cpu.run_gtfn:
         pytest.skip("ConstantFields are not supported yet.")
     Vertex = Dimension("Vertex")

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -479,6 +479,29 @@ def test_scalar_arg(fieldview_backend):
     assert np.allclose(ref, out.array())
 
 
+def test_nested_scalar_arg(fieldview_backend):
+    """Test scalar argument being turned into 0-dim field."""
+    if fieldview_backend == gtfn_cpu.run_gtfn:
+        pytest.skip("ConstantFields are not supported yet.")
+    Vertex = Dimension("Vertex")
+    size = 5
+    inp = 5.0
+    out = np_as_located_field(Vertex)(np.zeros([size]))
+
+    @field_operator(backend=fieldview_backend)
+    def scalar_arg_inner(scalar_inp: float64) -> Field[[Vertex], float64]:
+        return broadcast(scalar_inp + 1.0, (Vertex,))
+
+    @field_operator(backend=fieldview_backend)
+    def scalar_arg(scalar_inp: float64) -> Field[[Vertex], float64]:
+        return scalar_arg_inner(scalar_inp + 1.0)
+
+    scalar_arg(inp, out=out, offset_provider={})
+
+    ref = np.full([size], 7.0)
+    assert np.allclose(ref, out.array())
+
+
 def test_scalar_arg_with_field(fieldview_backend):
     if fieldview_backend == gtfn_cpu.run_gtfn:
         pytest.skip("IndexFields and ConstantFields are not supported yet.")


### PR DESCRIPTION
Fixes a typo in the lowering from FOAST to ITIR where a nested call to a field operator with a scalar argument failed. The following works now:

```python
@field_operator(backend=fieldview_backend)
def scalar_arg_inner(scalar_inp: float64) -> Field[[Vertex], float64]:
    return broadcast(scalar_inp + 1.0, (Vertex,))

@field_operator(backend=fieldview_backend)
def scalar_arg(scalar_inp: float64) -> Field[[Vertex], float64]:
    return scalar_arg_inner(scalar_inp + 1.0)

scalar_arg(inp, out=out, offset_provider={})
```