### PR TITLE
feature[next]: Extend Single Static Assignment (SSA) pass to support if statements

### DIFF
--- a/src/gt4py/next/ffront/ast_passes/single_static_assign.py
+++ b/src/gt4py/next/ffront/ast_passes/single_static_assign.py
@@ -11,10 +11,103 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
 
 import ast
+import typing
 
 from gt4py.next.ffront.fbuiltins import TYPE_BUILTIN_NAMES
+
+
+def _make_assign(target: str, source: str, location_node: ast.AST):
+    result = ast.Assign(
+        targets=[ast.Name(ctx=ast.Store(), id=target)], value=ast.Name(ctx=ast.Load(), id=source)
+    )
+    for node in ast.walk(result):
+        ast.copy_location(node, location_node)
+    return result
+
+
+def is_guaranteed_to_return(node: ast.stmt | list[ast.stmt]) -> bool:
+    if isinstance(node, list):
+        return any(is_guaranteed_to_return(child) for child in node)
+    if isinstance(node, ast.Return):
+        return True
+    if isinstance(node, ast.If):
+        return is_guaranteed_to_return(node.body) and is_guaranteed_to_return(node.orelse)
+    return False
+
+
+class Versioning:
+    """Helper class to keep track of whether versioning (definedness)."""
+
+    # invariant: if a version is an `int`, it's not negative
+    _versions: dict[str, None | int]
+
+    def __init__(self):
+        self._versions = {}
+
+    def define(self, name: str) -> None:
+        if name not in self._versions:
+            self._versions[name] = None
+
+    def assign(self, name: str) -> None:
+        if self.is_versioned(name):
+            self._versions[name] = typing.cast(int, self._versions[name]) + 1
+        else:
+            self._versions[name] = 0
+
+    def is_defined(self, name: str) -> bool:
+        return name in self._versions
+
+    def is_versioned(self, name: str) -> bool:
+        return self.is_defined(name) and self._versions[name] is not None
+
+    def __getitem__(self, name: str) -> None | int:
+        return self._versions[name]
+
+    def __iter__(self) -> typing.Iterator[tuple[str, None | int]]:
+        return iter(self._versions.items())
+
+    def copy(self) -> Versioning:
+        copy = Versioning()
+        copy._versions = {**self._versions}
+        return copy
+
+    @staticmethod
+    def merge(a: Versioning, b: Versioning) -> Versioning:
+        versions_a, version_b = a._versions, b._versions
+        names = set(versions_a.keys()) & set(version_b.keys())
+
+        merged_versioning = Versioning()
+        merged_versions = merged_versioning._versions
+
+        for name in names:
+            merged_versions[name] = Versioning._merge_versions(versions_a[name], version_b[name])
+
+        return merged_versioning
+
+    @staticmethod
+    def _merge_versions(a: None | int, b: None | int) -> None | int:
+        if a is None:
+            return b
+        elif b is None:
+            return a
+        return max(a, b)
+
+
+class NameEncoder:
+    """Helper class to encode names of versioned variables."""
+
+    _separator: str
+
+    def __init__(self, separator: str):
+        self._separator = separator
+
+    def encode_name(self, name: str, versions: Versioning) -> str:
+        if versions.is_versioned(name):
+            return f"{name}{self._separator}{versions[name]}"
+        return name
 
 
 class SingleStaticAssignPass(ast.NodeTransformer):
@@ -48,11 +141,16 @@ class SingleStaticAssignPass(ast.NodeTransformer):
         a__2 = 3 + a__1
         return a__2
 
-    Note that each variable name is assigned only once and never updated / overwritten.
+    Note that each variable name is assigned only once (per branch) and never updated / overwritten.
 
     Note also that after parsing, running the pass and unparsing we get invalid but
     readable python code. This is ok because this pass is not intended for
     python-to-python translation.
+
+    WARNING: This pass is not intended as a general-purpose SSA transformation.
+    The pass does not support any general Python AST. Known limitations include:
+        * Nested functions aren't supported
+        * While loops aren't supported
     """
 
     class RhsRenamer(ast.NodeTransformer):
@@ -63,17 +161,16 @@ class SingleStaticAssignPass(ast.NodeTransformer):
         """
 
         @classmethod
-        def apply(cls, name_counter, separator, node):
-            return cls(name_counter, separator).visit(node)
+        def apply(cls, versioning: Versioning, name_encoder: NameEncoder, node: ast.AST):
+            return cls(versioning, name_encoder).visit(node)
 
-        def __init__(self, name_counter, separator):
+        def __init__(self, versioning: Versioning, name_encoder: NameEncoder):
             super().__init__()
-            self.name_counter: dict[str, int] = name_counter
-            self.separator: str = separator
+            self.versioning: Versioning = versioning
+            self.name_encoder: NameEncoder = name_encoder
 
         def visit_Name(self, node: ast.Name) -> ast.Name:
-            if node.id in self.name_counter:
-                node.id = f"{node.id}{self.separator}{self.name_counter[node.id]}"
+            node.id = self.name_encoder.encode_name(node.id, self.versioning)
             return node
 
     @classmethod
