### PR TITLE
bug[next]: Fix shift / remap lowering

### DIFF
--- a/src/gt4py/next/ffront/field_operator_ast.py
+++ b/src/gt4py/next/ffront/field_operator_ast.py
@@ -148,7 +148,7 @@ class TernaryExpr(Expr):
 
 
 class Call(Expr):
-    func: Name
+    func: Expr
     args: list[Expr]
     kwargs: dict[str, Expr]
 

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -546,7 +546,6 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         arg_types = [arg.type for arg in new_args]
         kwarg_types = {name: arg.type for name, arg in new_kwargs.items()}
 
-        func_str_repr: str  # just for error handling
         if isinstance(
             new_func.type,
             (ts.FunctionType, ts_ffront.FieldOperatorType, ts_ffront.ScanOperatorType),
@@ -560,9 +559,8 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 raise FieldOperatorTypeDeductionError.from_foast_node(
                     node, msg="Functions can only be called directly!"
                 )
-            func_str_repr = new_func.id
         elif isinstance(new_func.type, ts.FieldType):
-            func_str_repr = str(new_func)
+            pass
         else:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
@@ -579,7 +577,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         except GTTypeError as err:
             raise FieldOperatorTypeDeductionError.from_foast_node(
-                node, msg=f"Invalid argument types in call to `{func_str_repr}`!"
+                node, msg=f"Invalid argument types in call to `{new_func}`!"
             ) from err
 
         return_type = type_info.return_type(func_type, with_args=arg_types, with_kwargs=kwarg_types)

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -206,17 +206,19 @@ class FieldOperatorLowering(NodeTranslator):
                 )
             case _:
                 raise FieldOperatorLoweringError("Unexpected shift arguments!")
-        return shift_offset(self.visit(node.func, **kwargs))
+        return im.lift_(im.lambda__("it")(im.deref_(shift_offset("it"))))(
+            self.visit(node.func, **kwargs)
+        )
 
     def visit_Call(self, node: foast.Call, **kwargs) -> itir.Expr:
         if type_info.type_class(node.func.type) is ts.FieldType:
             return self._visit_shift(node, **kwargs)
-        elif node.func.id in MATH_BUILTIN_NAMES:
+        elif isinstance(node.func, foast.Name) and node.func.id in MATH_BUILTIN_NAMES:
             return self._visit_math_built_in(node, **kwargs)
-        elif node.func.id in FUN_BUILTIN_NAMES:
+        elif isinstance(node.func, foast.Name) and node.func.id in FUN_BUILTIN_NAMES:
             visitor = getattr(self, f"_visit_{node.func.id}")
             return visitor(node, **kwargs)
