### PR TITLE
Functional: Index fields C++ backend support

### DIFF
--- a/src/functional/ffront/decorator.py
+++ b/src/functional/ffront/decorator.py
@@ -350,7 +350,7 @@ class Program:
                         "Constituents of composite arguments (e.g. the elements of a"
                         " tuple) need to have the same shape and dimensions."
                     )
-                size_args.extend(shape if shape else [None] * len(dims))
+                size_args.extend(shape if shape else [0] * len(dims))
         return tuple(rewritten_args), tuple(size_args), kwargs
 
     @functools.cached_property

--- a/src/functional/otf/binding/cpp_interface.py
+++ b/src/functional/otf/binding/cpp_interface.py
@@ -19,7 +19,7 @@ from typing import Final, Sequence, Type
 
 import numpy as np
 
-import functional.type_system.type_specifications as ts
+import functional.otf.binding.type_specifications as ts
 from functional.otf import languages
 from functional.otf.binding import interface
 
@@ -98,7 +98,7 @@ def render_scalar_type(scalar_type: ts.ScalarType) -> str:
 def _render_function_param(param: interface.Parameter, index: int) -> str:
     if isinstance(param.type_, ts.ScalarType):
         return f"{render_scalar_type(param.type_)} {param.name}"
-    elif isinstance(param.type_, ts.FieldType):
+    elif isinstance(param.type_, (ts.FieldType, ts.IndexFieldType)):
         return f"BufferT{index}&& {param.name}"
     else:
         raise ValueError("unsupported type for parameters")
@@ -114,7 +114,7 @@ def render_function_declaration(function: interface.Function, body: str) -> str:
     template_params = [
         f"class BufferT{index}"
         for index, param in enumerate(function.parameters)
-        if isinstance(param.type_, ts.FieldType)
+        if isinstance(param.type_, (ts.FieldType, ts.IndexFieldType))
     ]
     if template_params:
         return f"""

--- a/src/functional/otf/binding/cpp_interface.py
+++ b/src/functional/otf/binding/cpp_interface.py
@@ -19,7 +19,8 @@ from typing import Final, Sequence, Type
 
 import numpy as np
 
-import functional.otf.binding.type_specifications as ts
+import functional.otf.binding.type_specifications as ts_binding
+import functional.type_system.type_specifications as ts
 from functional.otf import languages
 from functional.otf.binding import interface
 
@@ -98,7 +99,7 @@ def render_scalar_type(scalar_type: ts.ScalarType) -> str:
 def _render_function_param(param: interface.Parameter, index: int) -> str:
     if isinstance(param.type_, ts.ScalarType):
         return f"{render_scalar_type(param.type_)} {param.name}"
-    elif isinstance(param.type_, (ts.FieldType, ts.IndexFieldType)):
+    elif isinstance(param.type_, (ts.FieldType, ts_binding.IndexFieldType)):
         return f"BufferT{index}&& {param.name}"
     else:
         raise ValueError("unsupported type for parameters")
@@ -114,7 +115,7 @@ def render_function_declaration(function: interface.Function, body: str) -> str:
     template_params = [
         f"class BufferT{index}"
         for index, param in enumerate(function.parameters)
-        if isinstance(param.type_, (ts.FieldType, ts.IndexFieldType))
+        if isinstance(param.type_, (ts.FieldType, ts_binding.IndexFieldType))
     ]
     if template_params:
         return f"""

--- a/src/functional/otf/binding/cpp_interface.py
+++ b/src/functional/otf/binding/cpp_interface.py
@@ -92,8 +92,12 @@ def render_scalar_type(scalar_type: ts.ScalarType) -> str:
         return "float"
     elif scalar_type.kind == ts.ScalarKind.FLOAT64:
         return "double"
+    elif scalar_type.kind == ts.ScalarKind.STRING:
+        return "std::string"
+    elif scalar_type.kind == ts.ScalarKind.DIMENSION:
+        raise AssertionError(f"Deprecated type '{scalar_type}' is not supported.")
     else:
-        raise ValueError("unsupported scalar type")
+        raise AssertionError(f"Scalar kind '{scalar_type}' is not implemented when it should be.")
 
 
 def _render_function_param(param: interface.Parameter, index: int) -> str:
