### PR TITLE
fix[next]: ITIR type inference for dynamic offsets

### DIFF
--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -718,7 +718,12 @@ class _TypeInferrer(eve.traits.VisitorWithSymbolTableTrait, eve.NodeTranslator):
 
     def _visit_shift(self, node: ir.FunCall, **kwargs) -> Type:
         # Calls to shift are handled as being part of the grammar, not
-        # as function calls, as the type depends on the offset provider
+        # as function calls, as the type depends on the offset provider.
+
+        # Visit arguments such that their type is also inferred (particularly important for
+        # dynamic offsets)
+        self.visit(node.args)
+
         current_loc_in, current_loc_out = _infer_shift_location_types(
             node.args, self.offset_provider, self.constraints
         )

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -606,6 +606,21 @@ def test_function_definition():
     assert ti.pformat(inferred.dtype) == "(T₀) → T₀"
 
 
+def test_dynamic_offset():
+    """Test that the type of a dynamic offset is correctly inferred."""
+    offset_it = ir.SymRef(id="offset_it")
+    testee = ir.FunCall(
+        fun=ir.SymRef(id="shift"),
+        args=[
+            ir.OffsetLiteral(value="V2E"),
+            ir.FunCall(fun=ir.SymRef(id="deref"), args=[offset_it]),
+        ],
+    )
+    inferred_all: dict[int, ti.Type] = ti.infer_all(testee)
+    offset_it_type = inferred_all[id(offset_it)]
+    assert isinstance(offset_it_type, ti.Val) and offset_it_type.kind == ti.Iterator()
+
+
 CARTESIAN_DOMAIN = ir.FunCall(
     fun=ir.SymRef(id="cartesian_domain"),
     args=[


### PR DESCRIPTION
Fixes the type inference for dynamic offsets, e.g.:
```
⟪V2Eₒ, ·offset_it⟫
```