### PR TITLE
feature[next] enable field origin in GTFN backend

### DIFF
--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -887,12 +887,14 @@ class LocatedFieldImpl(MutableLocatedField):
         *,
         setter: Callable[[FieldIndexOrIndices, Any], None],
         array: Callable[[], npt.NDArray],
+        origin: Optional[dict[common.Dimension, int]] = None,
     ):
         self.getter = getter
         self._axes = axes
         self.setter = setter
         self.array = array
         self.dtype = dtype
+        self.origin = origin
 
     def __getitem__(self, indices: ArrayIndexOrIndices) -> Any:
         return self.array()[indices]
@@ -1027,6 +1029,7 @@ def np_as_located_field(
             dtype=a.dtype,
             setter=setter,
             array=a.__array__,
+            origin=origin,
         )
 
     return _maker

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -183,7 +183,7 @@ class LocatedField(Protocol):
         ...
 
     @property
-    def __gt_origin__(self) -> tuple[int]:
+    def __gt_origin__(self) -> tuple[int, ...]:
         return tuple([0] * len(self.axes))
 
 
@@ -918,8 +918,12 @@ class LocatedFieldImpl(MutableLocatedField):
         return self.array()
 
     @property
-    def __gt_origin__(self) -> tuple[int]:
-        return cast(tuple[int], get_ordered_indices(self.axes, {k.value: v for k, v in self.origin.items()}))
+    def __gt_origin__(self) -> tuple[int, ...]:
+        if not self.origin:
+            return tuple([0] * len(self.axes))
+        return cast(
+            tuple[int], get_ordered_indices(self.axes, {k.value: v for k, v in self.origin.items()})
+        )
 
     @property
     def shape(self):

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -182,6 +182,10 @@ class LocatedField(Protocol):
     def field_getitem(self, indices: FieldIndexOrIndices) -> Any:
         ...
 
+    @property
+    def __gt_origin__(self) -> tuple[int]:
+        return tuple([0] * len(self.axes))
+
 
 class MutableLocatedField(LocatedField, Protocol):
     """A LocatedField with write access."""
@@ -912,6 +916,10 @@ class LocatedFieldImpl(MutableLocatedField):
 
     def __array__(self) -> np.ndarray:
         return self.array()
+
+    @property
+    def __gt_origin__(self) -> tuple[int]:
+        return cast(tuple[int], get_ordered_indices(self.axes, {k.value: v for k, v in self.origin.items()}))
 
     @property
     def shape(self):

--- a/src/gt4py/next/otf/binding/pybind.py
+++ b/src/gt4py/next/otf/binding/pybind.py
@@ -89,7 +89,10 @@ def _type_string(type_: ts.TypeSpec) -> str:
     if isinstance(type_, ts.TupleType):
         return f"std::tuple<{','.join(_type_string(t) for t in type_.types)}>"
     elif isinstance(type_, ts.FieldType):
-        return "pybind11::buffer"
+        ndims = len(type_.dims)
+        buffer_t = "pybind11::buffer"
+        origin_t = f"std::tuple<{', '.join(['ptrdiff_t'] * ndims)}>"
+        return f"std::pair<{buffer_t}, {origin_t}>"
     elif isinstance(type_, ts.ScalarType):
         return cpp_interface.render_scalar_type(type_)
     else:
@@ -142,17 +145,18 @@ class BindingCodeGenerator(TemplatedGenerator):
         return cpp_interface.render_function_call(call.target, args)
 
     def visit_BufferSID(self, sid: BufferSID, **kwargs):
-        return self.generic_visit(
-            sid, rendered_scalar_type=cpp_interface.render_scalar_type(sid.scalar_type)
-        )
+        pybuffer = f"{sid.source_buffer}.first"
+        dims = [self.visit(dim) for dim in sid.dimensions]
+        origin = f"{sid.source_buffer}.second"
+        origin_elems = [f"std::get<{i}>({origin})" for i in range(len(sid.dimensions))]
+        origin_tuple = f"gridtools::tuple{{{', '.join(origin_elems)}}}"
 
