### PR TITLE
Disable a randomly failing gt:gpu test

### DIFF
--- a/tests/cartesian_tests/unit_tests/test_exec_info.py
+++ b/tests/cartesian_tests/unit_tests/test_exec_info.py
@@ -189,6 +189,9 @@ class TestExecInfo:
     @given(data=hyp_st.data())
     @pytest.mark.parametrize("backend", ALL_BACKENDS)
     def test_backcompatibility(self, data, backend):
+        if backend == "gt:gpu":
+            pytest.skip("Random compilation failures.")
+
         # set backend as instance attribute
         self.backend = backend
 

--- a/tests/cartesian_tests/unit_tests/test_exec_info.py
+++ b/tests/cartesian_tests/unit_tests/test_exec_info.py
@@ -189,7 +189,7 @@ class TestExecInfo:
     @given(data=hyp_st.data())
     @pytest.mark.parametrize("backend", ALL_BACKENDS)
     def test_backcompatibility(self, data, backend):
-        if backend == "gt:gpu":
+        if backend == "gt:gpu" or backend == "cuda":
             pytest.skip("Random compilation failures.")
 
         # set backend as instance attribute


### PR DESCRIPTION
- [ ] TODO: add an issue `error: ‘HorizontalExecution140737044638160’ is not a member of ‘advection_def_impl_’; did you mean ‘HorizontalExecution140736918209968’?`