### PR TITLE
Add flock to gt_src_manager install

### DIFF
--- a/src/gt4py/backend/cuda_backend.py
+++ b/src/gt4py/backend/cuda_backend.py
@@ -158,8 +158,8 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
         self.check_options(self.builder.options)
 
         # Generate the Python binary extension (checking if GridTools sources are installed)
-        if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
-            raise RuntimeError("Missing GridTools sources.")
+        if not gt_src_manager.has_gt_sources():
+            gt_src_manager.install_gt_sources()
 
         pyext_module_name: Optional[str]
         pyext_file_path: Optional[str]

--- a/src/gt4py/backend/dace_backend.py
+++ b/src/gt4py/backend/dace_backend.py
@@ -707,8 +707,8 @@ class BaseDaceBackend(BaseGTBackend, CLIBackendMixin):
         self.check_options(self.builder.options)
 
         # Generate the Python binary extension (checking if GridTools sources are installed)
-        if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
-            raise RuntimeError("Missing GridTools sources.")
+        if not gt_src_manager.has_gt_sources():
+            gt_src_manager.install_gt_sources()
 
         pyext_module_name: Optional[str]
         pyext_file_path: Optional[str]

--- a/src/gt4py/backend/gtcpp_backend.py
+++ b/src/gt4py/backend/gtcpp_backend.py
@@ -147,8 +147,8 @@ class GTBaseBackend(BaseGTBackend, CLIBackendMixin):
         self.check_options(self.builder.options)
 
         # Generate the Python binary extension (checking if GridTools sources are installed)
-        if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
-            raise RuntimeError("Missing GridTools sources.")
+        if not gt_src_manager.has_gt_sources():
+            gt_src_manager.install_gt_sources()
 
         pyext_module_name: Optional[str]
         pyext_file_path: Optional[str]

--- a/src/gt4py/gt_src_manager.py
+++ b/src/gt4py/gt_src_manager.py
@@ -28,61 +28,48 @@ _GRIDTOOLS_INCLUDE_PATHS = gt_config.build_settings["gt_include_path"]
 _GRIDTOOLS_REPO_DIRNAMES = gt_config.GT_REPO_DIRNAME
 
 
-def install_gt_sources() -> bool:
-    if has_gt_sources():
-        return True
+def install_gt_sources() -> None:
+    if not has_gt_sources():
+        GIT_BRANCH = _GRIDTOOLS_GIT_BRANCH
+        GIT_REPO = _GRIDTOOLS_GIT_REPO
 
-    GIT_BRANCH = _GRIDTOOLS_GIT_BRANCH
-    GIT_REPO = _GRIDTOOLS_GIT_REPO
+        install_path = os.path.dirname(__file__)
+        external_path = os.path.abspath(os.path.join(install_path, "_external_src"))
+        target_path = os.path.join(external_path, _GRIDTOOLS_REPO_DIRNAMES)
+        lock_file = os.path.join(external_path, ".gridtools.lock")
 
-    install_path = os.path.dirname(__file__)
-    external_path = os.path.abspath(os.path.join(install_path, "_external_src"))
-    target_path = os.path.join(external_path, _GRIDTOOLS_REPO_DIRNAMES)
-    lock_file = os.path.join(external_path, ".gridtools.lock")
+        with open(lock_file, mode="w") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            if not has_gt_sources():
+                git_cmd = f"git clone --depth 1 -b {GIT_BRANCH} {GIT_REPO} {target_path}"
+                print(f"Getting GridTools C++ sources...\n$ {git_cmd}")
+                subprocess.check_call(git_cmd.split(), stderr=subprocess.STDOUT)
 
-    with open(lock_file, mode="w") as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
         if not has_gt_sources():