@@ -102,7 +106,7 @@ def _render_function_param(param: interface.Parameter, index: int) -> str:
     elif isinstance(param.type_, (ts.FieldType, ts_binding.IndexFieldType)):
         return f"BufferT{index}&& {param.name}"
     else:
-        raise ValueError("unsupported type for parameters")
+        raise ValueError(f"Type '{param.type_}' is not supported in C++ interfaces.")
 
 
 def render_function_declaration(function: interface.Function, body: str) -> str:

--- a/src/functional/otf/binding/interface.py
+++ b/src/functional/otf/binding/interface.py
@@ -15,9 +15,8 @@ from __future__ import annotations
 
 import dataclasses
 
-import numpy as np
-
 import eve.codegen
+import functional.type_system.type_specifications as ts
 from functional.otf import languages
 
 
@@ -26,22 +25,15 @@ def format_source(settings: languages.LanguageSettings, source):
 
 
 @dataclasses.dataclass(frozen=True)
-class ScalarParameter:
+class Parameter:
     name: str
-    scalar_type: np.dtype
-
-
-@dataclasses.dataclass(frozen=True)
-class BufferParameter:
-    name: str
-    dimensions: tuple[str, ...]
-    scalar_type: np.dtype
+    type_: ts.TypeSpec
 
 
 @dataclasses.dataclass(frozen=True)
 class Function:
     name: str
-    parameters: tuple[ScalarParameter | BufferParameter, ...]
+    parameters: tuple[Parameter, ...]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/functional/otf/binding/pybind.py
+++ b/src/functional/otf/binding/pybind.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 import eve
-import functional.otf.binding.type_specifications as ts
+import functional.otf.binding.type_specifications as ts_binding
+import functional.type_system.type_specifications as ts
 from eve.codegen import JinjaTemplate as as_jinja, TemplatedGenerator
 from functional.otf import languages, stages, workflow
 from functional.otf.binding import cpp_interface, interface
@@ -112,7 +113,7 @@ class BindingCodeGenerator(TemplatedGenerator):
     def visit_FunctionParameter(self, param: FunctionParameter):
         if isinstance(param.type_, ts.FieldType):
             type_str = "pybind11::buffer"
-        elif isinstance(param.type_, ts.IndexFieldType):
+        elif isinstance(param.type_, ts_binding.IndexFieldType):
             type_str = "pybind11::none"
         elif isinstance(param.type_, ts.ScalarType):
             type_str = cpp_interface.render_scalar_type(param.type_)
@@ -168,7 +169,7 @@ def make_argument(index: int, param: interface.Parameter) -> str | BufferSID | P
             scalar_type=param.type_.dtype,
             dim_config=index,
         )
-    elif isinstance(param.type_, ts.IndexFieldType):
+    elif isinstance(param.type_, ts_binding.IndexFieldType):
         return PositionalSID(dimension=DimensionType(name=param.type_.axis.value))
     else:
         return param.name

--- a/src/functional/otf/binding/pybind.py
+++ b/src/functional/otf/binding/pybind.py
@@ -118,7 +118,7 @@ class BindingCodeGenerator(TemplatedGenerator):
         elif isinstance(param.type_, ts.ScalarType):
             type_str = cpp_interface.render_scalar_type(param.type_)
         else:
-            raise ValueError("Invalid type.")
+            raise ValueError(f"Type '{param.type_}' is not supported in pybind11 interfaces.")
         return f"{type_str} {param.name}"
 
     ReturnStmt = as_jinja("""return {{expr}};""")

--- a/src/functional/otf/binding/pybind.py
+++ b/src/functional/otf/binding/pybind.py
@@ -160,9 +160,7 @@ def make_parameter(parameter: interface.Parameter) -> FunctionParameter:
     return FunctionParameter(name=parameter.name, type_=parameter.type_)
 
 
