### PR TITLE
fix[next]: improved tuple collapse

### DIFF
--- a/src/gt4py/next/iterator/ir.py
+++ b/src/gt4py/next/iterator/ir.py
@@ -68,6 +68,11 @@ class Literal(Expr):
     value: str
     type: str  # noqa: A003
 
+    @datamodels.validator("type")
+    def _type_validator(self: datamodels.DataModelTP, attribute: datamodels.Attribute, value):
+        if value not in TYPEBUILTINS:
+            raise ValueError(f"{value} is not a valid builtin type.")
+
 
 class NoneLiteral(Expr):
     _none_literal: int = 0
@@ -163,7 +168,9 @@ BINARY_LOGICAL_BUILTINS = {
     "xor_",
 }
 
-TYPEBUILTINS = {"int", "int32", "int64", "float", "float32", "float64", "bool"}
+INTEGER_BUILTINS = {"int", "int32", "int64"}
+FLOATING_POINT_BUILTINS = {"float", "float32", "float64"}
+TYPEBUILTINS = {*INTEGER_BUILTINS, *FLOATING_POINT_BUILTINS, "bool"}
 
 BUILTINS = {
     "cartesian_domain",

--- a/src/gt4py/next/iterator/ir_makers.py
+++ b/src/gt4py/next/iterator/ir_makers.py
@@ -220,6 +220,8 @@ def make_tuple(*args):
 
 def tuple_get(tuple_expr, index):
     """Create a tuple_get FunCall, shorthand for ``call("tuple_get")(tuple_expr, index)``."""
+    if isinstance(index, int):
+        index = literal(str(index), "int")
     return call("tuple_get")(tuple_expr, index)
 
 

--- a/src/gt4py/next/iterator/ir_makers.py
+++ b/src/gt4py/next/iterator/ir_makers.py
@@ -218,11 +218,9 @@ def make_tuple(*args):
     return call("make_tuple")(*args)
 
 
-def tuple_get(tuple_expr, index):
-    """Create a tuple_get FunCall, shorthand for ``call("tuple_get")(tuple_expr, index)``."""
-    if isinstance(index, int):
-        index = literal(str(index), "int")
-    return call("tuple_get")(tuple_expr, index)
+def tuple_get(index, tuple_expr):
+    """Create a tuple_get FunCall, shorthand for ``call("tuple_get")(index, tuple_expr)``."""
+    return call("tuple_get")(index, tuple_expr)
 
 
 def if_(cond, true_val, false_val):

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -46,7 +46,8 @@ class CollapseTuple(eve.NodeTranslator):
         node: ir.Node,
         *,
         ignore_tuple_size: bool = False,
-        collapse_make_tuple_tuple_get: bool = True,  # these options are mostly for allowing separate testing of the modes
+        # the following options are mostly for allowing separate testing of the modes
+        collapse_make_tuple_tuple_get: bool = True,
         collapse_tuple_get_make_tuple: bool = True,
     ) -> ir.Node:
         """

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -77,6 +77,7 @@ class CollapseTuple(eve.NodeTranslator):
                 assert isinstance(v, ir.FunCall)
                 assert isinstance(v.args[0], ir.Literal)
                 if not (int(v.args[0].value) == i and v.args[1] == first_expr):
+                    # tuple argument differs, just continue with the rest of the tree
                     return self.generic_visit(node)
 
             if self.ignore_tuple_size or _get_tuple_size(first_expr) == len(node.args):

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -33,7 +33,7 @@ class CollapseTuple(eve.NodeTranslator):
     Simplifies `make_tuple`, `tuple_get` calls.
 
       - `make_tuple(tuple_get(0, t), tuple_get(1, t), ..., tuple_get(N-1,t))` -> `t`
-      - `tuple_get(N, make_tuple(e_0, e_1, ..., e_N, e_N_plus_1))` -> `e_N`
+      - `tuple_get(i, make_tuple(e_0, e_1, ..., e_i, ..., e_N))` -> `e_i`
     """
 
     ignore_tuple_size: bool
