### PR TITLE
fix[next]: Fix CSE extraction for if statements

### DIFF
--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -125,7 +125,9 @@ class CollectSubexpressions(VisitorWithSymbolTableTrait, NodeVisitor):
 
             # remove all subexpressions that are not eligible for collection
             #  (either they occur in the condition or in both branches)
-            eligible_subexprs = arg_states[0].subexprs.keys() | (arg_states[1].subexprs.keys() & arg_states[2].subexprs.keys())
+            eligible_subexprs = arg_states[0].subexprs.keys() | (
+                arg_states[1].subexprs.keys() & arg_states[2].subexprs.keys()
+            )
             for arg_state in arg_states:
                 arg_state.remove_subexprs(arg_state.subexprs.keys() - eligible_subexprs)
 

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
@@ -178,6 +178,7 @@ def test_if_can_deref_eligible_extraction():
     actual = CSE().visit(testee)
     assert actual == expected
 
+
 def test_if_eligible_extraction():
     # Test that a subexpression only occurring in the condition of an `if_` is moved outside the
     # if statement.
@@ -189,9 +190,7 @@ def test_if_eligible_extraction():
         "d",
     )
     # (λ(_cs_1) → if _cs_1 ∧ _cs_1 then c else d)(a ∧ b)
-    expected = im.let("_cs_1", im.and_("a", "b"))(
-        im.if_(im.and_("_cs_1", "_cs_1"), "c", "d")
-    )
+    expected = im.let("_cs_1", im.and_("a", "b"))(im.if_(im.and_("_cs_1", "_cs_1"), "c", "d"))
 
     actual = CSE().visit(testee)
     assert actual == expected

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
@@ -177,3 +177,21 @@ def test_if_can_deref_eligible_extraction():
 
     actual = CSE().visit(testee)
     assert actual == expected
+
+def test_if_eligible_extraction():
+    # Test that a subexpression only occurring in the condition of an `if_` is moved outside the
+    # if statement.
+
+    # if ((a ∧ b) ∧ (a ∧ b)) then c else d
+    testee = im.if_(
+        im.and_(im.and_("a", "b"), im.and_("a", "b")),
+        "c",
+        "d",
+    )
+    # (λ(_cs_1) → if _cs_1 ∧ _cs_1 then c else d)(a ∧ b)
+    expected = im.let("_cs_1", im.and_("a", "b"))(
+        im.if_(im.and_("_cs_1", "_cs_1"), "c", "d")
+    )
+
+    actual = CSE().visit(testee)
+    assert actual == expected


### PR DESCRIPTION
The criterion for extracting common subexpressions out of `if_` calls was wrong. The correct criterion as implemented in this PR is that all subexpressions that either occur in the condition or both branches are eligible for extraction.