### PR TITLE
feature[next]: Improve CSE pass

### DIFF
--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -85,12 +85,15 @@ class CollectSubexpressions(VisitorWithSymbolTableTrait, NodeVisitor):
         used_symbol_ids: set[int] = dataclasses.field(default_factory=set)
 
         def remove_subexprs(self, nodes: list[ir.Node]):
-            node_ids = {node_id for node in nodes for node_id, _ in self.subexprs.get(node, [])}
+            node_ids_to_remove: set[int] = set()
             for node in nodes:
-                del self.subexprs[node]
+                subexpr_data = self.subexprs.pop(node, None)
+                if subexpr_data:
+                    node_ids, _ = zip(*subexpr_data)
+                    node_ids_to_remove |= set(node_ids)
             for subexpr_data in self.subexprs.values():
                 for _, collected_child_node_ids in subexpr_data:
-                    collected_child_node_ids -= node_ids
+                    collected_child_node_ids -= node_ids_to_remove
 
     @classmethod
     def apply(cls, node: ir.Node):

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -97,8 +97,8 @@ class CollectSubexpressions(VisitorWithSymbolTableTrait, NodeVisitor):
                     collected_child_node_ids -= node_ids
 
     @staticmethod
-    def merge_states(*states):
-        subexprs = {}
+    def merge_states(*states: State) -> State:
+        subexprs: dict[ir.Node, list[tuple[int, set[int]]]] = {}
         for state in states:
             for subexpr, data in state.subexprs.items():
                 subexprs.setdefault(subexpr, []).extend(data)

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -127,9 +127,7 @@ class CollectSubexpressions(VisitorWithSymbolTableTrait, NodeVisitor):
                     subexpr_count[subexpr] += 1
 
             # remove all subexpressions that are not eligible for collection
-            eligible_subexprs = {node.args[0].args[0]} | {
-                subexpr for subexpr, count in subexpr_count.items() if count >= 2
-            }
+            eligible_subexprs = {subexpr for subexpr, count in subexpr_count.items() if count >= 2}
             for arg_state in arg_states:
                 arg_state.remove_subexprs(arg_state.subexprs.keys() - eligible_subexprs)
 

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -13,6 +13,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import dataclasses
+import operator
+from functools import reduce
 
 from gt4py.eve import NodeTranslator, NodeVisitor, SymbolTableTrait, VisitorWithSymbolTableTrait
 from gt4py.eve.utils import UIDGenerator
@@ -78,39 +80,86 @@ def _is_if_can_deref(node: ir.Node):
 
 @dataclasses.dataclass
 class CollectSubexpressions(VisitorWithSymbolTableTrait, NodeVisitor):
-    subexprs: dict[ir.Node, list[tuple[int, set[int]]]] = dataclasses.field(
-        init=False, repr=False, default_factory=dict
-    )
+    @dataclasses.dataclass
+    class State:
+        subexprs: dict[ir.Node, list[tuple[int, set[int]]]] = dataclasses.field(
+            default_factory=dict
+        )
+        collected_child_node_ids: set[int] = dataclasses.field(default_factory=set)
+        used_symbol_ids: set[int] = dataclasses.field(default_factory=set)
+
+        def remove_subexprs(self, nodes: list[ir.Node]):
+            node_ids = {node_id for node in nodes for node_id, _ in self.subexprs.get(node, [])}
+            for node in nodes:
+                del self.subexprs[node]
+            for subexpr_data in self.subexprs.values():
+                for _, collected_child_node_ids in subexpr_data:
+                    collected_child_node_ids -= node_ids
+
+    @staticmethod
+    def merge_states(*states):
+        subexprs = {}
+        for state in states:
+            for subexpr, data in state.subexprs.items():
+                subexprs.setdefault(subexpr, []).extend(data)
+        collected_child_node_ids = reduce(
+            operator.or_, (state.collected_child_node_ids for state in states)
+        )
+        used_symbol_ids = reduce(operator.or_, (state.used_symbol_ids for state in states))
+        return CollectSubexpressions.State(subexprs, collected_child_node_ids, used_symbol_ids)
 
     @classmethod
     def apply(cls, node: ir.Node):
