### PR TITLE
Small fixes to FOAST -> ITIR lowering

### DIFF
--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -17,8 +17,6 @@ import itertools
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-import numpy as np
-
 from gt4py.eve import NodeTranslator
 from gt4py.next.common import DimensionKind
 from gt4py.next.ffront import (
@@ -318,9 +316,12 @@ class FieldOperatorLowering(NodeTranslator):
             return self._lift_if_field(node)(
                 im.call_("not_")(to_value(node.operand)(self.visit(node.operand, **kwargs)))
             )
+
+        dtype = type_info.extract_dtype(node.type)
+        assert type_info.is_arithmetic(dtype)
         return self._lift_if_field(node)(
             im.call_(node.op.value)(
-                im.literal_("0", "int"),
+                im.literal_("0", dtype.kind.name.lower()),
                 to_value(node.operand)(self.visit(node.operand, **kwargs)),
             )
         )
@@ -357,7 +358,9 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_shift(self, node: foast.Call, **kwargs) -> itir.FunCall:
         match node.args[0]:
             case foast.Subscript(value=foast.Name(id=offset_name), index=int(offset_index)):
-                return im.shift_(offset_name, offset_index)(self.visit(node.func, **kwargs))
+                return im.shift_(offset_name, itir.OffsetLiteral(value=offset_index))(
+                    self.visit(node.func, **kwargs)
+                )
             case foast.Name(id=offset_name):
                 return im.shift_(offset_name)(self.visit(node.func, **kwargs))
         raise FieldOperatorLoweringError("Unexpected shift arguments!")
@@ -388,20 +391,23 @@ class FieldOperatorLowering(NodeTranslator):
         )
 
     def _visit_max_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
-        # TODO(tehrengruber): replace greater_ with max_ builtin as soon as itir supports it
-        init_expr = itir.Literal(value=str(np.finfo(np.float64).min), type="float64")
+        dtype = type_info.extract_dtype(node.type)
+        min_value, _ = type_info.arithmetic_bounds(dtype)
+        init_expr = itir.Literal(value=str(min_value), type=dtype.kind.name.lower())
         return self._make_reduction_expr(
             node,
-            lambda expr: im.call_("if_")(im.greater_("acc", expr), "acc", expr),
+            lambda expr: im.call_("maximum")("acc", expr),
             init_expr,
             **kwargs,
         )
 
     def _visit_min_over(self, node: foast.Call, **kwargs) -> itir.FunCall:
-        init_expr = itir.Literal(value=str(np.finfo(np.float64).max), type="float64")
+        dtype = type_info.extract_dtype(node.type)
+        _, max_value = type_info.arithmetic_bounds(dtype)
+        init_expr = itir.Literal(value=str(max_value), type=dtype.kind.name.lower())
         return self._make_reduction_expr(
             node,
-            lambda expr: im.call_("if_")(im.less_("acc", expr), "acc", expr),
+            lambda expr: im.call_("minimum")("acc", expr),
             init_expr,
             **kwargs,
         )
@@ -548,7 +554,11 @@ class InsideReductionLowering(FieldOperatorLowering):
         if node.op is dialect_ast_enums.UnaryOperator.NOT:
             return im.call_(node.op.value)(self.visit(node.operand, **kwargs))
 
-        return im.call_(node.op.value)(im.literal_("0", "int"), self.visit(node.operand, **kwargs))
+        dtype = type_info.extract_dtype(node.type)
+        assert type_info.is_arithmetic(dtype)
+        return im.call_(node.op.value)(
+            im.literal_("0", dtype.kind.name.lower()), self.visit(node.operand, **kwargs)
+        )
 
     def _visit_shift(self, node: foast.Call, **kwargs) -> itir.SymRef:  # type: ignore[override]
         uid = f"{node.func.id}__{self._sequential_id()}"

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -358,9 +358,7 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_shift(self, node: foast.Call, **kwargs) -> itir.FunCall:
         match node.args[0]:
             case foast.Subscript(value=foast.Name(id=offset_name), index=int(offset_index)):
-                return im.shift_(offset_name, itir.OffsetLiteral(value=offset_index))(
-                    self.visit(node.func, **kwargs)
-                )
+                return im.shift_(offset_name, offset_index)(self.visit(node.func, **kwargs))
             case foast.Name(id=offset_name):
                 return im.shift_(offset_name)(self.visit(node.func, **kwargs))
         raise FieldOperatorLoweringError("Unexpected shift arguments!")

--- a/src/gt4py/next/ffront/itir_makers.py
+++ b/src/gt4py/next/ffront/itir_makers.py
@@ -258,7 +258,7 @@ def shift_(offset, value=None):
     Examples
     --------
     >>> shift_("i", 0)("a")
-    FunCall(fun=FunCall(fun=SymRef(id=SymbolRef('shift')), args=[OffsetLiteral(value='i'), Literal(value='0', type='int')]), args=[SymRef(id=SymbolRef('a'))])
+    FunCall(fun=FunCall(fun=SymRef(id=SymbolRef('shift')), args=[OffsetLiteral(value='i'), OffsetLiteral(value=0)]), args=[SymRef(id=SymbolRef('a'))])
 
     >>> shift_("V2E")("b")
     FunCall(fun=FunCall(fun=SymRef(id=SymbolRef('shift')), args=[OffsetLiteral(value='V2E')]), args=[SymRef(id=SymbolRef('b'))])