@@ -90,11 +90,9 @@ class CollapseTuple(eve.NodeTranslator):
             # `tuple_get(N, make_tuple(e_0, e_1, ..., e_N, e_N_plus_1)) -> `e_N`
             assert node.args[0].type in ir.INTEGER_BUILTINS
             make_tuple_call = node.args[1]
-            if (idx := int(node.args[0].value)) < len(make_tuple_call.args):
-                return node.args[1].args[idx]
-            else:
-                raise IndexError(
-                    f"CollapseTuple: Index {idx} is out of bounds for tuple of size {len(make_tuple_call.args)}"
-                )
-
+            idx = int(node.args[0].value)
+            assert idx < len(
+                make_tuple_call.args
+            ), f"Index {idx} is out of bounds for tuple of size {len(make_tuple_call.args)}"
+            return node.args[1].args[idx]
         return self.generic_visit(node)

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -87,7 +87,7 @@ class CollapseTuple(eve.NodeTranslator):
             and node.args[1].fun == ir.SymRef(id="make_tuple")
             and isinstance(node.args[0], ir.Literal)
         ):
-            # `tuple_get(N, make_tuple(e_0, e_1, ..., e_N, e_N_plus_1)) -> `e_N`
+            # `tuple_get(i, make_tuple(e_0, e_1, ..., e_i, ..., e_N))` -> `e_i`
             assert node.args[0].type in ir.INTEGER_BUILTINS
             make_tuple_call = node.args[1]
             idx = int(node.args[0].value)

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -33,7 +33,7 @@ class CollapseTuple(eve.NodeTranslator):
     Simplifies `make_tuple`, `tuple_get` calls.
 
       - `make_tuple(tuple_get(0, t), tuple_get(1, t), ..., tuple_get(N-1,t))` -> `t`
