### PR TITLE
Remove nonexistent `synchronize` call

### DIFF
--- a/examples/demo_horizontal_diffusion.ipynb
+++ b/examples/demo_horizontal_diffusion.ipynb
@@ -241,9 +241,6 @@
     }
    ],
    "source": [
-    "if \"gpu\" in backend:\n",
-    "    out_storage.synchronize() # does a copy if the cpu or gpu buffer is modified.\n",
-    "    \n",
     "projection = np.asarray(np.sum(out_storage, axis=2))\n",
     "plt.imshow(projection)"
    ]


### PR DESCRIPTION
This is removed now that storages are ndarrays.

