### PR TITLE
Fix typing of `cast_` builtin in ITIR type inference

### DIFF
--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -481,8 +481,6 @@ class _TypeInferrer(eve.NodeTranslator):
                 if len(node.args) != 2:
                     raise TypeError("cast_ requires exactly two arguments.")
                 val_arg_type = self.visit(node.args[0], constraints=constraints, symtypes=symtypes)
-                if not isinstance(val_arg_type, Val):
-                    raise TypeError("The first argument to `cast_` must be a value.")
                 type_arg = node.args[1]
                 if not isinstance(type_arg, ir.SymRef) or type_arg.id not in ir.TYPEBUILTINS:
                     raise TypeError("The second argument to `cast_` must be a type literal.")

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -293,7 +293,6 @@ BUILTIN_TYPES: typing.Final[dict[str, Type]] = {
         ret=Val_BOOL_T1,
     ),
     "if_": FunctionType(args=Tuple.from_elems(Val_BOOL_T1, Val_T0_T1, Val_T0_T1), ret=Val_T0_T1),
-    "cast_": FunctionType(args=Tuple.from_elems(Val_T0_T1, Val_T0_T1), ret=Val_T0_T1),
     "lift": FunctionType(
         args=Tuple.from_elems(
             FunctionType(
@@ -402,6 +401,7 @@ class _TypeInferrer(eve.NodeTranslator):
             "shift",
             "cartesian_domain",
             "unstructured_domain",
+            "cast_",
         ):
             raise TypeError(
                 f"Builtin '{node.id}' is only supported as applied/called function by the type checker"
@@ -477,6 +477,22 @@ class _TypeInferrer(eve.NodeTranslator):
                 )
                 constraints.add((tup, val))
                 return Val(kind=kind, dtype=elem, size=size)
+            if node.fun.id == "cast_":
+                if len(node.args) != 2:
+                    raise TypeError("cast_ requires exactly two arguments.")
+                val_arg_type = self.visit(node.args[0], constraints=constraints, symtypes=symtypes)
+                if not isinstance(val_arg_type, Val):
+                    raise TypeError("The first argument to `cast_` must be a value.")
+                type_arg = node.args[1]
+                if not isinstance(type_arg, ir.SymRef) or type_arg.id not in ir.TYPEBUILTINS:
+                    raise TypeError("The second argument to `cast_` must be a type literal.")
+                return Val(
+                    kind=val_arg_type.kind,
+                    dtype=Primitive(name=type_arg.id),
+                    size=val_arg_type.size,
+                    current_loc=val_arg_type.current_loc,
+                    defined_loc=val_arg_type.defined_loc,
+                )
             if node.fun.id == "shift":
                 # Calls to shift are handled as being part of the grammar, not
                 # as function calls, as the type depends on the offset provider

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -485,30 +485,23 @@ class _TypeInferrer(eve.NodeTranslator):
                 if not isinstance(type_arg, ir.SymRef) or type_arg.id not in ir.TYPEBUILTINS:
                     raise TypeError("The second argument to `cast_` must be a type literal.")
 
-                kind = TypeVar.fresh()
                 size = TypeVar.fresh()
-                current_loc = TypeVar.fresh()
-                defined_loc = TypeVar.fresh()
 
                 constraints.add(
                     (
                         val_arg_type,
                         Val(
-                            kind=kind,
+                            kind=Value(),
                             dtype=TypeVar.fresh(),
                             size=size,
-                            current_loc=current_loc,
-                            defined_loc=defined_loc,
                         ),
                     )
                 )
 
                 return Val(
-                    kind=kind,
+                    kind=Value(),
                     dtype=Primitive(name=type_arg.id),
                     size=size,
-                    current_loc=current_loc,
-                    defined_loc=defined_loc,
                 )
             if node.fun.id == "shift":
                 # Calls to shift are handled as being part of the grammar, not

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -486,12 +486,31 @@ class _TypeInferrer(eve.NodeTranslator):
                 type_arg = node.args[1]
                 if not isinstance(type_arg, ir.SymRef) or type_arg.id not in ir.TYPEBUILTINS:
                     raise TypeError("The second argument to `cast_` must be a type literal.")
+
+                kind = TypeVar.fresh()
+                size = TypeVar.fresh()
+                current_loc = TypeVar.fresh()
+                defined_loc = TypeVar.fresh()
+
+                constraints.add(
+                    (
+                        val_arg_type,
+                        Val(
+                            kind=kind,
+                            dtype=TypeVar.fresh(),
+                            size=size,
+                            current_loc=current_loc,
+                            defined_loc=defined_loc,
+                        ),
+                    )
+                )
+
                 return Val(
-                    kind=val_arg_type.kind,
+                    kind=kind,
                     dtype=Primitive(name=type_arg.id),
-                    size=val_arg_type.size,
-                    current_loc=val_arg_type.current_loc,
-                    defined_loc=val_arg_type.defined_loc,
+                    size=size,
+                    current_loc=current_loc,
+                    defined_loc=defined_loc,
                 )
             if node.fun.id == "shift":
                 # Calls to shift are handled as being part of the grammar, not

--- a/tests/next_tests/iterator_tests/test_builtins.py
+++ b/tests/next_tests/iterator_tests/test_builtins.py
@@ -13,7 +13,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import math
-import textwrap
 from typing import Callable, Iterable
 
 import numpy as np

--- a/tests/next_tests/iterator_tests/test_builtins.py
+++ b/tests/next_tests/iterator_tests/test_builtins.py
@@ -334,10 +334,10 @@ def test_can_deref(program_processor, stencil):
 @pytest.mark.parametrize(
     "input_value, dtype, expected_value",
     [
-        (float64("0.1"), "float32", float64(float32("0.1"))),
-        (int64(42), "bool", int64(1)),
-        (int64(2147483648), "int32", int64(-2147483648)),
-        (int64(2147483648), "int64", int64(2147483648)),  # int64 does not accidentally down-cast
+        (float64("0.1"), float32, float64(float32("0.1"))),
+        (int64(42), bool, int64(1)),
+        (int64(2147483648), int32, int64(-2147483648)),
+        (int64(2147483648), int64, int64(2147483648)),  # int64 does not accidentally down-cast
     ],
 )
 @pytest.mark.parametrize("as_column", [False, True])
@@ -348,20 +348,9 @@ def test_cast(program_processor, as_column, input_value, dtype, expected_value):
     inp = asfield(*asarray(input_value))[0]
     out = asfield((np.zeros_like(*asarray(expected_value))))[0]
 
-    # Note: We need to exec the stencil here since the dtype must be a type literal.
-    locals = {}
-    exec(
-        textwrap.dedent(
-            f"""
-            @fundef
-            def sten_cast(value):
-                return cast_(deref(value), {dtype})
-            """
-        ).strip(),
-        globals(),
-        locals,
-    )
-    sten_cast = locals["sten_cast"]
+    @fundef
+    def sten_cast(value):
+        return cast_(deref(value), dtype)
 
     run_processor(
         sten_cast[{IDim: range(1)}],

--- a/tests/next_tests/iterator_tests/test_builtins.py
+++ b/tests/next_tests/iterator_tests/test_builtins.py
@@ -13,6 +13,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import math
+import textwrap
 from typing import Callable, Iterable
 
 import numpy as np
@@ -333,10 +334,10 @@ def test_can_deref(program_processor, stencil):
 @pytest.mark.parametrize(
     "input_value, dtype, expected_value",
     [
-        (float64("0.1"), float32, float64(float32("0.1"))),
-        (int64(42), bool, int64(1)),
-        (int64(2147483648), int32, int64(-2147483648)),
-        (int64(2147483648), int64, int64(2147483648)),  # int64 does not accidentally down-cast
+        (float64("0.1"), "float32", float64(float32("0.1"))),
+        (int64(42), "bool", int64(1)),
+        (int64(2147483648), "int32", int64(-2147483648)),
+        (int64(2147483648), "int64", int64(2147483648)),  # int64 does not accidentally down-cast
     ],
 )
 @pytest.mark.parametrize("as_column", [False, True])
@@ -347,9 +348,20 @@ def test_cast(program_processor, as_column, input_value, dtype, expected_value):
     inp = asfield(*asarray(input_value))[0]
     out = asfield((np.zeros_like(*asarray(expected_value))))[0]
 
+    # Note: We need to exec the stencil here since the dtype must be a type literal.
+    locals = {}
+    exec(
+        textwrap.dedent(
+            f"""
     @fundef
     def sten_cast(value):
-        return cast_(deref(value), dtype)
+        return cast_(deref(value), {dtype})
+    """
+        ).strip(),
+        globals(),
+        locals,
+    )
+    sten_cast = locals["sten_cast"]
 
     run_processor(
         sten_cast[{IDim: range(1)}],

--- a/tests/next_tests/iterator_tests/test_builtins.py
+++ b/tests/next_tests/iterator_tests/test_builtins.py
@@ -353,10 +353,10 @@ def test_cast(program_processor, as_column, input_value, dtype, expected_value):
     exec(
         textwrap.dedent(
             f"""
-    @fundef
-    def sten_cast(value):
-        return cast_(deref(value), {dtype})
-    """
+            @fundef
+            def sten_cast(value):
+                return cast_(deref(value), {dtype})
+            """
         ).strip(),
         globals(),
         locals,

--- a/tests/next_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/iterator_tests/test_type_inference.py
@@ -146,6 +146,16 @@ def test_and():
     assert ti.pformat(inferred) == "(bool⁰, bool⁰) → bool⁰"
 
 
+def test_cast():
+    testee = ir.FunCall(
+        fun=ir.SymRef(id="cast_"), args=[ir.Literal(value="1.", type="float"), ir.SymRef(id="int")]
+    )
+    expected = ti.Val(kind=ti.Value(), dtype=ti.Primitive(name="int"), size=ti.TypeVar(idx=0))
+    inferred = ti.infer(testee)
+    assert inferred == expected
+    assert ti.pformat(inferred) == "int⁰"
+
+
 def test_lift():
     testee = ir.SymRef(id="lift")
     expected = ti.FunctionType(


### PR DESCRIPTION
The typing inference rule for `cast_` was not correctly implemented when the builtin was introduced. This PR fixes that by making `cast_` part of the grammar (similar to how this is handled in the frontend). This restriction could be lifted in the future (e.g. by introducting a type of a type).