### PR TITLE
Pull images before using them for CSCS CI pipeline

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -16,6 +16,7 @@ include:
 stages:
 - baseimage
 - image
+- pull
 - test
 
 build py38 baseimage:
@@ -75,11 +76,34 @@ build py310 image:
   variables:
     <<: *py310
 
-test py38:
+pull py38 image:
   extends: .container-runner-daint-gpu
   needs: ["build py38 image"]
-  stage: test
+  stage: pull
   image: $CSCS_REGISTRY_PATH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
+  script:
+    - 'true'
+  variables:
+    <<: *py38
+
+pull py39 image:
+  extends: pull py38 image
+  needs: ["build py39 image"]
+  stage: pull
+  variables:
+    <<: *py39
+
+pull py310 image:
+  extends: pull py38 image
+  needs: ["build py310 image"]
+  stage: pull
+  variables:
+    <<: *py310
+
+test py38:
+  extends: .container-runner-daint-gpu
+  needs: ["pull py38 image"]
+  stage: test
   script:
   - cd /gt4py.src
   - python -c "import cupy"
@@ -96,17 +120,18 @@ test py38:
     SLURM_TIMELIMIT: 120
     NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
+    PULL_IMAGE: 'NO'
     <<: *py38
 
 test py39:
   extends: test py38
-  needs: ["build py39 image"]
+  needs: ["pull py39 image"]
   variables:
     <<: *py39
 
 test py310:
   extends: test py38
-  needs: ["build py310 image"]
+  needs: ["pull py310 image"]
   variables:
     <<: *py310
   parallel:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -82,7 +82,7 @@ pull py38 image:
   stage: pull
   image: $CSCS_REGISTRY_PATH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
   script:
-    - 'true'
+  - 'true'
   variables:
     <<: *py38
 


### PR DESCRIPTION
Since there are many test jobs using the same image, and all of them are starting at the same time, there is a high chance that the same image will be pulled several times.
While this gives correct results it is suboptimal since we download the same layers and squash them multiple times.

It is better to pull the image before using it, therefore I added a pull stage, which does exactly that.