### PR TITLE
GTFN codegen: remove wrongly included file

### DIFF
--- a/src/functional/program_processors/codegens/gtfn/codegen.py
+++ b/src/functional/program_processors/codegens/gtfn/codegen.py
@@ -193,7 +193,6 @@ class GTFNCodegen(codegen.TemplatedGenerator):
         """
     #include <cmath>
     #include <gridtools/fn/${grid_type_str}.hpp>
-    #include <gridtools/fn/backend/naive.hpp>
 
     namespace generated{
 

--- a/tests/functional_tests/cpp_backend_tests/anton_lap_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/anton_lap_driver.cpp
@@ -1,12 +1,10 @@
-#include GENERATED_FILE
-
-#include <iostream>
-
 #include <gtest/gtest.h>
 
 #include <fn_select.hpp>
-#include <gridtools/sid/rename_dimensions.hpp>
 #include <test_environment.hpp>
+#include GENERATED_FILE
+
+#include <gridtools/sid/rename_dimensions.hpp>
 
 namespace {
 using namespace gridtools;

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_driver.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <fn_select.hpp>
+#include <test_environment.hpp>
 #include GENERATED_FILE
 
-#include <fn_select.hpp>
 #include <gridtools/sid/rename_dimensions.hpp>
-#include <test_environment.hpp>
 
 namespace {
 using namespace gridtools;

--- a/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/copy_stencil_field_view_driver.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <fn_select.hpp>
+#include <test_environment.hpp>
 #include GENERATED_FILE
 
-#include <fn_select.hpp>
 #include <gridtools/sid/rename_dimensions.hpp>
-#include <test_environment.hpp>
 
 namespace {
 using namespace gridtools;

--- a/tests/functional_tests/cpp_backend_tests/fvm_nabla_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/fvm_nabla_driver.cpp
@@ -1,9 +1,8 @@
 #include <gtest/gtest.h>
 
-#include GENERATED_FILE
-
 #include <fn_select.hpp>
 #include <test_environment.hpp>
+#include GENERATED_FILE
 
 namespace {
 using namespace gridtools;

--- a/tests/functional_tests/cpp_backend_tests/tridiagonal_solve_driver.cpp
+++ b/tests/functional_tests/cpp_backend_tests/tridiagonal_solve_driver.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <fn_select.hpp>
+#include <test_environment.hpp>
 #include GENERATED_FILE
 
-#include <fn_select.hpp>
 #include <gridtools/sid/rename_dimensions.hpp>
-#include <test_environment.hpp>
 
 namespace {
 using namespace gridtools;


### PR DESCRIPTION
The gtfn code is agnostic of the backend (naive/gpu), therefore the driver should include and pass the appropriate backend.