### PR TITLE
Allow function calls as function arguments

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -483,7 +483,11 @@ class CallInliner(ast.NodeTransformer):
 
         # Replace returns by assignments in subroutine
         if target_node is None:
-            if len(assign_targets) > 1:
+            if any(
+                isinstance(nd.value, ast.Tuple)
+                for nd in ast.walk(call_ast)
+                if isinstance(nd, ast.Return)
+            ):
                 raise GTScriptSyntaxError("Function returning tuple used in expression.")
             target_node = ast.Name(
                 ctx=ast.Store(),

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -488,7 +488,10 @@ class CallInliner(ast.NodeTransformer):
                 for nd in ast.walk(call_ast)
                 if isinstance(nd, ast.Return)
             ):
-                raise GTScriptSyntaxError("Function returning tuple used in expression.")
+                raise GTScriptSyntaxError(
+                    "Only functions with a single return value can be used in expressions, including as call arguments. "
+                    "Please assign the function results to symbols first."
+                )
             target_node = ast.Name(
                 ctx=ast.Store(),
                 lineno=node.lineno,

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -416,18 +416,10 @@ class CallInliner(ast.NodeTransformer):
     ):
         call_name = gt_meta.get_qualified_name_from_node(node.func)
 
+        node.args = [self.visit(arg) for arg in node.args]
         if call_name in gtscript.IGNORE_WHEN_INLINING:
-            # Not a function to inline. Visit arguments and return as-is.
-            node.args = [self.visit(arg) for arg in node.args]
+            # Not a function to inline, return as-is.
             return node
-        elif any(
-            isinstance(arg, ast.Call) and arg.func.id not in gtscript.MATH_BUILTINS
-            for arg in node.args
-        ):
-            raise GTScriptSyntaxError(
-                "Function calls are not supported in arguments to function calls",
-                loc=nodes.Location.from_ast_node(node),
-            )
         elif call_name not in self.context or not hasattr(self.context[call_name], "_gtscript_"):
             raise GTScriptSyntaxError("Unknown call", loc=nodes.Location.from_ast_node(node))
 

--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -483,6 +483,8 @@ class CallInliner(ast.NodeTransformer):
 
         # Replace returns by assignments in subroutine
         if target_node is None:
+            if len(assign_targets) > 1:
+                raise GTScriptSyntaxError("Function returning tuple used in expression.")
             target_node = ast.Name(
                 ctx=ast.Store(),
                 lineno=node.lineno,

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -307,7 +307,9 @@ class TestFunction:
                 inout_field = func() + 1
 
         with pytest.raises(
-            gt_frontend.GTScriptSyntaxError, match="Function returning tuple used in expression."
+            gt_frontend.GTScriptSyntaxError,
+            match="Only functions with a single return value can be used in expressions, including as call arguments. "
+            "Please assign the function results to symbols first.",
         ):
             parse_definition(
                 definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
@@ -331,7 +333,9 @@ class TestFunction:
                 inout_field = func_outer(func())
 
         with pytest.raises(
-            gt_frontend.GTScriptSyntaxError, match="Function returning tuple used in expression."
+            gt_frontend.GTScriptSyntaxError,
+            match="Only functions with a single return value can be used in expressions, including as call arguments. "
+            "Please assign the function results to symbols first.",
         ):
             parse_definition(
                 definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -705,27 +705,6 @@ class TestExternalsWithSubroutines:
             module=self.__class__.__name__,
         )
 
-    def test_no_nested_function_call(self):
-        @gtscript.function
-        def _lap(dx, phi):
-            return (phi[0, -1, 0] - 2.0 * phi[0, 0, 0] + phi[0, 1, 0]) / (dx * dx)
-
-        def definition_func(phi: gtscript.Field[np.float64], dx: float):
-            from gt4py.__externals__ import lap
-
-            with computation(PARALLEL), interval(...):
-                phi = lap(lap(phi, dx), dx)
-
-        with pytest.raises(gt_frontend.GTScriptSyntaxError, match="in arguments to function calls"):
-            parse_definition(
-                definition_func,
-                name=inspect.stack()[0][3],
-                module=self.__class__.__name__,
-                externals={
-                    "lap": _lap,
-                },
-            )
-
 
 class TestFunctionReturn:
     def test_no_return(self):

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -240,6 +240,59 @@ class TestFunction:
                 definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
             )
 
+    def test_use_in_expr(self):
+        @gtscript.function
+        def func():
+            return 1.0
+
+        def definition_func(inout_field: gtscript.Field[float]):
+            from gt4py.__gtscript__ import PARALLEL, computation, interval
+
+            with computation(PARALLEL), interval(...):
+                inout_field = func() + 1
+
+        parse_definition(
+            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
+        )
+
+    def test_use_as_func_arg(self):
+        @gtscript.function
+        def func():
+            return 1.0
+
+        @gtscript.function
+        def func_outer(arg):
+            return arg + 1
+
+        def definition_func(inout_field: gtscript.Field[float]):
+            from gt4py.__gtscript__ import PARALLEL, computation, interval
+
+            with computation(PARALLEL), interval(...):
+                inout_field = func_outer(func())
+
+        parse_definition(
+            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
+        )
+
+    def test_use_in_expr_in_func_arg(self):
+        @gtscript.function
+        def func():
+            return 1.0
+
+        @gtscript.function
+        def func_outer(arg):
+            return arg + 1
+
+        def definition_func(inout_field: gtscript.Field[float]):
+            from gt4py.__gtscript__ import PARALLEL, computation, interval
+
+            with computation(PARALLEL), interval(...):
+                inout_field = func_outer(func() + 1)
+
+        parse_definition(
+            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
+        )
+
 
 class TestImportedExternals:
     def test_all_legal_combinations(self):


### PR DESCRIPTION
Would resolve #248 

Since calls are already allowed in expresions like `lhs = 1 + func()` it seems reasonable to allow them as call arguments as well (or not allow either) but I'm not 100% sure of the implications in cases of extents. A critical review is appreciated. 