-    BufferSID = as_jinja(
-        """gridtools::sid::rename_numbered_dimensions<{{", ".join(dimensions)}}>(
-                gridtools::as_sid<{{rendered_scalar_type}},\
-                                  {{dimensions.__len__()}},\
-                                  gridtools::sid::unknown_kind>({{source_buffer}})
-            )"""
-    )
+        as_sid = f"gridtools::as_sid<{cpp_interface.render_scalar_type(sid.scalar_type)},\
+                {sid.dimensions.__len__()},\
+                gridtools::sid::unknown_kind>({pybuffer})"
+        shifted = f"gridtools::sid::shift_sid_origin({as_sid}, {origin_tuple})"
+        renamed = f"gridtools::sid::rename_numbered_dimensions<{', '.join(dims)}>({shifted})"
+        return renamed
 
     def visit_CompositeSID(self, node: CompositeSID, **kwargs):
         kwargs["composite_ids"] = (

--- a/src/gt4py/next/otf/binding/pybind.py
+++ b/src/gt4py/next/otf/binding/pybind.py
@@ -148,13 +148,11 @@ class BindingCodeGenerator(TemplatedGenerator):
         pybuffer = f"{sid.source_buffer}.first"
         dims = [self.visit(dim) for dim in sid.dimensions]
         origin = f"{sid.source_buffer}.second"
-        origin_elems = [f"std::get<{i}>({origin})" for i in range(len(sid.dimensions))]
-        origin_tuple = f"gridtools::tuple{{{', '.join(origin_elems)}}}"
 
         as_sid = f"gridtools::as_sid<{cpp_interface.render_scalar_type(sid.scalar_type)},\
                 {sid.dimensions.__len__()},\
                 gridtools::sid::unknown_kind>({pybuffer})"
-        shifted = f"gridtools::sid::shift_sid_origin({as_sid}, {origin_tuple})"
+        shifted = f"gridtools::sid::shift_sid_origin({as_sid}, {origin})"
         renamed = f"gridtools::sid::rename_numbered_dimensions<{', '.join(dims)}>({shifted})"
         return renamed
 

--- a/src/gt4py/next/program_processors/runners/gtfn_cpu.py
+++ b/src/gt4py/next/program_processors/runners/gtfn_cpu.py
@@ -30,19 +30,12 @@ from gt4py.next.type_system.type_translation import from_value
 
 # TODO(ricoh): Add support for the whole range of arguments that can be passed to a fencil.
 def convert_arg(arg: Any) -> Any:
-    from gt4py.next.iterator.embedded import LocatedField, get_ordered_indices
-
     if isinstance(arg, tuple):
         return tuple(convert_arg(a) for a in arg)
-    if isinstance(arg, LocatedField):
+    if hasattr(arg, "__array__") and hasattr(arg, "axes"):
         arr = np.asarray(arg)
-        if origin := getattr(arg, "origin", None):
-            dims = getattr(arg, "axes", None)
-            assert dims is not None
-            offsets = get_ordered_indices(dims, {k.value: v for k, v in origin.items()})
-        else:
-            offsets = tuple([0] * arr.ndim)
-        return arr, offsets
+        origin = getattr(arg, "__gt_origin__", tuple([0] * arr.ndim))
+        return arr, origin
     else:
         return arg
 

--- a/src/gt4py/next/program_processors/runners/gtfn_cpu.py
+++ b/src/gt4py/next/program_processors/runners/gtfn_cpu.py
@@ -30,7 +30,7 @@ from gt4py.next.type_system.type_translation import from_value
 
 # TODO(ricoh): Add support for the whole range of arguments that can be passed to a fencil.
 def convert_arg(arg: Any) -> Any:
-    from gt4py.next.iterator.embedded import get_ordered_indices, LocatedField
+    from gt4py.next.iterator.embedded import LocatedField, get_ordered_indices
 
     if isinstance(arg, tuple):
         return tuple(convert_arg(a) for a in arg)

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_trivial.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_trivial.py
@@ -48,9 +48,6 @@ def baz(baz_inp):
 def test_trivial(program_processor, lift_mode):
     program_processor, validate = program_processor
 
-    if program_processor == run_gtfn:
-        pytest.xfail("origin not yet supported in gtfn")
-
     rng = np.random.default_rng()
     inp = rng.uniform(size=(5, 7, 9))
     out = np.copy(inp)
@@ -79,9 +76,6 @@ def stencil_shifted_arg_to_lift(inp):
 
 def test_shifted_arg_to_lift(program_processor, lift_mode):
     program_processor, validate = program_processor
-
-    if program_processor == run_gtfn:
-        pytest.xfail("origin not yet supported in gtfn")
 
     if lift_mode != transforms.LiftMode.FORCE_INLINE:
         pytest.xfail("shifted input arguments not supported for lift_mode != LiftMode.FORCE_INLINE")

--- a/tests/next_tests/integration_tests/feature_tests/otf_tests/test_pybind_build.py
+++ b/tests/next_tests/integration_tests/feature_tests/otf_tests/test_pybind_build.py
@@ -35,7 +35,10 @@ def test_gtfn_cpp_with_cmake(program_source_with_name):
     )
     compiled_program = build_the_program(example_program_source)
     buf = (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))