-            git_cmd = f"git clone --depth 1 -b {GIT_BRANCH} {GIT_REPO} {target_path}"
-            print(f"Getting GridTools C++ sources...\n$ {git_cmd}")
-            subprocess.check_call(git_cmd.split(), stderr=subprocess.STDOUT)
-
-    is_ok = has_gt_sources()
-    if is_ok:
-        print("Success!!")
-    else:
-        print(
-            f"\nOooops! GridTools sources have not been installed!\n"
-            f"Install them manually in '{install_path}/_external_src/'\n\n"
-            f"\tExample: git clone --depth 1 -b {GIT_BRANCH} {GIT_REPO} {target_path}\n"
-        )
-
-    return is_ok
+            raise RuntimeError(
+                f"\nOooops! GridTools sources have not been installed!\n"
+                f"Install them manually in '{install_path}/_external_src/'\n\n"
+                f"\tExample: git clone --depth 1 -b {GIT_BRANCH} {GIT_REPO} {target_path}\n"
+            )
 
 
-def remove_gt_sources() -> bool:
+def remove_gt_sources() -> None:
     install_path = os.path.dirname(__file__)
     target_path = os.path.abspath(
         os.path.join(install_path, "_external_src", _GRIDTOOLS_REPO_DIRNAMES)
     )
 
-    is_ok = not os.path.exists(target_path)
-    if not is_ok:
+    if os.path.exists(target_path):
         rm_cmd = f"rm -Rf {target_path}"
         print(f"Deleting sources...\n$ {rm_cmd}")
         subprocess.run(rm_cmd.split())
 
-        is_ok = not os.path.exists(target_path)
-        if is_ok:
-            print("Success!!")
-        else:
-            print(
+        if os.path.exists(target_path):
+            raise RuntimeError(
                 f"\nOooops! Something went wrong. GridTools sources may have not been removed!\n"
                 f"Remove them manually from '{install_path}/_external_src/'\n\n"
                 f"\tExample: rm -Rf {target_path}"
             )
-
-    return is_ok
 
 
 def has_gt_sources() -> bool:

--- a/tests/reference_cpp_regression/build.py
+++ b/tests/reference_cpp_regression/build.py
@@ -27,9 +27,6 @@ GT4PY_INSTALLATION_PATH = os.path.dirname(inspect.getabsfile(gt4py))
 EXTERNAL_SRC_PATH = os.path.join(GT4PY_INSTALLATION_PATH, "_external_src")
 
 
-assert gt_src_manager.has_gt_sources() or gt_src_manager.install_gt_sources()
-
-
 def compile_reference():
     current_dir = os.path.dirname(__file__)
     build_opts = pyext_builder.get_gt_pyext_build_opts().copy()
@@ -53,4 +50,7 @@ def compile_reference():
 
 
 if __name__ == "__main__":
+    if not gt_src_manager.has_gt_sources():
+        gt_src_manager.install_gt_sources()
+
     compile_reference()

--- a/tests/test_unittest/test_gtc/test_cuir_compilation.py
+++ b/tests/test_unittest/test_gtc/test_cuir_compilation.py
@@ -29,8 +29,8 @@ from .cuir_utils import KernelFactory, ProgramFactory
 from .utils import match
 
 
-if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
-    raise RuntimeError("Missing GridTools sources.")
+if not gt_src_manager.has_gt_sources():
+    gt_src_manager.install_gt_sources()
 
 
 def build_gridtools_test(tmp_path: Path, code: str):

--- a/tests/test_unittest/test_gtc/test_gtcpp_compilation.py
+++ b/tests/test_unittest/test_gtc/test_gtcpp_compilation.py
@@ -39,8 +39,8 @@ from .gtcpp_utils import (
 from .utils import match
 
 
-if not gt_src_manager.has_gt_sources() and not gt_src_manager.install_gt_sources():
-    raise RuntimeError("Missing GridTools sources.")
+if not gt_src_manager.has_gt_sources():
+    gt_src_manager.install_gt_sources()
 
 
 def build_gridtools_test(tmp_path: Path, code: str):


### PR DESCRIPTION
## Description

Adds a OS file lock to the gridtools repo cloning process in `gt_src_manger`. This means no more than one process will clone it, so the will not clobber files.

The downside is that a file lock is left in the filesystem after cloning the repo. I would like to remove that, but I'm not sure when we have a guarantee that no procs are waiting on others to clone it.

Resolves #937.
