### PR TITLE
refactor[next]: add public API to top level

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -25,6 +25,13 @@ We deviate from the [Google Python Style Guide][google-style-guide] only in the 
 - We use [`black`][black] and [`isort`][isort] for source code and imports formatting, which may work differently than indicated by the guidelines in section [_3. Python Style Rules_](https://google.github.io/styleguide/pyguide.html#3-python-style-rules). For example, maximum line length is set to 100 instead of 79 (although docstring lines should still be limited to 79).
 - According to subsection [_2.19 Power Features_](https://google.github.io/styleguide/pyguide.html#219-power-features), direct use of _power features_ (e.g. custom metaclasses, import hacks, reflection) should be avoided, but standard library classes that internally use these power features are accepted. Following the same spirit, we allow the use of power features in infrastructure code with similar functionality and scope as the Python standard library.
 - According to subsection [_3.19.12 Imports For Typing_](https://google.github.io/styleguide/pyguide.html#31912-imports-for-typing), symbols from `typing` and `collections.abc` modules used in type annotations _"can be imported directly to keep common annotations concise and match standard typing practices"_. Following the same spirit, we allow symbols to be imported directly from third-party or internal modules when they only contain a collection of frequently used typying definitions.
+- Imports [_2.2 Imports_](https://google.github.io/styleguide/pyguide.html#22-imports):
+  - Importing individual classes and functions is allowed if they are to be used in DSL code and the DSL does not allow them to be qualified.
+  - Importing individual classes and functions is allowed in order to explicitly re-export them (via `__all__`). Each module which is allowed to re-export code objects has to be documented here with a reason.
+    - `gt4py.next` reexports FieldView classes and helpers in order to create a `numpy` like user experience.
+  - `from path.to.submodule import *` is **only** allowed in order to re-export the contents of a submodule if:
+    - the submodule in question defines `__all__` and
+    - the submodule in question exports many public API objects (example: `gt4py.next.ffront.fbuiltins`).
 
 ### Common questions
 
@@ -80,6 +87,12 @@ __all__ = ["func_a", "CONST_B"]
 Try to keep sections and items logically ordered, add section separator comments to make section boundaries explicit when needed. If there is not a single evident logical order, pick the order you consider best or use alphabetical order.
 
 Consider configuration files as another type of source code and apply the same criteria, using comments when possible for better readability.
+
+### Import conventions
+
+- Library code should import the defining module of a code object, unless a proxy is provided specifically for some reason
+- Test, doctest and example code should import the designated public API module (if exists) and use code objects from there
+- Test, doctest and example code should import public API objects from the designated public API module (if exists) if they are used in DSL code.
 
 ### Ignoring QA errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,10 @@ ignore = [
 ]
 max-complexity = 15
 max-line-length = 100  # It should be the same as in `tool.black.line-length` above
-per-file-ignores = ['src/gt4py/eve/extended_typing.py:F401,F405']
+per-file-ignores = [
+  'src/gt4py/eve/extended_typing.py:F401,F405',
+  'src/gt4py/next/__init__.py:F401'  # We import stuff there in order to reexport.
+]
 rst-roles = [
   'py:mod, mod',
   'py:func, func',

--- a/src/gt4py/next/__init__.py
+++ b/src/gt4py/next/__init__.py
@@ -13,12 +13,43 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from . import common, ffront, iterator, program_processors, type_inference
+from .common import Dimension, DimensionKind, Field
+from .ffront import fbuiltins
+from .ffront.decorator import field_operator, program, scan_operator
+from .ffront.fbuiltins import *  # noqa: F403  # fbuiltins defines __all__ and we explicitly want to reexport everything here
+from .ffront.fbuiltins import FieldOffset
+from .iterator.embedded import (
+    NeighborTableOffsetProvider,
+    StridedNeighborOffsetProvider,
+    index_field,
+    np_as_located_field,
+)
 
 
-__all__ = [
-    "common",
-    "ffront",
-    "iterator",
-    "program_processors",
-    "type_inference",
-]
+__all__ = (
+    [  # submodules
+        "common",
+        "ffront",
+        "iterator",
+        "program_processors",
+        "type_inference",
+    ]
+    + [  # from common
+        "Dimension",
+        "DimensionKind",
+        "Field",
+    ]
+    + [  # from iterator
+        "NeighborTableOffsetProvider",
+        "StridedNeighborOffsetProvider",
+        "index_field",
+        "np_as_located_field",
+    ]
+    + [  # from ffront
+        "FieldOffset",
+        "field_operator",
+        "program",
+        "scan_operator",
+    ]
+    + fbuiltins.__all__
+)

--- a/src/gt4py/next/ffront/fbuiltins.py
+++ b/src/gt4py/next/ffront/fbuiltins.py
@@ -201,6 +201,8 @@ BUILTIN_NAMES = TYPE_BUILTIN_NAMES + FUN_BUILTIN_NAMES
 BUILTINS = {name: globals()[name] for name in BUILTIN_NAMES}
 
 __all__ = BUILTIN_NAMES
+__all__.remove("Field")
+__all__.remove("Dimension")
 
 
 # TODO(tehrengruber): FieldOffset and runtime.Offset are not an exact conceptual

--- a/src/gt4py/next/ffront/foast_pretty_printer.py
+++ b/src/gt4py/next/ffront/foast_pretty_printer.py
@@ -225,8 +225,7 @@ def pretty_format(node: foast.LocatedNode) -> str:
     """
     Pretty print (to string) an `foast.LocatedNode`.
 
-    >>> from gt4py.next.common import Field, Dimension
-    >>> from gt4py.next.ffront.decorator import field_operator
+    >>> from gt4py.next import Field, Dimension, field_operator
     >>> IDim = Dimension("IDim")
     >>> @field_operator
     ... def field_op(a: Field[[IDim], int]) -> Field[[IDim], int]:

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -48,8 +48,7 @@ class FieldOperatorLowering(NodeTranslator):
     Examples
     --------
     >>> from gt4py.next.ffront.func_to_foast import FieldOperatorParser
-    >>> from gt4py.next.ffront.fbuiltins import float64
-    >>> from gt4py.next.common import Field, Dimension
+    >>> from gt4py.next import Field, Dimension, float64
     >>>
     >>> IDim = Dimension("IDim")
     >>> def fieldop(inp: Field[[IDim], "float64"]):

--- a/src/gt4py/next/ffront/func_to_foast.py
+++ b/src/gt4py/next/ffront/func_to_foast.py
@@ -52,7 +52,7 @@ class FieldOperatorParser(DialectParser[foast.FunctionDefinition]):
     Parse a function into a Field Operator AST (FOAST), which can
     be lowered into Iterator IR (ITIR)
 
-    >>> from gt4py.next.common import Field, Dimension
+    >>> from gt4py.next import Field, Dimension
     >>> float64 = float
     >>> IDim = Dimension("IDim")
     >>> def field_op(inp: Field[[IDim], float64]):

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -49,13 +49,11 @@ class ProgramLowering(traits.VisitorWithSymbolTableTrait, NodeTranslator):
     Examples
     --------
     >>> from gt4py.next.ffront.func_to_past import ProgramParser
-    >>> from gt4py.next.iterator.runtime import offset
     >>> from gt4py.next.iterator import ir
-    >>> from gt4py.next.ffront.fbuiltins import Dimension, Field
+    >>> from gt4py.next import Dimension, Field
     >>>
     >>> float64 = float
     >>> IDim = Dimension("IDim")
-    >>> Ioff = offset("Ioff")
     >>>
     >>> def fieldop(inp: Field[[IDim], "float64"]) -> Field[[IDim], "float64"]:
     ...    ...

--- a/tests/next_tests/integration_tests/feature_tests/cases.py
+++ b/tests/next_tests/integration_tests/feature_tests/cases.py
@@ -24,10 +24,11 @@ from typing import Any, Callable, Literal, Optional, Protocol, TypeAlias
 import numpy as np
 import pytest
 
+import gt4py.next as gtx
 from gt4py.eve import extended_typing as xtyping
 from gt4py.eve.extended_typing import Self
 from gt4py.next import common
-from gt4py.next.ffront import decorator, fbuiltins
+from gt4py.next.ffront import decorator
 from gt4py.next.iterator import embedded, ir as itir
 from gt4py.next.program_processors import processor_interface as ppi
 from gt4py.next.type_system import type_specifications as ts, type_translation
@@ -47,28 +48,28 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
 
 
 # mypy does not accept [IDim, ...] as a type
-IField: TypeAlias = common.Field[[IDim], np.int64]  # type: ignore [valid-type]
-IJKField: TypeAlias = common.Field[[IDim, JDim, KDim], np.int64]  # type: ignore [valid-type]
-IJKFloatField: TypeAlias = common.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
-VField: TypeAlias = common.Field[[Vertex], np.int64]  # type: ignore [valid-type]
-EField: TypeAlias = common.Field[[Edge], np.int64]  # type: ignore [valid-type]
+IField: TypeAlias = gtx.Field[[IDim], np.int64]  # type: ignore [valid-type]
+IJKField: TypeAlias = gtx.Field[[IDim, JDim, KDim], np.int64]  # type: ignore [valid-type]
+IJKFloatField: TypeAlias = gtx.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
+VField: TypeAlias = gtx.Field[[Vertex], np.int64]  # type: ignore [valid-type]
+EField: TypeAlias = gtx.Field[[Edge], np.int64]  # type: ignore [valid-type]
 
 # TODO(ricoh): unify the following with the `ffront_test_utils.reduction_setup`
 #   fixture if `ffront_test_utils.reduction_setup` is not completely superseded
 #   by `unstructured_case`.
-V2EDim = common.Dimension("V2E", kind=common.DimensionKind.LOCAL)
-E2VDim = common.Dimension("E2V", kind=common.DimensionKind.LOCAL)
-V2E = fbuiltins.FieldOffset("V2E", source=Edge, target=(Vertex, V2EDim))
-E2V = fbuiltins.FieldOffset("E2V", source=Vertex, target=(Edge, E2VDim))
+V2EDim = gtx.Dimension("V2E", kind=gtx.DimensionKind.LOCAL)
+E2VDim = gtx.Dimension("E2V", kind=gtx.DimensionKind.LOCAL)
+V2E = gtx.FieldOffset("V2E", source=Edge, target=(Vertex, V2EDim))
+E2V = gtx.FieldOffset("E2V", source=Vertex, target=(Edge, E2VDim))
 
 ScalarValue: TypeAlias = np.int32 | np.int64 | np.float32 | np.float64 | np.generic
-FieldValue: TypeAlias = common.Field | embedded.LocatedFieldImpl
+FieldValue: TypeAlias = gtx.Field | embedded.LocatedFieldImpl
 FieldViewArg: TypeAlias = FieldValue | ScalarValue | tuple["FieldViewArg", ...]
 FieldViewInout: TypeAlias = FieldValue | tuple["FieldViewInout", ...]
 ReferenceValue: TypeAlias = (
-    common.Field | np.typing.NDArray[ScalarValue] | tuple["ReferenceValue", ...]
+    gtx.Field | np.typing.NDArray[ScalarValue] | tuple["ReferenceValue", ...]
 )
-OffsetProvider: TypeAlias = dict[str, common.Connectivity | common.Dimension]
+OffsetProvider: TypeAlias = dict[str, common.Connectivity | gtx.Dimension]
 
 
 #: To allocate the return value of a field operator, we must pass
@@ -91,7 +92,7 @@ class DataInitializer(Protocol):
     def field(
         self,
         backend: ppi.ProgramProcessor,
-        sizes: dict[common.Dimension, int],
+        sizes: dict[gtx.Dimension, int],
         dtype: np.typing.DTypeLike,
     ) -> FieldValue:
         ...
@@ -118,10 +119,10 @@ class ConstInitializer(DataInitializer):
     def field(
         self,
         backend: ppi.ProgramProcessor,
-        sizes: dict[common.Dimension, int],
+        sizes: dict[gtx.Dimension, int],
         dtype: np.typing.DTypeLike,
     ) -> FieldValue:
-        return embedded.np_as_located_field(*sizes.keys())(
+        return gtx.np_as_located_field(*sizes.keys())(
             np.full(tuple(sizes.values()), self.value, dtype=dtype)
         )
 
@@ -154,14 +155,14 @@ class UniqueInitializer(DataInitializer):
     def field(
         self,
         backend: ppi.ProgramProcessor,
-        sizes: dict[common.Dimension, int],
+        sizes: dict[gtx.Dimension, int],
         dtype: np.typing.DTypeLike,
     ) -> FieldValue:
         start = self.start
         svals = tuple(sizes.values())
         n_data = int(np.prod(svals))
         self.start += n_data
-        return embedded.np_as_located_field(*sizes.keys())(
+        return gtx.np_as_located_field(*sizes.keys())(
             np.arange(start, start + n_data, dtype=dtype).reshape(svals)
         )
 
@@ -277,10 +278,10 @@ def allocate(
     fieldview_prog: decorator.FieldOperator | decorator.Program,
     name: str,
     *,
-    sizes: Optional[dict[common.Dimension, int]] = None,
+    sizes: Optional[dict[gtx.Dimension, int]] = None,
     strategy: Optional[DataInitializer] = None,
     dtype: Optional[np.typing.DTypeLike] = None,
-    extend: Optional[dict[common.Dimension, tuple[int, int]]] = None,
+    extend: Optional[dict[gtx.Dimension, tuple[int, int]]] = None,
 ) -> FieldViewArg:
     """
     Allocate a parameter or return value from a fieldview code object.
@@ -459,7 +460,7 @@ def unstructured_case(
 def _allocate_from_type(
     case: Case,
     arg_type: ts.TypeSpec,
-    sizes: dict[common.Dimension, int],
+    sizes: dict[gtx.Dimension, int],
     strategy: DataInitializer,
     dtype: Optional[np.typing.DTypeLike] = None,
     tuple_start: Optional[int] = None,
@@ -502,7 +503,7 @@ def get_param_types(
     }
 
 
-def get_param_size(param_type: ts.TypeSpec, sizes: dict[common.Dimension, int]) -> int:
+def get_param_size(param_type: ts.TypeSpec, sizes: dict[gtx.Dimension, int]) -> int:
     match param_type:
         case ts.FieldType(dims=dims):
             return int(np.prod([sizes[dim] for dim in sizes if dim in dims]))
@@ -515,9 +516,9 @@ def get_param_size(param_type: ts.TypeSpec, sizes: dict[common.Dimension, int]) 
 
 
 def extend_sizes(
-    sizes: dict[common.Dimension, int],
-    extend: Optional[dict[common.Dimension, tuple[int, int]]] = None,
-) -> dict[common.Dimension, int]:
+    sizes: dict[gtx.Dimension, int],
+    extend: Optional[dict[gtx.Dimension, tuple[int, int]]] = None,
+) -> dict[gtx.Dimension, int]:
     """Calculate the sizes per dimension given a set of extensions."""
     sizes = sizes.copy()
     if extend:
@@ -529,7 +530,7 @@ def extend_sizes(
 def get_default_data(
     case: Case,
     fieldview_prog: decorator.FieldOperator | decorator.Program,
-) -> tuple[tuple[common.Field | ScalarValue | tuple, ...], dict[str, common.Field]]:
+) -> tuple[tuple[gtx.Field | ScalarValue | tuple, ...], dict[str, gtx.Field]]:
     """
     Allocate default data for a fieldview code object given a test case.
 
@@ -559,6 +560,6 @@ class Case:
     """Parametrizable components for single feature integration tests."""
 
     backend: ppi.ProgramProcessor
-    offset_provider: dict[str, common.Connectivity | common.Dimension]
-    default_sizes: dict[common.Dimension, int]
+    offset_provider: dict[str, common.Connectivity | gtx.Dimension]
+    default_sizes: dict[gtx.Dimension, int]
     grid_type: common.GridType

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
@@ -13,8 +13,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import Field, int64, neighbor_sum
+from gt4py.next import Field, field_operator, int64, neighbor_sum, program
 
 from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils import *
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -17,10 +17,8 @@ import textwrap
 
 import pytest
 
-from gt4py.next.common import Dimension, DimensionKind, Field
+from gt4py.next import Dimension, DimensionKind, Field, field_operator, int64, scan_operator
 from gt4py.next.ffront.ast_passes import single_static_assign as ssa
-from gt4py.next.ffront.decorator import field_operator, scan_operator
-from gt4py.next.ffront.fbuiltins import int64
 from gt4py.next.ffront.foast_pretty_printer import pretty_format
 from gt4py.next.ffront.func_to_foast import FieldOperatorParser
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -13,16 +13,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#
-from gt4py.next.ffront.decorator import field_operator, program
-from gt4py.next.ffront.fbuiltins import (
+from gt4py.next import (
     Field,
     broadcast,
+    field_operator,
     float64,
     int64,
     max_over,
     min_over,
     neighbor_sum,
+    program,
     where,
 )
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_builtin_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_builtin_execution.py
@@ -18,11 +18,10 @@ from typing import Callable
 import numpy as np
 import pytest
 
+from gt4py.next import Field, float64, np_as_located_field
 from gt4py.next.ffront import dialect_ast_enums, fbuiltins, field_operator_ast as foast
 from gt4py.next.ffront.decorator import FieldOperator
-from gt4py.next.ffront.fbuiltins import Field, float64
 from gt4py.next.ffront.foast_passes.type_deduction import FieldOperatorTypeDeduction
-from gt4py.next.iterator.embedded import np_as_located_field
 from gt4py.next.type_system import type_translation
 
 from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils import *

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
@@ -13,15 +13,14 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#
-from gt4py.next.ffront.decorator import field_operator
-from gt4py.next.ffront.fbuiltins import (
+from gt4py.next import (
     Field,
     cbrt,
     ceil,
     cos,
     cosh,
     exp,
+    field_operator,
     float64,
     floor,
     int64,

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_program.py
@@ -19,10 +19,9 @@ import re
 import numpy as np
 import pytest
 
-from gt4py.next.common import Field, GTTypeError
-from gt4py.next.ffront.decorator import field_operator, program
+from gt4py.next import Field, field_operator, np_as_located_field, program
+from gt4py.next.common import GTTypeError
 from gt4py.next.ffront.past_passes.type_deduction import ProgramTypeError
-from gt4py.next.iterator.embedded import np_as_located_field
 from gt4py.next.program_processors.runners import gtfn_cpu, roundtrip
 
 from next_tests.past_common_fixtures import (

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
@@ -13,16 +13,13 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#
 from functools import reduce
 
 import numpy as np
 import pytest
 
-from gt4py.next.ffront.decorator import field_operator
-from gt4py.next.ffront.fbuiltins import Field, float64
+from gt4py.next import Field, field_operator, float64, index_field, np_as_located_field
 from gt4py.next.ffront.foast_passes.type_deduction import FieldOperatorTypeDeductionError
-from gt4py.next.iterator.embedded import index_field, np_as_located_field
 from gt4py.next.program_processors.runners import gtfn_cpu
 
 from next_tests.integration_tests.feature_tests import cases

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -17,11 +17,9 @@ from typing import Optional, Pattern
 import pytest
 
 import gt4py.next.ffront.type_specifications
-from gt4py.next.common import DimensionKind, GTTypeError
-from gt4py.next.ffront.ast_passes import single_static_assign as ssa
-from gt4py.next.ffront.experimental import as_offset
-from gt4py.next.ffront.fbuiltins import (
+from gt4py.next import (
     Dimension,
+    DimensionKind,
     Field,
     FieldOffset,
     astype,
@@ -32,6 +30,9 @@ from gt4py.next.ffront.fbuiltins import (
     neighbor_sum,
     where,
 )
+from gt4py.next.common import GTTypeError
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
+from gt4py.next.ffront.experimental import as_offset
 from gt4py.next.ffront.foast_passes.type_deduction import FieldOperatorTypeDeductionError
 from gt4py.next.ffront.func_to_foast import FieldOperatorParser
 from gt4py.next.type_system import type_info, type_specifications as ts

--- a/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/copy_stencil_field_view.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/copy_stencil_field_view.py
@@ -16,8 +16,7 @@ import sys
 
 from numpy import float64
 
-from gt4py.next.common import Field
-from gt4py.next.ffront.decorator import field_operator, program
+from gt4py.next import Field, field_operator, program
 from gt4py.next.iterator.runtime import CartesianAxis
 from gt4py.next.program_processors.codegens.gtfn.gtfn_backend import generate
 

--- a/tests/next_tests/past_common_fixtures.py
+++ b/tests/next_tests/past_common_fixtures.py
@@ -16,9 +16,7 @@ from typing import Tuple
 
 import pytest
 
-from gt4py.next.common import Field
-from gt4py.next.ffront.decorator import field_operator
-from gt4py.next.ffront.fbuiltins import Dimension, FieldOffset
+from gt4py.next import Dimension, Field, FieldOffset, field_operator
 
 
 float64 = float


### PR DESCRIPTION
## Description

Add a `numpy` style public API to `gt4py.next`, so that for writing the vast majority of stencils it will be enough to `import gt4py.next as gtx` and / or `import X from gt4py.next` where X is used inside FieldView code.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
