### PR TITLE
Functional: Fix problems with caching due to unstable ids in IR transformation

### DIFF
--- a/src/functional/iterator/transforms/cse.py
+++ b/src/functional/iterator/transforms/cse.py
@@ -1,8 +1,9 @@
+import dataclasses
 from collections import ChainMap
 from typing import Optional
 
 from eve import NodeTranslator, NodeVisitor
-from eve.utils import UIDs
+from eve.utils import UIDGenerator
 from functional.iterator import ir
 
 
@@ -56,6 +57,7 @@ class CollectSubexpressions(NodeVisitor):
             subexprs.setdefault(node, ([], parent))[0].append(id(node))
 
 
+@dataclasses.dataclass(frozen=True)
 class CommonSubexpressionElimination(NodeTranslator):
     """
     Perform common subexpression elimination.
@@ -67,6 +69,10 @@ class CommonSubexpressionElimination(NodeTranslator):
         >>> print(CommonSubexpressionElimination().visit(expr))
         (λ(_cs_1) → _cs_1 + _cs_1)(x + x)
     """
+
+    # we use one UID generator per instance such that the generated ids are
+    #  stable across multiple runs (required for caching to properly work)
+    uids: UIDGenerator = dataclasses.field(init=False, repr=False, default_factory=UIDGenerator)
 
     def visit_FunCall(self, node: ir.FunCall):
         if isinstance(node.fun, ir.SymRef) and node.fun.id in [
@@ -89,7 +95,7 @@ class CommonSubexpressionElimination(NodeTranslator):
                 # ignore if parent will be eliminated anyway
                 if parent and parent in subexprs and len(subexprs[parent][0]) > 1:
                     continue
-                expr_id = UIDs.sequential_id(prefix="_cs")
+                expr_id = self.uids.sequential_id(prefix="_cs")
                 params.append(ir.Sym(id=expr_id))
                 args.append(expr)
                 expr_ref = ir.SymRef(id=expr_id)

--- a/src/functional/iterator/transforms/pass_manager.py
+++ b/src/functional/iterator/transforms/pass_manager.py
@@ -59,7 +59,7 @@ def apply_common_transforms(
 
     if unroll_reduce:
         for _ in range(10):
-            unrolled = UnrollReduce().visit(ir, offset_provider=offset_provider)
+            unrolled = UnrollReduce.apply(ir, offset_provider=offset_provider)
             if unrolled == ir:
                 break
             ir = unrolled

--- a/src/functional/iterator/transforms/popup_tmps.py
+++ b/src/functional/iterator/transforms/popup_tmps.py
@@ -1,13 +1,15 @@
+import dataclasses
 from collections.abc import Callable
 from functools import partial
 from typing import Optional, Union, cast
 
 from eve import NodeTranslator
-from eve.utils import UIDs
+from eve.utils import UIDGenerator
 from functional.iterator import ir
 from functional.iterator.transforms.remap_symbols import RemapSymbolRefs
 
 
+@dataclasses.dataclass(frozen=True)
 class PopupTmps(NodeTranslator):
     """Transformation for “popping up” nested lifts to lambda arguments.
 
@@ -21,6 +23,10 @@ class PopupTmps(NodeTranslator):
     as we can not pop the expression to be a closure input (because closures
     just take unmodified fencil arguments as inputs).
     """
+
+    # we use one UID generator per instance such that the generated ids are
+    #  stable across multiple runs (required for caching to properly work)
+    uids: UIDGenerator = dataclasses.field(init=False, repr=False, default_factory=UIDGenerator)
 
     @staticmethod
     def _extract_lambda(
@@ -145,7 +151,7 @@ class PopupTmps(NodeTranslator):
 
             # if this is the first time we lift that expression, create a new
             # symbol for it and register it so the parent node knows about it
-            ref = ir.SymRef(id=UIDs.sequential_id(prefix="_lift"))
+            ref = ir.SymRef(id=self.uids.sequential_id(prefix="_lift"))
             lifts[call] = ref
             return ref
         return self.generic_visit(node, lifts=lifts)

--- a/src/functional/iterator/transforms/unroll_reduce.py
+++ b/src/functional/iterator/transforms/unroll_reduce.py
@@ -1,11 +1,21 @@
+import dataclasses
 from collections.abc import Iterable
 
 from eve import NodeTranslator
-from eve.utils import UIDs
+from eve.utils import UIDGenerator
 from functional.iterator import ir
 
 
+@dataclasses.dataclass(frozen=True)
 class UnrollReduce(NodeTranslator):
+    # we use one UID generator per instance such that the generated ids are
+    #  stable across multiple runs (required for caching to properly work)
+    uids: UIDGenerator = dataclasses.field(init=False, repr=False, default_factory=UIDGenerator)
+
+    @classmethod
+    def apply(cls, node: ir.Node, **kwargs):
+        return cls().visit(node, **kwargs)
+
     @staticmethod
     def _find_connectivity(reduce_args: Iterable[ir.Expr], offset_provider):
         connectivities = []
@@ -60,9 +70,9 @@ class UnrollReduce(NodeTranslator):
         max_neighbors = connectivity.max_neighbors
         has_skip_values = connectivity.has_skip_values
 
-        acc = ir.SymRef(id=UIDs.sequential_id(prefix="_acc"))
-        offset = ir.SymRef(id=UIDs.sequential_id(prefix="_i"))
-        step = ir.SymRef(id=UIDs.sequential_id(prefix="_step"))
+        acc = ir.SymRef(id=self.uids.sequential_id(prefix="_acc"))
+        offset = ir.SymRef(id=self.uids.sequential_id(prefix="_i"))
+        step = ir.SymRef(id=self.uids.sequential_id(prefix="_step"))
 
         assert isinstance(node.fun, ir.FunCall)
         fun, init = node.fun.args

--- a/tests/functional_tests/iterator_tests/test_unroll_reduce.py
+++ b/tests/functional_tests/iterator_tests/test_unroll_reduce.py
@@ -136,7 +136,7 @@ def test_no_skip_values(basic_reduction):
     expected = _expected(basic_reduction, "dim", 3, False)
 
     offset_provider = {"dim": SimpleNamespace(max_neighbors=3, has_skip_values=False)}
-    actual = UnrollReduce().visit(basic_reduction, offset_provider=offset_provider)
+    actual = UnrollReduce.apply(basic_reduction, offset_provider=offset_provider)
     assert actual == expected
 
 
@@ -144,7 +144,7 @@ def test_skip_values(basic_reduction):
     expected = _expected(basic_reduction, "dim", 3, True)
 
     offset_provider = {"dim": SimpleNamespace(max_neighbors=3, has_skip_values=True)}
-    actual = UnrollReduce().visit(basic_reduction, offset_provider=offset_provider)
+    actual = UnrollReduce.apply(basic_reduction, offset_provider=offset_provider)
     assert actual == expected
 
 
@@ -152,9 +152,7 @@ def test_reduction_with_shift_on_second_arg(reduction_with_shift_on_second_arg):
     expected = _expected(reduction_with_shift_on_second_arg, "dim", 3, False)
 
     offset_provider = {"dim": SimpleNamespace(max_neighbors=3, has_skip_values=False)}
-    actual = UnrollReduce().visit(
-        reduction_with_shift_on_second_arg, offset_provider=offset_provider
-    )
+    actual = UnrollReduce.apply(reduction_with_shift_on_second_arg, offset_provider=offset_provider)
     assert actual == expected
 
 
@@ -167,7 +165,7 @@ def test_reduction_with_irrelevant_full_shift(reduction_with_irrelevant_full_shi
             max_neighbors=1, has_skip_values=True
         ),  # different max_neighbors and skip value to trigger error
     }
-    actual = UnrollReduce().visit(
+    actual = UnrollReduce.apply(
         reduction_with_irrelevant_full_shift, offset_provider=offset_provider
     )
     assert actual == expected
@@ -196,4 +194,4 @@ def test_reduction_with_incompatible_shifts(reduction_with_incompatible_shifts, 
         "dim2": SimpleNamespace(max_neighbors=2, has_skip_values=False),
     }
     with pytest.raises(RuntimeError, match="incompatible"):
-        UnrollReduce().visit(reduction_with_incompatible_shifts, offset_provider=offset_provider)
+        UnrollReduce.apply(reduction_with_incompatible_shifts, offset_provider=offset_provider)


### PR DESCRIPTION
Previously some passes generated globally unique ids such that when one of those passes was executed multiple times in multiples field operator invocations a different id was used. Consequently a new cache id was generated and caching failed. This PR fixes that by using unique ids per pass invocation.