### PR TITLE
GTFN: enable more tests

### DIFF
--- a/tests/next_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/ffront_tests/ffront_test_utils.py
@@ -119,7 +119,8 @@ def reduction_setup():
         E2VDim=e2vdim,
         V2E=FieldOffset("V2E", source=edge, target=(vertex, v2edim)),
         E2V=FieldOffset("E2V", source=vertex, target=(edge, e2vdim)),
-        inp=index_field(edge, dtype=np.int64),
+        # inp=index_field(edge, dtype=np.int64), # TODO enable once we support index_fields in bindings
+        inp=np_as_located_field(edge)(np.arange(num_edges, dtype=np.int64)),
         out=np_as_located_field(vertex)(np.zeros([num_vertices], dtype=np.int64)),
         offset_provider={
             "V2E": NeighborTableOffsetProvider(v2e_arr, vertex, edge, 4),

--- a/tests/next_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/ffront_tests/test_execution.py
@@ -247,7 +247,7 @@ def test_scalar_in_domain_spec_and_fo_call(fieldview_backend):
     assert (out.array() == size).all()
 
 
-def test_scalar_scan():
+def test_scalar_scan(fieldview_backend):
     size = 10
     KDim = Dimension("K", kind=DimensionKind.VERTICAL)
     qc = np_as_located_field(IDim, KDim)(np.zeros((size, size)))
@@ -259,7 +259,7 @@ def test_scalar_scan():
         qc = qc_in + carry + scalar
         return qc
 
-    @program
+    @program(backend=fieldview_backend)
     def scan_scalar(qc: Field[[IDim, KDim], float], scalar: float):
         _scan_scalar(qc, scalar, out=qc)
 
@@ -267,7 +267,10 @@ def test_scalar_scan():
     assert np.allclose(np.asarray(qc), expected)
 
 
-def test_tuple_scalar_scan():
+def test_tuple_scalar_scan(fieldview_backend):
+    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
+        pytest.skip("Tuple arguments are not supported in gtfn yet.")
+
     size = 10
     KDim = Dimension("K", kind=DimensionKind.VERTICAL)
     qc = np_as_located_field(IDim, KDim)(np.zeros((size, size)))
@@ -280,7 +283,7 @@ def test_tuple_scalar_scan():
     ) -> float:
         return (qc_in + state + tuple_scalar[1][0] + tuple_scalar[1][1]) / tuple_scalar[0]
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def scan_tuple_scalar(
         qc: Field[[IDim, KDim], float], tuple_scalar: tuple[float, tuple[float, float]]
     ) -> Field[[IDim, KDim], float]:
@@ -333,7 +336,7 @@ def test_astype_float(fieldview_backend):
     assert np.allclose(c_int32.array(), out_int_32)
 
 
-def test_nested_tuple_return():
+def test_nested_tuple_return(fieldview_backend):
     a_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     b_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float = np_as_located_field(IDim)(np.zeros((size), dtype=float64))
@@ -344,7 +347,7 @@ def test_nested_tuple_return():
     ) -> tuple[Field[[IDim], float64], tuple[Field[[IDim], float64], Field[[IDim], float64]]]:
         return (a, (a, b))
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def combine(a: Field[[IDim], float64], b: Field[[IDim], float64]) -> Field[[IDim], float64]:
         packed = pack_tuple(a, b)
         return packed[0] + packed[1][0] + packed[1][1]
@@ -354,7 +357,7 @@ def test_nested_tuple_return():
     assert np.allclose(2 * a_I_float.array() + b_I_float.array(), out_I_float)
 
 
-def test_tuple_return_2(reduction_setup):
+def test_tuple_return_2(reduction_setup, fieldview_backend):
     rs = reduction_setup
     Edge = rs.Edge
     Vertex = rs.Vertex
@@ -369,7 +372,7 @@ def test_tuple_return_2(reduction_setup):
         b = neighbor_sum(b(V2E), axis=V2EDim)
         return a, b
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def combine_tuple(a: Field[[Edge], int64], b: Field[[Edge], int64]) -> Field[[Vertex], int64]:
         packed = reduction_tuple(a, b)
         return packed[0] + packed[1]
@@ -440,8 +443,6 @@ def test_tuple_arg(fieldview_backend):
 
 @pytest.mark.parametrize("forward", [True, False])
 def test_fieldop_from_scan(fieldview_backend, forward):
-    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.xfail("gtfn does not yet support scan pass.")
     init = 1.0
     out = np_as_located_field(KDim)(np.zeros((size,)))
     expected = np.arange(init + 1.0, init + 1.0 + size, 1)
