### PR TITLE
Typing fixes: ffront.typeinfo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -267,9 +267,6 @@ ignore_errors = True
 [mypy-functional.ffront.symbol_makers]
 ignore_errors = True
 
-[mypy-functional.ffront.type_info]
-ignore_errors = True
-
 [mypy-functional.iterator.embedded]
 ignore_errors = True
 


### PR DESCRIPTION
## Description

Un-ignore `typeinfo` and fix all the reported `mypy` errors


