### PR TITLE
fix[next]: Fix cpp_backend tests

### DIFF
--- a/tests/next_tests/cpp_backend_tests/fn_select_gt4py.hpp
+++ b/tests/next_tests/cpp_backend_tests/fn_select_gt4py.hpp
@@ -54,8 +54,7 @@ template <class... dims> struct block_sizes_t {
 } // namespace
 namespace gridtools::fn::backend {
 namespace naive_impl_ {
-template <class ThreadPool>
-struct naive_with_threadpool;
+template <class ThreadPool> struct naive_with_threadpool;
 template <class ThreadPool>
 storage::cpu_kfirst backend_storage_traits(naive_with_threadpool<ThreadPool>);
 template <class ThreadPool>

--- a/tests/next_tests/cpp_backend_tests/fn_select_gt4py.hpp
+++ b/tests/next_tests/cpp_backend_tests/fn_select_gt4py.hpp
@@ -54,12 +54,18 @@ template <class... dims> struct block_sizes_t {
 } // namespace
 namespace gridtools::fn::backend {
 namespace naive_impl_ {
-struct naive;
-storage::cpu_kfirst backend_storage_traits(naive);
-timer_dummy backend_timer_impl(naive);
-inline char const *backend_name(naive const &) { return "naive"; }
+template <class ThreadPool>
+struct naive_with_threadpool;
+template <class ThreadPool>
+storage::cpu_kfirst backend_storage_traits(naive_with_threadpool<ThreadPool>);
+template <class ThreadPool>
+timer_dummy backend_timer_impl(naive_with_threadpool<ThreadPool>);
+template <class ThreadPool>
+inline char const *backend_name(naive_with_threadpool<ThreadPool> const &) {
+  return "naive";
+}
 } // namespace naive_impl_
-
+    
 namespace gpu_impl_ {
 template <class> struct gpu;
 template <class BlockSizes>

--- a/tests/next_tests/cpp_backend_tests/fn_select_gt4py.hpp
+++ b/tests/next_tests/cpp_backend_tests/fn_select_gt4py.hpp
@@ -65,7 +65,7 @@ inline char const *backend_name(naive_with_threadpool<ThreadPool> const &) {
   return "naive";
 }
 } // namespace naive_impl_
-    
+
 namespace gpu_impl_ {
 template <class> struct gpu;
 template <class BlockSizes>


### PR DESCRIPTION
cpp_backend_tests currently use gridtools/master installed by CMake. There the backend changed in a way incompatible of how we setup our tests.

The proper fix will be to use the same version as the rest of GT4Py, i.e. the version installed from pypi.