@@ -82,11 +179,78 @@ class SingleStaticAssignPass(ast.NodeTransformer):
 
     def __init__(self, separator="__"):
         super().__init__()
-        self.name_counter: dict[str, int] = {}
-        self.separator: str = separator
+        self.versioning: Versioning = Versioning()
+        self.name_encoder: NameEncoder = NameEncoder(separator)
 
-    def _rename(self, node):
-        return self.RhsRenamer.apply(self.name_counter, self.separator, node)
+    def _rename(self, node: ast.AST):
+        return self.RhsRenamer.apply(self.versioning, self.name_encoder, node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        # For practical purposes, this is sufficient, but really not general at all.
+        # However, the algorithm was never intended to be general.
+
+        old_versioning = self.versioning.copy()
+
+        for arg in node.args.args:
+            self.versioning.define(arg.arg)
+
+        node.body = [self.visit(stmt) for stmt in node.body]
+
+        self.versioning = old_versioning
+        return node
+
+    def visit_If(self, node: ast.If) -> ast.If:
+        old_versioning = self.versioning
+
+        node.test = self._rename(node.test)
+
+        self.versioning = old_versioning.copy()
+        node.body = [self.visit(el) for el in node.body]
+        body_versioning = self.versioning
+        body_returns = is_guaranteed_to_return(node.body)
+
+        self.versioning = old_versioning.copy()
+        node.orelse = [self.visit(el) for el in node.orelse]
+        orelse_versioning = self.versioning
+        orelse_returns = is_guaranteed_to_return(node.orelse)
+
+        if body_returns and not orelse_returns:
+            self.versioning = orelse_versioning
+            return node
+
+        if orelse_returns and not body_returns:
+            self.versioning = body_versioning
+            return node
+
+        if body_returns and orelse_returns:
+            self.versioning = Versioning()
+            return node
+
+        assert not body_returns and not orelse_returns
+
+        self.versioning = Versioning.merge(body_versioning, orelse_versioning)
+
+        # ensure both branches conclude with the same unique names
+        for name, merged_version in self.versioning:
+            body_version = body_versioning[name]
+            orelse_version = orelse_versioning[name]
+
+            if body_version != merged_version:
+                new_assign = _make_assign(
+                    self.name_encoder.encode_name(name, self.versioning),
+                    self.name_encoder.encode_name(name, body_versioning),
+                    node,
+                )
+                node.body.append(new_assign)
+            elif orelse_version != merged_version:
+                new_assign = _make_assign(
+                    self.name_encoder.encode_name(name, self.versioning),
+                    self.name_encoder.encode_name(name, orelse_versioning),
+                    node,
+                )
+                node.orelse.append(new_assign)
+
+        return node
 
     def visit_Assign(self, node: ast.Assign) -> ast.Assign:
         # first update rhs names to reference the latest version
@@ -104,18 +268,19 @@ class SingleStaticAssignPass(ast.NodeTransformer):
             node.value = self._rename(node.value)
             node.target = self.visit(node.target)
         elif isinstance(node.target, ast.Name):
-            target_id = node.target.id
+            # An empty annotation always applies to the next assignment.
+            # So we need to use the correct versioning, but also ensure
+            # we restore the old versioning afterwards, because no assignment
+            # actually happens.
+            old_versioning = self.versioning.copy()
             node.target = self.visit(node.target)
-            self.name_counter[target_id] -= 1
+            self.versioning = old_versioning
         return node
 
     def visit_Name(self, node: ast.Name) -> ast.Name:
         if node.id in TYPE_BUILTIN_NAMES:
             return node
-        elif node.id in self.name_counter:
-            self.name_counter[node.id] += 1
-            node.id = f"{node.id}{self.separator}{self.name_counter[node.id]}"
-        else:
-            self.name_counter[node.id] = 0
-            node.id = f"{node.id}{self.separator}0"
+
+        self.versioning.assign(node.id)
+        node.id = self.name_encoder.encode_name(node.id, self.versioning)
         return node

--- a/src/gt4py/next/ffront/ast_passes/single_static_assign.py
+++ b/src/gt4py/next/ffront/ast_passes/single_static_assign.py
@@ -81,6 +81,7 @@ def _merge_assignment_tracker(a: _AssignmentTracker, b: _AssignmentTracker) -> _
     return _AssignmentTracker({k: max(a.count(k), b.count(k)) for k in common_names})
 
 
+@dataclasses.dataclass
 class SingleStaticAssignPass(ast.NodeTransformer):
     """
     Rename variables in assignments to avoid overwriting.
@@ -123,14 +124,11 @@ class SingleStaticAssignPass(ast.NodeTransformer):
         * Nested functions aren't supported
         * While loops aren't supported
     """
+    assignment_tracker: _AssignmentTracker = dataclasses.field(default_factory=_AssignmentTracker)
 
     @classmethod
     def apply(cls, node: ASTNodeT) -> ASTNodeT:
         return cls().visit(node)
-
-    def __init__(self):
-        super().__init__()
-        self.assignment_tracker: _AssignmentTracker = _AssignmentTracker()
 
     def _rename(self, node: ASTNodeT) -> ASTNodeT:
         for child_node in ast.walk(node):

--- a/src/gt4py/next/ffront/ast_passes/single_static_assign.py
+++ b/src/gt4py/next/ffront/ast_passes/single_static_assign.py
@@ -124,6 +124,7 @@ class SingleStaticAssignPass(ast.NodeTransformer):
         * Nested functions aren't supported
         * While loops aren't supported
     """
+
     assignment_tracker: _AssignmentTracker = dataclasses.field(default_factory=_AssignmentTracker)
 
     @classmethod

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -18,6 +18,7 @@ import textwrap
 import pytest
 
 from gt4py.next.common import Dimension, DimensionKind, Field
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.ffront.decorator import field_operator, scan_operator
 from gt4py.next.ffront.fbuiltins import int64
 from gt4py.next.ffront.foast_pretty_printer import pretty_format
@@ -80,10 +81,10 @@ def test_scanop():
         return inp
 
     expected = textwrap.dedent(
-        """
+        f"""
         @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1.0)
         def scan(inp: int64) -> int64:
-          foo__0 = inp
+          {ssa.unique_name("foo", 0)} = inp
           return inp
         """
     ).strip()

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -18,6 +18,7 @@ import pytest
 
 import gt4py.next.ffront.type_specifications
 from gt4py.next.common import DimensionKind, GTTypeError
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.ffront.experimental import as_offset
 from gt4py.next.ffront.fbuiltins import (
     Dimension,
@@ -302,11 +303,11 @@ def test_unpack_assign():
 
     parsed = FieldOperatorParser.apply_to_function(unpack_explicit_tuple)
 
-    assert parsed.body.annex.symtable["tmp_a__0"].type == ts.FieldType(
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp_a", 0)].type == ts.FieldType(
         dims=[TDim],
         dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None),
     )
