### PR TITLE
Setting cache directory programmatically

### DIFF
--- a/src/gt4py/stencil_builder.py
+++ b/src/gt4py/stencil_builder.py
@@ -229,7 +229,6 @@ class StencilBuilder:
         """
         self._build_data = {}
         self._externals = externals
-        self.with_caching(self.caching.name)
         return self
 
     @property


### PR DESCRIPTION
This light-weight PR proposes not to reset the caching strategy within `StencilBuilder` when setting the external parameters. This would allow to set the cache directory (both `root_name` and `dir_name`) without resorting to environmental variables.
 


