### PR TITLE
Bump mypy and fix eve typing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ flake8-mutable>=1.2.0
 flake8-rst-docstrings>=0.0.14
 isort~=5.10
 jupytext>=1.14
-mypy@git+https://github.com/python/mypy@release-0.980
+mypy@git+https://github.com/python/mypy@176b052
 pre-commit~=2.15
 psutil>=5.0
 pygments>=2.7

--- a/src/eve/codegen.py
+++ b/src/eve/codegen.py
@@ -508,7 +508,7 @@ class JinjaTemplate(BaseTemplate):
                 message += f" created at {self.definition_loc[0]}:{self.definition_loc[1]}"
                 try:
                     if hasattr(e, "lineno"):
-                        message += f" (error likely around line: {e.lineno})"  # type: ignore  # assume Jinja exception
+                        message += f" (error likely around line: {e.lineno})"
                 except Exception:
                     message = f"{message}:\n---\n{definition}\n---\n"
 

--- a/src/eve/extended_typing.py
+++ b/src/eve/extended_typing.py
@@ -35,12 +35,12 @@ import typing as _typing
 from typing import *  # noqa: F403
 from typing import overload  # Only needed to avoid false flake8 errors
 
-from typing_extensions import *  # type: ignore[misc]  # noqa: F403
+from typing_extensions import *  # type: ignore[assignment]  # noqa: F403
 
 
 if _sys.version_info >= (3, 9):
     # Standard library already supports PEP 585 (Type Hinting Generics In Standard Collections)
-    from builtins import (  # type: ignore[misc]  # isort:skip
+    from builtins import (  # type: ignore[assignment]  # isort:skip
         tuple as Tuple,
         list as List,
         dict as Dict,

--- a/src/eve/traits.py
+++ b/src/eve/traits.py
@@ -66,7 +66,7 @@ class SymbolTableTrait:
 
         def visit(self, node: concepts.RootNode, **kwargs: Any) -> Any:
             if hasattr(node.__class__, "_NODE_SYMBOLS_"):
-                self.visit(node.__class__._NODE_SYMBOLS_)  # type: ignore[union-attr]  # _NODE_SYMBOLS_ is optional
+                self.visit(node.__class__._NODE_SYMBOLS_)
             return super().visit(node, **kwargs)
 
         @classmethod
@@ -77,7 +77,7 @@ class SymbolTableTrait:
             # traversal here calling `generic_visit()` to directly inspect the children (after
             # adding any extra node symbols defined in the node class).
             if hasattr(node.__class__, "_NODE_SYMBOLS_"):
-                collector.visit(node.__class__._NODE_SYMBOLS_)  # type: ignore[attr-defined]  # _NODE_SYMBOLS_ is optional
+                collector.visit(node.__class__._NODE_SYMBOLS_)
             collector.generic_visit(node)
             return collector.collected_symbols
 

--- a/src/eve/type_definitions.py
+++ b/src/eve/type_definitions.py
@@ -80,7 +80,7 @@ class NothingType(type):
 class NOTHING(metaclass=NothingType):
     """Marker to avoid confusion with `None` in contexts where `None` could be a valid value."""
 
-    def __new__(cls: type) -> NoReturn:  # type: ignore[misc]  # should return an instance
+    def __new__(cls: type) -> NoReturn:
         raise TypeError(f"{cls.__name__} is used as a sentinel value and cannot be instantiated.")
 
 

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -36,7 +36,7 @@ import uuid
 import warnings
 
 import deepdiff  # type: ignore[import]
-import xxhash  # type: ignore[import]
+import xxhash
 from boltons.iterutils import (  # type: ignore[import]  # noqa: F401
     flatten as flatten,
     flatten_iter as flatten_iter,
@@ -362,7 +362,7 @@ def content_hash(*args: Any, hash_algorithm: str | xtyping.HashlibAlgorithm | No
 
     """
     if hash_algorithm is None:
-        hash_algorithm = xxhash.xxh64()
+        hash_algorithm = xxhash.xxh64()  # type: ignore[assignment]
     elif isinstance(hash_algorithm, str):
         hash_algorithm = hashlib.new(hash_algorithm)  # type: ignore[assignment]
 


### PR DESCRIPTION
Bumps mypy version to 176b052 (unreleased and needed for https://github.com/GridTools/gt4py/pull/1002) and fixes resulting typing errors in eve.