-    assert parsed.body.annex.symtable["tmp_b__0"].type == ts.FieldType(
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp_b", 0)].type == ts.FieldType(
         dims=[TDim],
         dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None),
     )
@@ -364,7 +365,7 @@ def test_assign_tuple():
 
     parsed = FieldOperatorParser.apply_to_function(temp_tuple)
 
-    assert parsed.body.annex.symtable["tmp__0"].type == ts.TupleType(
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp", 0)].type == ts.TupleType(
         types=[
             ts.FieldType(
                 dims=[TDim],

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
@@ -18,7 +18,10 @@
 import ast
 import textwrap
 
-from gt4py.next.ffront.ast_passes.single_static_assign import SingleStaticAssignPass
+from gt4py.next.ffront.ast_passes.single_static_assign import (
+    _UNIQUE_NAME_SEPERATOR as SEP,
+    SingleStaticAssignPass,
+)
 
 
 def ssaify_string(code: str) -> ast.AST:
@@ -36,9 +39,9 @@ def test_sequence():
     )
 
     lines = ast.unparse(ssa_ast).split("\n")
-    assert lines[0] == "tmp__0 = 1"
-    assert lines[1] == "tmp__1 = 2"
-    assert lines[2] == "tmp__2 = 3"
+    assert lines[0] == f"tmp{SEP}0 = 1"
+    assert lines[1] == f"tmp{SEP}1 = 2"
+    assert lines[2] == f"tmp{SEP}2 = 3"
 
 
 def test_self_on_rhs():
@@ -50,8 +53,8 @@ def test_self_on_rhs():
         """
     )
     lines = ast.unparse(ssa_ast).split("\n")
-    assert lines[0] == "tmp__0 = 1"
-    assert lines[1] == "tmp__1 = tmp__0 + 1"
+    assert lines[0] == f"tmp{SEP}0 = 1"
+    assert lines[1] == f"tmp{SEP}1 = tmp{SEP}0 + 1"
 
 
 def test_multi_assign():
@@ -62,7 +65,7 @@ def test_multi_assign():
         """
     )
     lines = ast.unparse(ssa_ast).split("\n")
-    assert lines[0] == "a__0 = a__1 = b__0 = a__2 = b__1 = 1"
+    assert lines[0] == f"a{SEP}0 = a{SEP}1 = b{SEP}0 = a{SEP}2 = b{SEP}1 = 1"
 
 
 def test_external_name_values():
@@ -74,8 +77,8 @@ def test_external_name_values():
         """
     )
     lines = ast.unparse(ssa_ast).split("\n")
-    assert lines[0] == "a__0 = inp"
-    assert lines[1] == "a__1 = a__0 + inp"
+    assert lines[0] == f"a{SEP}0 = inp"
+    assert lines[1] == f"a{SEP}1 = a{SEP}0 + inp"
 
 
 def test_overwrite_external():
@@ -88,9 +91,9 @@ def test_overwrite_external():
         """
     )
     lines = ast.unparse(ssa_ast).split("\n")
