### PR TITLE
Allow asynchronous building of gtscript stencils. (`gt4py.cartesian`)

### DIFF
--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -13,6 +13,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import multiprocessing
+import multiprocessing as mp
 import os
 from typing import Any, Dict, Optional
 
@@ -54,6 +55,7 @@ build_settings: Dict[str, Any] = {
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),
     "cpp_template_depth": os.environ.get("GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH),
+    "max_async_build_proc": os.environ.get("GT_MAX_ASYNC_BUILD_PROC", mp.cpu_count()),
 }
 
 if CUDA_HOST_CXX is not None:

--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -107,6 +107,7 @@ class BuildOptions(AttributeClassLike):
     rebuild = attribute(of=bool, default=False)
     raise_if_not_cached = attribute(of=bool, default=False)
     cache_settings = attribute(of=DictOf[str, Any], factory=dict)
+    build_async = attribute(of=bool, default=False)
     _impl_opts = attribute(of=DictOf[str, Any], factory=dict)
 
     @property

--- a/src/gt4py/cartesian/lazy_stencil.py
+++ b/src/gt4py/cartesian/lazy_stencil.py
@@ -40,6 +40,8 @@ class LazyStencil:
     def __init__(self, builder: "StencilBuilder"):
         self.builder = builder
         self.builder.caching.capture_externals()
+        if self.builder.options.build_async:
+            self.builder.build_async()
 
     @cached_property
     def implementation(self) -> "StencilObject":

--- a/src/gt4py/cartesian/stencil_builder.py
+++ b/src/gt4py/cartesian/stencil_builder.py
@@ -12,20 +12,56 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import concurrent.futures
 import pathlib
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Hashable, Optional, Tuple, Type, Union
 
 from gt4py import cartesian as gt4pyc
+from gt4py.cartesian.config import build_settings
 from gt4py.cartesian.definitions import BuildOptions, StencilID
 from gt4py.cartesian.gtc import gtir
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
 from gt4py.cartesian.type_hints import AnnotatedStencilFunc, StencilFunc
 
 
+FUTURES_REGISTRY: Dict[Tuple[Tuple[str, Hashable], ...], Optional["FutureStencil"]] = dict()
+build_process_executor = concurrent.futures.ProcessPoolExecutor(
+    build_settings["max_async_build_proc"]
+)
+
+
+def hashable_cache_info(cache_info: Dict[str, Hashable]) -> Tuple[Tuple[str, Hashable], ...]:
+    return tuple((k, v) for k, v in cache_info.items())
+
+
+def barrier():
+    for f in FUTURES_REGISTRY.values():
+        if f is not None:
+            f.result()
+
+
 if TYPE_CHECKING:
     from gt4py.cartesian.backend.base import Backend as BackendType, CLIBackendMixin
     from gt4py.cartesian.frontend.base import Frontend as FrontendType
     from gt4py.cartesian.stencil_object import StencilObject
+
+
+class FutureStencil:
+    future: concurrent.futures.Future
+    builder: "StencilBuilder"
+
+    def __init__(self, future: concurrent.futures.Future, builder: "StencilBuilder"):
+        self.future = future
+        self.builder = builder
+
+    def wait(self, *args, **kwargs):
+        self.future.result(*args, **kwargs)
+
+    def cancel(self):
+        return self.future.cancel()
+
+    def cancelled(self):
+        return self.future.cancelled()
 
 
 class StencilBuilder:
@@ -81,8 +117,7 @@ class StencilBuilder:
         self._externals: Dict[str, Any] = {}
         self._dtypes: Dict[Type, Type] = {}
 
-    def build(self) -> Type["StencilObject"]:
-        """Generate, compile and/or load everything necessary to provide a usable stencil class."""
+    def _build(self) -> Type["StencilObject"]:
         # load or generate
         stencil_class = None if self.options.rebuild else self.backend.load()
         if stencil_class is None:
@@ -92,6 +127,37 @@ class StencilBuilder:
                 )
             stencil_class = self.backend.generate()
         return stencil_class
+
+    def _generate_no_return(self):
+        # leads to loading twice, but result of load can't be pickled and therefore not returned when multiprocessing.
+        stencil_class = None if self.options.rebuild else self.backend.load()
+        if stencil_class is None:
+            self.backend.generate()
+
+    def build_async(self):
+        """Return a future that will hold a usable stencil class as result."""
+        key = hashable_cache_info(self.caching.generate_cache_info())
+        if key in FUTURES_REGISTRY:
+            print("found")
+            return FUTURES_REGISTRY[key]
+        else:
+            print("not found")
+            future = FutureStencil(build_process_executor.submit(self._generate_no_return), self)
+            FUTURES_REGISTRY[key] = future
+            return future
+
+    def build(self) -> Type["StencilObject"]:
+        """Generate, compile and/or load everything necessary to provide a usable stencil class."""
+        key = hashable_cache_info(self.caching.generate_cache_info())
+        if FUTURES_REGISTRY.get(key, None) is not None:
+            future = FUTURES_REGISTRY[key]
+            assert future is not None
+            future.cancel()
+            if not future.cancelled():
+                future.wait()
+            else:
+                FUTURES_REGISTRY[key] = None
+        return self._build()
 
     def generate_computation(self) -> Dict[str, Union[str, Dict]]:
         """Generate the stencil source code, fail if backend does not support CLI."""