--- a/src/gt4py/next/ffront/itir_makers.py
+++ b/src/gt4py/next/ffront/itir_makers.py
@@ -75,7 +75,7 @@ def ensure_expr(literal_or_expr: Union[str, int, itir.Expr]) -> itir.Expr:
     return literal_or_expr
 
 
-def ensure_offset(str_or_offset: Union[str, itir.OffsetLiteral]) -> itir.OffsetLiteral:
+def ensure_offset(str_or_offset: Union[str, int, itir.OffsetLiteral]) -> itir.OffsetLiteral:
     """
     Convert Python literals into an OffsetLiteral and let OffsetLiterals pass unchanged.
 
@@ -87,7 +87,7 @@ def ensure_offset(str_or_offset: Union[str, itir.OffsetLiteral]) -> itir.OffsetL
     >>> ensure_offset(itir.OffsetLiteral(value="J"))
     OffsetLiteral(value='J')
     """
-    if isinstance(str_or_offset, str):
+    if isinstance(str_or_offset, (str, int)):
         return itir.OffsetLiteral(value=str_or_offset)
     return str_or_offset
 
@@ -266,7 +266,7 @@ def shift_(offset, value=None):
     offset = ensure_offset(offset)
     args = [offset]
     if value is not None:
-        value = ensure_expr(value)
+        value = ensure_offset(value)
         args.append(value)
     return call_(call_("shift")(*args))
 

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -15,6 +15,8 @@
 import functools
 from typing import Callable, Iterator, Type, TypeGuard, cast
 
+import numpy as np
+
 from gt4py.eve.utils import XIterable, xiter
 from gt4py.next.common import Dimension, GTTypeError
 from gt4py.next.type_system import type_specifications as ts
