### PR TITLE
fix[next]: Yet another test parametrization cleanup

### DIFF
--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -453,7 +453,7 @@ def test_nested_reduction(reduction_setup, fieldview_backend):
     assert np.allclose(out, expected)
 
 
-@pytest.mark.skip("Not yet supported in lowering, requires `map_`ing of inner reduce op.")
+@pytest.mark.xfail("Not yet supported in lowering, requires `map_`ing of inner reduce op.")
 def test_nested_reduction_shift_first(reduction_setup, fieldview_backend):
     rs = reduction_setup
     V2EDim = rs.V2EDim

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -232,7 +232,7 @@ def test_nested_scalar_arg(fieldview_backend):
 
 def test_scalar_arg_with_field(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("IndexFields and ConstantFields are not supported yet.")
+        pytest.xfail("IndexFields and ConstantFields are not supported yet.")
 
     inp = index_field(Edge, dtype=float64)
     factor = 3.0
@@ -257,7 +257,7 @@ def test_scalar_arg_with_field(fieldview_backend):
 
 def test_scalar_in_domain_spec_and_fo_call(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip(
+        pytest.xfail(
             "Scalar arguments not supported to be used in both domain specification "
             "and as an argument to a field operator."
         )
@@ -300,7 +300,7 @@ def test_scalar_scan(fieldview_backend):
 
 def test_tuple_scalar_scan(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("Scalar tuple arguments are not supported in gtfn yet.")
+        pytest.xfail("Scalar tuple arguments are not supported in gtfn yet.")
 
     size = 10
     KDim = Dimension("K", kind=DimensionKind.VERTICAL)
@@ -575,7 +575,7 @@ def test_fieldop_from_scan(fieldview_backend, forward):
 
 def test_solve_triag(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("Has a bug.")
+        pytest.xfail("Transformation passes fail in putting `scan` to the top.")
     shape = (3, 7, 5)
     rng = np.random.default_rng()
     a_np, b_np, c_np, d_np = (rng.normal(size=shape) for _ in range(4))
@@ -796,7 +796,7 @@ def test_domain(fieldview_backend):
 
 def test_domain_input_bounds(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("FloorDiv not fully supported in gtfn.")
+        pytest.xfail("FloorDiv not fully supported in gtfn.")
     inp = np_as_located_field(IDim, JDim)(np.ones((size, size), dtype=float64))
     out = np_as_located_field(IDim, JDim)(2 * np.ones((size, size), dtype=float64))
 
@@ -900,7 +900,7 @@ def test_domain_tuple(fieldview_backend):
 
 def test_where_k_offset(fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("IndexFields are not supported yet.")
+        pytest.xfail("IndexFields are not supported yet.")
     a = np_as_located_field(IDim, KDim)(np.ones((size, size)))
     out = np_as_located_field(IDim, KDim)(np.zeros((size, size)))
     k_index = index_field(KDim)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -453,7 +453,7 @@ def test_nested_reduction(reduction_setup, fieldview_backend):
     assert np.allclose(out, expected)
 
 
-@pytest.mark.xfail("Not yet supported in lowering, requires `map_`ing of inner reduce op.")
+@pytest.mark.xfail(reason="Not yet supported in lowering, requires `map_`ing of inner reduce op.")
 def test_nested_reduction_shift_first(reduction_setup, fieldview_backend):
     rs = reduction_setup
     V2EDim = rs.V2EDim

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -173,8 +173,6 @@ def test_reduction_expression(reduction_setup, fieldview_backend):
 
 
 def test_conditional_nested_tuple(fieldview_backend):
-    if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("Tuple outputs not supported in gtfn backends")
     a_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     b_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))
     out_I_float = np_as_located_field(IDim)(np.random.randn(size).astype("float64"))

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
@@ -76,7 +76,7 @@ def test_floordiv(fieldview_backend):
     out_I_int = np_as_located_field(IDim)(np.zeros((size,), dtype=int64))
 
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip(
+        pytest.xfail(
             "FloorDiv not yet supported."
         )  # see https://github.com/GridTools/gt4py/issues/1136
 
@@ -93,7 +93,7 @@ def test_mod(fieldview_backend):
     out_I_int = np_as_located_field(IDim)(np.zeros((size,), dtype=int64))
 
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip(
+        pytest.xfail(
             "Modulo not properly supported for negative numbers."
         )  # see https://github.com/GridTools/gt4py/issues/1219
 

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_strided_offset_provider.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_strided_offset_provider.py
@@ -19,12 +19,9 @@ from gt4py.next.common import Dimension
 from gt4py.next.iterator.builtins import deref, lift, named_range, shift, unstructured_domain
 from gt4py.next.iterator.embedded import StridedNeighborOffsetProvider, np_as_located_field
 from gt4py.next.iterator.runtime import closure, fendef, fundef, offset
+from gt4py.next.program_processors.runners.gtfn_cpu import run_gtfn, run_gtfn_imperative
 
-from next_tests.unit_tests.conftest import (
-    program_processor,
-    program_processor_no_gtfn_exec,
-    run_processor,
-)
+from next_tests.unit_tests.conftest import program_processor, run_processor
 
 
 LocA = Dimension("LocA")
@@ -52,8 +49,10 @@ def fencil(size, out, inp):
     )
 
 
-def test_strided_offset_provider(program_processor_no_gtfn_exec):
-    program_processor, validate = program_processor_no_gtfn_exec
+def test_strided_offset_provider(program_processor):
+    program_processor, validate = program_processor
+    if program_processor in [run_gtfn, run_gtfn_imperative]:
+        pytest.xfail("StridedNeighborOffsetProvider not implemented in bindings.")
 
     LocA_size = 2
     max_neighbors = LocA2LocAB_offset_provider.max_neighbors

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_trivial.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_trivial.py
@@ -129,8 +129,6 @@ def fen_direct_deref(i_size, j_size, out, inp):
 
 def test_direct_deref(program_processor, lift_mode):
     program_processor, validate = program_processor
-    if program_processor == run_gtfn:
-        pytest.xfail("extract_fundefs_from_closures() doesn't work for builtins in gtfn")
 
     rng = np.random.default_rng()
     inp = rng.uniform(size=(5, 7))

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_with_toy_connectivity.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_with_toy_connectivity.py
@@ -188,8 +188,6 @@ def sparse_stencil(non_sparse, inp):
 
 def test_sparse_input_field(program_processor_no_gtfn_exec, lift_mode):
     program_processor, validate = program_processor_no_gtfn_exec
-    if program_processor == type_check.check:
-        pytest.xfail("Partial shifts not properly supported by type inference.")
     non_sparse = np_as_located_field(Edge)(np.zeros(18))
     inp = np_as_located_field(Vertex, V2E)(np.asarray([[1, 2, 3, 4]] * 9))
     out = np_as_located_field(Vertex)(np.zeros([9]))
@@ -212,8 +210,6 @@ def test_sparse_input_field(program_processor_no_gtfn_exec, lift_mode):
 
 def test_sparse_input_field_v2v(program_processor_no_gtfn_exec, lift_mode):
     program_processor, validate = program_processor_no_gtfn_exec
-    if program_processor == type_check.check:
-        pytest.xfail("Partial shifts not properly supported by type inference.")
 
     non_sparse = np_as_located_field(Edge)(np.zeros(18))
     inp = np_as_located_field(Vertex, V2V)(v2v_arr)

--- a/tests/next_tests/unit_tests/ffront_tests/test_foast_to_itir.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_foast_to_itir.py
@@ -211,7 +211,7 @@ def test_unpacking():
 
 
 def test_annotated_assignment():
-    pytest.skip("Annotated assignments are not properly supported at the moment.")
+    pytest.xfail("Annotated assignments are not properly supported at the moment.")
 
     def copy_field(inp: Field[[TDim], float64]):
         tmp: Field[[TDim], float64] = inp

--- a/tests/next_tests/unit_tests/ffront_tests/test_icon_like_scan.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_icon_like_scan.py
@@ -214,9 +214,9 @@ def test_setup():
 
 def test_solve_nonhydro_stencil_52_like_z_q(test_setup, fieldview_backend):
     if fieldview_backend in [gtfn_cpu.run_gtfn, gtfn_cpu.run_gtfn_imperative]:
-        pytest.skip("Needs implementation of scan projector.")
+        pytest.xfail("Needs implementation of scan projector.")
     if fieldview_backend == roundtrip.executor:
-        pytest.skip("Inline into scan breaks embedded execution.")
+        pytest.xfail("Inline into scan breaks embedded execution.")
 
     solve_nonhydro_stencil_52_like_z_q.with_backend(fieldview_backend)(
         test_setup.z_alpha,
@@ -232,7 +232,7 @@ def test_solve_nonhydro_stencil_52_like_z_q(test_setup, fieldview_backend):
 
 def test_solve_nonhydro_stencil_52_like_z_q_tup(test_setup, fieldview_backend):
     if fieldview_backend == roundtrip.executor:
-        pytest.skip(
+        pytest.xfail(
             "Inline into scan breaks embedded execution and relies on CollapseTuple ignore_tuple_size==True."
         )
 
@@ -250,7 +250,7 @@ def test_solve_nonhydro_stencil_52_like_z_q_tup(test_setup, fieldview_backend):
 
 def test_solve_nonhydro_stencil_52_like(test_setup, fieldview_backend):
     if fieldview_backend == roundtrip.executor:
-        pytest.skip("Inline into scan breaks embedded execution.")
+        pytest.xfail("Inline into scan breaks embedded execution.")
 
     solve_nonhydro_stencil_52_like.with_backend(fieldview_backend)(
         test_setup.z_alpha,
@@ -267,7 +267,7 @@ def test_solve_nonhydro_stencil_52_like(test_setup, fieldview_backend):
 
 def test_solve_nonhydro_stencil_52_like_with_gtfn_tuple_merge(test_setup, fieldview_backend):
     if fieldview_backend == roundtrip.executor:
-        pytest.skip("Only working in gtfn with CollapseTuple ignore_tuple_size==True.")
+        pytest.xfail("Only working in gtfn with CollapseTuple ignore_tuple_size==True.")
 
     solve_nonhydro_stencil_52_like_with_gtfn_tuple_merge.with_backend(fieldview_backend)(
         test_setup.z_alpha,


### PR DESCRIPTION
- Change `pytest.skip` to `pytest.xfail` when the skip reason is a bug or missing feature.
- Enable a few tests which are supported now.