### PR TITLE
`import attrs` requires attrs 21.3+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ package_dir =
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    attrs>=20.3
+    attrs>=21.3
     black>=22.3
     cached-property>=1.5
     click>=7.1


### PR DESCRIPTION
Found that the lower bound version specified in `setup.cfg` was too low to support `import attrs`.
