### PR TITLE
Ignore new 'B028' quoted-string check in flake8-bugbear

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -132,6 +132,7 @@ max-complexity = 15
 doctests = true
 ignore =
     B008    # Do not perform function calls in argument defaults
+    B028    # Consider replacing f"'{foo}'" with f"{foo!r}"  # TODO: review this ignore
     D1      # Public code object needs docstring
     DAR     # Disable dargling errors by default
     E203    # Whitespace before ':' (black formatter breaks this sometimes)


### PR DESCRIPTION
## Description

flake8-bugbear-23.1.14 introduced some changes that now trigger a lot of B028 errors in the codebase. This commit disables this check, at least for now, but it might be re-enabled in the future if it is useful.
