### PR TITLE
Update isort to fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
   - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 


### PR DESCRIPTION
CI is currently failing due to an issue in isort. The issue is fixed in recent versions of isort.
