### PR TITLE
Update cupy dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,20 +86,8 @@ cuda110 =
     cupy-cuda110
 cuda111 =
     cupy-cuda111
-cuda112 =
-    cupy-cuda112
-cuda113 =
-    cupy-cuda113
-cuda114 =
-    cupy-cuda114
-cuda115 =
-    cupy-cuda115
-cuda116 =
-    cupy-cuda116
-cuda117 =
-    cupy-cuda117
-cuda118 =
-    cupy-cuda118
+cuda11x =
+    cupy-cuda11x
 dace =
     dace>=0.14.1,<0.15
     sympy

--- a/tox.ini
+++ b/tox.ini
@@ -26,13 +26,7 @@ extras =
     cuda: cuda
     cuda110: cuda110
     cuda111: cuda111
-    cuda112: cuda112
-    cuda113: cuda113
-    cuda114: cuda114
-    cuda115: cuda115
-    cuda116: cuda116
-    cuda117: cuda117
-    cuda118: cuda118
+    cuda11x: cuda11x
 
 [testenv:py{38,39,310}-internal-cpu]
 commands =
@@ -46,13 +40,13 @@ commands =
     pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "not requires_gpu" {posargs}
     pytest --doctest-modules {envsitepackagesdir}/gt4py/eve
 
-[testenv:py{38,39,310}-internal-{cuda,cuda110,cuda111,cuda112,cuda113,cuda114,cuda115,cuda116,cuda117,cuda118}]
+[testenv:py{38,39,310}-internal-{cuda,cuda110,cuda111,cuda11x}]
 commands =
     pip list
     pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "requires_gpu and not requires_dace" {posargs}
     pytest --doctest-modules {envsitepackagesdir}/gt4py/eve
 
-[testenv:py{38,39,310}-all-{cuda,cuda110,cuda111,cuda112,cuda113,cuda114,cuda115,cuda116,cuda117,cuda118}]
+[testenv:py{38,39,310}-all-{cuda,cuda110,cuda111,cuda11x}]
 commands =
     pip list
     pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "requires_gpu" {posargs}


### PR DESCRIPTION
It's the same `cupy-cuda11x` package for everything >= CUDA11.2.