### PR TITLE
feature[next]: Save type to annex in ITIR type inference

### DIFF
--- a/src/gt4py/next/iterator/ir.py
+++ b/src/gt4py/next/iterator/ir.py
@@ -172,24 +172,28 @@ INTEGER_BUILTINS = {"int", "int32", "int64"}
 FLOATING_POINT_BUILTINS = {"float", "float32", "float64"}
 TYPEBUILTINS = {*INTEGER_BUILTINS, *FLOATING_POINT_BUILTINS, "bool"}
 
-BUILTINS = {
+GRAMMAR_BUILTINS = {
     "cartesian_domain",
     "unstructured_domain",
-    "named_range",
+    "make_tuple",
+    "tuple_get",
+    "shift",
     "neighbors",
+    "cast_",
+}
+
+BUILTINS = {
+    *GRAMMAR_BUILTINS,
+    "named_range",
     "list_get",
     "map_",
     "make_const_list",
     "lift",
-    "make_tuple",
-    "tuple_get",
     "reduce",
     "deref",
     "can_deref",
-    "shift",
     "scan",
     "if_",
-    "cast_",
     "floordiv",  # TODO see https://github.com/GridTools/gt4py/issues/1136
     *UNARY_MATH_NUMBER_BUILTINS,
     *UNARY_LOGICAL_BUILTINS,

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -899,7 +899,7 @@ class _TypeInferrer(eve.traits.VisitorWithSymbolTableTrait, eve.NodeTranslator):
 def _save_types_to_annex(node: ir.Node, types: dict[int, Type]) -> None:
     for child_node in node.pre_walk_values().if_isinstance(*TYPED_IR_NODES):
         try:
-            child_node.annex.type = types[id(child_node)]
+            child_node.annex.type = types[id(child_node)]  # type: ignore[attr-defined]
         except KeyError:
             if not (
                 isinstance(child_node, ir.SymRef)

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -920,6 +920,9 @@ def infer_all(
     Infer the types of the child expressions of a given iterator IR expression.
 
     The result is a dictionary mapping the (Python) id of child nodes to their type.
+
+    The `save_to_annex` flag is experimental and should only be used as a last resort when the
+    return dictionary is not enough.
     """
     # Collect preliminary types of all nodes and constraints on them
     inferrer = _TypeInferrer(offset_provider=offset_provider)

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -896,7 +896,7 @@ class _TypeInferrer(eve.traits.VisitorWithSymbolTableTrait, eve.NodeTranslator):
         )
 
 
-def _save_types_to_annex(node, types):
+def _save_types_to_annex(node: ir.Node, types: dict[int, Type]) -> None:
     for child_node in node.pre_walk_values().if_isinstance(*TYPED_IR_NODES):
         try:
             child_node.annex.type = types[id(child_node)]
@@ -906,12 +906,13 @@ def _save_types_to_annex(node, types):
                 and child_node.id in ir.GRAMMAR_BUILTINS | ir.TYPEBUILTINS
             ):
                 raise AssertionError(
-                    f"Expected a type to be inferred for node `{node}`, but none was found."
+                    f"Expected a type to be inferred for node `{child_node}`, but none was found."
                 )
 
 
 def infer_all(
     node: ir.Node,
+    *,
     offset_provider: Optional[dict[str, Connectivity | Dimension]] = None,
     reindex: bool = True,
     save_to_annex=False,
@@ -937,7 +938,10 @@ def infer_all(
     if reindex:
         unified_types = reindex_vars(list(unified_types))
 
-    result = {id_: unified_type for id_, unified_type in zip(collected_types.keys(), unified_types)}
+    result = {
+        id_: unified_type
+        for id_, unified_type in zip(collected_types.keys(), unified_types, strict=True)
+    }
 
     if save_to_annex:
         _save_types_to_annex(node, result)

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -652,6 +652,7 @@ class _TypeInferrer(eve.traits.VisitorWithSymbolTableTrait, eve.NodeTranslator):
             raise TypeError("`tuple_get` requires exactly two arguments.")
         if not isinstance(node.args[0], ir.Literal) or node.args[0].type != "int":
             raise TypeError("The first argument to `tuple_get` must be a literal int.")
+        self.visit(node.args[0], **kwargs)  # visit index so that its type is collected
         idx = int(node.args[0].value)
         tup = self.visit(node.args[1], **kwargs)
         kind = TypeVar.fresh()  # `kind == Iterator()` means splitting an iterator of tuples

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -900,10 +900,9 @@ def _save_types_to_annex(node, types):
         try:
             child_node.annex.type = types[id(child_node)]
         except KeyError:
-            if (
-                not isinstance(child_node, ir.SymRef)
-                or child_node.id in ir.GRAMMAR_BUILTINS
-                or child_node.id in ir.TYPEBUILTINS
+            if not (
+                isinstance(child_node, ir.SymRef)
+                and child_node.id in ir.GRAMMAR_BUILTINS | ir.TYPEBUILTINS
             ):
                 raise AssertionError(
                     f"Expected a type to be inferred for node `{node}`, but none was found."

--- a/src/gt4py/next/iterator/type_inference.py
+++ b/src/gt4py/next/iterator/type_inference.py
@@ -922,8 +922,8 @@ def infer_all(
 
     The result is a dictionary mapping the (Python) id of child nodes to their type.
 
-    The `save_to_annex` flag is experimental and should only be used as a last resort when the
-    return dictionary is not enough.
+    The `save_to_annex` flag should only be used as a last resort when the  return dictionary is
+    not enough.
     """
     # Collect preliminary types of all nodes and constraints on them
     inferrer = _TypeInferrer(offset_provider=offset_provider)

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -969,6 +969,13 @@ def test_fencil_definition_with_function_definitions():
     )
 
 
+def test_save_types_to_annex():
+    testee = im.lambda_("a")(im.plus("a", im.literal("1", "float32")))
+    ti.infer(testee, save_to_annex=True)
+    param_type = testee.params[0].annex.type
+    assert isinstance(param_type, ti.Val) and param_type.dtype.name == "float32"
+
+
 def test_pformat():
     vs = [ti.TypeVar(idx=i) for i in range(5)]
     assert ti.pformat(vs[0]) == "T₀"

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -817,7 +817,7 @@ def test_fencil_definition_same_closure_input():
             np.empty((0, 2), dtype=np.int64), Dimension("Edge"), Dimension("Vertex"), 2, False
         )
     }
-    inferred_all: dict[int, ti.Type] = ti.infer_all(testee, offset_provider)
+    inferred_all: dict[int, ti.Type] = ti.infer_all(testee, offset_provider=offset_provider)
 
     # validate locations of fencil params
     fencil_param_types = [inferred_all[id(testee.params[i])] for i in range(3)]


### PR DESCRIPTION
This PR allows saving the results of type inference in the ITIR nodes. This is particularly useful for passes that modify the tree, but need type information during the process (in my case this is for the temporary extraction pass).

```python
testee = im.lambda_("a")(im.plus("a", im.literal("1", "float32")))
ti.infer(testee, save_to_annex=True)
param_type = testee.params[0].annex.type
assert isinstance(param_type, ti.Val) and param_type.dtype.name == "float32"
```