### PR TITLE
Add min_over reduction operator 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
 * Häuselmann, Rico. ETH Zurich - CSCS
 * Kardos, Péter. ETH Zurich - EXCLAIM
 * Kellerhals, Samuel. ETH Zurich - EXCLAIM
+* Luz, Magdalena. ETH Zurich - EXCLAIM
 * Madonna, Alberto. ETH Zurich - CSCS
 * Mariotti, Kean. ETH Zurich - CSCS
 * Müller, Christoph. MeteoSwiss

--- a/src/functional/ffront/fbuiltins.py
+++ b/src/functional/ffront/fbuiltins.py
@@ -50,6 +50,7 @@ _reduction_like = BuiltInFunction(
 
 neighbor_sum = _reduction_like
 max_over = _reduction_like
+min_over = _reduction_like
 
 broadcast = BuiltInFunction(
     ct.FunctionType(
@@ -173,7 +174,13 @@ MATH_BUILTIN_NAMES = (
     + BINARY_MATH_NUMBER_BUILTIN_NAMES
 )
 
-FUN_BUILTIN_NAMES = ["neighbor_sum", "max_over", "broadcast", "where"] + MATH_BUILTIN_NAMES
+FUN_BUILTIN_NAMES = [
+    "neighbor_sum",
+    "min_over",
+    "max_over",
+    "broadcast",
+    "where",
+] + MATH_BUILTIN_NAMES
 
 
 EXTERNALS_MODULE_NAME = "__externals__"

--- a/src/functional/ffront/fbuiltins.py
+++ b/src/functional/ffront/fbuiltins.py
@@ -176,8 +176,8 @@ MATH_BUILTIN_NAMES = (
 
 FUN_BUILTIN_NAMES = [
     "neighbor_sum",
-    "min_over",
     "max_over",
+    "min_over",
     "broadcast",
     "where",
 ] + MATH_BUILTIN_NAMES

--- a/src/functional/ffront/foast_passes/type_deduction.py
+++ b/src/functional/ffront/foast_passes/type_deduction.py
@@ -496,6 +496,9 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
     def _visit_max_over(self, node: foast.Call, **kwargs) -> foast.Call:
         return self._visit_reduction(node, **kwargs)
 
+    def _visit_min_over(self, node: foast.Call, **kwargs) -> foast.Call:
+        return self._visit_reduction(node, **kwargs)
+
     def _visit_where(self, node: foast.Call, **kwargs) -> foast.Call:
         mask_type = cast(ct.FieldType, node.args[0].type)
         left_type = cast(ct.FieldType, node.args[1].type)

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -356,6 +356,15 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_reduce(self, node: foast.Call, **kwargs) -> itir.FunCall:
         return self._make_reduction_expr(node, lambda expr: im.plus_("acc", expr), 0, **kwargs)
 
+    def _visit_min_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
+        init_expr = itir.Literal(value=str(np.finfo(np.float64).max), type="float64")
+        return self._make_reduction_expr(
+            node,
+            lambda expr: im.call_("if_")(im.less_("acc", expr), "acc", expr),
+            init_expr,
+            **kwargs,
+        )
+
     def _visit_max_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
         # TODO(tehrengruber): replace greater_ with max_ builtin as soon as itir supports it
         init_expr = itir.Literal(value=str(np.finfo(np.float64).min), type="float64")

--- a/src/functional/ffront/foast_to_itir.py
+++ b/src/functional/ffront/foast_to_itir.py
@@ -356,21 +356,21 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_reduce(self, node: foast.Call, **kwargs) -> itir.FunCall:
         return self._make_reduction_expr(node, lambda expr: im.plus_("acc", expr), 0, **kwargs)
 
-    def _visit_min_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
-        init_expr = itir.Literal(value=str(np.finfo(np.float64).max), type="float64")
-        return self._make_reduction_expr(
-            node,
-            lambda expr: im.call_("if_")(im.less_("acc", expr), "acc", expr),
-            init_expr,
-            **kwargs,
-        )
-
     def _visit_max_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
         # TODO(tehrengruber): replace greater_ with max_ builtin as soon as itir supports it
         init_expr = itir.Literal(value=str(np.finfo(np.float64).min), type="float64")
         return self._make_reduction_expr(
             node,
             lambda expr: im.call_("if_")(im.greater_("acc", expr), "acc", expr),
+            init_expr,
+            **kwargs,
+        )
+
+    def _visit_min_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
+        init_expr = itir.Literal(value=str(np.finfo(np.float64).max), type="float64")
+        return self._make_reduction_expr(
+            node,
+            lambda expr: im.call_("if_")(im.less_("acc", expr), "acc", expr),
             init_expr,
             **kwargs,
         )

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -345,48 +345,6 @@ def reduction_setup():
     )  # type: ignore
 
 
-def test_minover_execution(reduction_setup, fieldview_backend):
-    """Testing the min_over functionality"""
-    if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.skip("not implemented yet")
-    rs = reduction_setup
-    Vertex = rs.Vertex
-    V2EDim = rs.V2EDim
-
-    in_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
-
-    @field_operator
-    def minover_fieldoperator(input: Field[[Vertex, V2EDim], int64]) -> Field[[Vertex], int64]:
-        return min_over(input, axis=V2EDim)
-
-    minover_fieldoperator(in_field, out=rs.out, offset_provider=rs.offset_provider)
-
-    ref = np.min(rs.v2e_table, axis=1)
-    assert np.allclose(ref, rs.out)
-
-
-def test_minover_execution_float(reduction_setup, fieldview_backend):
-    """Testing the min_over functionality"""
-    if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.skip("not implemented yet")
-    rs = reduction_setup
-    Vertex = rs.Vertex
-    V2EDim = rs.V2EDim
-
-    in_array = np.random.default_rng().uniform(low=-1, high=1, size=rs.v2e_table.shape)
-    in_field = np_as_located_field(Vertex, V2EDim)(in_array)
-    out_field = np_as_located_field(Vertex)(np.zeros(rs.num_vertices))
-
-    @field_operator
-    def minover_fieldoperator(input: Field[[Vertex, V2EDim], float64]) -> Field[[Vertex], float64]:
-        return min_over(input, axis=V2EDim)
-
-    minover_fieldoperator(in_field, out=out_field, offset_provider=rs.offset_provider)
-
-    ref = np.min(in_array, axis=1)
-    assert np.allclose(ref, out_field)
-
-
 def test_maxover_execution_sparse(reduction_setup, fieldview_backend):
     """Testing max_over functionality."""
     if fieldview_backend == gtfn_cpu.run_gtfn:
@@ -432,6 +390,48 @@ def test_maxover_execution_negatives(reduction_setup, fieldview_backend):
 
     ref = np.max(inp_field_arr[rs.v2e_table], axis=1)
     assert np.allclose(ref, rs.out)
+
+
+def test_minover_execution(reduction_setup, fieldview_backend):
+    """Testing the min_over functionality"""
+    if fieldview_backend == gtfn_cpu.run_gtfn:
+        pytest.skip("not implemented yet")
+    rs = reduction_setup
+    Vertex = rs.Vertex
+    V2EDim = rs.V2EDim
+
+    in_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
+
+    @field_operator
+    def minover_fieldoperator(input: Field[[Vertex, V2EDim], int64]) -> Field[[Vertex], int64]:
+        return min_over(input, axis=V2EDim)
+
+    minover_fieldoperator(in_field, out=rs.out, offset_provider=rs.offset_provider)
+
+    ref = np.min(rs.v2e_table, axis=1)
+    assert np.allclose(ref, rs.out)
+
+
+def test_minover_execution_float(reduction_setup, fieldview_backend):
+    """Testing the min_over functionality"""
+    if fieldview_backend == gtfn_cpu.run_gtfn:
+        pytest.skip("not implemented yet")
+    rs = reduction_setup
+    Vertex = rs.Vertex
+    V2EDim = rs.V2EDim
+
+    in_array = np.random.default_rng().uniform(low=-1, high=1, size=rs.v2e_table.shape)
+    in_field = np_as_located_field(Vertex, V2EDim)(in_array)
+    out_field = np_as_located_field(Vertex)(np.zeros(rs.num_vertices))
+
+    @field_operator
+    def minover_fieldoperator(input: Field[[Vertex, V2EDim], float64]) -> Field[[Vertex], float64]:
+        return min_over(input, axis=V2EDim)
+
+    minover_fieldoperator(in_field, out=out_field, offset_provider=rs.offset_provider)
+
+    ref = np.min(in_array, axis=1)
+    assert np.allclose(ref, out_field)
 
 
 def test_reduction_execution(reduction_setup, fieldview_backend):

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -365,6 +365,28 @@ def test_minover_execution(reduction_setup, fieldview_backend):
     assert np.allclose(ref, rs.out)
 
 
+def test_minover_execution_float(reduction_setup, fieldview_backend):
+    """Testing the min_over functionality"""
+    if fieldview_backend == gtfn_cpu.run_gtfn:
+        pytest.skip("not implemented yet")
+    rs = reduction_setup
+    Vertex = rs.Vertex
+    V2EDim = rs.V2EDim
+
+    in_array = np.random.default_rng().uniform(low=-1, high=1, size=rs.v2e_table.shape)
+    in_field = np_as_located_field(Vertex, V2EDim)(in_array)
+    out_field = np_as_located_field(Vertex)(np.zeros(rs.num_vertices))
+
+    @field_operator
+    def minover_fieldoperator(input: Field[[Vertex, V2EDim], float64]) -> Field[[Vertex], float64]:
+        return min_over(input, axis=V2EDim)
+
+    minover_fieldoperator(in_field, out=out_field, offset_provider=rs.offset_provider)
+
+    ref = np.min(in_array, axis=1)
+    assert np.allclose(ref, out_field)
+
+
 def test_maxover_execution_sparse(reduction_setup, fieldview_backend):
     """Testing max_over functionality."""
     if fieldview_backend == gtfn_cpu.run_gtfn:

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -32,6 +32,7 @@ from functional.ffront.fbuiltins import (
     int32,
     int64,
     max_over,
+    min_over,
     neighbor_sum,
     where,
 )
@@ -342,6 +343,26 @@ def reduction_setup():
         v2e_table=v2e_arr,
         e2v_table=e2v_arr,
     )  # type: ignore
+
+
+def test_minover_execution(reduction_setup, fieldview_backend):
+    """Testing the min_over functionality"""
+    if fieldview_backend == gtfn_cpu.run_gtfn:
+        pytest.skip("not implemented yet")
+    rs = reduction_setup
+    Vertex = rs.Vertex
+    V2EDim = rs.V2EDim
+
+    in_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
+
+    @field_operator
+    def minover_fieldoperator(input: Field[[Vertex, V2EDim], int64]) -> Field[[Vertex], int64]:
+        return min_over(input, axis=V2EDim)
+
+    minover_fieldoperator(in_field, out=rs.out, offset_provider=rs.offset_provider)
+
+    ref = np.min(rs.v2e_table, axis=1)
+    assert np.allclose(ref, rs.out)
 
 
 def test_maxover_execution_sparse(reduction_setup, fieldview_backend):


### PR DESCRIPTION
implementation of a min_over builtin analogous to the existing max_over:

```python
@field_operator
def min_over_operator(input: Field[[Vertex, V2EDim], int64]) -> Field[[Vertex], int64]:
        return min_over(input, axis=V2EDim)
```
 
to reduce values along a given axis to their minimum value.

