### PR TITLE
build: freeze typing_extensions version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
     - flake8-eradicate==1.4.0
     - flake8-mutable==1.2.0
     - flake8-pyproject==1.2.3
-    - pygments==2.14.0
+    - pygments==2.15.1
     ##[[[end]]]
     # - flake8-rst-docstrings  # Disabled for now due to random false positives
     exclude: |
@@ -146,9 +146,9 @@ repos:
   ## version = re.search('mypy==([0-9\.]*)', open("constraints.txt").read())[1] 
   ## print(f"#========= FROM constraints.txt: v{version} =========")
   ##]]]
-  #========= FROM constraints.txt: v1.1.1 =========
+  #========= FROM constraints.txt: v1.3.0 =========
   ##[[[end]]]
-  rev: v1.1.1  # MUST match version ^^^^ in constraints.txt (if the mirror is up-to-date)
+  rev: v1.3.0  # MUST match version ^^^^ in constraints.txt (if the mirror is up-to-date)
   hooks:
   - id: mypy
     additional_dependencies:  # versions from constraints.txt
@@ -161,26 +161,26 @@ repos:
     ##     print(f"- {pkg}==" + str(re.search(f'\n{pkg}==([0-9\.]*)', constraints)[1]))
     ##]]]
     - astunparse==1.6.3
-    - attrs==22.2.0
+    - attrs==23.1.0
     - black==23.3.0
     - boltons==23.0.0
     - cached-property==1.5.2
     - click==8.1.3
-    - cmake==3.26.1
+    - cmake==3.26.3
     - cytoolz==0.12.1
     - deepdiff==6.3.0
-    - devtools==0.10.0
-    - frozendict==2.3.6
-    - gridtools-cpp==2.2.3
+    - devtools==0.11.0
+    - frozendict==2.3.8
+    - gridtools-cpp==2.3.0
     - importlib-resources==5.12.0
     - jinja2==3.1.2
     - lark==1.1.5
     - mako==1.2.4
     - ninja==1.11.1
-    - numpy==1.24.2
-    - packaging==23.0
+    - numpy==1.24.3
+    - packaging==23.1
     - pybind11==2.10.4
-    - setuptools==67.6.1
+    - setuptools==67.8.0
     - tabulate==0.9.0
     - typing-extensions==4.5.0
     - xxhash==3.0.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,30 +8,31 @@ aenum==3.1.12             # via dace
 alabaster==0.7.13         # via sphinx
 asttokens==2.2.1          # via devtools
 astunparse==1.6.3 ; python_version < "3.9"  # via dace, gt4py (pyproject.toml)
-attrs==22.2.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, pytest
+attrs==23.1.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema
 babel==2.12.1             # via sphinx
 black==23.3.0             # via gt4py (pyproject.toml)
+blinker==1.6.2            # via flask
 boltons==23.0.0           # via gt4py (pyproject.toml)
 build==0.10.0             # via pip-tools
 cached-property==1.5.2    # via gt4py (pyproject.toml)
 cachetools==5.3.0         # via tox
-certifi==2022.12.7        # via requests
+certifi==2023.5.7         # via requests
 cffi==1.15.1              # via cryptography
 cfgv==3.3.1               # via pre-commit
 chardet==5.1.0            # via tox
 charset-normalizer==3.1.0  # via requests
-clang-format==16.0.0      # via -r requirements-dev.in, gt4py (pyproject.toml)
+clang-format==16.0.4      # via -r requirements-dev.in, gt4py (pyproject.toml)
 click==8.1.3              # via black, flask, gt4py (pyproject.toml), pip-tools
-cmake==3.26.1             # via gt4py (pyproject.toml)
+cmake==3.26.3             # via gt4py (pyproject.toml)
 cogapp==3.3.0             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
-coverage==7.2.2           # via -r requirements-dev.in, pytest-cov
-cryptography==40.0.1      # via types-paramiko, types-pyopenssl, types-redis
+coverage==7.2.6           # via -r requirements-dev.in, pytest-cov
+cryptography==40.0.2      # via types-paramiko, types-pyopenssl, types-redis
 cytoolz==0.12.1           # via gt4py (pyproject.toml)
 dace==0.14.2              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
 deepdiff==6.3.0           # via gt4py (pyproject.toml)
-devtools==0.10.0          # via gt4py (pyproject.toml)
+devtools==0.11.0          # via gt4py (pyproject.toml)
 dill==0.3.6               # via dace
 distlib==0.3.6            # via virtualenv
 docutils==0.18.1          # via restructuredtext-lint, sphinx, sphinx-rtd-theme
@@ -40,9 +41,9 @@ exceptiongroup==1.1.1     # via hypothesis, pytest
 execnet==1.9.0            # via pytest-cache, pytest-xdist
 executing==1.2.0          # via devtools
 factory-boy==3.2.1        # via -r requirements-dev.in, pytest-factoryboy
-faker==18.3.4             # via factory-boy
-fastjsonschema==2.16.3    # via nbformat
-filelock==3.10.7          # via tox, virtualenv
+faker==18.9.0             # via factory-boy
+fastjsonschema==2.17.1    # via nbformat
+filelock==3.12.0          # via tox, virtualenv
 flake8==5.0.4             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
 flake8-bugbear==23.3.12   # via -r requirements-dev.in
 flake8-builtins==2.1.0    # via -r requirements-dev.in
@@ -52,14 +53,14 @@ flake8-eradicate==1.4.0   # via -r requirements-dev.in
 flake8-mutable==1.2.0     # via -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -r requirements-dev.in
