### PR TITLE
Make aligned_index an optional keyword arg of storage methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,9 +114,6 @@ repos:
       src/gt4py/frontend/__init__.py |
       src/gt4py/frontend/nodes.py |
       src/gt4py/frontend/node_util.py |
-      src/gt4py/storage/__init__.py |
-      src/gt4py/storage/storage.py |
-      src/gt4py/storage/utils.py |
       src/gt4py/utils/__init__.py |
       src/gt4py/utils/base.py |
       src/gt4py/utils/attrib.py |
@@ -128,7 +125,6 @@ repos:
       tests/test_integration/utils.py |
       tests/test_unittest/test_call_interface.py |
       tests/test_unittest/test_gtscript_frontend.py |
-      tests/test_unittest/test_storage.py |
       )$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
@@ -152,7 +148,6 @@ repos:
       tests/test_integration/test_code_generation.py |
       tests/test_unittest/test_call_interface.py |
       tests/test_unittest/test_gtscript_frontend.py |
-      tests/test_unittest/test_storage.py |
       tests/test_unittest/test_gtc/test_common.py |
       tests/test_unittest/test_gtc/test_oir.py |
       tests/test_unittest/test_gtc/gtir_utils.py |

--- a/src/gt4py/storage/__init__.py
+++ b/src/gt4py/storage/__init__.py
@@ -15,10 +15,10 @@
 """GridTools storages classes."""
 
 
-from .storage import empty, from_array, full, ones, zeros
+from .storage import empty, from_array, full, ones, zeros  # noqa: F401
 
 
 try:
-    from .storage import dace_descriptor
+    from .storage import dace_descriptor  # noqa: F401
 except ImportError:
     pass

--- a/src/gt4py/storage/storage.py
+++ b/src/gt4py/storage/storage.py
@@ -13,7 +13,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from numbers import Number
-from typing import Any, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Union
 
 import numpy as np
 
@@ -49,11 +49,10 @@ def empty(
     dtype: DTypeLike = np.float64,
     *,
     backend: str,
-    aligned_index: Sequence[int],
+    aligned_index: Optional[Sequence[int]] = None,
     dimensions: Optional[Sequence[str]] = None,
 ) -> Union[np.ndarray, "cp.ndarray"]:
     """Allocate an array of uninitialized (undefined) values with performance-optimal strides and alignment.
-
 
     Parameters
     ----------
@@ -66,9 +65,9 @@ def empty(
     -----------------
         backend : `str`
             The target backend for which the allocation is optimized.
-        aligned_index: `Sequence` of `int`
+        aligned_index: `Sequence` of `int`, optional
             Indicate the index of the resulting array that most commonly corresponds to the origin of the compute
-            domain.
+            domain. If not passed, it is aligned at the data origin.
         dimensions: `Sequence` of `str`, optional
             Indicate the semantic meaning of the dimensions in the provided array. Only used for determining optimal
             strides, the information is not stored.
@@ -102,7 +101,7 @@ def empty(
     layout_map = gt_backend.from_name(backend).storage_info["layout_map"](dimensions)
 
     dtype = np.dtype(dtype)
-    _, res = allocate_f(aligned_index, shape, layout_map, dtype, alignment * dtype.itemsize)
+    _, res = allocate_f(shape, layout_map, dtype, alignment * dtype.itemsize, aligned_index)
     return res
 
 
@@ -111,11 +110,10 @@ def ones(
     dtype: DTypeLike = np.float64,
     *,
     backend: str,
-    aligned_index: Sequence[int],
+    aligned_index: Optional[Sequence[int]] = None,
     dimensions: Optional[Sequence[str]] = None,
 ) -> Union[np.ndarray, "cp.ndarray"]:
     """Allocate an array with values initialized to 1.0 with performance-optimal strides and alignment.
-
 
     Parameters
     ----------
