### PR TITLE
feature[eve]: Add functionality to preserve parts of the annex in `NodeTranslator`s

### DIFF
--- a/src/gt4py/eve/concepts.py
+++ b/src/gt4py/eve/concepts.py
@@ -197,9 +197,10 @@ class Node(datamodels.DataModel, trees.Tree, kw_only=True):  # type: ignore[call
     comparisons of the node, since it is not really a field. Thus, visitors
     and pipeline passes can freely attach computed attributes into the instance
     `annex`. Note that `annex` attribute is not implicitly copied in the
-    :class:`NodeTranslator`. If you want it to persist accross multiple
-    :class:`NodeTranslation` use a `root_validator` to dynamically (re)compute
-    the annex on node construction (see e.g. :class:`SymbolTableTrait`).
+    :class:`NodeTranslator`. If you want it to persist across multiple
+    :class:`NodeTranslation` either use a `root_validator` to dynamically (re)compute
+    the annex on node construction (see e.g. :class:`SymbolTableTrait`) or add the parts
+    of the annex that should be preserved to the list of `PRESERVED_ANNEX_ATTRS`.
     """
 
     __slots__ = ()

--- a/src/gt4py/eve/concepts.py
+++ b/src/gt4py/eve/concepts.py
@@ -198,9 +198,11 @@ class Node(datamodels.DataModel, trees.Tree, kw_only=True):  # type: ignore[call
     and pipeline passes can freely attach computed attributes into the instance
     `annex`. Note that `annex` attribute is not implicitly copied in the
     :class:`NodeTranslator`. If you want it to persist across multiple
-    :class:`NodeTranslation` either use a `root_validator` to dynamically (re)compute
-    the annex on node construction (see e.g. :class:`SymbolTableTrait`) or add the parts
-    of the annex that should be preserved to the list of `PRESERVED_ANNEX_ATTRS`.
+    :class:`NodeTranslator`s either use a `root_validator` to dynamically
+    (re)compute the annex on node construction (see e.g.
+    :class:`SymbolTableTrait`) or add the parts of the annex that should be
+    preserved to the `PRESERVED_ANNEX_ATTRS` attribute in the
+    :class:`NodeTranslator` class..
     """
 
     __slots__ = ()

--- a/src/gt4py/eve/visitors.py
+++ b/src/gt4py/eve/visitors.py
@@ -165,15 +165,14 @@ class NodeTranslator(NodeVisitor):
                     if (new_child := self.visit(child, **kwargs)) is not NOTHING
                 },
             )
-            if self.PRESERVED_ANNEX_ATTRS:
-                new_annex = copy.deepcopy(new_node.annex)
-                for k in self.PRESERVED_ANNEX_ATTRS:
-                    try:
-                        assert not hasattr(new_annex, k)
-                        setattr(new_annex, k, getattr(node.annex, k))
-                    except AttributeError:
-                        pass
-                object.__setattr__(new_node, "__node_annex__", new_annex)
+            if self.PRESERVED_ANNEX_ATTRS and (old_annex := getattr(node, "__node_annex__", None)):
+                # note: access to `new_node.annex` creates the annex in the property
+                new_annex_dict = new_node.annex.__dict__
+                for key in self.PRESERVED_ANNEX_ATTRS:
+                    if value := getattr(old_annex, key, None):
+                        assert key not in new_annex_dict
+                        new_annex_dict[key] = value
+
             return new_node
 
         if isinstance(node, (list, tuple, set, collections.abc.Set)) or (

--- a/src/gt4py/eve/visitors.py
+++ b/src/gt4py/eve/visitors.py
@@ -166,7 +166,7 @@ class NodeTranslator(NodeVisitor):
                 },
             )
             if self.PRESERVED_ANNEX_ATTRS and (old_annex := getattr(node, "__node_annex__", None)):
-                # note: access to `new_node.annex` creates the annex in the property
+                # note: access to `new_node.annex` implicitly creates the `__node_annex__` attribute in the property getter
                 new_annex_dict = new_node.annex.__dict__
                 for key in self.PRESERVED_ANNEX_ATTRS:
                     if value := getattr(old_annex, key, None):

--- a/src/gt4py/eve/visitors.py
+++ b/src/gt4py/eve/visitors.py
@@ -166,7 +166,7 @@ class NodeTranslator(NodeVisitor):
                 },
             )
             if self.PRESERVED_ANNEX_ATTRS and (old_annex := getattr(node, "__node_annex__", None)):
-                # note: access to `new_node.annex` implicitly creates the `__node_annex__` attribute in the property getter
+                # access to `new_node.annex` implicitly creates the `__node_annex__` attribute in the property getter
                 new_annex_dict = new_node.annex.__dict__
                 for key in self.PRESERVED_ANNEX_ATTRS:
                     if value := getattr(old_annex, key, None):

--- a/tests/eve_tests/unit_tests/test_visitors.py
+++ b/tests/eve_tests/unit_tests/test_visitors.py
@@ -1,0 +1,30 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2023, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from gt4py import eve
+
+
+def test_annex_preservation(compound_node: eve.Node):
+    compound_node.annex.foo = 1
+    compound_node.annex.bar = 2
+
+    class SampleTranslator(eve.NodeTranslator):
+        PRESERVED_ANNEX_ATTRS = ("foo",)
+
+    translated_node = SampleTranslator().visit(compound_node)
+
+    assert translated_node.annex.foo == 1
+    assert not hasattr(translated_node.annex, "bar")


### PR DESCRIPTION
Allows preserving parts of the annex using the `PRESERVED_ANNEX_ATTRS` class variable of a `NodeTranslator`.

@egparedes I was a little surprised to not find any tests for `NodeVisitor`s or `NodeTranslator`s. Am I missing something? Otherwise we should add some in the future.