-flask==2.2.3              # via dace
-frozendict==2.3.6         # via gt4py (pyproject.toml)
-gridtools-cpp==2.2.3      # via gt4py (pyproject.toml)
-hypothesis==6.70.2        # via -r requirements-dev.in, gt4py (pyproject.toml)
-identify==2.5.22          # via pre-commit
+flask==2.3.2              # via dace
+frozendict==2.3.8         # via gt4py (pyproject.toml)
+gridtools-cpp==2.3.0      # via gt4py (pyproject.toml)
+hypothesis==6.75.3        # via -r requirements-dev.in, gt4py (pyproject.toml)
+identify==2.5.24          # via pre-commit
 idna==3.4                 # via requests
 imagesize==1.4.1          # via sphinx
-importlib-metadata==6.1.0  # via flask, sphinx
+importlib-metadata==6.6.0  # via flask, sphinx
 importlib-resources==5.12.0 ; python_version < "3.9"  # via gt4py (pyproject.toml), jsonschema
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
@@ -77,48 +78,48 @@ mccabe==0.7.0             # via flake8
 mdit-py-plugins==0.3.5    # via jupytext
 mdurl==0.1.2              # via markdown-it-py
 mpmath==1.3.0             # via sympy
-mypy==1.1.1               # via -r requirements-dev.in
+mypy==1.3.0               # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
 nbformat==5.8.0           # via jupytext
 networkx==3.1             # via dace
 ninja==1.11.1             # via gt4py (pyproject.toml)
-nodeenv==1.7.0            # via pre-commit
-numpy==1.24.2             # via dace, gt4py (pyproject.toml), types-jack-client
+nodeenv==1.8.0            # via pre-commit
+numpy==1.24.3             # via dace, gt4py (pyproject.toml), types-jack-client
 ordered-set==4.1.0        # via deepdiff
-packaging==23.0           # via black, build, gt4py (pyproject.toml), pyproject-api, pytest, sphinx, tox
+packaging==23.1           # via black, build, gt4py (pyproject.toml), pyproject-api, pytest, sphinx, tox
 pathspec==0.11.1          # via black
-pip-tools==6.12.3         # via -r requirements-dev.in
-pipdeptree==2.7.0         # via -r requirements-dev.in
+pip-tools==6.13.0         # via -r requirements-dev.in
+pipdeptree==2.7.1         # via -r requirements-dev.in
 pkgutil-resolve-name==1.3.10  # via jsonschema
-platformdirs==3.2.0       # via black, jupyter-core, tox, virtualenv
+platformdirs==3.5.1       # via black, jupyter-core, tox, virtualenv
 pluggy==1.0.0             # via pytest, tox
 ply==3.11                 # via dace
-pre-commit==3.2.2         # via -r requirements-dev.in
-psutil==5.9.4             # via -r requirements-dev.in, pytest-xdist
+pre-commit==3.3.2         # via -r requirements-dev.in
+psutil==5.9.5             # via -r requirements-dev.in, pytest-xdist
 pybind11==2.10.4          # via gt4py (pyproject.toml)
 pycodestyle==2.9.1        # via flake8, flake8-debugger
 pycparser==2.21           # via cffi
 pydocstyle==6.3.0         # via flake8-docstrings
 pyflakes==2.5.0           # via flake8
-pygments==2.14.0          # via -r requirements-dev.in, flake8-rst-docstrings, sphinx
+pygments==2.15.1          # via -r requirements-dev.in, flake8-rst-docstrings, sphinx
 pyproject-api==1.5.1      # via tox
 pyproject-hooks==1.0.0    # via build
 pyrsistent==0.19.3        # via jsonschema
-pytest==7.2.2             # via -r requirements-dev.in, gt4py (pyproject.toml), pytest-cache, pytest-cov, pytest-factoryboy, pytest-xdist
+pytest==7.3.1             # via -r requirements-dev.in, gt4py (pyproject.toml), pytest-cache, pytest-cov, pytest-factoryboy, pytest-xdist
 pytest-cache==1.0         # via -r requirements-dev.in
 pytest-cov==4.0.0         # via -r requirements-dev.in
 pytest-factoryboy==2.5.1  # via -r requirements-dev.in
-pytest-xdist==3.2.1       # via -r requirements-dev.in
+pytest-xdist==3.3.1       # via -r requirements-dev.in
 python-dateutil==2.8.2    # via faker
 pytz==2023.3              # via babel
 pyyaml==6.0               # via dace, jupytext, pre-commit
-requests==2.28.2          # via dace, sphinx
+requests==2.31.0          # via dace, sphinx
 restructuredtext-lint==1.4.0  # via flake8-rst-docstrings
 six==1.16.0               # via asttokens, astunparse, python-dateutil
 snowballstemmer==2.2.0    # via pydocstyle, sphinx
 sortedcontainers==2.4.0   # via hypothesis
-sphinx==6.1.3             # via -r requirements-dev.in, sphinx-rtd-theme, sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.0   # via -r requirements-dev.in
+sphinx==6.2.1             # via -r requirements-dev.in, sphinx-rtd-theme, sphinxcontrib-jquery
+sphinx-rtd-theme==1.2.1   # via -r requirements-dev.in
 sphinxcontrib-applehelp==1.0.4  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==2.0.1  # via sphinx
@@ -131,26 +132,26 @@ tabulate==0.9.0           # via gt4py (pyproject.toml)
 toml==0.10.2              # via jupytext
 tomli==2.0.1              # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, mypy, pyproject-api, pyproject-hooks, pytest, tox
 toolz==0.12.0             # via cytoolz
