### PR TITLE
Functional: Fix for InlineLambdas (or rather RemapSymbolRefs) Bug

### DIFF
--- a/src/functional/iterator/transforms/inline_lambdas.py
+++ b/src/functional/iterator/transforms/inline_lambdas.py
@@ -69,16 +69,12 @@ class InlineLambdas(NodeTranslator):
                 if not any(eligible_params):
                     return node
 
-            refs = (
-                set.union(
-                    *(
-                        arg.pre_walk_values().if_isinstance(ir.SymRef).getattr("id").to_set()
-                        for i, arg in enumerate(node.args)
-                        if eligible_params[i]
-                    )
+            refs = set().union(
+                *(
+                    arg.pre_walk_values().if_isinstance(ir.SymRef).getattr("id").to_set()
+                    for i, arg in enumerate(node.args)
+                    if eligible_params[i]
                 )
-                if len(node.args) > 0
-                else set()
             )
             syms = node.fun.expr.pre_walk_values().if_isinstance(ir.Sym).getattr("id").to_set()
             clashes = refs & syms

--- a/src/functional/iterator/transforms/remap_symbols.py
+++ b/src/functional/iterator/transforms/remap_symbols.py
@@ -13,7 +13,7 @@ class RemapSymbolRefs(NodeTranslator):
         new_symbol_map = {k: v for k, v in symbol_map.items() if k not in params}
         return ir.Lambda(
             params=node.params,
-            expr=self.generic_visit(node.expr, symbol_map=new_symbol_map),
+            expr=self.visit(node.expr, symbol_map=new_symbol_map),
         )
 
     def generic_visit(self, node: ir.Node, **kwargs: Any):  # type: ignore[override]


### PR DESCRIPTION
## Description

Fixes a failure of RemapSymbolRefs (and thus InlineLambdas) when a SymRef appears directly in a lambda body. Bug found by @tehrengruber in FVM code.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


