### PR TITLE
Update flake8 repo to point to github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
   hooks:
   - id: isort
 
-- repo: https://gitlab.com/PyCQA/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:
   - id: flake8


### PR DESCRIPTION
## Description

The gitlab repo seems to have been deleted.