@@ -128,9 +126,9 @@ def ones(
     -----------------
         backend : `str`
             The target backend for which the allocation is optimized.
-        aligned_index: `Sequence` of `int`
+        aligned_index: `Sequence` of `int`, optional
             Indicate the index of the resulting array that most commonly corresponds to the origin of the compute
-            domain.
+            domain. If not passed, it is aligned at the data origin.
         dimensions: `Sequence` of `str`, optional
             Indicate the semantic meaning of the dimensions in the provided array. Only used for determining optimal
             strides, the information is not stored.
@@ -165,11 +163,10 @@ def full(
     dtype: DTypeLike = np.float64,
     *,
     backend: str,
-    aligned_index: Sequence[int],
+    aligned_index: Optional[Sequence[int]] = None,
     dimensions: Optional[Sequence[str]] = None,
 ) -> Union[np.ndarray, "cp.ndarray"]:
     """Allocate an array with values initialized to `fill_value` with performance-optimal strides and alignment.
-
 
     Parameters
     ----------
@@ -184,9 +181,9 @@ def full(
     -----------------
         backend : `str`
             The target backend for which the allocation is optimized.
-        aligned_index: `Sequence` of `int`
+        aligned_index: `Sequence` of `int`, optional
             Indicate the index of the resulting array that most commonly corresponds to the origin of the compute
-            domain.
+            domain. If not passed, it is aligned at the data origin.
         dimensions: `Sequence` of `str`, optional
             Indicate the semantic meaning of the dimensions in the provided array. Only used for determining optimal
             strides, the information is not stored.
@@ -220,11 +217,10 @@ def zeros(
     dtype: DTypeLike = np.float64,
     *,
     backend: str,
-    aligned_index: Sequence[int],
+    aligned_index: Optional[Sequence[int]] = None,
     dimensions: Optional[Sequence[str]] = None,
 ) -> Union[np.ndarray, "cp.ndarray"]:
     """Allocate an array with values initialized to 0.0 with performance-optimal strides and alignment.
-
 
     Parameters
     ----------
@@ -237,9 +233,9 @@ def zeros(
     -----------------
         backend : `str`
             The target backend for which the allocation is optimized.
-        aligned_index: `Sequence` of `int`
+        aligned_index: `Sequence` of `int`, optional
             Indicate the index of the resulting array that most commonly corresponds to the origin of the compute
-            domain.
+            domain. If not passed, it is aligned at the data origin.
         dimensions: `Sequence` of `str`, optional
             Indicate the semantic meaning of the dimensions in the provided array. Only used for determining optimal
             strides, the information is not stored.
@@ -273,12 +269,12 @@ def from_array(
     dtype: DTypeLike = np.float64,
     *,
     backend: str,
-    aligned_index: Sequence[int],
+    aligned_index: Optional[Sequence[int]] = None,
     dimensions: Optional[Sequence[str]] = None,
 ) -> Union[np.ndarray, "cp.ndarray"]:
-    """Allocate an array with values initialized to those of `data` with performance-optimal strides and alignment. This
-    copies the values from `data` to the resulting buffer.
+    """Allocate an array with values initialized to those of `data` with performance-optimal strides and alignment.
 
+    This copies the values from `data` to the resulting buffer.
 
     Parameters
     ----------
@@ -291,9 +287,9 @@ def from_array(
     -----------------
         backend : `str`
             The target backend for which the allocation is optimized.
-        aligned_index: `Sequence` of `int`
+        aligned_index: `Sequence` of `int`, optional
             Indicate the index of the resulting array that most commonly corresponds to the origin of the compute
-            domain.
+            domain. If not passed, it is aligned at the data origin.
         dimensions: `Sequence` of `str`, optional
             Indicate the semantic meaning of the dimensions in the provided array. Only used for determining optimal
             strides, the information is not stored.
@@ -346,7 +342,7 @@ if dace is not None:
         dtype: DTypeLike = np.float64,
         *,
         backend: str,
-        aligned_index: Sequence[int],
+        aligned_index: Optional[Sequence[int]] = None,
         dimensions: Optional[Sequence[str]] = None,
     ) -> dace.data.Array:
         """Return a DaCe data descriptor which describes performance-optimal strides and alignment.
@@ -362,9 +358,9 @@ if dace is not None:
         -----------------
             backend : `str`
                 The target backend for which the described allocation is optimized.
-            aligned_index: `Sequence` of `int`
+            aligned_index: `Sequence` of `int`, optional
                 Indicate the index of the resulting array that most commonly corresponds to the origin of the compute
-                domain.
+                domain. If not passed, it is aligned at the data origin.
             dimensions: `Sequence` of `str`, optional
                 Indicate the semantic meaning of the dimensions in the data descriptor. Only used for determining
                 optimal strides, the information is not stored.

--- a/src/gt4py/storage/utils.py
+++ b/src/gt4py/storage/utils.py
@@ -62,17 +62,14 @@ def normalize_storage_spec(aligned_index, shape, dtype, dimensions):
 
     Returns
     -------
-
     tuple(aligned_index, shape, dtype, mask)
         The output tuple fields verify the following semantics:
-
             - aligned_index: tuple of ints with default origin values for the non-masked dimensions
             - shape: tuple of ints with shape values for the non-masked dimensions
             - dtype: scalar numpy.dtype (non-structured and without subarrays)
             - backend: backend identifier string (numpy, gt:cpu_kfirst, gt:gpu, ...)
             - dimensions: a tuple of dimension identifier strings
     """
-
     from gt4py.gtscript import Axis  # prevent circular import
 
     if dimensions is None:
@@ -190,7 +187,7 @@ def allocate_gpu(
     dtype: DTypeLike,
     alignment_bytes: int,
     aligned_index: Optional[Sequence[int]],
-) -> Tuple[cp.ndarray, cp.ndarray]:
+) -> Tuple["cp.ndarray", "cp.ndarray"]:
     dtype = np.dtype(dtype)
     assert (
         alignment_bytes % dtype.itemsize

--- a/src/gt4py/storage/utils.py
+++ b/src/gt4py/storage/utils.py
@@ -290,15 +290,15 @@ def as_cupy(array: FieldLike) -> "cp.ndarray":
     return cp.asarray(array)
 
 
-def get_dims(object: GtDimsInterface) -> Optional[Tuple[str, ...]]:
-    dims = getattr(object, "__gt_dims__", None)
+def get_dims(obj: GtDimsInterface) -> Optional[Tuple[str, ...]]:
+    dims = getattr(obj, "__gt_dims__", None)
     if dims is None:
         return dims
     return tuple(str(d) for d in dims)
 
 
-def get_origin(object: GtOriginInterface) -> Optional[Tuple[int, ...]]:
-    origin = getattr(object, "__gt_origin__", None)
+def get_origin(obj: GtOriginInterface) -> Optional[Tuple[int, ...]]:
+    origin = getattr(obj, "__gt_origin__", None)
     if origin is None:
         return origin
     return tuple(int(o) for o in origin)

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -27,7 +27,7 @@ except ImportError:
 import gt4py.backend as gt_backend
 import gt4py.storage
 from gt4py import gtscript
-from gt4py.storage.utils import normalize_storage_spec
+from gt4py.storage.utils import allocate_cpu, allocate_gpu, normalize_storage_spec
 
 from ..definitions import CPU_BACKENDS, GPU_BACKENDS
 
@@ -126,9 +126,7 @@ def test_allocate_cpu(param_dict):
     shape = param_dict["shape"]
     layout_map = param_dict["layout_order"]
 
-    raw_buffer, field = gt4py.storage.util.allocate_cpu(
-        aligned_index, shape, layout_map, dtype, alignment_bytes
-    )
+    raw_buffer, field = allocate_cpu(shape, layout_map, dtype, alignment_bytes, aligned_index)
 
     # check that field is a view of raw_buffer
     assert field.base is raw_buffer
@@ -189,8 +187,8 @@ def test_allocate_gpu(param_dict):
     aligned_index = param_dict["aligned_index"]
     shape = param_dict["shape"]
     layout_map = param_dict["layout_order"]
-    device_raw_buffer, device_field = gt4py.storage.utils.allocate_gpu(
-        aligned_index, shape, layout_map, dtype, alignment_bytes
+    device_raw_buffer, device_field = allocate_gpu(
+        shape, layout_map, dtype, alignment_bytes, aligned_index
     )
 
     # check that the memory of field is contained in raws buffer

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -191,7 +191,9 @@ def test_allocate_gpu(param_dict):
         shape, layout_map, dtype, alignment_bytes, aligned_index
     )
 
-    # check that the memory of field is contained in raws buffer
+    # Would like to check device_field.base against device_raw_buffer but
+    # as_strided returns an ndarray where device_field.base is set to None.
+    # Instead, check that the memory of field is contained in raws buffer
     assert (
         device_field.data.ptr >= device_raw_buffer.data.ptr
         and device_field[-1:].data.ptr <= device_raw_buffer[-1:].data.ptr

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -25,8 +25,7 @@ except ImportError:
     cp = None
 
 import gt4py.backend as gt_backend
-import gt4py.storage as gt_store
-import gt4py.storage.utils as gt_storage_utils
+import gt4py.storage
 from gt4py import gtscript
 from gt4py.storage.utils import normalize_storage_spec
 
@@ -37,6 +36,7 @@ try:
     import dace
 except ImportError:
     dace = None
+
 
 # ---- Hypothesis strategies ----
 @hyp_st.composite
@@ -69,7 +69,7 @@ def allocation_strategy(draw):
     shape_strats = []
     aligned_index_strats = []
 
-    for i in range(dimension):
+    for _i in range(dimension):
         shape_strats = shape_strats + [hyp_st.integers(min_value=1, max_value=64)]
     shape = draw(hyp_st.tuples(*shape_strats))
     for i in range(dimension):
@@ -126,7 +126,7 @@ def test_allocate_cpu(param_dict):
     shape = param_dict["shape"]
     layout_map = param_dict["layout_order"]
 
-    raw_buffer, field = gt_storage_utils.allocate_cpu(
+    raw_buffer, field = gt4py.storage.util.allocate_cpu(
         aligned_index, shape, layout_map, dtype, alignment_bytes
     )
 
@@ -142,7 +142,7 @@ def test_allocate_cpu(param_dict):
     # check if the first compute-domain point in the last dimension is aligned for 100 random "columns"
     import random
 
-    for i in range(100):
+    for _i in range(100):
         slices = []
         for hidx in range(len(shape)):
             if hidx == np.argmax(layout_map):
@@ -153,7 +153,7 @@ def test_allocate_cpu(param_dict):
 
     # check that writing does not give errors, e.g. because of going out of bounds
     slices = []
-    for hidx in range(len(shape)):
+    for _hidx in range(len(shape)):
         slices = slices + [0]
     field[tuple(slices)] = 1
 
@@ -175,7 +175,7 @@ def test_allocate_cpu(param_dict):
     except IndexError:
         pass
     else:
-        assert False
+        raise AssertionError()
 
     # check if shape is properly set
     assert field.shape == shape
@@ -189,12 +189,11 @@ def test_allocate_gpu(param_dict):
     aligned_index = param_dict["aligned_index"]
     shape = param_dict["shape"]
     layout_map = param_dict["layout_order"]
-    device_raw_buffer, device_field = gt_storage_utils.allocate_gpu(
+    device_raw_buffer, device_field = gt4py.storage.utils.allocate_gpu(
         aligned_index, shape, layout_map, dtype, alignment_bytes
     )
 
-    # assert (device_field.base is device_raw_buffer) # as_strided actually returns an ndarray where base=None??
-    # instead check that the memory of field is contained in raws buffer:
+    # check that the memory of field is contained in raws buffer
     assert (
         device_field.data.ptr >= device_raw_buffer.data.ptr
         and device_field[-1:].data.ptr <= device_raw_buffer[-1:].data.ptr
@@ -203,7 +202,7 @@ def test_allocate_gpu(param_dict):
     # check if the first compute-domain point in the last dimension is aligned for 100 random "columns"
     import random
 
-    for i in range(100):
+    for _i in range(100):
         slices = []
         for hidx in range(len(shape)):
             if hidx == np.argmax(layout_map):
@@ -214,7 +213,7 @@ def test_allocate_gpu(param_dict):
 
     # check that writing does not give errors, e.g. because of going out of bounds
     slices = []
-    for hidx in range(len(shape)):
+    for _hidx in range(len(shape)):
         slices = slices + [0]
     device_field[tuple(slices)] = 1
 
@@ -348,11 +347,11 @@ class TestNormalizeStorageSpec:
 @pytest.mark.parametrize(
     "alloc_fun",
     [
-        gt_store.empty,
-        gt_store.ones,
-        gt_store.zeros,
-        lambda *args, **kwargs: gt_store.full(*args, fill_value=7, **kwargs),
-        lambda shape, dtype, **kwargs: gt_store.from_array(
+        gt4py.storage.empty,
+        gt4py.storage.ones,
+        gt4py.storage.zeros,
+        lambda *args, **kwargs: gt4py.storage.full(*args, fill_value=7, **kwargs),
+        lambda shape, dtype, **kwargs: gt4py.storage.from_array(
             np.empty(shape, dtype=dtype),
             dtype=dtype,
             **kwargs,
@@ -369,11 +368,11 @@ def test_cpu_constructor(alloc_fun, backend):
 @pytest.mark.parametrize(
     "alloc_fun",
     [
-        gt_store.empty,
-        gt_store.ones,
-        gt_store.zeros,
-        lambda *args, **kwargs: gt_store.full(*args, fill_value=7, **kwargs),
-        lambda shape, dtype, **kwargs: gt_store.from_array(
+        gt4py.storage.empty,
+        gt4py.storage.ones,
+        gt4py.storage.zeros,
+        lambda *args, **kwargs: gt4py.storage.full(*args, fill_value=7, **kwargs),
+        lambda shape, dtype, **kwargs: gt4py.storage.from_array(
             np.empty(shape, dtype=dtype),
             dtype=dtype,
             **kwargs,
@@ -399,7 +398,7 @@ def test_masked_storage_gpu(param_dict):
     shape = param_dict["shape"]
 
     # no assert when all is defined in descriptor, no grid_group
-    array = gt_store.empty(
+    array = gt4py.storage.empty(
         dtype=np.float64,
         aligned_index=aligned_index,
         shape=shape,
@@ -422,7 +421,7 @@ def test_masked_storage_asserts():
     backend = "gt:cpu_kfirst"
 
     with pytest.raises(ValueError):
-        gt_store.empty(
+        gt4py.storage.empty(
             dtype=np.float64,
             aligned_index=aligned_index,
             shape=shape,
@@ -433,7 +432,7 @@ def test_masked_storage_asserts():
 
 def test_non_existing_backend():
     with pytest.raises(RuntimeError, match="backend"):
-        gt_store.empty(
+        gt4py.storage.empty(
             shape=[10, 10, 10],
             backend="non_existing_backend",
             aligned_index=[0, 0, 0],
@@ -473,7 +472,7 @@ class TestDescriptor:
     )
     def test_device(self, backend):
         backend_cls = gt_backend.from_name(backend)
-        descriptor: dace.data.Array = gt_store.dace_descriptor(
+        descriptor: dace.data.Array = gt4py.storage.dace_descriptor(
             backend=backend,
             shape=(3, 7, 13),
             aligned_index=(1, 2, 3),
@@ -494,13 +493,13 @@ class TestDescriptor:
     def test_start_offset(self, backend):
         backend_cls = gt_backend.from_name(backend)
         aligned_index = (1, 2, 3)
-        stor = gt_store.ones(
+        stor = gt4py.storage.ones(
             backend=backend,
             shape=(3, 7, 13),
             aligned_index=aligned_index,
             dtype=np.float64,
         )
-        descriptor: dace.data.Array = gt_store.dace_descriptor(
+        descriptor: dace.data.Array = gt4py.storage.dace_descriptor(
             backend=backend,
             shape=(3, 7, 13),
             aligned_index=(1, 2, 3),


### PR DESCRIPTION
## Description

Built-in numpy allocation methods can now be used to create storages, but the axes nearly always end up in the wrong order unless you do some numpy magic. Given that, the allocation methods from gt4py.storage are still nearly always used, so requiring `aligned_index` doesn't make sense. Users are finding it confusing that they have to pass `aligned_index` to these, given that they do not set a default origin for the `ndarray`.

What this does:
- makes that keyword argument optional
- adds a bit of type hinting internally to make the methods more understandable
- adds the storage files to pre-commit and fixes the few errors flake8 found