--- a/tests/cartesian_tests/unit_tests/test_lazy_stencil.py
+++ b/tests/cartesian_tests/unit_tests/test_lazy_stencil.py
@@ -14,16 +14,30 @@
 
 """Test the backend-agnostic build system."""
 
+
+import time
+
 import pytest
 
 import gt4py
 from gt4py import cartesian as gt4pyc
+from gt4py.cartesian import gtscript
 from gt4py.cartesian.frontend.gtscript_frontend import GTScriptDefinitionError
 from gt4py.cartesian.gtscript import PARALLEL, Field, computation, interval
 from gt4py.cartesian.lazy_stencil import LazyStencil
-from gt4py.cartesian.stencil_builder import StencilBuilder
+from gt4py.cartesian.stencil_builder import FUTURES_REGISTRY, StencilBuilder
 
 from ..definitions import ALL_BACKENDS
+
+
+@pytest.fixture(scope="function")
+def reset_async_executor():
+    for f in FUTURES_REGISTRY.values():
+        if f is not None:
+            f.cancel()
+            if not f.cancelled():
+                f.wait()
+    FUTURES_REGISTRY.clear()
 
 
 def copy_stencil_definition(out_f: Field[float], in_f: Field[float]):  # type: ignore
@@ -77,7 +91,8 @@ def test_lazy_syntax_check(frontend, backend):
         )
 
 
-def test_lazy_call(frontend, backend):
+@pytest.mark.parametrize("build_async", [False, True])
+def test_lazy_call(frontend, backend, build_async):
     """Test that the lazy stencil is callable like the compiled stencil object."""
     import numpy
 
@@ -89,8 +104,70 @@ def test_lazy_call(frontend, backend):
     )
     lazy_s = LazyStencil(
         StencilBuilder(copy_stencil_definition, frontend=frontend, backend=backend).with_options(
-            name="copy", module=copy_stencil_definition.__module__, rebuild=True
+            name="copy",
+            module=copy_stencil_definition.__module__,
+            rebuild=True,
+            build_async=build_async,
         )
     )
     lazy_s(b, a)
     assert b[0, 0, 0] == 1.0
+
+
+class TestAsyncConsistency:
+    def test_same_key(self, backend, reset_async_executor):
+        assert len(FUTURES_REGISTRY) == 0
+        gtscript.lazy_stencil(
+            definition=copy_stencil_definition, backend="numpy", rebuild=True, eager="async"
+        )
+        gtscript.lazy_stencil(
+            definition=copy_stencil_definition, backend="numpy", rebuild=True, eager="async"
+        )
+        assert len(FUTURES_REGISTRY) == 1
+
+    def test_separate_keys(self, backend, reset_async_executor):
+        assert len(FUTURES_REGISTRY) == 0
+        gtscript.lazy_stencil(
+            definition=copy_stencil_definition, backend="numpy", rebuild=True, eager="async"
+        )
+        gtscript.lazy_stencil(
+            definition=copy_stencil_definition, backend="dace:cpu", rebuild=True, eager="async"
+        )
+        assert len(FUTURES_REGISTRY) == 2
+
+
+class TestAsyncTiming:
+    def test_async_submit_fast(self, backend, reset_async_executor):
+        """Test that the async lazy_stencil call actually only schedules the build by comparing time to a full build."""
+        start = time.perf_counter()
+        gtscript.lazy_stencil(
+            definition=copy_stencil_definition, backend=backend.name, rebuild=True, eager="async"
+        )
+        mid = time.perf_counter()
+        gtscript.stencil(
+            definition=copy_stencil_definition, backend=backend.name, rebuild=True, eager=True
+        )
+        end = time.perf_counter()
+
+        submit_time = mid - start
+        full_build_time = end - mid
+        assert full_build_time > 5 * submit_time
+
+    def test_async_finished_fast(self, backend, reset_async_executor):
+        """Test caching after waiting for async lazy_stencil call."""
+        start = time.perf_counter()
+        ls = gtscript.lazy_stencil(
+            definition=copy_stencil_definition, backend=backend.name, rebuild=True, eager=False
+        )
+        mid1 = time.perf_counter()
+        future = ls.builder.build_async()
+        future.wait()
+        mid2 = time.perf_counter()
+        gtscript.stencil(definition=copy_stencil_definition, backend=backend.name, eager=True)
+        end = time.perf_counter()
+
+        submit_time = mid1 - start
+        wait_time = mid2 - mid1
+        cached_build_time = end - mid2
+        assert wait_time > 5 * submit_time
+        assert wait_time > 5 * cached_build_time


### PR DESCRIPTION
ToDo:
- [ ] stress-test e.g. by means of use in `pace`
- [ ] update docs

Note that since `StencilObject` can not be pickled, it can't be returned from multiprocessing / result of `concurrent.future` with a ProcessPoolExecutor. In the implementation at hand, instead the `load` step is run multiple times (once in the building child process and once in the main process). If this is ok is to be seen (e.g. from `pace).