### PR TITLE
Imperative Backend Bugfix (Init Conditional Problem)

### DIFF
--- a/src/gt4py/next/program_processors/codegens/gtfn/codegen.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/codegen.py
@@ -269,10 +269,12 @@ class GTFNIMCodegen(GTFNCodegen):
 
     InitStmt = as_fmt("{init_type} {lhs} {op} {rhs};")
 
+    DefaultInitialized = as_fmt("{init_type} {name} = {{}};")
+
     Conditional = as_mako(
         """
           using ${cond_type} = typename std::common_type<decltype(${if_rhs_}), decltype(${else_rhs_})>::type;
-          ${init_stmt}
+          ${initializer}
           if (${cond}) {
             ${if_stmt}
           } else {

--- a/src/gt4py/next/program_processors/codegens/gtfn/gtfn_im_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/gtfn_im_ir.py
@@ -35,9 +35,14 @@ class InitStmt(AssignStmt):
     init_type: str = "auto"
 
 
+class DefaultInitialized(Stmt):
+    init_type: str = "auto"
+    name: Sym
+
+
 class Conditional(Stmt):
     cond_type: str
-    init_stmt: Stmt
+    initializer: Union[DefaultInitialized, InitStmt]
     cond: Expr
     if_stmt: AssignStmt
     else_stmt: AssignStmt

--- a/src/gt4py/next/program_processors/codegens/gtfn/gtfn_ir_to_gtfn_im_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/gtfn_ir_to_gtfn_im_ir.py
@@ -23,6 +23,7 @@ from gt4py.next.program_processors.codegens.gtfn import gtfn_ir, gtfn_ir_common
 from gt4py.next.program_processors.codegens.gtfn.gtfn_im_ir import (
     AssignStmt,
     Conditional,
+    DefaultInitialized,
     ImperativeFunctionDefinition,
     InitStmt,
     ReturnStmt,
@@ -316,10 +317,9 @@ class GTFN_IM_lowering(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
         self.imp_list_ir.append(
             Conditional(
                 cond_type=f"{cond_idx}_t",
-                init_stmt=InitStmt(
+                initializer=DefaultInitialized(
                     init_type=f"{cond_idx}_t",
-                    lhs=gtfn_ir_common.Sym(id=cond_idx),
-                    rhs=gtfn_ir.Literal(value="0.", type="float64"),
+                    name=gtfn_ir_common.Sym(id=cond_idx),
                 ),
                 cond=cond,
                 if_stmt=AssignStmt(lhs=gtfn_ir_common.SymRef(id=cond_idx), rhs=if_),


### PR DESCRIPTION
## Description

There was an issue with initializing the temporary variable holding the result of a conditional: 

```
      using cond_8_t =
          typename std::common_type<decltype(tupl_7), decltypetupl_7)>::type;
      cond_8_t cond_8 = 0.;
      ^^^^^^^^^^^^^^^^^^^^^
      can not initialize tuple with double
```
 
Instead of initializing with `0.`, the behavior was changed to use uniformed initialization with {}. In the above example this would read

```
cond_2_t cond_2 = {};
```