### PR TITLE
Change type promotion from np.can_cast to c style

### DIFF
--- a/src/gtc/passes/gtir_upcaster.py
+++ b/src/gtc/passes/gtir_upcaster.py
@@ -58,7 +58,7 @@ def _numpy_ufunc_upcasting_rule(*dtypes, ufunc: np.ufunc):
         inputs, output = t.split("->")
         assert len(inputs) == len(dtypes)
         if all(
-            np.can_cast(data_type_to_typestr(arg_dtype), cand_typestr)
+            arg_dtype <= typestr_to_data_type(np.dtype(cand_typestr).str)
             for arg_dtype, cand_typestr in zip(dtypes, inputs)
         ):
             assert typestr_to_data_type(np.dtype(output).str) != DataType.INVALID

--- a/tests/test_unittest/test_gtc/test_gtir_upcaster.py
+++ b/tests/test_unittest/test_gtc/test_gtir_upcaster.py
@@ -121,7 +121,7 @@ def test_upcast_integers_division():
     upcast_and_validate(
         testee,
         [
-            Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
-            Cast(dtype=DataType.FLOAT64, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="1", dtype=DataType.INT32)),
+            Cast(dtype=DataType.FLOAT32, expr=LiteralFactory(value="2", dtype=DataType.INT32)),
         ],
     )


### PR DESCRIPTION
So far, upcasting is determined according to numpy rules. Here I propose to change a part of it, namely to allow c-style upcasting for testing if types can be cast, while still selecting the target type according to NumPy operator implementations (`ufunc.types`), choosing the implementation according to c-style type promotion instead of `np.can_cast` (the latter is more strict, e.g. only allows casting of integers to float64, never float32).

This will fix an issue where the simple stencil 
```
@gtscript.stencil(backend='gt:cpu_ifirst', rebuild=True)
def stencil(out: gtscript.Field[np.float64], *, param: np.float32):
    with computation(PARALLEL), interval(...):
        out = 2 * param * param

```
was raising in gtir_to_oir.