-      - `tuple_get(N, make_tuple(e_0, e_1, ..., e_N, e_N_plus_1)) -> `e_N`
+      - `tuple_get(N, make_tuple(e_0, e_1, ..., e_N, e_N_plus_1))` -> `e_N`
     """
 
     ignore_tuple_size: bool

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -59,5 +59,13 @@ class CollapseTuple(eve.NodeTranslator):
 
             if self.ignore_tuple_size or _get_tuple_size(first_expr) == len(node.args):
                 return first_expr
+        if (
+            node.fun == ir.SymRef(id="tuple_get")
+            and isinstance(node.args[1], ir.FunCall)
+            and node.args[1].fun == ir.SymRef(id="make_tuple")
+            and isinstance(node.args[0], ir.Literal)
+        ):
+            assert node.args[0].type in ["int", "int32", "int64"]  # TODO
+            return node.args[1].args[int(node.args[0].value)]  # TODO simplify
 
         return self.generic_visit(node)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -499,7 +499,6 @@ def test_tuple_return_2(reduction_setup, fieldview_backend):
     assert np.allclose(ref, rs.out)
 
 
-@pytest.mark.xfail
 def test_tuple_with_local_field_in_reduction_shifted(reduction_setup, fieldview_backend):
     rs = reduction_setup
     V2EDim = rs.V2EDim
@@ -519,12 +518,7 @@ def test_tuple_with_local_field_in_reduction_shifted(reduction_setup, fieldview_
         edge_field: Field[[Edge], float64], vertex_field: Field[[Vertex], float64]
     ) -> Field[[Edge], float64]:
         tup = edge_field(V2E), vertex_field
-        # the shift inside the reduction fails as tup is a tuple of iterators
-        #  (as it contains a local field) which can not be shifted
         red = neighbor_sum(tup[0] + vertex_field, axis=V2EDim)
-        # even if the above is fixed we need to be careful with a subsequent
-        #  shift as the lifted lambda will contain tup as an argument which -
-        #  again - can not be shifted.
         return red(E2V[0])
 
     reduce_tuple_element(a, b, out=out, offset_provider=rs.offset_provider)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -18,27 +18,25 @@ from gt4py.next.iterator import ir, ir_makers as im
 from gt4py.next.iterator.transforms.collapse_tuple import CollapseTuple
 
 
-def _tup_of_size_2(first=im.ref("first_elem"), second=im.ref("second_elem")) -> ir.Expr:
-    return im.make_tuple(first, second)
-
-
 def test_simple_make_tuple_tuple_get():
-    t = _tup_of_size_2()
-    testee = im.make_tuple(im.tuple_get(0, t), im.tuple_get(1, t))
+    tuple_of_size_2 = im.make_tuple("first", "second")
+    testee = im.make_tuple(im.tuple_get(0, tuple_of_size_2), im.tuple_get(1, tuple_of_size_2))
 
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
 
-    expected = _tup_of_size_2()
+    expected = tuple_of_size_2
     assert actual == expected
 
 
 def test_nested_make_tuple_tuple_get():
-    t = im.call(im.lambda_()(_tup_of_size_2()))()
-    testee = im.make_tuple(im.tuple_get(0, t), im.tuple_get(1, t))
+    tup_of_size2_from_lambda = im.call(im.lambda_()(im.make_tuple("first", "second")))()
+    testee = im.make_tuple(
+        im.tuple_get(0, tup_of_size2_from_lambda), im.tuple_get(1, tup_of_size2_from_lambda)
+    )
 
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
 
-    assert actual == t
+    assert actual == tup_of_size2_from_lambda
 
 
 def test_different_tuples_make_tuple_tuple_get():
@@ -52,26 +50,26 @@ def test_different_tuples_make_tuple_tuple_get():
 
 
 def test_incompatible_order_make_tuple_tuple_get():
-    t = _tup_of_size_2()
-    testee = im.make_tuple(im.tuple_get(1, t), im.tuple_get(0, t))
+    tuple_of_size_2 = im.make_tuple("first", "second")
+    testee = im.make_tuple(im.tuple_get(1, tuple_of_size_2), im.tuple_get(0, tuple_of_size_2))
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
     assert actual == testee  # did nothing
 
 
 def test_incompatible_size_make_tuple_tuple_get():
-    testee = im.make_tuple(im.tuple_get(0, _tup_of_size_2()))
+    testee = im.make_tuple(im.tuple_get(0, im.make_tuple("first", "second")))
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
     assert actual == testee  # did nothing
 
 
 def test_merged_with_smaller_outer_size_make_tuple_tuple_get():
-    testee = im.make_tuple(im.tuple_get(0, _tup_of_size_2()))
+    testee = im.make_tuple(im.tuple_get(0, im.make_tuple("first", "second")))
     actual = CollapseTuple.apply(testee, ignore_tuple_size=True)
-    assert actual == _tup_of_size_2()
+    assert actual == im.make_tuple("first", "second")
 
 
 def test_simple_tuple_get_make_tuple():
     expected = im.ref("bar")
-    testee = im.tuple_get(1, _tup_of_size_2(im.ref("foo"), expected))
+    testee = im.tuple_get(1, im.make_tuple("foo", expected))
     actual = CollapseTuple.apply(testee, collapse_make_tuple_tuple_get=False)
     assert expected == actual

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -15,21 +15,16 @@
 import pytest
 
 import gt4py.next.iterator.ir_makers as im
-from gt4py.next.iterator import ir
 from gt4py.next.iterator.transforms.collapse_tuple import CollapseTuple
 
 
-def _tuple_get(i: int, t: ir.Expr) -> ir.Expr:
-    return im.tuple_get(im.literal(str(i), "int"), t)
-
-
-def _tup_of_size_2(first=ir.SymRef(id="first_elem"), second=ir.SymRef(id="second_elem")) -> ir.Expr:
+def _tup_of_size_2(first=im.ref("first_elem"), second=im.ref("second_elem")) -> ir.Expr:
     return im.make_tuple(first, second)
 
 
 def test_simple_make_tuple_tuple_get():
     t = _tup_of_size_2()
-    testee = im.make_tuple(_tuple_get(0, t), _tuple_get(1, t))
+    testee = im.make_tuple(im.tuple_get(0, t), im.tuple_get(1, t))
 
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
 
@@ -39,7 +34,7 @@ def test_simple_make_tuple_tuple_get():
 
 def test_nested_make_tuple_tuple_get():
     t = im.call(im.lambda_()(_tup_of_size_2()))()
-    testee = im.make_tuple(_tuple_get(0, t), _tuple_get(1, t))
+    testee = im.make_tuple(im.tuple_get(0, t), im.tuple_get(1, t))
 
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
 
@@ -49,7 +44,7 @@ def test_nested_make_tuple_tuple_get():
 def test_different_tuples_make_tuple_tuple_get():
     t0 = im.make_tuple("foo0", "bar0")
     t1 = im.make_tuple("foo1", "bar1")
-    testee = im.make_tuple(_tuple_get(0, t0), _tuple_get(1, t1))
+    testee = im.make_tuple(im.tuple_get(0, t0), im.tuple_get(1, t1))
 
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
 
@@ -58,33 +53,30 @@ def test_different_tuples_make_tuple_tuple_get():
 
 def test_incompatible_order_make_tuple_tuple_get():
     t = _tup_of_size_2()
-    testee = ir.FunCall(
-        fun=ir.SymRef(id="make_tuple"),
-        args=[_tuple_get(1, t), _tuple_get(0, t)],
-    )
+    testee = im.make_tuple(im.tuple_get(1, t), im.tuple_get(0, t))
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
     assert actual == testee  # did nothing
 
 
 def test_incompatible_size_make_tuple_tuple_get():
-    testee = ir.FunCall(fun=ir.SymRef(id="make_tuple"), args=[_tuple_get(0, _tup_of_size_2())])
+    testee = im.make_tuple(im.tuple_get(0, _tup_of_size_2()))
     actual = CollapseTuple.apply(testee, collapse_tuple_get_make_tuple=False)
     assert actual == testee  # did nothing
 
 
 def test_merged_with_smaller_outer_size_make_tuple_tuple_get():
-    testee = ir.FunCall(fun=ir.SymRef(id="make_tuple"), args=[_tuple_get(0, _tup_of_size_2())])
+    testee = im.make_tuple(im.tuple_get(0, _tup_of_size_2()))
     actual = CollapseTuple.apply(testee, ignore_tuple_size=True)
     assert actual == _tup_of_size_2()
 
 
 def test_simple_tuple_get_make_tuple():
-    expected = ir.SymRef(id="bar")
-    testee = _tuple_get(1, _tup_of_size_2(ir.SymRef(id="foo"), expected))
+    expected = im.ref("bar")
+    testee = im.tuple_get(1, _tup_of_size_2(im.ref("foo"), expected))
     actual = CollapseTuple.apply(testee, collapse_make_tuple_tuple_get=False)
     assert expected == actual
 
 
 def test_oob_tuple_get_make_tuple():
     with pytest.raises(IndexError, match=r"CollapseTuple:.*out of bounds.*tuple of size 2"):
-        CollapseTuple.apply(_tuple_get(2, _tup_of_size_2()), collapse_make_tuple_tuple_get=False)
+        CollapseTuple.apply(im.tuple_get(2, _tup_of_size_2()), collapse_make_tuple_tuple_get=False)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -18,43 +18,69 @@ from gt4py.next.iterator import ir
 from gt4py.next.iterator.transforms.collapse_tuple import CollapseTuple
 
 
-def _tuple_get(i: int, t: ir.Expr):
+def _tuple_get(i: int, t: ir.Expr) -> ir.Expr:
     return ir.FunCall(fun=ir.SymRef(id="tuple_get"), args=[ir.Literal(value=str(i), type="int"), t])
 
 
-@pytest.fixture
-def tup_of_size_2():
+def _tup_of_size_2(first=ir.SymRef(id="first_elem"), second=ir.SymRef(id="second_elem")) -> ir.Expr:
+    return ir.FunCall(fun=ir.SymRef(id="make_tuple"), args=[first, second])
+
+
+def _nested_tup_of_size_2() -> ir.Expr:
+    # nested in a lambda to
+    # - let type inference compute the size of the tuple
+    # - avoid that this expression wrapped in `tuple_get` can be trivially simplified
     return ir.FunCall(
-        fun=ir.SymRef(id="make_tuple"), args=[ir.SymRef(id="foo"), ir.SymRef(id="foo")]
+        fun=ir.Lambda(
+            params=[],
+            expr=_tup_of_size_2(),
+        ),
+        args=[],
     )
 
 
-def test_simple(tup_of_size_2):
+def test_simple():
     testee = ir.FunCall(
         fun=ir.SymRef(id="make_tuple"),
-        args=[_tuple_get(0, tup_of_size_2), _tuple_get(1, tup_of_size_2)],
+        args=[_tuple_get(0, _nested_tup_of_size_2()), _tuple_get(1, _nested_tup_of_size_2())],
     )
-    expected = tup_of_size_2
+    expected = _nested_tup_of_size_2()
     actual = CollapseTuple.apply(testee)
     assert actual == expected
 
 
-def test_incompatible_order(tup_of_size_2):
+def test_incompatible_order():
     testee = ir.FunCall(
         fun=ir.SymRef(id="make_tuple"),
-        args=[_tuple_get(1, tup_of_size_2), _tuple_get(0, tup_of_size_2)],
+        args=[_tuple_get(1, _nested_tup_of_size_2()), _tuple_get(0, _nested_tup_of_size_2())],
     )
     actual = CollapseTuple.apply(testee)
     assert actual == testee  # did nothing
 
 
-def test_incompatible_size(tup_of_size_2):
-    testee = ir.FunCall(fun=ir.SymRef(id="make_tuple"), args=[_tuple_get(0, tup_of_size_2)])
+def test_incompatible_size():
+    testee = ir.FunCall(
+        fun=ir.SymRef(id="make_tuple"), args=[_tuple_get(0, _nested_tup_of_size_2())]
+    )
     actual = CollapseTuple.apply(testee)
     assert actual == testee  # did nothing
 
 
-def test_merged_with_smaller_outer_size(tup_of_size_2):
-    testee = ir.FunCall(fun=ir.SymRef(id="make_tuple"), args=[_tuple_get(0, tup_of_size_2)])
+def test_merged_with_smaller_outer_size():
+    testee = ir.FunCall(
+        fun=ir.SymRef(id="make_tuple"), args=[_tuple_get(0, _nested_tup_of_size_2())]
+    )
     actual = CollapseTuple.apply(testee, ignore_tuple_size=True)
-    assert actual == tup_of_size_2
+    assert actual == _nested_tup_of_size_2()
+
+
+def test_merged_tuple_get_make_tuple():
+    expected = ir.SymRef(id="bar")
+    testee = _tuple_get(1, _tup_of_size_2(ir.SymRef(id="foo"), expected))
+    actual = CollapseTuple.apply(testee)
+    assert expected == actual
+
+
+def test_merged_tuple_get_make_tuple_oob():
+    with pytest.raises(IndexError, match=r"CollapseTuple:.*out of bounds.*tuple of size 2"):
+        CollapseTuple.apply(_tuple_get(2, _tup_of_size_2()))

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-import gt4py.next.iterator.ir_makers as im
+from gt4py.next.iterator import ir, ir_makers as im
 from gt4py.next.iterator.transforms.collapse_tuple import CollapseTuple
 
 

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -75,8 +75,3 @@ def test_simple_tuple_get_make_tuple():
     testee = im.tuple_get(1, _tup_of_size_2(im.ref("foo"), expected))
     actual = CollapseTuple.apply(testee, collapse_make_tuple_tuple_get=False)
     assert expected == actual
-
-
-def test_oob_tuple_get_make_tuple():
-    with pytest.raises(IndexError, match=r"CollapseTuple:.*out of bounds.*tuple of size 2"):
-        CollapseTuple.apply(im.tuple_get(2, _tup_of_size_2()), collapse_make_tuple_tuple_get=False)


### PR DESCRIPTION
Extend TupleCollapse pass to also collapse `tuple_get(N, make_tuple(e_0, e_1, ..., e_N, e_N_plus_1))` -> `e_N`.