-    assert lines[0] == "a__0 = inp"
-    assert lines[1] == "inp__0 = a__0 + inp"
-    assert lines[2] == "b__0 = inp__0"
+    assert lines[0] == f"a{SEP}0 = inp"
+    assert lines[1] == f"inp{SEP}0 = a{SEP}0 + inp"
+    assert lines[2] == f"b{SEP}0 = inp{SEP}0"
 
 
 def test_unpacking_swap():
@@ -103,9 +106,9 @@ def test_unpacking_swap():
         """
     )
     lines = ast.unparse(ssa_ast).split("\n")
-    assert lines[0] == "a__0 = 5"
-    assert lines[1] == "b__0 = 1"
-    assert lines[2] == "(b__1, a__1) = (a__0, b__0)"
+    assert lines[0] == f"a{SEP}0 = 5"
+    assert lines[1] == f"b{SEP}0 = 1"
+    assert lines[2] == f"(b{SEP}1, a{SEP}1) = (a{SEP}0, b{SEP}0)"
 
 
 def test_annotated_assign():
@@ -117,7 +120,7 @@ def test_annotated_assign():
             """
         )
     ).splitlines()
-    assert lines[0] == "a__0: int = 5"
+    assert lines[0] == f"a{SEP}0: int = 5"
 
 
 def test_empty_annotated_assign():
@@ -130,9 +133,9 @@ def test_empty_annotated_assign():
             """
         )
     ).splitlines()
-    assert lines[0] == "a__0 = 0"
-    assert lines[1] == "a__1: int"
-    assert lines[2] == "b__0 = a__0"
+    assert lines[0] == f"a{SEP}0 = 0"
+    assert lines[1] == f"a{SEP}1: int"
+    assert lines[2] == f"b{SEP}0 = a{SEP}0"
 
 
 def test_if():
@@ -148,15 +151,15 @@ def test_if():
         )
     ).splitlines()
 
-    assert lines[1] == "    a__0 = 1"
-    assert lines[3] == "    a__0 = 2"
-    assert lines[4] == "a__1 = 3"
+    assert lines[1] == f"    a{SEP}0 = 1"
+    assert lines[3] == f"    a{SEP}0 = 2"
+    assert lines[4] == f"a{SEP}1 = 3"
 
 
 def test_if_variable_condition():
     result = ast.unparse(
         ssaify_string(
-            """
+            f"""
             if b:
                 a = 1
             """
@@ -164,9 +167,9 @@ def test_if_variable_condition():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if b:
-            a__0 = 1
+            a{SEP}0 = 1
         """
     ).strip()
 
@@ -176,7 +179,7 @@ def test_if_variable_condition():
 def test_nested_if():
     result = ast.unparse(
         ssaify_string(
-            """
+            f"""
             if True:
                 a = 1
             else:
@@ -190,18 +193,18 @@ def test_nested_if():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = 1
-            a__2 = a__0
+            a{SEP}0 = 1
+            a{SEP}2 = a{SEP}0
         else:
-            a__0 = 2
+            a{SEP}0 = 2
             if True:
-                a__1 = 3
+                a{SEP}1 = 3
             else:
-                a__1 = a__0
-            a__2 = 4
-        a__3 = 5
+                a{SEP}1 = a{SEP}0
+            a{SEP}2 = 4
+        a{SEP}3 = 5
     """
     ).strip()
 
