### PR TITLE
Functional: Tuple arguments

### DIFF
--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -173,6 +173,11 @@ def make_symbol_type_from_value(value: Any) -> ct.SymbolType:
         dims = list(value.axes)
         dtype = make_symbol_type_from_typing(value.dtype.type)
         symbol_type = ct.FieldType(dims=dims, dtype=dtype)
+    elif isinstance(value, tuple):
+        # TODO(tehrengruber): remove special casing when `make_symbol_type_from_typing`
+        #  supports `Field`s (i.e. the special casing above for `LocatedField`)
+        #  disappears.
+        return ct.TupleType(types=[make_symbol_type_from_value(el) for el in value])
     else:
         type_ = xtyping.infer_type(value, annotate_callable_kwargs=True)
         symbol_type = make_symbol_type_from_typing(type_)

--- a/src/functional/ffront/symbol_makers.py
+++ b/src/functional/ffront/symbol_makers.py
@@ -174,9 +174,10 @@ def make_symbol_type_from_value(value: Any) -> ct.SymbolType:
         dtype = make_symbol_type_from_typing(value.dtype.type)
         symbol_type = ct.FieldType(dims=dims, dtype=dtype)
     elif isinstance(value, tuple):
-        # TODO(tehrengruber): remove special casing when `make_symbol_type_from_typing`
-        #  supports `Field`s (i.e. the special casing above for `LocatedField`)
-        #  disappears.
+        # Since the elements of the tuple might be one of the special cases
+        # above, we can not resort to generic `infer_type` but need to do it
+        # manually here. If we get rid of all the special cases this is
+        # not needed anymore.
         return ct.TupleType(types=[make_symbol_type_from_value(el) for el in value])
     else:
         type_ = xtyping.infer_type(value, annotate_callable_kwargs=True)

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -808,6 +808,22 @@ def test_tuple_with_local_field_in_reduction_shifted(reduction_setup):
     assert np.allclose(expected, out)
 
 
+def test_tuple_arg(fieldview_backend):
+    if fieldview_backend == gtfn_cpu.run_gtfn:
+        pytest.skip("Tuple arguments are not supported yet.")
+    size = 10
+    a = np_as_located_field(IDim)(np.ones((size,)))
+    b = np_as_located_field(IDim)(2 * np.ones((size,)))
+    out = np_as_located_field(IDim)(np.zeros((size,)))
+    @field_operator(backend=fieldview_backend)
+    def unpack_tuple(inp: tuple[Field[[IDim], float64], Field[[IDim], float64]]) -> Field[[IDim], float64]:
+        return 3.*inp[0] + inp[1]
+
+    unpack_tuple((a, b), out=out, offset_provider={})
+
+    assert np.allclose(3 * a.array() + b.array(), out)
+
+
 @pytest.mark.parametrize("forward", [True, False])
 def test_simple_scan(fieldview_backend, forward):
     if fieldview_backend == gtfn_cpu.run_gtfn:

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -810,7 +810,7 @@ def test_tuple_with_local_field_in_reduction_shifted(reduction_setup):
 
 def test_tuple_arg(fieldview_backend):
     if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.skip("Tuple arguments are not supported yet.")
+        pytest.skip("Tuple arguments are not supported in gtfn yet.")
     size = 10
     a = np_as_located_field(IDim)(np.ones((size,)))
     b = np_as_located_field(IDim)(2 * np.ones((size,)))

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -818,13 +818,13 @@ def test_tuple_arg(fieldview_backend):
 
     @field_operator(backend=fieldview_backend)
     def unpack_tuple(
-        inp: tuple[Field[[IDim], float64], Field[[IDim], float64]]
+        inp: tuple[tuple[Field[[IDim], float64], Field[[IDim], float64]], Field[[IDim], float64]]
     ) -> Field[[IDim], float64]:
-        return 3.0 * inp[0] + inp[1]
+        return 3.0 * inp[0][0] + inp[0][1] + inp[1]
 
-    unpack_tuple((a, b), out=out, offset_provider={})
+    unpack_tuple(((a, b), a), out=out, offset_provider={})
 
-    assert np.allclose(3 * a.array() + b.array(), out)
+    assert np.allclose(3 * a.array() + b.array() + a.array(), out)
 
 
 @pytest.mark.parametrize("forward", [True, False])

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -815,9 +815,12 @@ def test_tuple_arg(fieldview_backend):
     a = np_as_located_field(IDim)(np.ones((size,)))
     b = np_as_located_field(IDim)(2 * np.ones((size,)))
     out = np_as_located_field(IDim)(np.zeros((size,)))
+
     @field_operator(backend=fieldview_backend)
-    def unpack_tuple(inp: tuple[Field[[IDim], float64], Field[[IDim], float64]]) -> Field[[IDim], float64]:
-        return 3.*inp[0] + inp[1]
+    def unpack_tuple(
+        inp: tuple[Field[[IDim], float64], Field[[IDim], float64]]
+    ) -> Field[[IDim], float64]:
+        return 3.0 * inp[0] + inp[1]
 
     unpack_tuple((a, b), out=out, offset_provider={})
 


### PR DESCRIPTION
Allows passing tuples to field operators. This PR essentially just adds a test and fixes an unrelated thing, lowering etc. just worked :-)

Note: Only the embedded backend is supported for now.

```python
@field_operator(backend=fieldview_backend)
def unpack_tuple(inp: tuple[Field[[IDim], float64], Field[[IDim], float64]]) -> Field[[IDim], float64]:
    return 3.*inp[0] + inp[1]

unpack_tuple((a, b), out=out, offset_provider={})
```