+        subexprs: dict[ir.Node, list[tuple[int, set[int]]]] = {}
         obj = cls()
-        obj.visit(
-            node, used_symbol_ids=set(), collected_child_node_ids=set(), allow_collection=True
-        )
+        obj.visit(node, state=cls.State(subexprs))
         # return subexpression in pre-order of the tree, i.e. the nodes closer to the root come
         # first, and skip the root node itself
-        return {k: v for k, v in reversed(obj.subexprs.items()) if k is not node}
+        return {k: v for k, v in reversed(subexprs.items()) if k is not node}
 
     def visit(self, node, **kwargs):
-        # TODO(tehrengruber): improve this case as we might miss subexpression that could be eliminated
-        # disable collection (for all child nodes) if node matches `if_(can_deref(...), ..., ...)`
-        if _is_if_can_deref(node):
-            kwargs["allow_collection"] = False
-
         if not isinstance(node, SymbolTableTrait) and not _is_collectable_expr(node):
             return super().visit(node, **kwargs)
 
-        parents_collected_child_node_ids = kwargs.pop("collected_child_node_ids")
-        parents_used_symbol_ids = kwargs.pop("used_symbol_ids")
-        used_symbol_ids = set[int]()
+        parent_state = kwargs.pop("state")
         collected_child_node_ids = set[int]()
-        super().visit(
-            node,
-            used_symbol_ids=used_symbol_ids,
-            collected_child_node_ids=collected_child_node_ids,
-            **kwargs,
-        )
+        used_symbol_ids = set[int]()
+
+        # Special handling of `if_(can_deref(...), ..., ...)` like expressions that avoids
+        # extracting subexpressions from `if_` calls unless they are used in at least two
+        # of the three arguments.
+        if _is_if_can_deref(node):
+            # collect subexpressions for all arguments to the `if_`
+            arg_states = [self.State() for _ in range(3)]
+            for i, arg in enumerate(node.args):
+                self.visit(arg, state=arg_states[i], **kwargs)
+
+            # for each subexpression find in how many of the three arguments they occur
+            subexpr_count = {}
+            for arg_state in arg_states:
+                for subexpr in arg_state.subexprs.keys():
+                    subexpr_count.setdefault(subexpr, 0)
+                    subexpr_count[subexpr] += 1
+
+            # remove all subexpressions that are not eligible for collection
+            eligible_subexprs = {node.args[0].args[0]} | {
+                subexpr for subexpr, count in subexpr_count.items() if count >= 2
+            }
+            for arg_state in arg_states:
+                arg_state.remove_subexprs(arg_state.subexprs.keys() - eligible_subexprs)
+
+            # merge the states of the three arguments and update the state of the parent
+            new_state = self.merge_states(*arg_states)
+            for subexpr, data in new_state.subexprs.items():
+                parent_state.subexprs.setdefault(subexpr, []).extend(data)
+            collected_child_node_ids = new_state.collected_child_node_ids
+            used_symbol_ids = new_state.used_symbol_ids
+        else:
+            super().visit(
+                node,
+                state=self.State(parent_state.subexprs, collected_child_node_ids, used_symbol_ids),
+                **kwargs,
+            )
 
         if isinstance(node, SymbolTableTrait):
             # remove symbols used in child nodes if they are declared in the current node
@@ -118,22 +167,22 @@ class CollectSubexpressions(VisitorWithSymbolTableTrait, NodeVisitor):
 
         # if no symbols are used that are defined in the root node, i.e. the node given to `apply`,
         # we collect the subexpression
