### PR TITLE
Functional: Fix docstring of `UnpackedAssignPass` pass

### DIFF
--- a/src/functional/ffront/ast_passes/simple_assign.py
+++ b/src/functional/ffront/ast_passes/simple_assign.py
@@ -84,10 +84,8 @@ class UnpackedAssignPass(NodeYielder):
     """
     Explicitly unpack assignments.
 
-    Requires AST in SSA form and assumes only single target assigns, check the following passes.
-
-     * ``SingleStaticAssignPass``
-     * ``SingleAssignTargetPass``
+    Requires an AST with only single target assigns (see
+    ``SingleAssignTargetPass``).
 
     Example
     -------


### PR DESCRIPTION
Fixed docstring that became outdated after https://github.com/GridTools/gt4py/pull/853.