### PR TITLE
feat[next]: use context vars instead of global state in embedded iterator execution

### DIFF
--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -186,9 +186,7 @@ class MutableLocatedField(LocatedField, Protocol):
 #: Column range used in column mode (`column_axis != None`) in the current closure execution context.
 column_range: cvars.ContextVar[range] = cvars.ContextVar("column_range")
 #: Offset provider dict in the current closure execution context.
-offset_provider: cvars.ContextVar[OffsetProvider] = cvars.ContextVar(
-    "offset_provider"
-)
+offset_provider: cvars.ContextVar[OffsetProvider] = cvars.ContextVar("offset_provider")
 
 
 class Column(np.lib.mixins.NDArrayOperatorsMixin):

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -772,11 +772,11 @@ class MDIterator:
 
     def shift(self, *offsets: OffsetPart) -> MDIterator:
         complete_offsets = group_offsets(*offsets)
-        _offset_provider = offset_provider_cvar.get()
-        assert _offset_provider is not None
+        offset_provider = offset_provider_cvar.get()
+        assert offset_provider is not None
         return MDIterator(
             self.field,
-            shift_position(self.pos, *complete_offsets, offset_provider=_offset_provider),
+            shift_position(self.pos, *complete_offsets, offset_provider=offset_provider),
             column_axis=self.column_axis,
         )
 
@@ -1090,9 +1090,9 @@ class _ConstList(Generic[DT]):
 def neighbors(offset: runtime.Offset, it: ItIterator) -> _List:
     offset_str = offset.value if isinstance(offset, runtime.Offset) else offset
     assert isinstance(offset_str, str)