-        if not used_symbol_ids and _is_collectable_expr(node) and kwargs["allow_collection"]:
-            self.subexprs.setdefault(node, []).append((id(node), collected_child_node_ids))
+        if not used_symbol_ids and _is_collectable_expr(node):
+            parent_state.subexprs.setdefault(node, []).append((id(node), collected_child_node_ids))
 
             # propagate to parent that we have collected its child
-            parents_collected_child_node_ids.add(id(node))
+            parent_state.collected_child_node_ids.add(id(node))
 
         # propagate used symbol ids to parent
-        parents_used_symbol_ids.update(used_symbol_ids)
+        parent_state.used_symbol_ids.update(used_symbol_ids)
 
         # propagate to parent which of its children we have collected
         # TODO(tehrengruber): This is expensive for a large tree. Use something like a "ChainSet".
-        parents_collected_child_node_ids.update(collected_child_node_ids)
+        parent_state.collected_child_node_ids.update(collected_child_node_ids)
 
-    def visit_SymRef(self, node: ir.SymRef, *, symtable, used_symbol_ids, **kwargs):
+    def visit_SymRef(self, node: ir.SymRef, *, symtable, state, **kwargs):
         if node.id in symtable:  # root symbol otherwise
-            used_symbol_ids.add(id(symtable[node.id]))
+            state.used_symbol_ids.add(id(symtable[node.id]))
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
@@ -136,7 +136,7 @@ def test_lambda_redef_same_arg_scope():
 
 def test_if_can_deref_no_extraction():
     # Test that a subexpression only occurring in one branch of an `if_` is not moved outside the
