### PR TITLE
Fix codegen of dace:cpu 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ cuda117 =
 cuda11x =
     cupy-cuda11x
 dace =
-    dace>=0.14.1,<0.15
+    dace>=0.14.2,<0.15
     sympy
 formatting =
     clang-format>=9.0


### PR DESCRIPTION
Currently CI is failing with the latest released version of DaCe.

The reason is that DaCe fixed a bug where threadprivate variables allocated in persistent scope didn't get a SDFG-unique label. The fix breaks GT4Py's own bindings label which relies on specific undocumented behavior to be able to use the GT threadpool. This may break again in the future. 