-tox==4.4.8                # via -r requirements-dev.in
+tox==4.5.1                # via -r requirements-dev.in
 traitlets==5.9.0          # via jupyter-core, nbformat
-types-aiofiles==23.1.0.1  # via types-all
+types-aiofiles==23.1.0.3  # via types-all
 types-all==1.0.0          # via -r requirements-dev.in
 types-annoy==1.17.8.3     # via types-all
 types-atomicwrites==1.4.5.1  # via types-all
 types-backports==0.1.3    # via types-all
 types-backports-abc==0.5.2  # via types-all
-types-bleach==6.0.0.2     # via types-all
-types-boto==2.49.18.7     # via types-all
+types-bleach==6.0.0.3     # via types-all
+types-boto==2.49.18.8     # via types-all
 types-cachetools==5.3.0.5  # via types-all
 types-certifi==2021.10.8.3  # via types-all
-types-cffi==1.15.1.10     # via types-jack-client
+types-cffi==1.15.1.13     # via types-jack-client
 types-characteristic==14.3.7  # via types-all
-types-chardet==5.0.4.3    # via types-all
+types-chardet==5.0.4.6    # via types-all
 types-click==7.1.8        # via types-all, types-flask
 types-click-spinner==0.1.13.4  # via types-all
 types-colorama==0.4.15.11  # via types-all
 types-contextvars==2.4.7.2  # via types-all
-types-croniter==1.3.2.7   # via types-all
+types-croniter==1.3.2.9   # via types-all
 types-cryptography==3.3.23.2  # via types-all, types-openssl-python, types-pyjwt
 types-dataclasses==0.6.6  # via types-all
 types-dateparser==1.1.4.9  # via types-all
@@ -158,7 +159,7 @@ types-datetimerange==2.0.0.5  # via types-all
 types-decorator==5.1.8.3  # via types-all
 types-deprecated==1.2.9.2  # via types-all
 types-docopt==0.6.11.3    # via types-all
-types-docutils==0.19.1.7  # via types-all
+types-docutils==0.20.0.1  # via types-all
 types-emoji==2.1.0.3      # via types-all
 types-enum34==1.1.8       # via types-all
 types-fb303==1.0.0        # via types-all, types-scribe
@@ -174,7 +175,7 @@ types-itsdangerous==1.1.6  # via types-all
 types-jack-client==0.5.10.8  # via types-all
 types-jinja2==2.11.9      # via types-all, types-flask
 types-kazoo==0.1.3        # via types-all
-types-markdown==3.4.2.7   # via types-all
+types-markdown==3.4.2.9   # via types-all
 types-markupsafe==1.1.10  # via types-all, types-jinja2
 types-maxminddb==1.5.0    # via types-all, types-geoip2
 types-mock==5.0.0.6       # via types-all
@@ -182,33 +183,33 @@ types-mypy-extensions==1.0.0.3  # via types-all
 types-nmap==0.1.6         # via types-all
 types-openssl-python==0.1.3  # via types-all
 types-orjson==3.6.2       # via types-all
-types-paramiko==3.0.0.7   # via types-all, types-pysftp
+types-paramiko==3.0.0.10  # via types-all, types-pysftp
 types-pathlib2==2.3.0     # via types-all
-types-pillow==9.4.0.19    # via types-all
+types-pillow==9.5.0.4     # via types-all
 types-pkg-resources==0.1.3  # via types-all
 types-polib==1.2.0.0      # via types-all
-types-protobuf==4.22.0.2  # via types-all
+types-protobuf==4.23.0.1  # via types-all
 types-pyaudio==0.2.16.6   # via types-all
 types-pycurl==7.45.2.4    # via types-all
 types-pyfarmhash==0.3.1.1  # via types-all
 types-pyjwt==1.7.1        # via types-all
 types-pymssql==2.1.0      # via types-all
-types-pymysql==1.0.19.6   # via types-all
-types-pyopenssl==23.1.0.1  # via types-redis
+types-pymysql==1.0.19.7   # via types-all
+types-pyopenssl==23.1.0.3  # via types-redis
 types-pyrfc3339==1.1.1.4  # via types-all
 types-pysftp==0.2.17.5    # via types-all
-types-python-dateutil==2.8.19.12  # via types-all, types-datetimerange
+types-python-dateutil==2.8.19.13  # via types-all, types-datetimerange
 types-python-gflags==3.1.7.2  # via types-all
 types-python-slugify==8.0.0.2  # via types-all
 types-pytz==2023.3.0.0    # via types-all, types-tzlocal
-types-pyvmomi==8.0.0.1    # via types-all
-types-pyyaml==6.0.12.9    # via types-all
-types-redis==4.5.4.1      # via types-all
-types-requests==2.28.11.17  # via types-all
+types-pyvmomi==8.0.0.4    # via types-all
+types-pyyaml==6.0.12.10   # via types-all
+types-redis==4.5.5.2      # via types-all
+types-requests==2.31.0.0  # via types-all
 types-retry==0.9.9.3      # via types-all
 types-routes==2.5.0       # via types-all
 types-scribe==2.0.0       # via types-all
-types-simplejson==3.18.0.3  # via types-all
+types-simplejson==3.19.0.1  # via types-all
 types-singledispatch==4.0.0.1  # via types-all
 types-six==1.16.21.8      # via types-all
 types-tabulate==0.9.0.2   # via types-all
@@ -216,21 +217,21 @@ types-termcolor==1.1.6.2  # via types-all
 types-toml==0.10.8.6      # via types-all
 types-tornado==5.1.1      # via types-all
 types-typed-ast==1.5.8.6  # via types-all