@@ -225,6 +227,16 @@ def is_arithmetic(symbol_type: ts.TypeSpec) -> bool:
     True
     """
     return is_floating_point(symbol_type) or is_integral(symbol_type)
+
+
+def arithmetic_bounds(arithmetic_type: ts.ScalarType):
+    assert is_arithmetic(arithmetic_type)
+    return {
+        ts.ScalarKind.FLOAT32: (np.finfo(np.float32).min, np.finfo(np.float32).max),
+        ts.ScalarKind.FLOAT64: (np.finfo(np.float64).min, np.finfo(np.float64).max),
+        ts.ScalarKind.INT32: (np.iinfo(np.int64).min, np.iinfo(np.int64).max),
+        ts.ScalarKind.INT64: (np.iinfo(np.int32).min, np.iinfo(np.int32).max),
+    }[arithmetic_type.kind]
 
 
 def is_type_or_tuple_of_type(type_: ts.TypeSpec, expected_type: type | tuple) -> bool:

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -234,8 +234,8 @@ def arithmetic_bounds(arithmetic_type: ts.ScalarType):
     return {
         ts.ScalarKind.FLOAT32: (np.finfo(np.float32).min, np.finfo(np.float32).max),
         ts.ScalarKind.FLOAT64: (np.finfo(np.float64).min, np.finfo(np.float64).max),
-        ts.ScalarKind.INT32: (np.iinfo(np.int64).min, np.iinfo(np.int64).max),
-        ts.ScalarKind.INT64: (np.iinfo(np.int32).min, np.iinfo(np.int32).max),
+        ts.ScalarKind.INT32: (np.iinfo(np.int32).min, np.iinfo(np.int32).max),
+        ts.ScalarKind.INT64: (np.iinfo(np.int64).min, np.iinfo(np.int64).max),
     }[arithmetic_type.kind]
 
 

--- a/tests/next_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/ffront_tests/test_execution.py
@@ -144,9 +144,6 @@ def test_tuples(fieldview_backend):
     b_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float = np_as_located_field(IDim)(np.zeros((size), dtype=float64))
 
-    if fieldview_backend == gtfn_cpu.run_gtfn:
-        pytest.skip("Tuples are not supported yet.")
-
     @field_operator
     def tuples(
         inp1: Field[[IDim], float64], inp2: Field[[IDim], float64]
@@ -857,6 +854,9 @@ def test_implicit_broadcast_mixed_dims(fieldview_backend):
 
 
 def test_tuple_unpacking(fieldview_backend):
+    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
+        pytest.skip("Tuple arguments are not supported in gtfn yet.")
+
     size = 10
     inp = np_as_located_field(IDim)(np.ones((size)))
     out1 = np_as_located_field(IDim)(np.ones((size)))
@@ -887,6 +887,9 @@ def test_tuple_unpacking(fieldview_backend):
 
 
 def test_tuple_unpacking_star_multi(fieldview_backend):
+    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
+        pytest.skip("Tuple arguments are not supported in gtfn yet.")
+
     size = 10
     inp = np_as_located_field(IDim)(np.ones((size)))
     out = tuple(np_as_located_field(IDim)(np.ones(size) * i) for i in range(3 * 4))

--- a/tests/next_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/ffront_tests/test_execution.py
@@ -384,7 +384,7 @@ def test_tuple_return_2(reduction_setup, fieldview_backend):
 
 
 @pytest.mark.xfail(raises=NotImplementedError)
-def test_tuple_with_local_field_in_reduction_shifted(reduction_setup):
+def test_tuple_with_local_field_in_reduction_shifted(reduction_setup, fieldview_backend):
     rs = reduction_setup
     Edge = rs.Edge
     Vertex = rs.Vertex
@@ -400,7 +400,7 @@ def test_tuple_with_local_field_in_reduction_shifted(reduction_setup):
     b = np_as_located_field(Vertex)(2 * np.ones((num_vertices,)))
     out = np_as_located_field(Edge)(np.zeros((num_edges,)))
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def reduce_tuple_element(
         edge_field: Field[[Edge], float64], vertex_field: Field[[Vertex], float64]
     ) -> Field[[Edge], float64]:
@@ -864,7 +864,7 @@ def test_tuple_unpacking(fieldview_backend):
     out3 = np_as_located_field(IDim)(np.ones((size)))
     out4 = np_as_located_field(IDim)(np.ones((size)))
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def unpack(
         inp: Field[[IDim], float64],
     ) -> tuple[
@@ -906,7 +906,7 @@ def test_tuple_unpacking_star_multi(fieldview_backend):
         Field[[IDim], float64],
     ]
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def unpack(
         inp: Field[[IDim], float64],
     ) -> OutType:
@@ -928,7 +928,7 @@ def test_tuple_unpacking_too_many_values(fieldview_backend):
         match=(r"Could not deduce type: Too many values to unpack \(expected 3\)"),
     ):
 
-        @field_operator
+        @field_operator(backend=fieldview_backend)
         def _star_unpack() -> tuple[int, float64, int]:
             a, b, c = (1, 2.0, 3, 4, 5, 6, 7.0)
             return a, b, c
@@ -939,7 +939,7 @@ def test_tuple_unpacking_too_many_values(fieldview_backend):
         FieldOperatorTypeDeductionError, match=(r"Assignment value must be of type tuple!")
     ):
 
-        @field_operator
+        @field_operator(backend=fieldview_backend)
         def _invalid_unpack() -> tuple[int, float64, int]:
             a, b, c = 1
             return a

--- a/tests/next_tests/ffront_tests/test_foast_lowering.py
+++ b/tests/next_tests/ffront_tests/test_foast_lowering.py
@@ -165,11 +165,15 @@ def test_unary_ops():
 
     reference = im.let(
         "tmp__0",
-        im.lift_(im.lambda__("inp")(im.plus_(0, im.deref_("inp"))))("inp"),
+        im.lift_(im.lambda__("inp")(im.plus_(im.literal_("0", "float64"), im.deref_("inp"))))(
+            "inp"
+        ),
     )(
         im.let(
             "tmp__1",
-            im.lift_(im.lambda__("tmp__0")(im.minus_(0, im.deref_("tmp__0"))))("tmp__0"),
+            im.lift_(
+                im.lambda__("tmp__0")(im.minus_(im.literal_("0", "float64"), im.deref_("tmp__0")))
+            )("tmp__0"),
         )("tmp__1")
     )
 

--- a/tests/next_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/ffront_tests/test_gt4py_builtins.py
@@ -80,7 +80,7 @@ def test_minover_execution(reduction_setup, fieldview_backend):
     Vertex, V2EDim = rs.Vertex, rs.V2EDim
     in_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def minover_fieldoperator(input: Field[[Vertex, V2EDim], int64]) -> Field[[Vertex], int64]:
         return min_over(input, axis=V2EDim)
 
@@ -101,7 +101,7 @@ def test_minover_execution_float(reduction_setup, fieldview_backend):
     in_field = np_as_located_field(Vertex, V2EDim)(in_array)
     out_field = np_as_located_field(Vertex)(np.zeros(rs.num_vertices))
 
-    @field_operator
+    @field_operator(backend=fieldview_backend)
     def minover_fieldoperator(input: Field[[Vertex, V2EDim], float64]) -> Field[[Vertex], float64]:
         return min_over(input, axis=V2EDim)
 
@@ -323,7 +323,7 @@ def test_conditional_shifted(fieldview_backend):
     out_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     mask = np_as_located_field(IDim)(np.zeros((size,), dtype=bool))
 
-    @field_operator()
+    @field_operator
     def conditional_shifted(
         mask: Field[[IDim], bool], a: Field[[IDim], float64], b: Field[[IDim], float64]
     ) -> Field[[IDim], float64]:


### PR DESCRIPTION
Just some fixes for minor bugs I found while working on the temporaries.
 - Fix literal dtype used for unary expressions
 - Use `maximum` and `minimum` for `max_over`, `min_over`
 - User proper initial values for `max_over`, `min_over` on other dtypes than `float64`