-    tup = [(np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)), (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))]
+    tup = [
+        (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)),
+        (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)),
+    ]
     sc = np.float32(3.1415926)
     res = compiled_program(buf, tup, sc)
     assert math.isclose(res, 6 * 5 * 3.1415926, rel_tol=1e-4)
@@ -51,7 +54,10 @@ def test_gtfn_cpp_with_compiledb(program_source_with_name):
     )
     compiled_program = build_the_program(example_program_source)
     buf = (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))
-    tup = [(np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)), (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))]
+    tup = [
+        (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)),
+        (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)),
+    ]
     sc = np.float32(3.1415926)
     res = compiled_program(buf, tup, sc)
     assert math.isclose(res, 6 * 5 * 3.1415926, rel_tol=1e-4)

--- a/tests/next_tests/integration_tests/feature_tests/otf_tests/test_pybind_build.py
+++ b/tests/next_tests/integration_tests/feature_tests/otf_tests/test_pybind_build.py
@@ -34,8 +34,8 @@ def test_gtfn_cpp_with_cmake(program_source_with_name):
         ),
     )
     compiled_program = build_the_program(example_program_source)
-    buf = np.zeros(shape=(6, 5), dtype=np.float32)
-    tup = [np.zeros(shape=(6, 5), dtype=np.float32), np.zeros(shape=(6, 5), dtype=np.float32)]
+    buf = (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))
+    tup = [(np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)), (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))]
     sc = np.float32(3.1415926)
     res = compiled_program(buf, tup, sc)
     assert math.isclose(res, 6 * 5 * 3.1415926, rel_tol=1e-4)
@@ -50,8 +50,8 @@ def test_gtfn_cpp_with_compiledb(program_source_with_name):
         ),
     )
     compiled_program = build_the_program(example_program_source)
-    buf = np.zeros(shape=(6, 5), dtype=np.float32)
-    tup = [np.zeros(shape=(6, 5), dtype=np.float32), np.zeros(shape=(6, 5), dtype=np.float32)]
+    buf = (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))
+    tup = [(np.zeros(shape=(6, 5), dtype=np.float32), (0, 0)), (np.zeros(shape=(6, 5), dtype=np.float32), (0, 0))]
     sc = np.float32(3.1415926)
     res = compiled_program(buf, tup, sc)
     assert math.isclose(res, 6 * 5 * 3.1415926, rel_tol=1e-4)

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_hdiff.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_hdiff.py
@@ -74,7 +74,9 @@ def hdiff(inp, coeff, out, x, y):
 def test_hdiff(hdiff_reference, program_processor, lift_mode):
     program_processor, validate = program_processor
     if program_processor == run_gtfn or program_processor == run_gtfn_imperative:
-        pytest.xfail("origin not yet supported in gtfn")
+        from gt4py.next.iterator import transforms
+        if lift_mode != transforms.LiftMode.FORCE_INLINE:
+            pytest.xfail("origin not yet supported in gtfn")
 
     inp, coeff, out = hdiff_reference
     shape = (out.shape[0], out.shape[1])

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_hdiff.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_hdiff.py
@@ -77,7 +77,7 @@ def test_hdiff(hdiff_reference, program_processor, lift_mode):
         from gt4py.next.iterator import transforms
 
         if lift_mode != transforms.LiftMode.FORCE_INLINE:
-            pytest.xfail("origin not yet supported in gtfn")
+            pytest.xfail("there is an issue with temporaries that crashes the application")
 
     inp, coeff, out = hdiff_reference
     shape = (out.shape[0], out.shape[1])

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_hdiff.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_hdiff.py
@@ -75,6 +75,7 @@ def test_hdiff(hdiff_reference, program_processor, lift_mode):
     program_processor, validate = program_processor
     if program_processor == run_gtfn or program_processor == run_gtfn_imperative:
         from gt4py.next.iterator import transforms
+
         if lift_mode != transforms.LiftMode.FORCE_INLINE:
             pytest.xfail("origin not yet supported in gtfn")
 

--- a/tests/next_tests/unit_tests/otf_tests/binding_tests/test_pybind.py
+++ b/tests/next_tests/unit_tests/otf_tests/binding_tests/test_pybind.py
@@ -48,28 +48,22 @@ def test_bindings(program_source_example):
               gridtools::sid::rename_numbered_dimensions<
                   generated::I_t, generated::J_t>(gridtools::sid::shift_sid_origin(
                   gridtools::as_sid<float, 2, gridtools::sid::unknown_kind>(buf.first),
-                  gridtools::tuple{std::get<0>(buf.second), std::get<1>(buf.second)})),
+                  buf.second)),
               gridtools::sid::composite::keys<gridtools::integral_constant<int, 0>,
                                               gridtools::integral_constant<int, 1>>::
                   make_values(
-                      gridtools::sid::rename_numbered_dimensions<
-                          generated::I_t,
-                          generated::J_t>(gridtools::sid::shift_sid_origin(
-                          gridtools::as_sid<float, 2, gridtools::sid::unknown_kind>(
-                              gridtools::tuple_util::get<0>(tup).first),
-                          gridtools::tuple{
-                              std::get<0>(gridtools::tuple_util::get<0>(tup).second),
-                              std::get<1>(gridtools::tuple_util::get<0>(tup).second)})),
+                      gridtools::sid::rename_numbered_dimensions<generated::I_t,
+                                                                 generated::J_t>(
+                          gridtools::sid::shift_sid_origin(
+                              gridtools::as_sid<float, 2, gridtools::sid::unknown_kind>(
+                                  gridtools::tuple_util::get<0>(tup).first),
+                              gridtools::tuple_util::get<0>(tup).second)),
                       gridtools::sid::rename_numbered_dimensions<generated::I_t,
                                                                  generated::J_t>(
                           gridtools::sid::shift_sid_origin(
                               gridtools::as_sid<float, 2, gridtools::sid::unknown_kind>(
                                   gridtools::tuple_util::get<1>(tup).first),
-                              gridtools::tuple{
-                                  std::get<0>(
-                                      gridtools::tuple_util::get<1>(tup).second),
-                                  std::get<1>(
-                                      gridtools::tuple_util::get<1>(tup).second)}))),
+                              gridtools::tuple_util::get<1>(tup).second))),
               sc);
         }
         


### PR DESCRIPTION
Pass the origin of `LocatedField`s through the bindings to GridTools.