### PR TITLE
Emit a warning for use of __INLINED

### DIFF
--- a/src/gt4py/frontend/gtscript_frontend.py
+++ b/src/gt4py/frontend/gtscript_frontend.py
@@ -21,6 +21,7 @@ import numbers
 import textwrap
 import time
 import types
+import warnings
 from typing import Any, Dict, Final, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -573,15 +574,12 @@ class CallInliner(ast.NodeTransformer):
 
 class CompiledIfInliner(ast.NodeTransformer):
     @classmethod
-    def apply(cls, ast_object, context):
-        preprocessor = cls(context)
-        preprocessor(ast_object)
+    def apply(cls, ast_object: ast.AST, context: Dict[str, Any], stencil_name: str):
+        cls(context, stencil_name).visit(ast_object)
 
-    def __init__(self, context):
+    def __init__(self, context: Dict[str, Any], stencil_name: str):
         self.context = context
-
-    def __call__(self, ast_object):
-        self.visit(ast_object)
+        self.stencil_name = stencil_name
 
     def visit_If(self, node: ast.If):
         # Compile-time evaluation of "if" conditions
@@ -592,13 +590,17 @@ class CompiledIfInliner(ast.NodeTransformer):
             and node.test.func.id == "__INLINED"
             and len(node.test.args) == 1
         ):
+            warnings.warn(
+                f"stencil {self.stencil_name}, line {node.lineno}, column {node.col_offset}: compile-time if condition via __INLINED deprecated",
+                category=DeprecationWarning,
+            )
             eval_node = node.test.args[0]
             condition_value = gt_utils.meta.ast_eval(eval_node, self.context, default=NOTHING)
             if condition_value is not NOTHING:
                 node = node.body if condition_value else node.orelse
             else:
                 raise GTScriptSyntaxError(
-                    "Evaluation of compile-time 'IF' condition failed at the preprocessing step"
+                    "Evaluation of compile-time 'if' condition failed at the preprocessing step"
                 )
 
         return node if node else None
@@ -1919,7 +1921,7 @@ class GTScriptParser(ast.NodeVisitor):
         CallInliner.apply(main_func_node, context=local_context)
 
         # Evaluate and inline compile-time conditionals
-        CompiledIfInliner.apply(main_func_node, context=local_context)
+        CompiledIfInliner.apply(main_func_node, context=local_context, stencil_name=self.main_name)
 
         AssertionChecker.apply(main_func_node, context=local_context, source=self.source)
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -1322,8 +1322,8 @@ class TestNativeFunctions:
         parse_definition(func, name=inspect.stack()[0][3], module=self.__class__.__name__)
 
 
-class TestWarnInline:
-    def test_inline_emits_warning(self):
+class TestWarnInlined:
+    def test_inlined_emits_warning(self):
         def func(field: gtscript.Field[np.float_]):
             from gt4py.__externals__ import SET_TO_ONE
 

--- a/tests/test_unittest/test_gtscript_frontend.py
+++ b/tests/test_unittest/test_gtscript_frontend.py
@@ -25,6 +25,7 @@ from gt4py import gtscript
 from gt4py.frontend import gtscript_frontend as gt_frontend
 from gt4py.frontend import nodes
 from gt4py.gtscript import (
+    __INLINED,
     IJ,
     IJK,
     PARALLEL,
@@ -1319,6 +1320,25 @@ class TestNativeFunctions:
                 in_field = asin(in_field) + 1 if 1 < in_field else sin(in_field)
 
         parse_definition(func, name=inspect.stack()[0][3], module=self.__class__.__name__)
+
+
+class TestWarnInline:
+    def test_inline_emits_warning(self):
+        def func(field: gtscript.Field[np.float_]):
+            from gt4py.__externals__ import SET_TO_ONE
+
+            with computation(PARALLEL), interval(...):
+                field = 0
+                if __INLINED(SET_TO_ONE):
+                    field = 1
+
+        with pytest.warns(DeprecationWarning, match="__INLINED deprecated"):
+            parse_definition(
+                func,
+                name=inspect.stack()[0][3],
+                module=self.__class__.__name__,
+                externals={"SET_TO_ONE": True},
+            )
 
 
 class TestAnnotations:


### PR DESCRIPTION
## Description

Add a new warning for use of `__INLINED` and test that it happens.

Resolves #1068.