### PR TITLE
Restrict typing extensions dependency to ver 4.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     packaging>=20.0
     pybind11>=2.5
     toolz>=0.11
-    typing-extensions>=4.2
+    typing-extensions>=4.2,<4.4
     xxhash>=1.4.4
 
 [options.package_data]


### PR DESCRIPTION
Temporary fix, refer to https://github.com/GridTools/gt4py/issues/968