@@ -211,7 +214,7 @@ def test_nested_if():
 def test_nested_if_chain():
     result = ast.unparse(
         ssaify_string(
-            """
+            f"""
             if True:
                 a = 1
             else:
@@ -225,18 +228,18 @@ def test_nested_if_chain():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = 1
-            a__2 = a__0
+            a{SEP}0 = 1
+            a{SEP}2 = a{SEP}0
         else:
-            a__0 = 2
+            a{SEP}0 = 2
             if True:
-                a__1 = a__0 + 1
+                a{SEP}1 = a{SEP}0 + 1
             else:
-                a__1 = a__0
-            a__2 = a__1 + 1
-        a__3 = a__2 + 1
+                a{SEP}1 = a{SEP}0
+            a{SEP}2 = a{SEP}1 + 1
+        a{SEP}3 = a{SEP}2 + 1
     """
     ).strip()
 
@@ -246,7 +249,7 @@ def test_nested_if_chain():
 def test_if_branch_local():
     result = ast.unparse(
         ssaify_string(
-            """
+            f"""
             if True:
                 a = 0
                 a = a + 1
@@ -258,13 +261,13 @@ def test_if_branch_local():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = 0
-            a__1 = a__0 + 1
+            a{SEP}0 = 0
+            a{SEP}1 = a{SEP}0 + 1
         else:
-            b__0 = 1
-            b__1 = b__0 + 1
+            b{SEP}0 = 1
+            b{SEP}1 = b{SEP}0 + 1
         """
     ).strip()
 
@@ -274,7 +277,7 @@ def test_if_branch_local():
 def test_if_only_one_branch():
     result = ast.unparse(
         ssaify_string(
-            """
+            f"""
             if True:
                 a = 0
             b = a
@@ -283,10 +286,10 @@ def test_if_only_one_branch():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = 0
-        b__0 = a
+            a{SEP}0 = 0
+        b{SEP}0 = a
         """
     ).strip()
 
@@ -307,12 +310,12 @@ def test_if_only_one_branch_other():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = 0
+            a{SEP}0 = 0
         else:
-            c__0 = 1
-        b__0 = c
+            c{SEP}0 = 1
+        b{SEP}0 = c
         """
     ).strip()
 
@@ -341,22 +344,22 @@ def test_if_nested_all_branches_defined():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
             if True:
-                a__0 = 0
-                a__1 = a__0 + 1
-                a__2 = a__1 + 1
-                a__3 = a__2 + 1
-                a__4 = a__3 + 1
+                a{SEP}0 = 0
+                a{SEP}1 = a{SEP}0 + 1
+                a{SEP}2 = a{SEP}1 + 1
+                a{SEP}3 = a{SEP}2 + 1
+                a{SEP}4 = a{SEP}3 + 1
             else:
-                a__0 = 0
-                a__1 = a__0 + 1
-                a__2 = a__1 + 1
-                a__4 = a__2
+                a{SEP}0 = 0
+                a{SEP}1 = a{SEP}0 + 1
+                a{SEP}2 = a{SEP}1 + 1
+                a{SEP}4 = a{SEP}2
         else:
-            a__0 = 0
-            a__4 = a__0
+            a{SEP}0 = 0
+            a{SEP}4 = a{SEP}0
         """
     ).strip()
 
@@ -384,22 +387,22 @@ def test_elif_all_branches_defined():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = 0
-            a__1 = a__0 + 1
-            a__2 = a__1 + 1
-            a__3 = a__2 + 1
-            a__4 = a__3 + 1
+            a{SEP}0 = 0
+            a{SEP}1 = a{SEP}0 + 1
+            a{SEP}2 = a{SEP}1 + 1
+            a{SEP}3 = a{SEP}2 + 1
+            a{SEP}4 = a{SEP}3 + 1
         else:
             if True:
-                a__0 = 0
-                a__1 = a__0 + 1
-                a__2 = a__1 + 1
+                a{SEP}0 = 0
+                a{SEP}1 = a{SEP}0 + 1
+                a{SEP}2 = a{SEP}1 + 1
             else:
-                a__0 = 0
-                a__2 = a__0
-            a__4 = a__2
+                a{SEP}0 = 0
+                a{SEP}2 = a{SEP}0
+            a{SEP}4 = a{SEP}2
         """
     ).strip()
 
@@ -430,24 +433,24 @@ def test_nested_ifs_single_change():
     )
 
     expected = textwrap.dedent(
-        """
-        a__0 = 0
+        f"""
+        a{SEP}0 = 0
         if True:
-            b__0 = 0
-            a__1 = a__0
+            b{SEP}0 = 0
+            a{SEP}1 = a{SEP}0
         elif True:
             if True:
-                b__0 = 1
-                a__1 = a__0
+                b{SEP}0 = 1
+                a{SEP}1 = a{SEP}0
             elif True:
-                b__0 = 2
-                a__1 = a__0 + 1
+                b{SEP}0 = 2
+                a{SEP}1 = a{SEP}0 + 1
             else:
-                b__0 = 3
-                a__1 = a__0
+                b{SEP}0 = 3
+                a{SEP}1 = a{SEP}0
         else:
-            b__0 = 4
-            a__1 = a__0
+            b{SEP}0 = 4
+            a{SEP}1 = a{SEP}0
         """
     ).strip()
 
@@ -467,13 +470,13 @@ def test_if_one_sided_inside_function():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f(a):
             if True:
-                a__0 = a + 1
+                a{SEP}0 = a + 1
             else:
-                a__0 = a
-            return a__0
+                a{SEP}0 = a
+            return a{SEP}0
         """
     ).strip()
 
@@ -495,12 +498,12 @@ def test_if_preservers_definite_assignment_analysis1():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f():
             if True:
-                a__0 = 1
+                a{SEP}0 = 1
             else:
-                b__0 = 0
+                b{SEP}0 = 0
             return (a, b)
         """
     ).strip()
@@ -523,13 +526,13 @@ def test_if_preservers_definite_assignment_analysis2():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f():
             if True:
-                a__0 = 1
+                a{SEP}0 = 1
             else:
-                a__0 = 0
-            return (a__0, b)
+                a{SEP}0 = 0
+            return (a{SEP}0, b)
         """
     ).strip()
 
@@ -550,14 +553,14 @@ def test_if_preservers_definite_assignment_analysis3():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f():
-            a__0 = 0
+            a{SEP}0 = 0
             if True:
-                a__1 = 1
+                a{SEP}1 = 1
             else:
-                a__1 = a__0
-            return (a__1, b)
+                a{SEP}1 = a{SEP}0
+            return (a{SEP}1, b)
         """
     ).strip()
 
@@ -569,17 +572,17 @@ def test_broken_collisions():
 
     result = ast.unparse(
         ssaify_string(
-            """
-            a = a__0 + 1
-            return a, a__0
+            f"""
+            a = a{SEP}0 + 1
+            return a, a{SEP}0
             """
         )
     )
 
     expected = textwrap.dedent(
-        """
-        a__0 = a__0 + 1
-        return (a__0, a__0)
+        f"""
+        a{SEP}0 = a{SEP}0 + 1
+        return (a{SEP}0, a{SEP}0)
         """
     ).strip()
 
@@ -591,17 +594,17 @@ def test_collision_function_parameters():
 
     result = ast.unparse(
         ssaify_string(
-            """
-            def f(a, a__0):
-                return a__0
+            f"""
+            def f(a, a{SEP}0):
+                return a{SEP}0
             """
         )
     )
 
     expected = textwrap.dedent(
-        """
-        def f(a, a__0):
-            return a__0
+        f"""
+        def f(a, a{SEP}0):
+            return a{SEP}0
         """
     ).strip()
 
@@ -622,9 +625,9 @@ def test_broken_if():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         if True:
-            a__0 = a + 1
+            a{SEP}0 = a + 1
         return a
         """
     ).strip()
@@ -643,9 +646,9 @@ def test_annotated_assign():
     )
 
     expected = textwrap.dedent(
-        """
-        a__0: int
-        a__0 = a + 1
+        f"""
+        a{SEP}0: int
+        a{SEP}0 = a + 1
         """
     ).strip()
 
@@ -670,16 +673,16 @@ def test_if_true_branch_returns():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f(a, b):
             if True:
-                a__0 = a + 1
-                d__0 = 5
-                return a__0
+                a{SEP}0 = a + 1
+                d{SEP}0 = 5
+                return a{SEP}0
             else:
-                b__0 = b + 1
-                e__0 = 6
-            return (a, b__0, d, e__0)
+                b{SEP}0 = b + 1
+                e{SEP}0 = 6
+            return (a, b{SEP}0, d, e{SEP}0)
         """
     ).strip()
 
@@ -705,17 +708,17 @@ def test_if_false_branch_returns():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f(a, b):
-            b__0 = a + 3
+            b{SEP}0 = a + 3
             if True:
-                b__1 = b__0 + 1
-                e__0 = 6
+                b{SEP}1 = b{SEP}0 + 1
+                e{SEP}0 = 6
             else:
-                a__0 = a + 1
-                d__0 = 5
-                return a__0
-            return (a, b__1, d, e__0)
+                a{SEP}0 = a + 1
+                d{SEP}0 = 5
+                return a{SEP}0
+            return (a, b{SEP}1, d, e{SEP}0)
         """
     ).strip()
 
@@ -741,16 +744,16 @@ def test_if_both_branches_return():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
         def f(a, b):
             if True:
-                b__0 = b + 1
-                e__0 = 6
-                return e__0
+                b{SEP}0 = b + 1
+                e{SEP}0 = 6
+                return e{SEP}0
             else:
-                a__0 = a + 1
-                d__0 = 5
-                return a__0
+                a{SEP}0 = a + 1
+                d{SEP}0 = 5
+                return a{SEP}0
             return (a, b, d, e)
         """
     ).strip()
