### PR TITLE
refactor[next]: Change default datatype for tests to float

### DIFF
--- a/tests/next_tests/integration_tests/feature_tests/cases.py
+++ b/tests/next_tests/integration_tests/feature_tests/cases.py
@@ -50,8 +50,8 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
 IField: TypeAlias = common.Field[[IDim], np.float64]  # type: ignore [valid-type]
 IJKField: TypeAlias = common.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
 IJKIntField: TypeAlias = common.Field[[IDim, JDim, KDim], np.int64]  # type: ignore [valid-type]
-VField: TypeAlias = common.Field[[Vertex], np.int64]  # type: ignore [valid-type]
-EField: TypeAlias = common.Field[[Edge], np.int64]  # type: ignore [valid-type]
+VField: TypeAlias = common.Field[[Vertex], np.float64]  # type: ignore [valid-type]
+EField: TypeAlias = common.Field[[Edge], np.float64]  # type: ignore [valid-type]
 
 # TODO(ricoh): unify the following with the `ffront_test_utils.reduction_setup`
 #   fixture if `ffront_test_utils.reduction_setup` is not completely superseded

--- a/tests/next_tests/integration_tests/feature_tests/cases.py
+++ b/tests/next_tests/integration_tests/feature_tests/cases.py
@@ -49,7 +49,6 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
 # mypy does not accept [IDim, ...] as a type
 IField: TypeAlias = common.Field[[IDim], np.float64]  # type: ignore [valid-type]
 IJKField: TypeAlias = common.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
-IJKIntField: TypeAlias = common.Field[[IDim, JDim, KDim], np.int64]  # type: ignore [valid-type]
 VField: TypeAlias = common.Field[[Vertex], np.float64]  # type: ignore [valid-type]
 EField: TypeAlias = common.Field[[Edge], np.float64]  # type: ignore [valid-type]
 

--- a/tests/next_tests/integration_tests/feature_tests/cases.py
+++ b/tests/next_tests/integration_tests/feature_tests/cases.py
@@ -47,9 +47,9 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
 
 
 # mypy does not accept [IDim, ...] as a type
-IField: TypeAlias = common.Field[[IDim], np.int64]  # type: ignore [valid-type]
-IJKField: TypeAlias = common.Field[[IDim, JDim, KDim], np.int64]  # type: ignore [valid-type]
-IJKFloatField: TypeAlias = common.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
+IField: TypeAlias = common.Field[[IDim], np.float64]  # type: ignore [valid-type]
+IJKField: TypeAlias = common.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
+IJKIntField: TypeAlias = common.Field[[IDim, JDim, KDim], np.int64]  # type: ignore [valid-type]
 VField: TypeAlias = common.Field[[Vertex], np.int64]  # type: ignore [valid-type]
 EField: TypeAlias = common.Field[[Edge], np.int64]  # type: ignore [valid-type]
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -163,7 +163,7 @@ def test_fold_shifts(cartesian_case):  # noqa: F811 # fixtures
 
 def test_tuples(cartesian_case):  # noqa: F811 # fixtures
     @field_operator
-    def testee(a: cases.IJKFloatField, b: cases.IJKFloatField) -> cases.IJKFloatField:
+    def testee(a: cases.IJKField, b: cases.IJKField) -> cases.IJKField:
         inps = a, b
         scalars = 1.3, float64(5.0), float64("3.4")
         return (inps[0] * scalars[0] + inps[1] * scalars[1]) * scalars[2]
@@ -210,7 +210,7 @@ def test_nested_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
 
 def test_scalar_arg_with_field(cartesian_case):  # noqa: F811 # fixtures
     @field_operator
-    def testee(a: cases.IJKField, b: int) -> cases.IJKField:
+    def testee(a: cases.IJKField, b: float64) -> cases.IJKField:
         tmp = b * a
         return tmp(Ioff[1])
 
@@ -230,11 +230,11 @@ def test_scalar_in_domain_spec_and_fo_call(cartesian_case):  # noqa: F811 # fixt
         )
 
     @field_operator
-    def testee_op(size: int) -> cases.IField:
+    def testee_op(size: int64) -> Field[[IDim], int64]:
         return broadcast(size, (IDim,))
 
     @program
-    def testee(size: int, out: cases.IField):
+    def testee(size: int64, out: Field[[IDim], int64]):
         testee_op(size, out=out, domain={IDim: (0, size)})
 
     size = cartesian_case.default_sizes[IDim]

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -177,16 +177,16 @@ def test_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
     """Test scalar argument being turned into 0-dim field."""
 
     @field_operator
-    def testee(a: int) -> cases.VField:
-        return broadcast(a + 1, (Vertex,))
+    def testee(a: float64) -> cases.VField:
+        return broadcast(a + 1.0, (Vertex,))
 
     cases.verify_with_default_data(
         unstructured_case,
         testee,
         ref=lambda a: np.full(
             [unstructured_case.default_sizes[Vertex]],
-            a + 1,
-            dtype=int,
+            a + 1.0,
+            dtype=float64,
         ),
         comparison=lambda a, b: np.all(a == b),
     )
@@ -194,17 +194,17 @@ def test_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
 
 def test_nested_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
     @field_operator
-    def testee_inner(a: int) -> cases.VField:
-        return broadcast(a + 1, (Vertex,))
+    def testee_inner(a: float64) -> cases.VField:
+        return broadcast(a + 1.0, (Vertex,))
 
     @field_operator