-    # if statement.
+    # if statement. A case using `can_deref` is used here as it is common.
 
     # if can_deref(⟪Iₒ, 1ₒ⟫(it)) then ·⟪Iₒ, 1ₒ⟫(it) + ·⟪Iₒ, 1ₒ⟫(it) else 1
     testee = im.if_(
@@ -160,7 +160,7 @@ def test_if_can_deref_no_extraction():
 
 def test_if_can_deref_eligible_extraction():
     # Test that a subexpression only occurring in both branches of an `if_` is moved outside the
-    # if statement.
+    # if statement. A case using `can_deref` is used here as it is common.
 
     # if can_deref(⟪Iₒ, 1ₒ⟫(it)) then ·⟪Iₒ, 1ₒ⟫(it) else ·⟪Iₒ, 1ₒ⟫(it) + ·⟪Iₒ, 1ₒ⟫(it)
     testee = im.if_(

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
@@ -114,14 +114,15 @@ def test_lambda_redef_same_arg_scope():
     def common_expr():
         return im.lambda_("a")(im.plus("a", im.plus(1, 1)))
 
-    # (λ(f1) → (λ(f2) → f1(2) + f2(2))(λ(a) → a + 1))(λ(a) → a + 1)
+    # (λ(f1) → (λ(f2) → f1(2) + f2(2))(λ(a) → a + (1 + 1)))(λ(a) → a + (1 + 1)) + (1 + 1 + (1 + 1))
     testee = im.plus(
         im.let("f1", common_expr())(
             im.let("f2", common_expr())(im.plus(im.call("f1")(2), im.call("f2")(2)))
         ),
         im.plus(im.plus(1, 1), im.plus(1, 1)),
     )
-    # (λ(_cs_1) → (λ(_cs_2) → _cs_2 + _cs_2)(_cs_1(2)))(λ(a) → a + 1)
+    # (λ(_cs_3) → (λ(_cs_1) → (λ(_cs_4) → _cs_4 + _cs_4 + (_cs_3 + _cs_3))(_cs_1(2)))(
+    #   λ(a) → a + _cs_3))(1 + 1)
     expected = im.let("_cs_3", im.plus(1, 1))(
         im.let("_cs_1", im.lambda_("a")(im.plus("a", "_cs_3")))(
             im.let("_cs_4", im.call("_cs_1")(2))(
@@ -133,22 +134,45 @@ def test_lambda_redef_same_arg_scope():
     assert actual == expected
 
 
-def test_if_can_deref():
-    """
-    Test no subexpression is moved outside expressions of the form `if_(can_deref(...), ..., ...)`
-    """
+def test_if_can_deref_no_extraction():
+    # Test that a subexpression only occurring in one branch of an `if_` is not moved outside the
+    # if statement.
+
+    # if can_deref(⟪Iₒ, 1ₒ⟫(it)) then ·⟪Iₒ, 1ₒ⟫(it) + ·⟪Iₒ, 1ₒ⟫(it) else 1
+    testee = im.if_(
+        im.call("can_deref")(im.shift("I", 1)("it")),
+        im.plus(im.deref(im.shift("I", 1)("it")), im.deref(im.shift("I", 1)("it"))),
+        # use something more involved where a subexpression can still be eliminated
+        im.literal("1", "int"),
+    )
+    # (λ(_cs_1) → if can_deref(_cs_1) then (λ(_cs_2) → _cs_2 + _cs_2)(·_cs_1) else 1)(⟪Iₒ, 1ₒ⟫(it))
+    expected = im.let("_cs_1", im.shift("I", 1)("it"))(
+        im.if_(
+            im.call("can_deref")("_cs_1"),
+            im.let("_cs_2", im.deref("_cs_1"))(im.plus("_cs_2", "_cs_2")),
+            im.literal("1", "int"),
+        )
+    )
+
+    actual = CSE().visit(testee)
+    assert actual == expected
+
+
+def test_if_can_deref_eligible_extraction():
+    # Test that a subexpression only occurring in both branches of an `if_` is moved outside the
+    # if statement.
+
     # if can_deref(⟪Iₒ, 1ₒ⟫(it)) then ·⟪Iₒ, 1ₒ⟫(it) else ·⟪Iₒ, 1ₒ⟫(it) + ·⟪Iₒ, 1ₒ⟫(it)
     testee = im.if_(
         im.call("can_deref")(im.shift("I", 1)("it")),
         im.deref(im.shift("I", 1)("it")),
-        # use something more involved where a subexpression can still be eliminated
         im.plus(im.deref(im.shift("I", 1)("it")), im.deref(im.shift("I", 1)("it"))),
     )
-    # if can_deref(⟪Iₒ, 1ₒ⟫(it)) then ·⟪Iₒ, 1ₒ⟫(it) else (λ(_cs_1) → _cs_1 + _cs_1)(·⟪Iₒ, 1ₒ⟫(it))
-    expected = im.if_(
-        im.call("can_deref")(im.shift("I", 1)("it")),
-        im.deref(im.shift("I", 1)("it")),
-        im.let("_cs_1", im.deref(im.shift("I", 1)("it")))(im.plus("_cs_1", "_cs_1")),
+    # (λ(_cs_3) → (λ(_cs_1) → if can_deref(_cs_3) then _cs_1 else _cs_1 + _cs_1)(·_cs_3))(⟪Iₒ, 1ₒ⟫(it))
+    expected = im.let("_cs_3", im.shift("I", 1)("it"))(
+        im.let("_cs_1", im.deref("_cs_3"))(
+            im.if_(im.call("can_deref")("_cs_3"), "_cs_1", im.plus("_cs_1", "_cs_1"))
+        )
     )
 
     actual = CSE().visit(testee)


### PR DESCRIPTION
After #1246 the CSE pass stopped extracting from expressions of the form:
```
if can_deref(⟪Iₒ, 1ₒ⟫(it)) then ·⟪Iₒ, 1ₒ⟫(it) else ·⟪Iₒ, 1ₒ⟫(it) + ·⟪Iₒ, 1ₒ⟫(it)
```
This PR enables extraction for such cases again as long as an expression is used in at least two of the three arguments (condition, true branch, else branch).