### PR TITLE
Update Jfrog docker registry URL

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,12 @@ include:
 .py39: &py39
   PYVERSION_PREFIX: py39
   PYVERSION: 3.9.1
+  CSCS_REGISTRY_NEW: jfrog.svc.cscs.ch
 
 .py38: &py38
   PYVERSION_PREFIX: py38
   PYVERSION: 3.8.5
+  CSCS_REGISTRY_NEW: jfrog.svc.cscs.ch
 
 .status: &status
   STATUS_IMAGE: dropd/github-status:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,10 +31,10 @@ build py38:
   extends: .dind
   stage: image
   variables:
-    BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/gt4py-ci:$PYVERSION
+    BUILD_IMAGE: $CSCS_REGISTRY_NEW/$IMAGE_NAME/gt4py-ci:$PYVERSION
     <<: *py38
   script:
-  - docker login -u $CSCS_REGISTRY_USER --password-stdin $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
+  - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY_NEW
   - docker pull $BUILD_IMAGE || echo "has not been built yet"
   - docker build --network=host --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg PYVERSION=$PYVERSION --build-arg CI_PROJECT_DIR=$CI_PROJECT_DIR -t $BUILD_IMAGE .
   - docker push $BUILD_IMAGE
@@ -57,7 +57,7 @@ test py38:
   - trying
   needs: ["build py38"]
   stage: test
-  image: $CSCS_REGISTRY_IMAGE/gt4py-ci:$PYVERSION
+  image: $CSCS_REGISTRY_NEW/$IMAGE_NAME/gt4py-ci:$PYVERSION
   script:
   - python -c "import cupy"
   - pip install clang-format

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ build py38:
     BUILD_IMAGE: $CSCS_REGISTRY_NEW/$IMAGE_NAME/gt4py-ci:$PYVERSION
     <<: *py38
   script:
-  - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY_NEW
+  - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD jfrog.svc.cscs.ch
   - docker pull $BUILD_IMAGE || echo "has not been built yet"
   - docker build --network=host --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg PYVERSION=$PYVERSION --build-arg CI_PROJECT_DIR=$CI_PROJECT_DIR -t $BUILD_IMAGE .
   - docker push $BUILD_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,13 @@ include:
   PYVERSION_PREFIX: py39
   PYVERSION: 3.9.1
   CSCS_REGISTRY_NEW: jfrog.svc.cscs.ch
+  IMAGE_NAME: contbuild/cscs-ci/gridtools/gt4py
 
 .py38: &py38
   PYVERSION_PREFIX: py38
   PYVERSION: 3.8.5
   CSCS_REGISTRY_NEW: jfrog.svc.cscs.ch
+  IMAGE_NAME: contbuild/cscs-ci/gridtools/gt4py
 
 .status: &status
   STATUS_IMAGE: dropd/github-status:latest
@@ -36,7 +38,7 @@ build py38:
     BUILD_IMAGE: $CSCS_REGISTRY_NEW/$IMAGE_NAME/gt4py-ci:$PYVERSION
     <<: *py38
   script:
-  - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD jfrog.svc.cscs.ch
+  - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY_NEW
   - docker pull $BUILD_IMAGE || echo "has not been built yet"
   - docker build --network=host --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg PYVERSION=$PYVERSION --build-arg CI_PROJECT_DIR=$CI_PROJECT_DIR -t $BUILD_IMAGE .
   - docker push $BUILD_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ build py38:
     BUILD_IMAGE: $CSCS_REGISTRY_IMAGE/gt4py-ci:$PYVERSION
     <<: *py38
   script:
-  - docker login -u $CSCS_REGISTRY_USER -p $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
+  - docker login -u $CSCS_REGISTRY_USER --password-stdin $CSCS_REGISTRY_PASSWORD $CSCS_REGISTRY
   - docker pull $BUILD_IMAGE || echo "has not been built yet"
   - docker build --network=host --cache-from $BUILD_IMAGE --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg PYVERSION=$PYVERSION --build-arg CI_PROJECT_DIR=$CI_PROJECT_DIR -t $BUILD_IMAGE .
   - docker push $BUILD_IMAGE


### PR DESCRIPTION
## Description

Update JFrog artifactory URL.

Somehow the artifactory is not available anymore at the URL pointed to by the CSCS-CI organization's CSCS_REGISTRY variable. This breaks all CIGR pipelines in general. 
The existing credentials work however on the new location. The reason the new URL is hardcoded into the gitlab-ci.yml is that we can not change the externally managed variable.

## Requirements

Before submitting this PR, please make sure:

- [x] You have run the code checks, tests and documentation build successfully
- [x] All fixes and all new functionality are tested and documentation is up to date
- [x] You looked at the [review checklist](https://github.com/GridTools/gt4py/blob/master/REVIEW_CHECKLIST.txt)

Additionally, if this PR contains code authored by new contributors:

- [x] All the authors are covered by a valid contributor assignment agreement,
signed by the employer if needed, provided to ETH Zurich
- [x] The names of all the new contributors have been added to an updated
version of the AUTHORS.rst file included in the PR
 