-def make_argument(
-    index: int, param: interface.Parameter
-) -> str | BufferSID | PositionalSID:
+def make_argument(index: int, param: interface.Parameter) -> str | BufferSID | PositionalSID:
     if isinstance(param.type_, ts.FieldType):
         return BufferSID(
             source_buffer=param.name,

--- a/src/functional/otf/binding/type_specifications.py
+++ b/src/functional/otf/binding/type_specifications.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+import functional.type_system.type_specifications as ts
+from functional import common as func_common
+from functional.type_system.type_specifications import (  # noqa: F401
+    CallableType as CallableType,
+    DataType as DataType,
+    DeferredType as DeferredType,
+    DimensionType as DimensionType,
+    FieldType as FieldType,
+    FunctionType as FunctionType,
+    OffsetType as OffsetType,
+    ScalarKind as ScalarKind,
+    ScalarType as ScalarType,
+    TupleType as TupleType,
+    TypeSpec as TypeSpec,
+    VoidType as VoidType,
+)
+
+
+@dataclass(frozen=True)
+class IndexFieldType(ts.DataType):
+    axis: func_common.Dimension
+    dtype: ts.ScalarType
+
+    def __str__(self):
+        return f"IndexField[{self.axis.value}, {self.dtype}]"

--- a/src/functional/otf/binding/type_specifications.py
+++ b/src/functional/otf/binding/type_specifications.py
@@ -2,20 +2,6 @@ from dataclasses import dataclass
 
 import functional.type_system.type_specifications as ts
 from functional import common as func_common
-from functional.type_system.type_specifications import (  # noqa: F401
-    CallableType as CallableType,
-    DataType as DataType,
-    DeferredType as DeferredType,
-    DimensionType as DimensionType,
-    FieldType as FieldType,
-    FunctionType as FunctionType,
-    OffsetType as OffsetType,
-    ScalarKind as ScalarKind,
-    ScalarType as ScalarType,
-    TupleType as TupleType,
-    TypeSpec as TypeSpec,
-    VoidType as VoidType,
-)
 
 
 @dataclass(frozen=True)

--- a/src/functional/otf/binding/type_translation.py
+++ b/src/functional/otf/binding/type_translation.py
@@ -1,8 +1,8 @@
-from functional.type_system import type_translation
-from functional.type_system import type_specifications as ts
-from functional.otf.binding import type_specifications as ts_binding
 from typing import Any, Optional
+
 from functional.iterator.embedded import IndexField
+from functional.otf.binding import type_specifications as ts_binding
+from functional.type_system import type_specifications as ts, type_translation
 
 
 def from_type_hint(

--- a/src/functional/otf/binding/type_translation.py
+++ b/src/functional/otf/binding/type_translation.py
@@ -1,0 +1,23 @@
+from functional.type_system import type_translation
+from functional.type_system import type_specifications as ts
+from functional.otf.binding import type_specifications as ts_binding
+from typing import Any, Optional
+from functional.iterator.embedded import IndexField
+
+
+def from_type_hint(
+    type_hint: Any,
+    *,
+    globalns: Optional[dict[str, Any]] = None,
+    localns: Optional[dict[str, Any]] = None,
+) -> ts.TypeSpec:
+    return type_translation.from_type_hint(type_hint, globalns=globalns, localns=localns)
+
+
+def from_value(value: Any) -> ts.TypeSpec:
+    if isinstance(value, IndexField):
+        dtype = type_translation.from_type_hint(value.dtype.type)
+        assert isinstance(dtype, ts.ScalarType)
+        return ts_binding.IndexFieldType(axis=value.axis, dtype=dtype)
+    else:
+        return type_translation.from_value(value)

--- a/src/functional/otf/compilation/cache.py
+++ b/src/functional/otf/compilation/cache.py
@@ -19,7 +19,6 @@ import hashlib
 import pathlib
 import tempfile
 
-import functional.type_system.type_specifications as ts
 from functional.otf import stages
 from functional.otf.binding import interface
 
@@ -38,12 +37,7 @@ _persistent_cache_dir_path = pathlib.Path(tempfile.gettempdir()) / "gt4py_cache"
 def _serialize_param(
     parameter: interface.Parameter,
 ) -> str:
-    if isinstance(parameter.type_, ts.ScalarType):
-        return f"{parameter.name}: {str(parameter.type_)}"
-    elif isinstance(parameter.type_, ts.FieldType):
-        dim_names = (dim.value for dim in parameter.type_.dims)
-        return f"{parameter.name}: {str(parameter.type_)}<{', '.join(dim_names)}>"
-    raise ValueError("unsupported parameter type")
+    return f"{parameter.name}: {str(parameter.type_)}"
 
 
 def _serialize_library_dependency(dependency: interface.LibraryDependency) -> str:

--- a/src/functional/otf/compilation/cache.py
+++ b/src/functional/otf/compilation/cache.py
@@ -19,6 +19,7 @@ import hashlib
 import pathlib
 import tempfile
 
+import functional.type_system.type_specifications as ts
 from functional.otf import stages
 from functional.otf.binding import interface
 
@@ -35,13 +36,14 @@ _persistent_cache_dir_path = pathlib.Path(tempfile.gettempdir()) / "gt4py_cache"
 
 
 def _serialize_param(
-    parameter: interface.ScalarParameter | interface.BufferParameter,
+    parameter: interface.Parameter,
 ) -> str:
-    if isinstance(parameter, interface.ScalarParameter):
-        return f"{parameter.name}: {str(parameter.scalar_type)}"
-    elif isinstance(parameter, interface.BufferParameter):
-        return f"{parameter.name}: {str(parameter.scalar_type)}<{', '.join(parameter.dimensions)}>"
-    raise ValueError("Invalid parameter type. This is a bug.")
+    if isinstance(parameter.type_, ts.ScalarType):
+        return f"{parameter.name}: {str(parameter.type_)}"
+    elif isinstance(parameter.type_, ts.FieldType):
+        dim_names = (dim.value for dim in parameter.type_.dims)
+        return f"{parameter.name}: {str(parameter.type_)}<{', '.join(dim_names)}>"
+    raise ValueError("unsupported parameter type")
 
 
 def _serialize_library_dependency(dependency: interface.LibraryDependency) -> str:

--- a/src/functional/program_processors/codegens/gtfn/gtfn_module.py
+++ b/src/functional/program_processors/codegens/gtfn/gtfn_module.py
@@ -17,11 +17,12 @@ import dataclasses
 from typing import Any, Final, TypeVar
 
 import functional.otf.binding.type_specifications as ts
+from functional.iterator.embedded import IndexField
 from functional.otf import languages, stages, step_types, workflow
 from functional.otf.binding import cpp_interface, interface
 from functional.program_processors.codegens.gtfn import gtfn_backend
 from functional.type_system import type_translation
-from functional.iterator.embedded import IndexField
+
 
 T = TypeVar("T")
 

--- a/src/functional/program_processors/codegens/gtfn/gtfn_module.py
+++ b/src/functional/program_processors/codegens/gtfn/gtfn_module.py
@@ -16,28 +16,17 @@
 import dataclasses
 from typing import Any, Final, TypeVar
 
-import functional.otf.binding.type_specifications as ts
-from functional.iterator.embedded import IndexField
 from functional.otf import languages, stages, step_types, workflow
-from functional.otf.binding import cpp_interface, interface
+from functional.otf.binding import cpp_interface, interface, type_translation as tt_binding
 from functional.program_processors.codegens.gtfn import gtfn_backend
-from functional.type_system import type_translation
 
 
 T = TypeVar("T")
 
 
 def get_param_description(name: str, obj: Any) -> interface.Parameter:
-    # TODO: make type_translation extendable and specialize it for the
-    #   bindings to distinguish between buffer-backed fields and index
-    #   fields.
-    if isinstance(obj, IndexField):
-        dtype = type_translation.from_type_hint(obj.dtype.type)
-        assert isinstance(dtype, ts.ScalarType)
-        return interface.Parameter(name, ts.IndexFieldType(axis=obj.axis, dtype=dtype))
-    else:
-        type_ = type_translation.from_value(obj)
-        return interface.Parameter(name, type_)
+    type_ = tt_binding.from_value(obj)
+    return interface.Parameter(name, type_)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/functional/program_processors/runners/gtfn_cpu.py
+++ b/src/functional/program_processors/runners/gtfn_cpu.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Final, Optional
 import numpy as np
 
 from functional.iterator import ir as itir
+from functional.iterator.embedded import IndexField
 from functional.otf import languages, stages, workflow
 from functional.otf.binding import cpp_interface, pybind
 from functional.otf.compilation import cache, compiler
@@ -31,6 +32,8 @@ from functional.program_processors.codegens.gtfn import gtfn_module
 def convert_arg(arg: Any) -> Any:
     if hasattr(arg, "__array__"):
         return np.asarray(arg)
+    elif isinstance(arg, IndexField):
+        return None
     else:
         return arg
 

--- a/tests/functional_tests/ffront_tests/test_execution.py
+++ b/tests/functional_tests/ffront_tests/test_execution.py
@@ -202,7 +202,7 @@ def test_nested_scalar_arg(fieldview_backend):
 
 def test_scalar_arg_with_field(fieldview_backend):
     if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.skip("IndexFields and ConstantFields are not supported yet.")
+        pytest.skip("ConstantFields are not supported yet.")
 
     inp = index_field(Edge, dtype=float64)
     factor = 3.0
@@ -723,8 +723,6 @@ def test_domain_tuple(fieldview_backend):
 
 
 def test_where_k_offset(fieldview_backend):
-    if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.skip("IndexFields are not supported yet.")
     a = np_as_located_field(IDim, KDim)(np.ones((size, size)))
     out = np_as_located_field(IDim, KDim)(np.zeros((size, size)))
     k_index = index_field(KDim)

--- a/tests/functional_tests/otf_tests/test_cpp_gen.py
+++ b/tests/functional_tests/otf_tests/test_cpp_gen.py
@@ -14,9 +14,15 @@
 import numpy as np
 import pytest
 
+import functional.common as common
 import functional.otf.binding.cpp_interface as cpp
+import functional.type_system.type_specifications as ts
 from eve.codegen import format_source
 from functional.otf.binding import interface
+
+
+IDim = common.Dimension("IDim")
+JDim = common.Dimension("JDim")
 
 
 def test_render_types():
@@ -29,8 +35,8 @@ def function_scalar_example():
     return interface.Function(
         name="example",
         parameters=[
-            interface.ScalarParameter("a", np.dtype(float)),
-            interface.ScalarParameter("b", np.dtype(int)),
+            interface.Parameter("a", ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+            interface.Parameter("b", ts.ScalarType(kind=ts.ScalarKind.INT64)),
         ],
     )
 
@@ -42,7 +48,7 @@ def test_render_function_declaration_scalar(function_scalar_example):
     expected = format_source(
         "cpp",
         """\
-    decltype(auto) example(double a, long b) {
+    decltype(auto) example(double a, int64_t b) {
         return;
     }\
     """,
@@ -66,8 +72,12 @@ def function_buffer_example():
     return interface.Function(
         name="example",
         parameters=[
-            interface.BufferParameter("a_buf", 2, float),
-            interface.BufferParameter("b_buf", 1, int),
+            interface.Parameter(
+                "a_buf", ts.FieldType(dims=[IDim, JDim], dtype=ts.ScalarType(ts.ScalarKind.FLOAT64))
+            ),
+            interface.Parameter(
+                "b_buf", ts.FieldType(dims=[IDim], dtype=ts.ScalarType(ts.ScalarKind.INT64))
+            ),
         ],
     )
 

--- a/tests/functional_tests/otf_tests/test_pybind_step.py
+++ b/tests/functional_tests/otf_tests/test_pybind_step.py
@@ -32,8 +32,8 @@ def test_bindings(program_source_example):
 
         decltype(auto) stencil_wrapper(pybind11::buffer buf, float sc) {
           return stencil(
-              gridtools::sid::rename_numbered_dimensions<generated::I_t,
-                                                         generated::J_t>(
+              gridtools::sid::rename_numbered_dimensions<generated::IDim_t,
+                                                         generated::JDim_t>(
                   gridtools::as_sid<float, 2, gridtools::integral_constant<int, 0>,
                                     999'999'999>(buf)),
               sc);


### PR DESCRIPTION
Adds index fields as a distinct argument type for the C++ binding generator. The binding generator generates the correct C++ code that passes `gridtools::stencil::positional` iterators to the GTFN C++ program code.