### PR TITLE
Functional: Fix scan tuple output

### DIFF
--- a/src/functional/iterator/embedded.py
+++ b/src/functional/iterator/embedded.py
@@ -179,7 +179,12 @@ class Column(np.lib.mixins.NDArrayOperatorsMixin):
         self.data = data
 
     def __getitem__(self, i: int) -> Any:
-        return self.data[i - self.kstart]
+        result = self.data[i - self.kstart]
+        # if the element type is a tuple return a regular type instead of a
+        #  numpy type
+        if self.data.dtype.names:
+            return tuple(result)
+        return result
 
     def tuple_get(self, i: int) -> Column:
         if self.data.dtype.names:

--- a/src/functional/iterator/transforms/inline_lambdas.py
+++ b/src/functional/iterator/transforms/inline_lambdas.py
@@ -31,7 +31,7 @@ class CountSymbolRefs(NodeVisitor):
 
 @dataclasses.dataclass
 class InlineLambdas(NodeTranslator):
-    """Inline lambda calls by substituting every arguments by its value."""
+    """Inline lambda calls by substituting every argument by its value."""
 
     opcount_preserving: bool
 


### PR DESCRIPTION
Fixes writing the tuple result of a scan operator into multiple output fields.

```python
@scan_operator(axis=KDim, forward=True, init=init, backend=fieldview_backend)
def simple_scan_operator(carry: tuple[float, float], x: float) -> tuple[float, float]:
    return (x, carry[1] + 1.0)

simple_scan_operator(x, out=(out1, out2))
```

This should fix the problem surfacing here: https://github.com/C2SM/icon4py/commit/b279780504e4e9467af53b388518103cf9596cb9#diff-f24f39bd690c6fffc48b87978e947d4df6e45eb767814ca796aee287bb8cb070L116

FYI @nfarabullini @leuty @egparedes 