### PR TITLE
docs[cartesian]: fix paths in documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,6 +21,7 @@
 - Mariotti, Kean. ETH Zurich - CSCS
 - Müller, Christoph. MeteoSwiss
 - Osuna, Carlos. MeteoSwiss
+- Paone, Edoardo. ETH Zurich - CSCS
 - Röthlin, Matthias. MeteoSwiss
 - Serafini, Giacomo. MeteoSwiss
 - Szenes, Kalman. ETH Zurich - CSCS

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install -r ./gt4py/requirements-dev.txt
 and then build the docs with
 
 ```bash
-cd gt4py/docs
+cd gt4py/docs/user/cartesian
 make html  # run 'make help' for a list of targets
 ```
 

--- a/examples/cartesian/demo_burgers.ipynb
+++ b/examples/cartesian/demo_burgers.ipynb
@@ -95,7 +95,7 @@
     "import numpy as np\n",
     "\n",
     "import gt4py.storage\n",
-    "import gt4py.gtscript as gtscript\n",
+    "import gt4py.cartesian.gtscript as gtscript\n",
     "\n",
     "# use case\n",
     "use_case = \"zhao\"  # \"zhao\", \"hopf_cole\"\n",

--- a/examples/cartesian/demo_horizontal_diffusion.ipynb
+++ b/examples/cartesian/demo_horizontal_diffusion.ipynb
@@ -57,7 +57,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "import gt4py.storage\n",
-    "import gt4py.gtscript as gtscript"
+    "import gt4py.cartesian.gtscript as gtscript"
    ]
   },
   {

--- a/examples/cartesian/demo_isentropic_diagnostics.ipynb
+++ b/examples/cartesian/demo_isentropic_diagnostics.ipynb
@@ -92,7 +92,7 @@
     "import numpy as np\n",
     "\n",
     "import gt4py.storage\n",
-    "import gt4py.gtscript as gtscript\n",
+    "import gt4py.cartesian.gtscript as gtscript\n",
     "\n",
     "# grid size\n",
     "nx = 32\n",


### PR DESCRIPTION
## Description
Some paths in the user documentation had become obsolete, after moving cartesian implementation to inner-level folder.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [x] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