@@ -779,19 +782,19 @@ def test_if_nested_returns():
     )
 
     expected = textwrap.dedent(
-        """
+        f"""
             def f(a, b):
                 if True:
-                    b__0 = b + 1
-                    e__0 = 6
-                    if e__0 == b__0:
-                        return e__0
+                    b{SEP}0 = b + 1
+                    e{SEP}0 = 6
+                    if e{SEP}0 == b{SEP}0:
+                        return e{SEP}0
                     else:
-                        return b__0
+                        return b{SEP}0
                 else:
-                    a__0 = a + 1
-                    d__0 = 5
-                return (a__0, b, d__0, e)
+                    a{SEP}0 = a + 1
+                    d{SEP}0 = 5
+                return (a{SEP}0, b, d{SEP}0, e)
         """
     ).strip()
 

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
@@ -19,7 +19,7 @@ import ast
 import textwrap
 
 from gt4py.next.ffront.ast_passes.single_static_assign import (
-    _UNIQUE_NAME_SEPERATOR as SEP,
+    _UNIQUE_NAME_SEPARATOR as SEP,
     SingleStaticAssignPass,
 )
 

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
@@ -133,3 +133,666 @@ def test_empty_annotated_assign():
     assert lines[0] == "a__0 = 0"
     assert lines[1] == "a__1: int"
     assert lines[2] == "b__0 = a__0"
+
+
+def test_if():
+    lines = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 1
+            else:
+                a = 2
+            a = 3
+            """
+        )
+    ).splitlines()
+
+    assert lines[1] == "    a__0 = 1"
+    assert lines[3] == "    a__0 = 2"
+    assert lines[4] == "a__1 = 3"
+
+
+def test_if_variable_condition():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if b:
+                a = 1
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if b:
+            a__0 = 1
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_nested_if():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 1
+            else:
+                a = 2
+                if True:
+                    a = 3
+                a = 4
+            a = 5
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 1
+            a__2 = a__0
+        else:
+            a__0 = 2
+            if True:
+                a__1 = 3
+            else:
+                a__1 = a__0
+            a__2 = 4
+        a__3 = 5
+    """
+    ).strip()
+
+    assert result == expected
+
+
+def test_nested_if_chain():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 1
+            else:
+                a = 2
+                if True:
+                    a = a+1
+                a = a+1
+            a = a+1
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 1
+            a__2 = a__0
+        else:
+            a__0 = 2
+            if True:
+                a__1 = a__0 + 1
+            else:
+                a__1 = a__0
+            a__2 = a__1 + 1
+        a__3 = a__2 + 1
+    """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_branch_local():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 0
+                a = a + 1
+            else:
+                b = 1
+                b = b + 1
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 0
+            a__1 = a__0 + 1
+        else:
+            b__0 = 1
+            b__1 = b__0 + 1
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_only_one_branch():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 0
+            b = a
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 0
+        b__0 = a
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_only_one_branch_other():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 0
+            else:
+                c = 1
+            b = c
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 0
+        else:
+            c__0 = 1
+        b__0 = c
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_nested_all_branches_defined():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                if True:
+                    a = 0
+                    a = a + 1
+                    a = a + 1
+                    a = a + 1
+                    a = a + 1
+                else:
+                    a = 0
+                    a = a + 1
+                    a = a + 1
+            else:
+                a = 0
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            if True:
+                a__0 = 0
+                a__1 = a__0 + 1
+                a__2 = a__1 + 1
+                a__3 = a__2 + 1
+                a__4 = a__3 + 1
+            else:
+                a__0 = 0
+                a__1 = a__0 + 1
+                a__2 = a__1 + 1
+                a__4 = a__2
+        else:
+            a__0 = 0
+            a__4 = a__0
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_elif_all_branches_defined():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = 0
+                a = a + 1
+                a = a + 1
+                a = a + 1
+                a = a + 1
+            elif True:
+                a = 0
+                a = a + 1
+                a = a + 1
+            else:
+                a = 0
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = 0
+            a__1 = a__0 + 1
+            a__2 = a__1 + 1
+            a__3 = a__2 + 1
+            a__4 = a__3 + 1
+        else:
+            if True:
+                a__0 = 0
+                a__1 = a__0 + 1
+                a__2 = a__1 + 1
+            else:
+                a__0 = 0
+                a__2 = a__0
+            a__4 = a__2
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_nested_ifs_single_change():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            a = 0
+            if True:
+                b = 0
+            elif True:
+                if True:
+                    b = 1
+                else:
+                    if True:
+                        b = 2
+                        # because of this nested change, all branches need additions
+                        a = a + 1
+                    else:
+                        b = 3
+            else:
+                b = 4
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        a__0 = 0
+        if True:
+            b__0 = 0
+            a__1 = a__0
+        elif True:
+            if True:
+                b__0 = 1
+                a__1 = a__0
+            elif True:
+                b__0 = 2
+                a__1 = a__0 + 1
+            else:
+                b__0 = 3
+                a__1 = a__0
+        else:
+            b__0 = 4
+            a__1 = a__0
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_one_sided_inside_function():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f(a):
+                if True:
+                    a = a + 1
+                return a
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f(a):
+            if True:
+                a__0 = a + 1
+            else:
+                a__0 = a
+            return a__0
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_preservers_definite_assignment_analysis1():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f():
+                if True:
+                    a = 1
+                else:
+                    b = 0
+                return a, b
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f():
+            if True:
+                a__0 = 1
+            else:
+                b__0 = 0
+            return (a, b)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_preservers_definite_assignment_analysis2():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f():
+                if True:
+                    a = 1
+                else:
+                    a = 0
+                return a, b
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f():
+            if True:
+                a__0 = 1
+            else:
+                a__0 = 0
+            return (a__0, b)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_preservers_definite_assignment_analysis3():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f():
+                a = 0
+                if True:
+                    a = 1
+                return a, b
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f():
+            a__0 = 0
+            if True:
+                a__1 = 1
+            else:
+                a__1 = a__0
+            return (a__1, b)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_broken_collisions():
+    # Known bug of the current SSA implementation
+
+    result = ast.unparse(
+        ssaify_string(
+            """
+            a = a__0 + 1
+            return a, a__0
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        a__0 = a__0 + 1
+        return (a__0, a__0)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_collision_function_parameters():
+    # An earlier version couldn't handle this case correctly
+
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f(a, a__0):
+                return a__0
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f(a, a__0):
+            return a__0
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_broken_if():
+    # Known bug of the current SSA implementation
+
+    result = ast.unparse(
+        ssaify_string(
+            """
+            if True:
+                a = a + 1
+            return a
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        if True:
+            a__0 = a + 1
+        return a
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_annotated_assign():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            a: int # annotations always apply to the next assignment
+            a = a + 1
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        a__0: int
+        a__0 = a + 1
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_true_branch_returns():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f(a, b):
+                if True:
+                    a = a + 1
+                    d = 5
+                    return a
+                else:
+                    b = b + 1
+                    e = 6
+                return a, b, d, e
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f(a, b):
+            if True:
+                a__0 = a + 1
+                d__0 = 5
+                return a__0
+            else:
+                b__0 = b + 1
+                e__0 = 6
+            return (a, b__0, d, e__0)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_false_branch_returns():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f(a, b):
+                b = a + 3
+                if True:
+                    b = b + 1
+                    e = 6
+                else:
+                    a = a + 1
+                    d = 5
+                    return a
+                return a, b, d, e
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f(a, b):
+            b__0 = a + 3
+            if True:
+                b__1 = b__0 + 1
+                e__0 = 6
+            else:
+                a__0 = a + 1
+                d__0 = 5
+                return a__0
+            return (a, b__1, d, e__0)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_both_branches_return():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f(a, b):
+                if True:
+                    b = b + 1
+                    e = 6
+                    return e
+                else:
+                    a = a + 1
+                    d = 5
+                    return a
+                return a, b, d, e # this is dead-code
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+        def f(a, b):
+            if True:
+                b__0 = b + 1
+                e__0 = 6
+                return e__0
+            else:
+                a__0 = a + 1
+                d__0 = 5
+                return a__0
+            return (a, b, d, e)
+        """
+    ).strip()
+
+    assert result == expected
+
+
+def test_if_nested_returns():
+    result = ast.unparse(
+        ssaify_string(
+            """
+            def f(a, b):
+                if True:
+                    b = b + 1
+                    e = 6
+                    if e == b:
+                        return e
+                    else:
+                        return b
+                else:
+                    a = a + 1
+                    d = 5
+                return a, b, d, e
+            """
+        )
+    )
+
+    expected = textwrap.dedent(
+        """
+            def f(a, b):
+                if True:
+                    b__0 = b + 1
+                    e__0 = 6
+                    if e__0 == b__0:
+                        return e__0
+                    else:
+                        return b__0
+                else:
+                    a__0 = a + 1
+                    d__0 = 5
+                return (a__0, b, d__0, e)
+        """
+    ).strip()
+
+    assert result == expected

--- a/tests/next_tests/unit_tests/ffront_tests/test_func_to_foast.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_func_to_foast.py
@@ -42,6 +42,7 @@ import pytest
 from gt4py.eve.pattern_matching import ObjectPattern as P
 from gt4py.next.common import Field, GTTypeError
 from gt4py.next.ffront import field_operator_ast as foast
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.ffront.fbuiltins import (
     Dimension,
     astype,
@@ -172,7 +173,7 @@ def test_temp_assignment():
 
     parsed = FieldOperatorParser.apply_to_function(copy_field)
 
-    assert parsed.body.annex.symtable["tmp__0"].type == ts.FieldType(
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp", 0)].type == ts.FieldType(
         dims=[TDim],
         dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None),
     )

--- a/tests/next_tests/unit_tests/ffront_tests/test_past_to_itir.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_past_to_itir.py
@@ -156,14 +156,22 @@ def test_inout_prohibited(identity_def):
         GTTypeError,
         match=(r"Call to function with field as input and output not allowed."),
     ):
-        ProgramLowering.apply(ProgramParser.apply_to_function(inout_field_program))
+        ProgramLowering.apply(
+            ProgramParser.apply_to_function(inout_field_program),
+            function_definitions=[],
+            grid_type=GridType.CARTESIAN,
+        )
 
 
 def test_invalid_call_sig_program(invalid_call_sig_program_def):
     with pytest.raises(
         GTTypeError,
     ) as exc_info:
-        ProgramLowering.apply(ProgramParser.apply_to_function(invalid_call_sig_program_def))
+        ProgramLowering.apply(
+            ProgramParser.apply_to_function(invalid_call_sig_program_def),
+            function_definitions=[],
+            grid_type=GridType.CARTESIAN,
+        )
 
     assert exc_info.match("Invalid call to `identity`")
     # TODO(tehrengruber): re-enable again when call signature check doesn't return


### PR DESCRIPTION
This PR extends the SSA pass (operating on the Python AST) to support if statements such that every variable is assigned only once _per branch_, e.g. this
```python
if True:
    a = 1
else:
    a = 2
    if True:
        a = 3
    a = 4
a = 5
```
is transformed into
```python
if True:
    a__0 = 1
    a__2 = a__0
else:
    a__0 = 2
    if True:
        a__1 = 3
    else:
        a__1 = a__0
    a__2 = 4
a__3 = 5
```
Most of the code was written by @BenWeber42 reviewed by me. See https://github.com/GridTools/gt4py/pull/972 for the discussion. The PR is a prerequisite for https://github.com/GridTools/gt4py/pull/1079 and was spun off from there to ease review.