### PR TITLE
Return type of fieldoperator should not broadcast

### DIFF
--- a/src/functional/ffront/type_info.py
+++ b/src/functional/ffront/type_info.py
@@ -437,8 +437,6 @@ def return_type_fieldop(
     with_kwargs: dict[str, ct.SymbolType],
 ):
     ret_type = return_type(fieldop_type.definition, with_args=with_args, with_kwargs=with_kwargs)
-    if isinstance(ret_type, ct.ScalarType):
-        return ct.FieldType(dims=[], dtype=ret_type)
     return ret_type
 
 

--- a/src/functional/program_processors/codegens/gtfn/codegen.py
+++ b/src/functional/program_processors/codegens/gtfn/codegen.py
@@ -131,7 +131,7 @@ class GTFNCodegen(codegen.TemplatedGenerator):
         """
     )
 
-    Scan = as_fmt("assign({output}, {function}(), {init}, {', '.join(inputs)})")
+    Scan = as_fmt("assign({output}, {function}(), {', '.join([init] + inputs)})")
     ScanExecution = as_fmt(
         "{backend}.vertical_executor({axis})().{'.'.join('arg(' + a + ')' for a in args)}.{'.'.join(scans)}.execute();"
     )

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -887,10 +887,7 @@ def test_tuple_arg(fieldview_backend):
 
 
 @pytest.mark.parametrize("forward", [True, False])
-def test_simple_scan(fieldview_backend, forward):
-    if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.xfail("gtfn does not yet support scan pass.")
-
+def test_fieldop_from_scan(fieldview_backend, forward):
     KDim = Dimension("K", kind=DimensionKind.VERTICAL)
     size = 10
     init = 1.0
@@ -899,9 +896,13 @@ def test_simple_scan(fieldview_backend, forward):
     if not forward:
         expected = np.flip(expected)
 
+    @field_operator
+    def add(carry: float, foo: float) -> float:
+        return carry + foo
+
     @scan_operator(axis=KDim, forward=forward, init=init, backend=fieldview_backend)
     def simple_scan_operator(carry: float) -> float:
-        return carry + 1.0
+        return add(carry, 1.0)
 
     simple_scan_operator(out=out, offset_provider={})
 


### PR DESCRIPTION
While not explicitly written in the ADR #956, I think this is the behavior that we discussed, otherwise it's not possible to chain field_operators that return scalars.

As a side-effect, it enables using field_operators from scans. We can discuss if we want to change this behavior longer term.

Additional: fix the gtfn code generator to work with scans without argument.