-types-tzlocal==4.3.0.0    # via types-all
-types-ujson==5.7.0.1      # via types-all
-types-urllib3==1.26.25.10  # via types-requests
-types-waitress==2.1.4.7   # via types-all
+types-tzlocal==5.0.1.0    # via types-all
+types-ujson==5.7.0.5      # via types-all
+types-urllib3==1.26.25.13  # via types-requests
+types-waitress==2.1.4.8   # via types-all
 types-werkzeug==1.0.9     # via types-all, types-flask
 types-xxhash==3.0.5.2     # via types-all
 typing-extensions==4.5.0  # via black, gt4py (pyproject.toml), mypy, pytest-factoryboy
-urllib3==1.26.15          # via requests
-virtualenv==20.21.0       # via pre-commit, tox
-websockets==11.0          # via dace
-werkzeug==2.2.3           # via flask
+urllib3==2.0.2            # via requests
+virtualenv==20.23.0       # via pre-commit, tox
+websockets==11.0.3        # via dace
+werkzeug==2.3.4           # via flask
 wheel==0.40.0             # via astunparse, pip-tools
 xxhash==3.0.0             # via gt4py (pyproject.toml)
 zipp==3.15.0              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1               # via pip-tools
-setuptools==67.6.1        # via gt4py (pyproject.toml), nodeenv, pip-tools
+pip==23.1.2               # via pip-tools
+setuptools==67.8.0        # via gt4py (pyproject.toml), nodeenv, pip-tools

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -40,7 +40,7 @@ flake8-pyproject==1.2.2
 flake8-rst-docstrings==0.0.14
 flake8==5.0.4
 frozendict==2.3
-gridtools-cpp==2.2.3
+gridtools-cpp==2.3.0
 hypothesis==6.0.0
 importlib-resources==5.0;python_version<'3.9'
 isort==5.10

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -38,7 +38,7 @@ flake8-pyproject==1.2.2
 flake8-rst-docstrings==0.0.14
 flake8==5.0.4
 frozendict==2.3
-gridtools-cpp==2.2.3
+gridtools-cpp==2.3.0
 hypothesis==6.0.0
 importlib-resources==5.0;python_version<'3.9'
 isort==5.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=60.6", "wheel", "cython"]
+build-backend = 'setuptools.build_meta'
+requires = ['setuptools>=60.6', 'wheel', 'cython']
 
 # ---- Project description ----
 # -- Standard options (PEP 621) --
@@ -24,29 +24,29 @@ classifiers = [
 ]
 dependencies = [
   "astunparse>=1.6.3;python_version<'3.9'",
-  "attrs>=21.3",
-  "black>=22.3",
-  "boltons>=20.1",
-  "cached-property>=1.5.1",
-  "click>=8.0.0",
-  "cmake>=3.22",
-  "cytoolz>=0.12.0",
-  "deepdiff>=5.6.0",
-  "devtools>=0.6",
-  "frozendict>=2.3",
-  "gridtools-cpp>=2.3.0,==2.*",
+  'attrs>=21.3',
+  'black>=22.3',
+  'boltons>=20.1',
+  'cached-property>=1.5.1',
+  'click>=8.0.0',
+  'cmake>=3.22',
+  'cytoolz>=0.12.0',
+  'deepdiff>=5.6.0',
+  'devtools>=0.6',
+  'frozendict>=2.3',
+  'gridtools-cpp>=2.3.0,==2.*',
   "importlib-resources>=5.0;python_version<'3.9'",
-  "jinja2>=3.0.0",
-  "lark>=1.1.2",
-  "mako>=1.1",
-  "ninja>=1.10",
-  "numpy>=1.21.2",
-  "packaging>=20.0",
-  "pybind11>=2.5",
-  "setuptools>=65.5.0",
-  "tabulate>=0.8.10",
-  "typing-extensions>=4.2",
-  "xxhash>=1.4.4,<3.1.0"
+  'jinja2>=3.0.0',
+  'lark>=1.1.2',
+  'mako>=1.1',
+  'ninja>=1.10',
+  'numpy>=1.21.2',
+  'packaging>=20.0',
+  'pybind11>=2.5',
+  'setuptools>=65.5.0',
+  'tabulate>=0.8.10',
+  'typing-extensions>=4.2,<4.6.0',
+  'xxhash>=1.4.4,<3.1.0'
 ]
 description = 'Python library for generating high-performance implementations of stencil kernels for weather and climate modeling from a domain-specific language (DSL)'
 dynamic = ['version']
@@ -65,37 +65,37 @@ readme = 'README.md'
 requires-python = '>=3.8'
 
 [project.optional-dependencies]
-cuda = ["cupy"]
-cuda110 = ["cupy-cuda110"]
-cuda111 = ["cupy-cuda111"]
-cuda112 = ["cupy-cuda112"]
-cuda113 = ["cupy-cuda113"]
-cuda114 = ["cupy-cuda114"]
-cuda115 = ["cupy-cuda115"]
-cuda116 = ["cupy-cuda116"]
-cuda117 = ["cupy-cuda117"]
-cuda11x = ["cupy-cuda11x"]
-dace = ["dace>=0.14.2,<0.15", "sympy>=1.7"]
-formatting = ["clang-format>=9.0"]
+cuda = ['cupy']
+cuda110 = ['cupy-cuda110']
+cuda111 = ['cupy-cuda111']
+cuda112 = ['cupy-cuda112']
+cuda113 = ['cupy-cuda113']
+cuda114 = ['cupy-cuda114']
+cuda115 = ['cupy-cuda115']
+cuda116 = ['cupy-cuda116']
+cuda117 = ['cupy-cuda117']
+cuda11x = ['cupy-cuda11x']
+dace = ['dace>=0.14.2,<0.15', 'sympy>=1.7']
+formatting = ['clang-format>=9.0']
 # Always add all extra packages to 'full' for a simple full gt4py installation
 full = [
-  "clang-format>=9.0",
-  "dace>=0.14.2,<0.15",
-  "hypothesis>=6.0.0",
-  "pytest>=7.0",
-  "sympy>=1.7",
-  "scipy>=1.7.2"
+  'clang-format>=9.0',
+  'dace>=0.14.2,<0.15',
+  'hypothesis>=6.0.0',
+  'pytest>=7.0',
+  'sympy>=1.7',
+  'scipy>=1.7.2'
 ]