-        elif node.func.id in TYPE_BUILTIN_NAMES:
+        elif isinstance(node.func, foast.Name) and node.func.id in TYPE_BUILTIN_NAMES:
             return self._visit_type_constr(node, **kwargs)
         elif isinstance(
             node.func.type,

--- a/src/gt4py/next/ffront/func_to_foast.py
+++ b/src/gt4py/next/ffront/func_to_foast.py
@@ -463,17 +463,14 @@ class FieldOperatorParser(DialectParser[foast.FunctionDefinition]):
         return node.func.id  # type: ignore[attr-defined]  # We want this to fail if the attribute does not exist unexpectedly.
 
     def visit_Call(self, node: ast.Call, **kwargs) -> foast.Call:
-        if not isinstance(node.func, ast.Name):
-            raise FieldOperatorSyntaxError.from_AST(
-                node, msg="Functions can only be called directly!"
-            )
+        # TODO(tehrengruber): is this still needed or redundant with the checks in type deduction?
+        if isinstance(node.func, ast.Name):
+            func_name = self._func_name(node)
 
-        func_name = self._func_name(node)
-
-        if func_name in fbuiltins.FUN_BUILTIN_NAMES:
-            self._verify_builtin_function(node)
-        if func_name in fbuiltins.TYPE_BUILTIN_NAMES:
-            self._verify_builtin_type_constructor(node)
+            if func_name in fbuiltins.FUN_BUILTIN_NAMES:
+                self._verify_builtin_function(node)
+            if func_name in fbuiltins.TYPE_BUILTIN_NAMES:
+                self._verify_builtin_type_constructor(node)
 
         return foast.Call(
             func=self.visit(node.func, **kwargs),

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
@@ -57,6 +57,7 @@ Koff = FieldOffset("Koff", source=KDim, target=(KDim,))
 
 Vertex = Dimension("Vertex")
 Edge = Dimension("Edge")
+Cell = Dimension("Cell")
 EdgeOffset = FieldOffset("EdgeOffset", source=Edge, target=(Edge,))
 
 size = 10
@@ -66,9 +67,6 @@ size = 10
 def reduction_setup():
     num_vertices = 9
     num_cells = 8
-    vertex = Dimension("Vertex")
-    edge = Dimension("Edge")
-    cell = Dimension("Cell")
     v2edim = Dimension("V2E", kind=DimensionKind.LOCAL)
     e2vdim = Dimension("E2V", kind=DimensionKind.LOCAL)
     c2vdim = Dimension("C2V", kind=DimensionKind.LOCAL)
@@ -129,9 +127,6 @@ def reduction_setup():
             "num_vertices",
             "num_edges",
             "num_cells",
-            "Vertex",
-            "Edge",
-            "Cell",
             "V2EDim",
             "E2VDim",
             "C2VDim",
@@ -150,25 +145,22 @@ def reduction_setup():
         num_vertices=num_vertices,
         num_edges=num_edges,
         num_cells=num_cells,
-        Vertex=vertex,
-        Edge=edge,
-        Cell=cell,
         V2EDim=v2edim,
         E2VDim=e2vdim,
         C2VDim=c2vdim,
         C2EDim=c2edim,
-        V2E=FieldOffset("V2E", source=edge, target=(vertex, v2edim)),
-        E2V=FieldOffset("E2V", source=vertex, target=(edge, e2vdim)),
-        C2V=FieldOffset("C2V", source=vertex, target=(cell, c2vdim)),
-        C2E=FieldOffset("C2E", source=edge, target=(cell, c2edim)),
+        V2E=FieldOffset("V2E", source=Edge, target=(Vertex, v2edim)),
+        E2V=FieldOffset("E2V", source=Vertex, target=(Edge, e2vdim)),
+        C2V=FieldOffset("C2V", source=Vertex, target=(Cell, c2vdim)),
+        C2E=FieldOffset("C2E", source=Edge, target=(Cell, c2edim)),
         # inp=index_field(edge, dtype=np.int64), # TODO enable once we support index_fields in bindings
-        inp=np_as_located_field(edge)(np.arange(num_edges, dtype=np.int64)),
-        out=np_as_located_field(vertex)(np.zeros([num_vertices], dtype=np.int64)),
+        inp=np_as_located_field(Edge)(np.arange(num_edges, dtype=np.int64)),
+        out=np_as_located_field(Vertex)(np.zeros([num_vertices], dtype=np.int64)),
         offset_provider={
-            "V2E": NeighborTableOffsetProvider(v2e_arr, vertex, edge, 4),
-            "E2V": NeighborTableOffsetProvider(e2v_arr, edge, vertex, 2, has_skip_values=False),
-            "C2V": NeighborTableOffsetProvider(c2v_arr, cell, vertex, 4, has_skip_values=False),
-            "C2E": NeighborTableOffsetProvider(c2e_arr, cell, edge, 4, has_skip_values=False),
+            "V2E": NeighborTableOffsetProvider(v2e_arr, Vertex, Edge, 4),
+            "E2V": NeighborTableOffsetProvider(e2v_arr, Edge, Vertex, 2, has_skip_values=False),
+            "C2V": NeighborTableOffsetProvider(c2v_arr, Cell, Vertex, 4, has_skip_values=False),
+            "C2E": NeighborTableOffsetProvider(c2e_arr, Cell, Edge, 4, has_skip_values=False),
         },
         v2e_table=v2e_arr,
         e2v_table=e2v_arr,

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
@@ -65,10 +65,14 @@ size = 10
 @pytest.fixture
 def reduction_setup():
     num_vertices = 9
-    edge = Dimension("Edge")
+    num_cells = 8
     vertex = Dimension("Vertex")
+    edge = Dimension("Edge")
+    cell = Dimension("Cell")
     v2edim = Dimension("V2E", kind=DimensionKind.LOCAL)
     e2vdim = Dimension("E2V", kind=DimensionKind.LOCAL)
+    c2vdim = Dimension("C2V", kind=DimensionKind.LOCAL)
+    c2edim = Dimension("C2E", kind=DimensionKind.LOCAL)
 
     v2e_arr = np.array(
         [
@@ -81,6 +85,32 @@ def reduction_setup():
             [6, 12, 8, 15],  # 6
             [7, 13, 6, 16],
             [8, 14, 7, 17],
+        ]
+    )
+
+    c2v_arr = np.array(
+        [
+            [0, 1, 4, 3],
+            [1, 2, 5, 6],
+            [3, 4, 7, 6],
+            [4, 5, 8, 7],
+            [6, 7, 1, 0],
+            [7, 8, 2, 1],
+            [2, 0, 3, 5],
+            [5, 3, 6, 8],
+        ]
+    )
+
+    c2e_arr = np.array(
+        [
+            [0, 10, 3, 9],
+            [1, 11, 4, 10],
+            [3, 13, 6, 12],
+            [4, 14, 7, 13],
+            [6, 16, 0, 15],
+            [7, 17, 1, 16],
+            [2, 9, 5, 11],
+            [5, 12, 8, 14],
         ]
     )
 
@@ -98,12 +128,18 @@ def reduction_setup():
         [
             "num_vertices",
             "num_edges",
-            "Edge",
+            "num_cells",
             "Vertex",
+            "Edge",
+            "Cell",
             "V2EDim",
             "E2VDim",
+            "C2VDim",
+            "C2EDim",
             "V2E",
             "E2V",
+            "C2V",
+            "C2E",
             "inp",
             "out",
             "offset_provider",
@@ -113,18 +149,26 @@ def reduction_setup():
     )(
         num_vertices=num_vertices,
         num_edges=num_edges,
-        Edge=edge,
+        num_cells=num_cells,
         Vertex=vertex,
+        Edge=edge,
+        Cell=cell,
         V2EDim=v2edim,
         E2VDim=e2vdim,
+        C2VDim=c2vdim,
+        C2EDim=c2edim,
         V2E=FieldOffset("V2E", source=edge, target=(vertex, v2edim)),
         E2V=FieldOffset("E2V", source=vertex, target=(edge, e2vdim)),
+        C2V=FieldOffset("C2V", source=vertex, target=(cell, c2vdim)),
+        C2E=FieldOffset("C2E", source=edge, target=(cell, c2edim)),
         # inp=index_field(edge, dtype=np.int64), # TODO enable once we support index_fields in bindings
         inp=np_as_located_field(edge)(np.arange(num_edges, dtype=np.int64)),
         out=np_as_located_field(vertex)(np.zeros([num_vertices], dtype=np.int64)),
         offset_provider={
             "V2E": NeighborTableOffsetProvider(v2e_arr, vertex, edge, 4),
             "E2V": NeighborTableOffsetProvider(e2v_arr, edge, vertex, 2, has_skip_values=False),
+            "C2V": NeighborTableOffsetProvider(c2v_arr, cell, vertex, 4, has_skip_values=False),
+            "C2E": NeighborTableOffsetProvider(c2e_arr, cell, edge, 4, has_skip_values=False),
         },
         v2e_table=v2e_arr,
         e2v_table=e2v_arr,

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -435,8 +435,6 @@ def test_nested_tuple_return(fieldview_backend):
 
 def test_nested_reduction(reduction_setup, fieldview_backend):
     rs = reduction_setup
-    Edge = rs.Edge
-    Vertex = rs.Vertex
     V2EDim = rs.V2EDim
     E2VDim = rs.E2VDim
     V2E = rs.V2E
@@ -458,8 +456,6 @@ def test_nested_reduction(reduction_setup, fieldview_backend):
 @pytest.mark.skip("Not yet supported in lowering, requires `map_`ing of inner reduce op.")
 def test_nested_reduction_shift_first(reduction_setup, fieldview_backend):
     rs = reduction_setup
-    Edge = rs.Edge
-    Vertex = rs.Vertex
     V2EDim = rs.V2EDim
     E2VDim = rs.E2VDim
     V2E = rs.V2E
@@ -481,8 +477,6 @@ def test_nested_reduction_shift_first(reduction_setup, fieldview_backend):
 
 def test_tuple_return_2(reduction_setup, fieldview_backend):
     rs = reduction_setup
-    Edge = rs.Edge
-    Vertex = rs.Vertex
     V2EDim = rs.V2EDim
     V2E = rs.V2E
 
@@ -508,8 +502,6 @@ def test_tuple_return_2(reduction_setup, fieldview_backend):
 @pytest.mark.xfail
 def test_tuple_with_local_field_in_reduction_shifted(reduction_setup, fieldview_backend):
     rs = reduction_setup
-    Edge = rs.Edge
-    Vertex = rs.Vertex
     V2EDim = rs.V2EDim
     V2E = rs.V2E
     E2V = rs.E2V
@@ -679,8 +671,6 @@ def test_ternary_operator_tuple(left, right, fieldview_backend):
 
 def test_ternary_builtin_neighbor_sum(reduction_setup, fieldview_backend):
     rs = reduction_setup
-    Edge = rs.Edge
-    Vertex = rs.Vertex
     V2EDim = rs.V2EDim
     V2E = rs.V2E
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -95,7 +95,7 @@ def test_minover_execution_float(reduction_setup, fieldview_backend):
         pytest.skip("not implemented yet")
 
     rs = reduction_setup
-    Vertex, V2EDim = rs.Vertex, rs.V2EDim
+    V2EDim = rs.V2EDim
     in_array = np.random.default_rng().uniform(low=-1, high=1, size=rs.v2e_table.shape)
     in_field = np_as_located_field(Vertex, V2EDim)(in_array)
     out_field = np_as_located_field(Vertex)(np.zeros(rs.num_vertices))

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -35,7 +35,7 @@ def test_maxover_execution(reduction_setup, fieldview_backend):
         pytest.skip("not yet supported.")
 
     rs = reduction_setup
-    Vertex, V2EDim = rs.Vertex, rs.V2EDim
+    V2EDim = rs.V2EDim
     inp_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
 
     @field_operator(backend=fieldview_backend)
@@ -76,7 +76,7 @@ def test_minover_execution(reduction_setup, fieldview_backend):
         pytest.skip("not implemented yet")
 
     rs = reduction_setup
-    Vertex, V2EDim = rs.Vertex, rs.V2EDim
+    V2EDim = rs.V2EDim
     in_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
 
     @field_operator(backend=fieldview_backend)
@@ -135,7 +135,7 @@ def test_reduction_execution_nb(reduction_setup, fieldview_backend):
         pytest.skip("not yet supported.")
 
     rs = reduction_setup
-    Vertex, V2EDim = rs.Vertex, rs.V2EDim
+    V2EDim = rs.V2EDim
     nb_field = np_as_located_field(Vertex, V2EDim)(rs.v2e_table)
 
     @field_operator(backend=fieldview_backend)
@@ -154,7 +154,7 @@ def test_reduction_expression(reduction_setup, fieldview_backend):
         pytest.skip("Has a bug.")
 
     rs = reduction_setup
-    V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
+    V2EDim, V2E = rs.V2EDim, rs.V2E
 
     @field_operator
     def reduce_expr(edge_f: Field[[Edge], int64]) -> Field[[Vertex], int64]:

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -54,8 +54,7 @@ def test_maxover_execution_negatives(reduction_setup, fieldview_backend):
         pytest.skip("not yet supported.")
 
     rs = reduction_setup
-    Vertex, V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
-    Edge = rs.Edge
+    V2EDim, V2E = rs.V2EDim, rs.V2E
     edge_num = np.max(rs.v2e_table)
     inp_field_arr = np.arange(-edge_num // 2, edge_num // 2 + 1, 1, dtype=int)
     inp_field = np_as_located_field(Edge)(inp_field_arr)
@@ -114,8 +113,7 @@ def test_minover_execution_float(reduction_setup, fieldview_backend):
 def test_reduction_execution(reduction_setup, fieldview_backend):
     """Testing a trivial neighbor sum."""
     rs = reduction_setup
-    Edge = rs.Edge
-    Vertex, V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
+    V2EDim, V2E = rs.V2EDim, rs.V2E
 
     @field_operator
     def reduction(edge_f: Field[[Edge], int64]) -> Field[[Vertex], int64]:
@@ -156,8 +154,7 @@ def test_reduction_expression(reduction_setup, fieldview_backend):
         pytest.skip("Has a bug.")
 
     rs = reduction_setup
-    Vertex, V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
-    Edge = rs.Edge
+    V2EDim, V2E = rs.Vertex, rs.V2EDim, rs.V2E
 
     @field_operator
     def reduce_expr(edge_f: Field[[Edge], int64]) -> Field[[Vertex], int64]:

--- a/tests/next_tests/unit_tests/ffront_tests/test_foast_to_itir.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_foast_to_itir.py
@@ -111,7 +111,7 @@ def test_shift():
     parsed = FieldOperatorParser.apply_to_function(shift_by_one)
     lowered = FieldOperatorLowering.apply(parsed)
 
-    reference = im.shift_("Ioff", 1)("inp")
+    reference = im.lift_(im.lambda__("it")(im.deref_(im.shift_("Ioff", 1)("it"))))("inp")
 
     assert lowered.expr == reference
 
@@ -125,7 +125,7 @@ def test_negative_shift():
     parsed = FieldOperatorParser.apply_to_function(shift_by_one)
     lowered = FieldOperatorLowering.apply(parsed)
 
-    reference = im.shift_("Ioff", -1)("inp")
+    reference = im.lift_(im.lambda__("it")(im.deref_(im.shift_("Ioff", -1)("it"))))("inp")
 
     assert lowered.expr == reference
 


### PR DESCRIPTION
While working on something else I recognized a rather sneaky bug in the lowering of shifts from FOAST to ITIR. Contrary to the rest of the lowering we were not wrapping the shifts inside a lifted stencil, which can lead to bugs in user code. This is particularly devastating when executing with the gtfn backend in Release Mode, as you might just run into a segfault or incorrect results. I am actually rather surprised this did not surface earlier somewhere as something like this
```python
@field_operator(backend=fieldview_backend)
def composed_shift_unstructured_intermediate_result(
    inp: Field[[Vertex], float64]
) -> Field[[Cell], float64]:
    tmp = inp(E2V[0])
    return tmp(C2E[0])
```
lowers to the (incorrect) ITIR:
```
λ(inp) → ·(λ(tmp__0) → ⟪C2Eₒ, 0ₒ⟫(tmp__0))(⟪E2Vₒ, 0ₒ⟫(inp))
```
(Note how the ordering of the shifts is wrong). I had found this bug much earlier while working on (https://github.com/GridTools/gt4py/pull/965), but sadly the change went lost while merging (was very easy to overlook so @havogt and me bost missed it). What I did not recognize back then was that this bug could actually be triggered. I assumed it only occurred for expression like `field(E2V[0])(C2E[0])` which were not allowed (for unrelated reasons). For completeness this PR also adds support for such expressions. In principle it is possible to remove this feature from the PR.