-    _offset_provider = offset_provider_cvar.get()
-    assert _offset_provider is not None
-    connectivity = _offset_provider[offset_str]
+    offset_provider = offset_provider_cvar.get()
+    assert offset_provider is not None
+    connectivity = offset_provider[offset_str]
     assert isinstance(connectivity, common.Connectivity)
     return _List(
         shifted.deref()
@@ -1149,9 +1149,9 @@ class SparseListIterator:
     offsets: Sequence[OffsetPart] = dataclasses.field(default_factory=list, kw_only=True)
 
     def deref(self) -> Any:
-        _offset_provider = offset_provider_cvar.get()
-        assert _offset_provider is not None
-        connectivity = _offset_provider[self.list_offset]
+        offset_provider = offset_provider_cvar.get()
+        assert offset_provider is not None
+        connectivity = offset_provider[self.list_offset]
         assert isinstance(connectivity, common.Connectivity)
         return _List(
             shifted.deref()

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -183,7 +183,9 @@ class MutableLocatedField(LocatedField, Protocol):
         ...
 
 
+#: Column range used in column mode (`column_axis != None`) in the current closure execution context.
 context_column_range: cvars.ContextVar[range] = cvars.ContextVar("context_column_range")
+#: Offset provider dict in the current closure execution context.
 context_offset_provider: cvars.ContextVar[OffsetProvider] = cvars.ContextVar(
     "context_offset_provider"
 )

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -184,10 +184,10 @@ class MutableLocatedField(LocatedField, Protocol):
 
 
 #: Column range used in column mode (`column_axis != None`) in the current closure execution context.
-context_column_range: cvars.ContextVar[range] = cvars.ContextVar("context_column_range")
+column_range: cvars.ContextVar[range] = cvars.ContextVar("column_range")
 #: Offset provider dict in the current closure execution context.
-context_offset_provider: cvars.ContextVar[OffsetProvider] = cvars.ContextVar(
-    "context_offset_provider"
+offset_provider: cvars.ContextVar[OffsetProvider] = cvars.ContextVar(
+    "offset_provider"
 )
 
 
@@ -201,7 +201,7 @@ class Column(np.lib.mixins.NDArrayOperatorsMixin):
     def __init__(self, kstart: int, data: np.ndarray | Scalar) -> None:
         self.kstart = kstart
         assert isinstance(data, (np.ndarray, Scalar))  # type: ignore # mypy bug
-        _column_range = context_column_range.get()
+        _column_range = column_range.get()
         self.data = data if isinstance(data, np.ndarray) else np.full(len(_column_range), data)
 
     def __getitem__(self, i: int) -> Any:
@@ -725,7 +725,7 @@ def _make_tuple(
     *,
     column_axis: Optional[Tag] = None,
 ) -> Column | npt.DTypeLike | tuple[tuple | Column | npt.DTypeLike, ...]:
-    _column_range = context_column_range.get()
+    _column_range = column_range.get()
     if isinstance(field_or_tuple, tuple):
         if column_axis is not None:
             assert _column_range
@@ -774,7 +774,7 @@ class MDIterator:
 
     def shift(self, *offsets: OffsetPart) -> MDIterator:
         complete_offsets = group_offsets(*offsets)
-        _offset_provider = context_offset_provider.get()
+        _offset_provider = offset_provider.get()
         assert _offset_provider is not None
         return MDIterator(
             self.field,
@@ -799,7 +799,7 @@ class MDIterator:
             if not all(axis.value in shifted_pos.keys() for axis in axes if axis is not None):
                 raise IndexError("Iterator position doesn't point to valid location for its field.")
         slice_column = dict[Tag, range]()
-        _column_range = context_column_range.get()
+        _column_range = column_range.get()
         if self.column_axis is not None:
             assert _column_range is not None
             k_pos = shifted_pos.pop(self.column_axis)
@@ -842,7 +842,7 @@ def make_in_iterator(
         init = [None] * sparse_dimensions.count(sparse_dim)
         new_pos[sparse_dim] = init  # type: ignore[assignment] # looks like mypy is confused
     if column_axis is not None:
-        _column_range = context_column_range.get()
+        _column_range = column_range.get()
         # if we deal with column stencil the column position is just an offset by which the whole column needs to be shifted
         assert _column_range is not None
         new_pos[column_axis] = _column_range.start
@@ -1092,7 +1092,7 @@ class _ConstList(Generic[DT]):
 def neighbors(offset: runtime.Offset, it: ItIterator) -> _List:
     offset_str = offset.value if isinstance(offset, runtime.Offset) else offset
     assert isinstance(offset_str, str)
-    _offset_provider = context_offset_provider.get()
+    _offset_provider = offset_provider.get()
     assert _offset_provider is not None
     connectivity = _offset_provider[offset_str]
     assert isinstance(connectivity, common.Connectivity)
@@ -1151,7 +1151,7 @@ class SparseListIterator:
     offsets: Sequence[OffsetPart] = dataclasses.field(default_factory=list, kw_only=True)
 
     def deref(self) -> Any:
-        _offset_provider = context_offset_provider.get()
+        _offset_provider = offset_provider.get()
         assert _offset_provider is not None
         connectivity = _offset_provider[self.list_offset]
         assert isinstance(connectivity, common.Connectivity)
@@ -1301,7 +1301,7 @@ def _column_dtype(elem: Any) -> np.dtype:
 @builtins.scan.register(EMBEDDED)
 def scan(scan_pass, is_forward: bool, init):
     def impl(*iters: ItIterator):
-        _column_range = context_column_range.get()
+        _column_range = column_range.get()
         if _column_range is None:
             raise RuntimeError("Column range is not defined, cannot scan.")
 
@@ -1360,8 +1360,8 @@ def fendef_embedded(fun: Callable[..., None], *args: Any, **kwargs: Any):
 
         def _closure_runner():
             # Set context variables before executing the closure
-            context_column_range.set(_column_range)
-            context_offset_provider.set(_offset_provider)
+            column_range.set(_column_range)
+            offset_provider.set(_offset_provider)
 
             for pos in _domain_iterator(domain):
                 promoted_ins = [promote_scalars(inp) for inp in ins]

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
@@ -147,30 +147,3 @@ def test_column_array_function_wrong_shape():
             np.where(cond, wrong_shape, b)
 
     _run_within_context(test_func)
-
-
-def test_column_multithread():
-    def test_func(i: int, output: list) -> None:
-        a = embedded.Column(1, -i)
-
-        assert isinstance(a, embedded.Column)
-        assert a.kstart == 1
-        assert all(a.data == -i)
-        assert len(a.data) == i
-
-        output[i] = True
-
-    results = [False] * 4
-    threads = [
-        threading.Thread(
-            target=_run_within_context,
-            args=(lambda i=i: test_func(i, results),),
-            kwargs={"column_range": range(1, i + 1)},
-        )
-        for i in range(4)
-    ]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    assert all(results)

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
@@ -105,10 +105,10 @@ def test_column_array_function_wrong_kstart():
 
 
 def test_column_array_function_wrong_shape():
-    prev_token = embedded.context_column_range.set(None)
-    cond = embedded.Column(1, np.asarray([True, False]))
-    wrong_shape = embedded.Column(2, np.asarray([1, 1, 1]))
-    b = embedded.Column(1, np.asarray([2, 2]))
+    with context_column_range(None):
+        cond = embedded.Column(1, np.asarray([True, False]))
+        wrong_shape = embedded.Column(2, np.asarray([1, 1, 1]))
+        b = embedded.Column(1, np.asarray([2, 2]))
 
-    with pytest.raises(ValueError):
-        np.where(cond, wrong_shape, b)
+        with pytest.raises(ValueError):
+            np.where(cond, wrong_shape, b)

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
@@ -12,85 +12,103 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import contextlib
+from typing import Optional
+
 import numpy as np
 import pytest
 
-from gt4py.next.iterator.embedded import Column
+from gt4py.next.iterator import embedded
+
+
+@contextlib.contextmanager
+def context_column_range(column_range: Optional[range]) -> None:
+    token = embedded.context_column_range.set(None)
+    yield
+    embedded.context_column_range.reset(token)
 
 
 def test_column_ufunc():
-    a = Column(1, np.asarray(range(0, 3)))
-    b = Column(1, np.asarray(range(3, 6)))
+    with context_column_range(None):
+        a = embedded.Column(1, np.asarray(range(0, 3)))
+        b = embedded.Column(1, np.asarray(range(3, 6)))
 
-    res = a + b
-    assert isinstance(res, Column)
-    assert np.array_equal(res.data, a.data + b.data)
-    assert res.kstart == 1
+        res = a + b
+        assert isinstance(res, embedded.Column)
+        assert np.array_equal(res.data, a.data + b.data)
+        assert res.kstart == 1
 
 
 def test_column_ufunc_with_scalar():
-    a = Column(1, np.asarray(range(0, 3)))
-    res = 1.0 + a
-    assert isinstance(res, Column)
-    assert np.array_equal(res.data, a.data + 1.0)
-    assert res.kstart == 1
+    with context_column_range(None):
+        a = embedded.Column(1, np.asarray(range(0, 3)))
+        res = 1.0 + a
+        assert isinstance(res, embedded.Column)
+        assert np.array_equal(res.data, a.data + 1.0)
+        assert res.kstart == 1
 
 
 def test_column_ufunc_wrong_kstart():
-    a = Column(1, np.asarray(range(0, 3)))
-    wrong_kstart = Column(2, np.asarray(range(3, 6)))
+    with context_column_range(None):
+        a = embedded.Column(1, np.asarray(range(0, 3)))
+        wrong_kstart = embedded.Column(2, np.asarray(range(3, 6)))
 
-    with pytest.raises(ValueError):
-        a + wrong_kstart
+        with pytest.raises(ValueError):
+            a + wrong_kstart
 
 
 def test_column_ufunc_wrong_shape():
-    a = Column(1, np.asarray(range(0, 3)))
-    wrong_shape = Column(1, np.asarray([1, 2]))
+    with context_column_range(None):
+        a = embedded.Column(1, np.asarray(range(0, 3)))
+        wrong_shape = embedded.Column(1, np.asarray([1, 2]))
 
-    with pytest.raises(ValueError):
-        a + wrong_shape
+        with pytest.raises(ValueError):
+            a + wrong_shape
 
 
 def test_column_array_function():
-    cond = Column(1, np.asarray([True, False]))
-    a = Column(1, np.asarray([1, 1]))
-    b = Column(1, np.asarray([2, 2]))
+    with context_column_range(None):
+        cond = embedded.Column(1, np.asarray([True, False]))
+        a = embedded.Column(1, np.asarray([1, 1]))
+        b = embedded.Column(1, np.asarray([2, 2]))
 
-    res = np.where(cond, a, b)
-    ref = np.asarray([1, 2])
+        res = np.where(cond, a, b)
+        ref = np.asarray([1, 2])
 
-    assert isinstance(res, Column)
-    assert np.array_equal(res.data, ref)
-    assert res.kstart == 1
+        assert isinstance(res, embedded.Column)
+        assert np.array_equal(res.data, ref)
+        assert res.kstart == 1
 
 
 def test_column_array_function_with_scalar():
-    cond = Column(1, np.asarray([True, False]))
-    a = 1
-    b = Column(1, np.asarray([2, 2]))
+    with context_column_range(None):
+        cond = embedded.Column(1, np.asarray([True, False]))
+        a = 1
+        b = embedded.Column(1, np.asarray([2, 2]))
 
-    res = np.where(cond, a, b)
-    ref = np.asarray([1, 2])
+        res = np.where(cond, a, b)
+        ref = np.asarray([1, 2])
 
-    assert isinstance(res, Column)
-    assert np.array_equal(res.data, ref)
-    assert res.kstart == 1
+        assert isinstance(res, embedded.Column)
+        assert np.array_equal(res.data, ref)
+        assert res.kstart == 1
 
 
 def test_column_array_function_wrong_kstart():
-    cond = Column(1, np.asarray([True, False]))
-    wrong_kstart = Column(2, np.asarray([1, 1]))
-    b = Column(1, np.asarray([2, 2]))
+    with context_column_range(None):
+        cond = embedded.Column(1, np.asarray([True, False]))
+        wrong_kstart = embedded.Column(2, np.asarray([1, 1]))
+        b = embedded.Column(1, np.asarray([2, 2]))
 
-    with pytest.raises(ValueError):
-        np.where(cond, wrong_kstart, b)
+        with pytest.raises(ValueError):
+            np.where(cond, wrong_kstart, b)
 
 
 def test_column_array_function_wrong_shape():
-    cond = Column(1, np.asarray([True, False]))
-    wrong_shape = Column(2, np.asarray([1, 1, 1]))
-    b = Column(1, np.asarray([2, 2]))
+    prev_token = embedded.context_column_range.set(None)
+    cond = embedded.Column(1, np.asarray([True, False]))
+    wrong_shape = embedded.Column(2, np.asarray([1, 1, 1]))
+    b = embedded.Column(1, np.asarray([2, 2]))
 
     with pytest.raises(ValueError):
         np.where(cond, wrong_shape, b)

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
@@ -22,14 +22,14 @@ from gt4py.next.iterator import embedded
 
 
 @contextlib.contextmanager
-def context_column_range(column_range: Optional[range]) -> None:
-    token = embedded.context_column_range.set(None)
+def column_range(column_range: Optional[range]) -> None:
+    token = embedded.column_range.set(None)
     yield
-    embedded.context_column_range.reset(token)
+    embedded.column_range.reset(token)
 
 
 def test_column_ufunc():
-    with context_column_range(None):
+    with column_range(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         b = embedded.Column(1, np.asarray(range(3, 6)))
 
@@ -40,7 +40,7 @@ def test_column_ufunc():
 
 
 def test_column_ufunc_with_scalar():
-    with context_column_range(None):
+    with column_range(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         res = 1.0 + a
         assert isinstance(res, embedded.Column)
@@ -49,7 +49,7 @@ def test_column_ufunc_with_scalar():
 
 
 def test_column_ufunc_wrong_kstart():
-    with context_column_range(None):
+    with column_range(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         wrong_kstart = embedded.Column(2, np.asarray(range(3, 6)))
 
@@ -58,7 +58,7 @@ def test_column_ufunc_wrong_kstart():
 
 
 def test_column_ufunc_wrong_shape():
-    with context_column_range(None):
+    with column_range(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         wrong_shape = embedded.Column(1, np.asarray([1, 2]))
 
@@ -67,7 +67,7 @@ def test_column_ufunc_wrong_shape():
 
 
 def test_column_array_function():
-    with context_column_range(None):
+    with column_range(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         a = embedded.Column(1, np.asarray([1, 1]))
         b = embedded.Column(1, np.asarray([2, 2]))
@@ -81,7 +81,7 @@ def test_column_array_function():
 
 
 def test_column_array_function_with_scalar():
-    with context_column_range(None):
+    with column_range(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         a = 1
         b = embedded.Column(1, np.asarray([2, 2]))
@@ -95,7 +95,7 @@ def test_column_array_function_with_scalar():
 
 
 def test_column_array_function_wrong_kstart():
-    with context_column_range(None):
+    with column_range(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         wrong_kstart = embedded.Column(2, np.asarray([1, 1]))
         b = embedded.Column(1, np.asarray([2, 2]))
@@ -105,7 +105,7 @@ def test_column_array_function_wrong_kstart():
 
 
 def test_column_array_function_wrong_shape():
-    with context_column_range(None):
+    with column_range(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         wrong_shape = embedded.Column(2, np.asarray([1, 1, 1]))
         b = embedded.Column(1, np.asarray([2, 2]))

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_internals.py
@@ -22,14 +22,14 @@ from gt4py.next.iterator import embedded
 
 
 @contextlib.contextmanager
-def column_range(column_range: Optional[range]) -> None:
-    token = embedded.column_range.set(None)
+def column_range_context(column_range: Optional[range]) -> None:
+    token = embedded.column_range_cvar.set(None)
     yield
-    embedded.column_range.reset(token)
+    embedded.column_range_cvar.reset(token)
 
 
 def test_column_ufunc():
-    with column_range(None):
+    with column_range_context(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         b = embedded.Column(1, np.asarray(range(3, 6)))
 
@@ -40,7 +40,7 @@ def test_column_ufunc():
 
 
 def test_column_ufunc_with_scalar():
-    with column_range(None):
+    with column_range_context(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         res = 1.0 + a
         assert isinstance(res, embedded.Column)
@@ -49,7 +49,7 @@ def test_column_ufunc_with_scalar():
 
 
 def test_column_ufunc_wrong_kstart():
-    with column_range(None):
+    with column_range_context(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         wrong_kstart = embedded.Column(2, np.asarray(range(3, 6)))
 
@@ -58,7 +58,7 @@ def test_column_ufunc_wrong_kstart():
 
 
 def test_column_ufunc_wrong_shape():
-    with column_range(None):
+    with column_range_context(None):
         a = embedded.Column(1, np.asarray(range(0, 3)))
         wrong_shape = embedded.Column(1, np.asarray([1, 2]))
 
@@ -67,7 +67,7 @@ def test_column_ufunc_wrong_shape():
 
 
 def test_column_array_function():
-    with column_range(None):
+    with column_range_context(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         a = embedded.Column(1, np.asarray([1, 1]))
         b = embedded.Column(1, np.asarray([2, 2]))
@@ -81,7 +81,7 @@ def test_column_array_function():
 
 
 def test_column_array_function_with_scalar():
-    with column_range(None):
+    with column_range_context(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         a = 1
         b = embedded.Column(1, np.asarray([2, 2]))
@@ -95,7 +95,7 @@ def test_column_array_function_with_scalar():
 
 
 def test_column_array_function_wrong_kstart():
-    with column_range(None):
+    with column_range_context(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         wrong_kstart = embedded.Column(2, np.asarray([1, 1]))
         b = embedded.Column(1, np.asarray([2, 2]))
@@ -105,7 +105,7 @@ def test_column_array_function_wrong_kstart():
 
 
 def test_column_array_function_wrong_shape():
-    with column_range(None):
+    with column_range_context(None):
         cond = embedded.Column(1, np.asarray([True, False]))
         wrong_shape = embedded.Column(2, np.asarray([1, 1, 1]))
         b = embedded.Column(1, np.asarray([2, 2]))


### PR DESCRIPTION
Changed:
- In the iterator embedded execution, both `column_range` and `offset_provider` global variables have been converted to context variables and fencil closures are now executed in isolated contexts with properly initialized values, to avoid using global state.