### PR TITLE
Allow aligned_index to be None

### DIFF
--- a/src/gt4py/storage/utils.py
+++ b/src/gt4py/storage/utils.py
@@ -79,6 +79,9 @@ def normalize_storage_spec(aligned_index, shape, dtype, dimensions):
             else list("IJK") + [str(d) for d in range(len(shape) - 3)]
         )
 
+    if aligned_index is None:
+        aligned_index = [0] * len(shape)
+
     if not all(
         isinstance(d, (str, Axis)) and (str(d).isdigit() or str(d) in "IJK") for d in dimensions
     ):

--- a/tests/test_unittest/test_storage.py
+++ b/tests/test_unittest/test_storage.py
@@ -76,6 +76,7 @@ def allocation_strategy(draw):
         aligned_index_strats = aligned_index_strats + [
             hyp_st.integers(min_value=0, max_value=min(32, shape[i] - 1))
         ]
+
     aligned_index = draw(hyp_st.tuples(*aligned_index_strats))
     layout_order = draw(hyp_st.permutations(tuple(range(dimension))))
     return dict(
@@ -266,8 +267,11 @@ class TestNormalizeStorageSpec:
         assert dtype_out == dtype
         assert dimensions_out == dimensions
 
-        with pytest.raises(TypeError, match="aligned_index"):
-            normalize_storage_spec(None, shape, dtype, dimensions)
+        aligned_index_out, shape_out, dtype_out, dimensions_out = normalize_storage_spec(
+            None, shape, dtype, dimensions
+        )
+        assert aligned_index_out == (0, 0, 0)
+
         with pytest.raises(TypeError, match="aligned_index"):
             normalize_storage_spec(("1", "1", "1"), shape, dtype, dimensions)
         with pytest.raises(ValueError, match="aligned_index"):


### PR DESCRIPTION
## Description

There was a bug previously that didn't actually allow `aligned_index` to be unset in the storage creation calls. This fixes that.