-performance = ["scipy>=1.7.2"]
-testing = ["hypothesis>=6.0.0", "pytest>=7.0"]
+performance = ['scipy>=1.7.2']
+testing = ['hypothesis>=6.0.0', 'pytest>=7.0']
 
 [project.scripts]
-gtpyc = "gt4py.cartesian.cli:gtpyc"
+gtpyc = 'gt4py.cartesian.cli:gtpyc'
 
 [project.urls]
-Documentation = "https://gridtools.github.io/gt4py"
-Homepage = "https://gridtools.github.io/"
-Source = "https://github.com/GridTools/gt4py"
+Documentation = 'https://gridtools.github.io/gt4py'
+Homepage = 'https://gridtools.github.io/'
+Source = 'https://github.com/GridTools/gt4py'
 
 # ---- Other tools ----
 # -- black --
@@ -169,7 +169,7 @@ ignore = [
   'W503'  # Line break occurred before a binary operator
 ]
 max-complexity = 15
-max-line-length = 100
+max-line-length = 100  # It should be the same as in `tool.black.line-length` above
 per-file-ignores = ['src/gt4py/eve/extended_typing.py:F401,F405']
 rst-roles = [
   'py:mod, mod',
@@ -214,7 +214,7 @@ known_third_party = [
   'xxhash'
 ]
 lexicographical = true
-line_length = 100
+line_length = 100  # It should be the same as in `tool.black.line-length` above
 lines_after_imports = 2
 profile = 'black'
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'TESTS', 'LOCALFOLDER']
@@ -338,7 +338,77 @@ markers = [
 norecursedirs = ['dist', 'build', 'cpp_backend_tests/build*', '_local/*', '.*']
 testpaths = 'tests'
 
-# -- Setuptools-specific --
+# -- ruff --
+[tool.ruff]
+ignore = [
+  'E501',
+  'B008',  # Do not perform function calls in argument defaults
+  'B028',  # Consider replacing f"'{foo}'" with f"{foo!r}"  # TODO: review
+  'B905'  # B905 `zip()` without an explicit `strict=` parameter  # TODO: review
+]
+ignore-init-module-imports = true
+line-length = 100  # It should be the same as in `tool.black.line-length` above
+respect-gitignore = true
+# Rules:
+# E: pycodestyle
+# F: Pyflakes
+# I: isort
+# B: flake8-bugbear
+# A: flake8-builtins
+# T100: flake8-debugger
+# ERA: eradicate
+# NPY: NumPy-specific rules
+# RUF: Ruff-specific rules
+select = ['E', 'F', 'I', 'B', 'A', 'T100', 'ERA', 'NPY', 'RUF']
+show-fixes = true
+# show-source = true
+target-version = 'py310'
+typing-modules = ['gt4py.eve.extended_typing']
+unfixable = []
+
+[tool.ruff.isort]
+combine-as-imports = true
+# force-wrap-aliases = true
+known-first-party = ['gt4py', '__externals__', '__gtscript__']
+known-third-party = [
+  'attr',
+  'black',
+  'boltons',
+  'cached_property',
+  'click',
+  'dace',
+  'devtools',
+  'factory',
+  'hypothesis',
+  'importlib_resources',
+  'jinja2',
+  'mako',
+  'networkx',
+  'numpy',
+  'packaging',
+  'pybind11',
+  'pytest',
+  'pytest_factoryboy',
+  'setuptools',
+  'tabulate',
+  'typing_extensions',
+  'xxhash'
+]
+lines-after-imports = 2
+order-by-type = true
+section-order = ['future', 'standard-library', 'third-party', 'first-party', 'tests', 'local-folder']
+split-on-trailing-comma = false
+
+[tool.ruff.isort.sections]
+'tests' = ['cartesian_tests', 'eve_tests', 'next_tests', 'storage_tests']
+
+[tool.ruff.mccabe]
+max-complexity = 15
+
+[tool.ruff.per-file-ignores]
+'src/gt4py/eve/extended_typing.py' = ['F401', 'F405']
+
+# -- setuptools build backend --
 [tool.setuptools]
 platforms = ['Linux', 'Mac']
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,30 +8,31 @@ aenum==3.1.12             # via dace
 alabaster==0.7.13         # via sphinx
 asttokens==2.2.1          # via devtools
 astunparse==1.6.3 ; python_version < "3.9"  # via dace, gt4py (pyproject.toml)
-attrs==22.2.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, pytest
+attrs==23.1.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema
 babel==2.12.1             # via sphinx
 black==23.3.0             # via gt4py (pyproject.toml)
+blinker==1.6.2            # via flask
 boltons==23.0.0           # via gt4py (pyproject.toml)
 build==0.10.0             # via pip-tools
 cached-property==1.5.2    # via gt4py (pyproject.toml)
 cachetools==5.3.0         # via tox
-certifi==2022.12.7        # via requests
+certifi==2023.5.7         # via requests
 cffi==1.15.1              # via cryptography
 cfgv==3.3.1               # via pre-commit
 chardet==5.1.0            # via tox
 charset-normalizer==3.1.0  # via requests
-clang-format==16.0.0      # via -r requirements-dev.in, gt4py (pyproject.toml)
+clang-format==16.0.4      # via -r requirements-dev.in, gt4py (pyproject.toml)
 click==8.1.3              # via black, flask, gt4py (pyproject.toml), pip-tools
-cmake==3.26.1             # via gt4py (pyproject.toml)
+cmake==3.26.3             # via gt4py (pyproject.toml)
 cogapp==3.3.0             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
-coverage[toml]==7.2.2     # via -r requirements-dev.in, pytest-cov
-cryptography==40.0.1      # via types-paramiko, types-pyopenssl, types-redis
+coverage[toml]==7.2.6     # via -r requirements-dev.in, pytest-cov
+cryptography==40.0.2      # via types-paramiko, types-pyopenssl, types-redis
 cytoolz==0.12.1           # via gt4py (pyproject.toml)
 dace==0.14.2              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
 deepdiff==6.3.0           # via gt4py (pyproject.toml)
-devtools==0.10.0          # via gt4py (pyproject.toml)
+devtools==0.11.0          # via gt4py (pyproject.toml)
 dill==0.3.6               # via dace
 distlib==0.3.6            # via virtualenv
 docutils==0.18.1          # via restructuredtext-lint, sphinx, sphinx-rtd-theme
@@ -40,9 +41,9 @@ exceptiongroup==1.1.1     # via hypothesis, pytest
 execnet==1.9.0            # via pytest-cache, pytest-xdist
 executing==1.2.0          # via devtools
 factory-boy==3.2.1        # via -r requirements-dev.in, pytest-factoryboy
-faker==18.3.4             # via factory-boy
-fastjsonschema==2.16.3    # via nbformat
-filelock==3.10.7          # via tox, virtualenv
+faker==18.9.0             # via factory-boy
+fastjsonschema==2.17.1    # via nbformat
+filelock==3.12.0          # via tox, virtualenv
 flake8==5.0.4             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
 flake8-bugbear==23.3.12   # via -r requirements-dev.in
 flake8-builtins==2.1.0    # via -r requirements-dev.in
@@ -52,14 +53,14 @@ flake8-eradicate==1.4.0   # via -r requirements-dev.in
 flake8-mutable==1.2.0     # via -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -r requirements-dev.in
-flask==2.2.3              # via dace
-frozendict==2.3.6         # via gt4py (pyproject.toml)
+flask==2.3.2              # via dace
+frozendict==2.3.8         # via gt4py (pyproject.toml)
 gridtools-cpp==2.3.0      # via gt4py (pyproject.toml)
-hypothesis==6.70.2        # via -r requirements-dev.in, gt4py (pyproject.toml)
-identify==2.5.22          # via pre-commit
+hypothesis==6.75.3        # via -r requirements-dev.in, gt4py (pyproject.toml)
+identify==2.5.24          # via pre-commit
 idna==3.4                 # via requests
 imagesize==1.4.1          # via sphinx
-importlib-metadata==6.1.0  # via flask, sphinx
+importlib-metadata==6.6.0  # via flask, sphinx
 importlib-resources==5.12.0 ; python_version < "3.9"  # via gt4py (pyproject.toml), jsonschema
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
@@ -77,48 +78,48 @@ mccabe==0.7.0             # via flake8
 mdit-py-plugins==0.3.5    # via jupytext
 mdurl==0.1.2              # via markdown-it-py
 mpmath==1.3.0             # via sympy
-mypy==1.1.1               # via -r requirements-dev.in
+mypy==1.3.0               # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
 nbformat==5.8.0           # via jupytext
 networkx==3.1             # via dace
 ninja==1.11.1             # via gt4py (pyproject.toml)
-nodeenv==1.7.0            # via pre-commit
-numpy==1.24.2             # via dace, gt4py (pyproject.toml), types-jack-client
+nodeenv==1.8.0            # via pre-commit
+numpy==1.24.3             # via dace, gt4py (pyproject.toml), types-jack-client
 ordered-set==4.1.0        # via deepdiff
-packaging==23.0           # via black, build, gt4py (pyproject.toml), pyproject-api, pytest, sphinx, tox
+packaging==23.1           # via black, build, gt4py (pyproject.toml), pyproject-api, pytest, sphinx, tox
 pathspec==0.11.1          # via black
-pip-tools==6.12.3         # via -r requirements-dev.in
-pipdeptree==2.7.0         # via -r requirements-dev.in
+pip-tools==6.13.0         # via -r requirements-dev.in
+pipdeptree==2.7.1         # via -r requirements-dev.in
 pkgutil-resolve-name==1.3.10  # via jsonschema
-platformdirs==3.2.0       # via black, jupyter-core, tox, virtualenv
+platformdirs==3.5.1       # via black, jupyter-core, tox, virtualenv
 pluggy==1.0.0             # via pytest, tox
 ply==3.11                 # via dace
-pre-commit==3.2.2         # via -r requirements-dev.in
-psutil==5.9.4             # via -r requirements-dev.in, pytest-xdist
+pre-commit==3.3.2         # via -r requirements-dev.in
+psutil==5.9.5             # via -r requirements-dev.in, pytest-xdist
 pybind11==2.10.4          # via gt4py (pyproject.toml)
 pycodestyle==2.9.1        # via flake8, flake8-debugger
 pycparser==2.21           # via cffi
 pydocstyle==6.3.0         # via flake8-docstrings
 pyflakes==2.5.0           # via flake8
-pygments==2.14.0          # via -r requirements-dev.in, flake8-rst-docstrings, sphinx
+pygments==2.15.1          # via -r requirements-dev.in, flake8-rst-docstrings, sphinx
 pyproject-api==1.5.1      # via tox
 pyproject-hooks==1.0.0    # via build
 pyrsistent==0.19.3        # via jsonschema
-pytest==7.2.2             # via -r requirements-dev.in, gt4py (pyproject.toml), pytest-cache, pytest-cov, pytest-factoryboy, pytest-xdist
+pytest==7.3.1             # via -r requirements-dev.in, gt4py (pyproject.toml), pytest-cache, pytest-cov, pytest-factoryboy, pytest-xdist
 pytest-cache==1.0         # via -r requirements-dev.in
 pytest-cov==4.0.0         # via -r requirements-dev.in
 pytest-factoryboy==2.5.1  # via -r requirements-dev.in
-pytest-xdist[psutil]==3.2.1  # via -r requirements-dev.in
+pytest-xdist[psutil]==3.3.1  # via -r requirements-dev.in
 python-dateutil==2.8.2    # via faker
 pytz==2023.3              # via babel
 pyyaml==6.0               # via dace, jupytext, pre-commit
-requests==2.28.2          # via dace, sphinx
+requests==2.31.0          # via dace, sphinx
 restructuredtext-lint==1.4.0  # via flake8-rst-docstrings
 six==1.16.0               # via asttokens, astunparse, python-dateutil
 snowballstemmer==2.2.0    # via pydocstyle, sphinx
 sortedcontainers==2.4.0   # via hypothesis
-sphinx==6.1.3             # via -r requirements-dev.in, sphinx-rtd-theme, sphinxcontrib-jquery
-sphinx-rtd-theme==1.2.0   # via -r requirements-dev.in
+sphinx==6.2.1             # via -r requirements-dev.in, sphinx-rtd-theme, sphinxcontrib-jquery
+sphinx-rtd-theme==1.2.1   # via -r requirements-dev.in
 sphinxcontrib-applehelp==1.0.4  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==2.0.1  # via sphinx
@@ -131,26 +132,26 @@ tabulate==0.9.0           # via gt4py (pyproject.toml)
 toml==0.10.2              # via jupytext
 tomli==2.0.1              # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, mypy, pyproject-api, pyproject-hooks, pytest, tox
 toolz==0.12.0             # via cytoolz
-tox==4.4.8                # via -r requirements-dev.in
+tox==4.5.1                # via -r requirements-dev.in
 traitlets==5.9.0          # via jupyter-core, nbformat
-types-aiofiles==23.1.0.1  # via types-all
+types-aiofiles==23.1.0.3  # via types-all
 types-all==1.0.0          # via -r requirements-dev.in
 types-annoy==1.17.8.3     # via types-all
 types-atomicwrites==1.4.5.1  # via types-all
 types-backports==0.1.3    # via types-all
 types-backports-abc==0.5.2  # via types-all
-types-bleach==6.0.0.2     # via types-all
-types-boto==2.49.18.7     # via types-all
+types-bleach==6.0.0.3     # via types-all
+types-boto==2.49.18.8     # via types-all
 types-cachetools==5.3.0.5  # via types-all
 types-certifi==2021.10.8.3  # via types-all
-types-cffi==1.15.1.10     # via types-jack-client
+types-cffi==1.15.1.13     # via types-jack-client
 types-characteristic==14.3.7  # via types-all
-types-chardet==5.0.4.3    # via types-all
+types-chardet==5.0.4.6    # via types-all
 types-click==7.1.8        # via types-all, types-flask
 types-click-spinner==0.1.13.4  # via types-all
 types-colorama==0.4.15.11  # via types-all
 types-contextvars==2.4.7.2  # via types-all
-types-croniter==1.3.2.7   # via types-all
+types-croniter==1.3.2.9   # via types-all
 types-cryptography==3.3.23.2  # via types-all, types-openssl-python, types-pyjwt
 types-dataclasses==0.6.6  # via types-all
 types-dateparser==1.1.4.9  # via types-all
@@ -158,7 +159,7 @@ types-datetimerange==2.0.0.5  # via types-all
 types-decorator==5.1.8.3  # via types-all
 types-deprecated==1.2.9.2  # via types-all
 types-docopt==0.6.11.3    # via types-all
-types-docutils==0.19.1.7  # via types-all
+types-docutils==0.20.0.1  # via types-all
 types-emoji==2.1.0.3      # via types-all
 types-enum34==1.1.8       # via types-all
 types-fb303==1.0.0        # via types-all, types-scribe
@@ -174,7 +175,7 @@ types-itsdangerous==1.1.6  # via types-all
 types-jack-client==0.5.10.8  # via types-all
 types-jinja2==2.11.9      # via types-all, types-flask
 types-kazoo==0.1.3        # via types-all
-types-markdown==3.4.2.7   # via types-all
+types-markdown==3.4.2.9   # via types-all
 types-markupsafe==1.1.10  # via types-all, types-jinja2
 types-maxminddb==1.5.0    # via types-all, types-geoip2
 types-mock==5.0.0.6       # via types-all
@@ -182,33 +183,33 @@ types-mypy-extensions==1.0.0.3  # via types-all
 types-nmap==0.1.6         # via types-all
 types-openssl-python==0.1.3  # via types-all
 types-orjson==3.6.2       # via types-all
-types-paramiko==3.0.0.7   # via types-all, types-pysftp
+types-paramiko==3.0.0.10  # via types-all, types-pysftp
 types-pathlib2==2.3.0     # via types-all
-types-pillow==9.4.0.19    # via types-all
+types-pillow==9.5.0.4     # via types-all
 types-pkg-resources==0.1.3  # via types-all
 types-polib==1.2.0.0      # via types-all
-types-protobuf==4.22.0.2  # via types-all
+types-protobuf==4.23.0.1  # via types-all
 types-pyaudio==0.2.16.6   # via types-all
 types-pycurl==7.45.2.4    # via types-all
 types-pyfarmhash==0.3.1.1  # via types-all
 types-pyjwt==1.7.1        # via types-all
 types-pymssql==2.1.0      # via types-all
-types-pymysql==1.0.19.6   # via types-all
-types-pyopenssl==23.1.0.1  # via types-redis
+types-pymysql==1.0.19.7   # via types-all
+types-pyopenssl==23.1.0.3  # via types-redis
 types-pyrfc3339==1.1.1.4  # via types-all
 types-pysftp==0.2.17.5    # via types-all
-types-python-dateutil==2.8.19.12  # via types-all, types-datetimerange
+types-python-dateutil==2.8.19.13  # via types-all, types-datetimerange
 types-python-gflags==3.1.7.2  # via types-all
 types-python-slugify==8.0.0.2  # via types-all
 types-pytz==2023.3.0.0    # via types-all, types-tzlocal
-types-pyvmomi==8.0.0.1    # via types-all
-types-pyyaml==6.0.12.9    # via types-all
-types-redis==4.5.4.1      # via types-all
-types-requests==2.28.11.17  # via types-all
+types-pyvmomi==8.0.0.4    # via types-all
+types-pyyaml==6.0.12.10   # via types-all
+types-redis==4.5.5.2      # via types-all
+types-requests==2.31.0.0  # via types-all
 types-retry==0.9.9.3      # via types-all
 types-routes==2.5.0       # via types-all
 types-scribe==2.0.0       # via types-all
-types-simplejson==3.18.0.3  # via types-all
+types-simplejson==3.19.0.1  # via types-all
 types-singledispatch==4.0.0.1  # via types-all
 types-six==1.16.21.8      # via types-all
 types-tabulate==0.9.0.2   # via types-all
@@ -216,21 +217,21 @@ types-termcolor==1.1.6.2  # via types-all
 types-toml==0.10.8.6      # via types-all
 types-tornado==5.1.1      # via types-all
 types-typed-ast==1.5.8.6  # via types-all
-types-tzlocal==4.3.0.0    # via types-all
-types-ujson==5.7.0.1      # via types-all
-types-urllib3==1.26.25.10  # via types-requests
-types-waitress==2.1.4.7   # via types-all
+types-tzlocal==5.0.1.0    # via types-all
+types-ujson==5.7.0.5      # via types-all
+types-urllib3==1.26.25.13  # via types-requests
+types-waitress==2.1.4.8   # via types-all
 types-werkzeug==1.0.9     # via types-all, types-flask
 types-xxhash==3.0.5.2     # via types-all
 typing-extensions==4.5.0  # via black, gt4py (pyproject.toml), mypy, pytest-factoryboy
-urllib3==1.26.15          # via requests
-virtualenv==20.21.0       # via pre-commit, tox
-websockets==11.0          # via dace
-werkzeug==2.2.3           # via flask
+urllib3==2.0.2            # via requests
+virtualenv==20.23.0       # via pre-commit, tox
+websockets==11.0.3        # via dace
+werkzeug==2.3.4           # via flask
 wheel==0.40.0             # via astunparse, pip-tools
 xxhash==3.0.0             # via gt4py (pyproject.toml)
 zipp==3.15.0              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1               # via pip-tools
-setuptools==67.6.1        # via gt4py (pyproject.toml), nodeenv, pip-tools
+pip==23.1.2               # via pip-tools
+setuptools==67.8.0        # via gt4py (pyproject.toml), nodeenv, pip-tools

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -35,7 +35,7 @@ from typing import *  # noqa: F403
 from typing import overload  # Only needed to avoid false flake8 errors
 
 import typing_extensions as _typing_extensions
-from typing_extensions import *  # type: ignore[assignment]  # noqa: F403
+from typing_extensions import *  # type: ignore[assignment,no-redef]  # noqa: F403
 
 
 if _sys.version_info >= (3, 9):
@@ -246,7 +246,7 @@ class NonProtocolABCMeta(_typing._ProtocolMeta):
     """Subclass of :cls:`typing.Protocol`'s metaclass doing instance and subclass checks as ABCMeta."""
 
     __instancecheck__ = _abc.ABCMeta.__instancecheck__  # type: ignore[assignment]
-    __subclasshook__ = None
+    __subclasshook__ = None  # type: ignore[assignment]
 
 
 _ProtoT = TypeVar("_ProtoT", bound=_abc.ABCMeta)
@@ -378,7 +378,7 @@ def extended_runtime_checkable(  # noqa: C901  # too complex but unavoidable
                         return NotImplemented
                 return True
 
-            cls.__subclasshook__ = _patched_proto_hook  # type: ignore[attr-defined]
+            cls.__subclasshook__ = _patched_proto_hook  # type: ignore[attr-defined,method-assign]
 
         return cls
 


### PR DESCRIPTION
## Description

Update project configuration to freeze required version of typing_extension to avoid breaking changes in latest versions.

Other changes:
- Add `ruff` tool configuration
- Minor format fixes in pyproject.toml