@@ -463,8 +464,7 @@ def test_fieldop_from_scan(fieldview_backend, forward):
 
 def test_solve_triag(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.xfail("gtfn does not yet support scan pass.")
-
+        pytest.skip("Has a bug.")
     shape = (3, 7, 5)
     rng = np.random.default_rng()
     a_np, b_np, c_np, d_np = (rng.normal(size=shape) for _ in range(4))
@@ -507,7 +507,7 @@ def test_solve_triag(fieldview_backend):
     np.allclose(expected, out)
 
 
-def test_ternary_operator():
+def test_ternary_operator(fieldview_backend):
     a_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     b_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float = np_as_located_field(IDim)(np.zeros((size), dtype=float64))
@@ -515,7 +515,7 @@ def test_ternary_operator():
     left = 2.0
     right = 3.0
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def ternary_field_op(
         a: Field[[IDim], float], b: Field[[IDim], float], left: float, right: float
     ) -> Field[[IDim], float]:
@@ -525,7 +525,7 @@ def test_ternary_operator():
     e = np.asarray(a_I_float) if left < right else np.asarray(b_I_float)
     np.allclose(e, out_I_float)
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def ternary_field_op_scalars(left: float, right: float) -> Field[[IDim], float]:
         return broadcast(3.0, (IDim,)) if left > right else broadcast(4.0, (IDim,))
 
@@ -534,7 +534,9 @@ def test_ternary_operator():
     np.allclose(e, out_I_float)
 
 
-def test_ternary_operator_tuple():
+def test_ternary_operator_tuple(fieldview_backend):
+    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
+        pytest.skip("Tuple arguments are not supported in gtfn yet.")
     a_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     b_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float = np_as_located_field(IDim)(np.zeros((size), dtype=float64))
@@ -543,7 +545,7 @@ def test_ternary_operator_tuple():
     left = 2.0
     right = 3.0
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def ternary_field_op(
         a: Field[[IDim], float], b: Field[[IDim], float], left: float, right: float
     ) -> tuple[Field[[IDim], float], Field[[IDim], float]]:
@@ -562,7 +564,7 @@ def test_ternary_operator_tuple():
     np.allclose(f, out_I_float_1)
 
 
-def test_ternary_builtin_neighbor_sum(reduction_setup):
+def test_ternary_builtin_neighbor_sum(reduction_setup, fieldview_backend):
     rs = reduction_setup
     Edge = rs.Edge
     Vertex = rs.Vertex
@@ -576,7 +578,7 @@ def test_ternary_builtin_neighbor_sum(reduction_setup):
     b = np_as_located_field(Edge)(2 * np.ones((num_edges,)))
     out = np_as_located_field(Vertex)(np.zeros((num_vertices,)))
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def ternary_reduce(a: Field[[Edge], float], b: Field[[Edge], float]) -> Field[[Vertex], float]:
         out = neighbor_sum(b(V2E) if 2 < 3 else a(V2E), axis=V2EDim)
         return out
@@ -592,14 +594,14 @@ def test_ternary_builtin_neighbor_sum(reduction_setup):
     assert np.allclose(expected, out)
 
 
-def test_ternary_scan():
+def test_ternary_scan(fieldview_backend):
     init = 0.0
     a_float = 4
     a = np_as_located_field(KDim)(a_float * np.ones((size,)))
     out = np_as_located_field(KDim)(np.zeros((size,)))
     expected = np.asarray([i if i <= a_float else a_float + 1 for i in range(1, size + 1)])
 
-    @scan_operator(axis=KDim, forward=True, init=init)
+    @scan_operator(axis=KDim, forward=True, init=init, backend=fieldview_backend)
     def simple_scan_operator(carry: float, a: float) -> float:
         return carry if carry > a else carry + 1.0
 
@@ -943,7 +945,7 @@ def test_tuple_unpacking_too_many_values(fieldview_backend):
             return a
 
 
-def test_constant_closure_vars():
+def test_constant_closure_vars(fieldview_backend):
     from gt4py.eve.utils import FrozenNamespace
 
     constants = FrozenNamespace(
@@ -951,7 +953,7 @@ def test_constant_closure_vars():
         E=np.float32(2.718),
     )
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def consume_constants(input: Field[[IDim], np.float32]) -> Field[[IDim], np.float32]:
         return constants.PI * constants.E * input
 

--- a/tests/next_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/ffront_tests/test_gt4py_builtins.py
@@ -50,7 +50,7 @@ def test_maxover_execution(reduction_setup, fieldview_backend):
 
 def test_maxover_execution_negatives(reduction_setup, fieldview_backend):
     """Testing max_over functionality for negative values in array."""
-    if fieldview_backend in [gtfn_cpu.run_gtfn or fieldview_backend, gtfn_cpu.run_gtfn_imperative]:
+    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
         pytest.skip("not yet supported.")
 
     rs = reduction_setup
@@ -113,9 +113,6 @@ def test_minover_execution_float(reduction_setup, fieldview_backend):
 
 def test_reduction_execution(reduction_setup, fieldview_backend):
     """Testing a trivial neighbor sum."""
-    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("IndexFields are not supported yet.")
-
     rs = reduction_setup
     Edge = rs.Edge
     Vertex, V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
@@ -156,7 +153,7 @@ def test_reduction_execution_nb(reduction_setup, fieldview_backend):
 def test_reduction_expression(reduction_setup, fieldview_backend):
     """Test reduction with an expression directly inside the call."""
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("IndexFields are not supported yet.")
+        pytest.skip("Has a bug.")
 
     rs = reduction_setup
     Vertex, V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
@@ -178,14 +175,16 @@ def test_reduction_expression(reduction_setup, fieldview_backend):
     assert np.allclose(ref, rs.out.array())
 
 
-def test_conditional_nested_tuple():
+def test_conditional_nested_tuple(fieldview_backend):
+    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
+        pytest.skip("Tuple outputs not supported in gtfn backends")
     a_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     b_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float_1 = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     mask = np_as_located_field(IDim)(np.zeros((size,), dtype=bool))
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def conditional_nested_tuple(
         mask: Field[[IDim], bool], a: Field[[IDim], float64], b: Field[[IDim], float64]
     ) -> tuple[

--- a/tests/next_tests/iterator_tests/test_with_toy_connectivity.py
+++ b/tests/next_tests/iterator_tests/test_with_toy_connectivity.py
@@ -43,6 +43,14 @@ from gt4py.next.program_processors.runners import gtfn_cpu
 from .conftest import run_processor
 
 
+def edge_index_field():  # TODO replace by index_field once supported in bindings
+    return np_as_located_field(Edge)(np.arange(e2v_arr.shape[0]))
+
+
+def vertex_index_field():  # TODO replace by index_field once supported in bindings
+    return np_as_located_field(Vertex)(np.arange(v2e_arr.shape[0]))
+
+
 @fundef
 def sum_edges_to_vertices(in_edges):
     return (
@@ -53,9 +61,9 @@ def sum_edges_to_vertices(in_edges):
     )
 
 
-def test_sum_edges_to_vertices(program_processor_no_gtfn_exec, lift_mode):
-    program_processor, validate = program_processor_no_gtfn_exec
-    inp = index_field(Edge)
+def test_sum_edges_to_vertices(program_processor, lift_mode):
+    program_processor, validate = program_processor
+    inp = edge_index_field()
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
@@ -76,9 +84,11 @@ def sum_edges_to_vertices_reduce(in_edges):
     return reduce(plus, 0)(shift(V2E)(in_edges))
 
 
-def test_sum_edges_to_vertices_reduce(program_processor_no_gtfn_exec, lift_mode):
-    program_processor, validate = program_processor_no_gtfn_exec
-    inp = index_field(Edge)
+def test_sum_edges_to_vertices_reduce(program_processor, lift_mode):
+    program_processor, validate = program_processor
+    if program_processor == gtfn_cpu.run_gtfn_imperative:
+        pytest.skip("gtfn_imperative has a bug.")
+    inp = edge_index_field()
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
@@ -99,11 +109,9 @@ def first_vertex_neigh_of_first_edge_neigh_of_cells(in_vertices):
     return deref(shift(E2V, 0)(shift(C2E, 0)(in_vertices)))
 
 
-def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(
-    program_processor_no_gtfn_exec, lift_mode
-):
-    program_processor, validate = program_processor_no_gtfn_exec
-    inp = index_field(Vertex)
+def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(program_processor, lift_mode):
+    program_processor, validate = program_processor
+    inp = vertex_index_field()
     out = np_as_located_field(Cell)(np.zeros([9]))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
@@ -293,11 +301,7 @@ def lift_stencil(inp):
 
 def test_lift(program_processor, lift_mode):
     program_processor, validate = program_processor
-    inp = index_field(Vertex)
-    if program_processor in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        # TODO(tehrengruber): only a temporary solution until index fields are supported in the
-        #  gtfn backend.
-        inp = np_as_located_field(Vertex)(np.array([inp.field_getitem(i) for i in range(0, 9)]))
+    inp = vertex_index_field()
     out = np_as_located_field(Vertex)(np.zeros([9]))
     ref = np.asarray(np.asarray(range(9)))
 


### PR DESCRIPTION
Several tests were disabled but are now supported in GTFN. For some `index_field` is temporarily replaced by a numpy array with indices.