### PR TITLE
Functional: POC Python AST SSA pass for Ifs

### DIFF
--- a/tests/functional_tests/ffront_tests/test_single_static_assign.py
+++ b/tests/functional_tests/ffront_tests/test_single_static_assign.py
@@ -152,11 +152,9 @@ def test_if():
     assert lines[3] == "    a__0 = 2"
     assert lines[4] == "a__1 = 3"
 
-    blub = 1 + 1
-
 
 def test_nested_if():
-    lines = ast.unparse(
+    result = ast.unparse(
         ssaify_string(
             """
             if True:
@@ -169,10 +167,57 @@ def test_nested_if():
             a = 5
             """
         )
-    ).splitlines()
+    )
 
-    assert lines[1] == "    a__0 = 1"
-    assert lines[3] == "    a__0 = 2"
-    assert lines[5] == "        a__1 = 3"
-    assert lines[6] == "    a__2 = 4"
-    assert lines[7] == "a__3 = 5"
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 1
+            a__2 = a__0
+        else:
+            a__0 = 2
+            if True:
+                a__1 = 3
+            else:
+                a__1 = a__0
+            a__2 = 4
+        a__3 = 5
+    """
+    ).strip()
+
+    assert result == expected
+
+
+def test_nested_if_chain():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 1
+            else:
+                a = 2
+                if True:
+                    a = a+1
+                a = a+1
+            a = a+1
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 1
+            a__2 = a__0
+        else:
+            a__0 = 2
+            if True:
+                a__1 = a__0 + 1
+            else:
+                a__1 = a__0
+            a__2 = a__1 + 1
+        a__3 = a__2 + 1
+    """
+    ).strip()
+
+    assert result == expected

--- a/tests/functional_tests/ffront_tests/test_single_static_assign.py
+++ b/tests/functional_tests/ffront_tests/test_single_static_assign.py
@@ -133,3 +133,46 @@ def test_empty_annotated_assign():
     assert lines[0] == "a__0 = 0"
     assert lines[1] == "a__1: int"
     assert lines[2] == "b__0 = a__0"
+
+
+def test_if():
+    lines = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 1
+            else:
+                a = 2
+            a = 3
+            """
+        )
+    ).splitlines()
+
+    assert lines[1] == "    a__0 = 1"
+    assert lines[3] == "    a__0 = 2"
+    assert lines[4] == "a__1 = 3"
+
+    blub = 1 + 1
+
+
+def test_nested_if():
+    lines = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 1
+            else:
+                a = 2
+                if True:
+                    a = 3
+                a = 4
+            a = 5
+            """
+        )
+    ).splitlines()
+
+    assert lines[1] == "    a__0 = 1"
+    assert lines[3] == "    a__0 = 2"
+    assert lines[5] == "        a__1 = 3"
+    assert lines[6] == "    a__2 = 4"
+    assert lines[7] == "a__3 = 5"


### PR DESCRIPTION
Proof of concept to support `if` statements in the Python AST Single-Static-Assignment preprocessing pass. After this PR
```python
if True:
    a = 1
else:
    a = 2
a = 3
```
is transformed into:
```python
if True:
    a__0 = 1
else:
    a__0 = 2
a__1 = 3
```

A more complicated example:
```python
if True:
    a = 1
else:
    a = 2
    if True:
        a = a+1
    a = a+1
a = a+1
```
is transformed into:
```python
if True:
    a__0 = 1
    a__2 = a__0
else:
    a__0 = 2
    if True:
        a__1 = a__0 + 1
    else:
        a__1 = a__0
    a__2 = a__1 + 1
a__3 = a__2 + 1
```