-    def testee(a: int) -> cases.VField:
-        return testee_inner(a + 1)
+    def testee(a: float64) -> cases.VField:
+        return testee_inner(a + 1.0)
 
     cases.verify_with_default_data(
         unstructured_case,
         testee,
-        ref=lambda a: np.full([unstructured_case.default_sizes[Vertex]], a + 2, dtype=int),
+        ref=lambda a: np.full([unstructured_case.default_sizes[Vertex]], a + 2.0, dtype=float64),
     )
 
 
@@ -241,7 +241,7 @@ def test_scalar_in_domain_spec_and_fo_call(cartesian_case):  # noqa: F811 # fixt
     out = cases.allocate(cartesian_case, testee, "out").zeros()()
 
     cases.verify(
-        cartesian_case, testee, size, out=out, ref=np.full_like(out.array(), size, dtype=int)
+        cartesian_case, testee, size, out=out, ref=np.full_like(out.array(), size, dtype=np.int64)
     )
 
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
@@ -65,7 +65,7 @@ def test_power(fieldview_backend):
 
     @field_operator(backend=fieldview_backend)
     def pow(inp1: Field[[IDim], float64]) -> Field[[IDim], float64]:
-        return inp1**2
+        return inp1**2.0
 
     pow(a_I_float, out=out_I_float, offset_provider={})
     assert np.allclose(a_I_float.array() ** 2, out_I_float)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
@@ -85,10 +85,10 @@ def test_simple_if_conditional(condition1, condition2, cartesian_case):
     ) -> cases.IField:
         if condition1:
             result1 = a
-            result2 = a + 1
+            result2 = a + 1.
         else:
             result1 = b
-            result2 = b + 1
+            result2 = b + 1.
         return result1 if condition2 else result2
 
     a = cases.allocate(cartesian_case, simple_if, "a")()
@@ -255,10 +255,10 @@ def test_nested_if_stmt_conditinal(cartesian_case, condition1, condition2):
         if condition1:
             tmp1 = inp
             if condition2:
-                return tmp1 + 1
-            result = tmp1 + 2
+                return tmp1 + 1.
+            result = tmp1 + 2.
         else:
-            result = inp + 3
+            result = inp + 3.
         return result
 
     inp = cases.allocate(cartesian_case, nested_if_conditional_return, "inp")()
@@ -293,14 +293,14 @@ def test_nested_if(cartesian_case, condition):
             if not condition:
                 inner = a
             else:
-                inner = a + 1
+                inner = a + 1.
             result = inner
         else:
             result = b
             if condition:
-                another_inner = 3
+                another_inner = 3.
             else:
-                another_inner = 5
+                another_inner = 5.
             result = result + another_inner
         return result
 
@@ -328,13 +328,13 @@ def test_if_without_else(cartesian_case, condition1, condition2):
     def if_without_else(
         a: cases.IField, b: cases.IField, condition1: bool, condition2: bool
     ) -> cases.IField:
-        result = b + 1
+        result = b + 1.
 
         if condition1:
             if not condition2:
                 inner = a
             else:
-                inner = a + 2
+                inner = a + 2.
             result = inner
         return result
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
@@ -85,10 +85,10 @@ def test_simple_if_conditional(condition1, condition2, cartesian_case):
     ) -> cases.IField:
         if condition1:
             result1 = a
-            result2 = a + 1.
+            result2 = a + 1.0
         else:
             result1 = b
-            result2 = b + 1.
+            result2 = b + 1.0
         return result1 if condition2 else result2
 
     a = cases.allocate(cartesian_case, simple_if, "a")()
@@ -255,10 +255,10 @@ def test_nested_if_stmt_conditinal(cartesian_case, condition1, condition2):
         if condition1:
             tmp1 = inp
             if condition2:
-                return tmp1 + 1.
-            result = tmp1 + 2.
+                return tmp1 + 1.0
+            result = tmp1 + 2.0
         else:
-            result = inp + 3.
+            result = inp + 3.0
         return result
 
     inp = cases.allocate(cartesian_case, nested_if_conditional_return, "inp")()
@@ -293,14 +293,14 @@ def test_nested_if(cartesian_case, condition):
             if not condition:
                 inner = a
             else:
-                inner = a + 1.
+                inner = a + 1.0
             result = inner
         else:
             result = b
             if condition:
-                another_inner = 3.
+                another_inner = 3.0
             else:
-                another_inner = 5.
+                another_inner = 5.0
             result = result + another_inner
         return result
 
@@ -328,13 +328,13 @@ def test_if_without_else(cartesian_case, condition1, condition2):
     def if_without_else(
         a: cases.IField, b: cases.IField, condition1: bool, condition2: bool
     ) -> cases.IField:
-        result = b + 1.
+        result = b + 1.0
 
         if condition1:
             if not condition2:
                 inner = a
             else:
-                inner = a + 2.
+                inner = a + 2.0
             result = inner
         return result
 


### PR DESCRIPTION
Currently most tests use `int64` as the default dtype for fields:
```
IField: TypeAlias = common.Field[[IDim], np.int64]
```
This PR changes this to `float` for 2 reasons:
- Most of our use cases are with fields of floats.
- Using int literals, e.g. `1`, `2` will break after https://github.com/GridTools/gt4py/pull/1255 has been merged as they will be `int32` instead of `int64`.