### PR TITLE
feature[next]: Fix function signature validation for tuple arguments

### DIFF
--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -36,13 +36,14 @@ def promote_zero_dims(
 
     def promote_arg(param: ts.TypeSpec, arg: ts.TypeSpec) -> ts.TypeSpec:
         def _as_field(arg_el: ts.TypeSpec, path: tuple[int, ...]) -> ts.TypeSpec:
-            param_el = reduce(lambda type_, idx: type_.types[idx] if isinstance(type_, ts.TupleType) else None, path, param)  # type: ignore[arg-type, return-value]
-
-            if param_el is None:
-                # The parameter has a different structure than the actual argument. Just return
-                # the argument unpromoted and let the further error handling take care of printing
-                # a meaningful error.
-                return arg_el
+            param_el = param
+            for idx in path:
+                if not isinstance(param_el, ts.TupleType):
+                    # The parameter has a different structure than the actual argument. Just return
+                    # the argument unpromoted and let the further error handling take care of printing
+                    # a meaningful error.
+                    return arg_el
+                param_el = param_el.types[idx]
 
             if _is_zero_dim_field(param_el) and (
                 type_info.is_number(arg_el) or type_info.is_logical(arg_el)

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -36,7 +36,13 @@ def promote_zero_dims(
 
     def promote_arg(param: ts.TypeSpec, arg: ts.TypeSpec) -> ts.TypeSpec:
         def _as_field(arg_el: ts.TypeSpec, path: tuple[int, ...]) -> ts.TypeSpec:
-            param_el = reduce(lambda type_, idx: type_.types[idx], path, param)  # type: ignore[attr-defined]
+            param_el = reduce(lambda type_, idx: type_.types[idx] if isinstance(type_, ts.TupleType) else None, path, param)  # type: ignore[attr-defined]
+
+            if param_el is None:
+                # The parameter has a different structure than the actual argument. Just return
+                # the argument unpromoted and let the further error handling take care of printing
+                # a meaningful error.
+                return arg_el
 
             if _is_zero_dim_field(param_el) and type_info.is_number(arg_el):
                 if type_info.extract_dtype(param_el) == type_info.extract_dtype(arg_el):

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -36,7 +36,7 @@ def promote_zero_dims(
 
     def promote_arg(param: ts.TypeSpec, arg: ts.TypeSpec) -> ts.TypeSpec:
         def _as_field(arg_el: ts.TypeSpec, path: tuple[int, ...]) -> ts.TypeSpec:
-            param_el = reduce(lambda type_, idx: type_.types[idx] if isinstance(type_, ts.TupleType) else None, path, param)  # type: ignore[attr-defined]
+            param_el = reduce(lambda type_, idx: type_.types[idx] if isinstance(type_, ts.TupleType) else None, path, param)  # type: ignore[arg-type, return-value]
 
             if param_el is None:
                 # The parameter has a different structure than the actual argument. Just return

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -44,7 +44,9 @@ def promote_zero_dims(
                 # a meaningful error.
                 return arg_el
 
-            if _is_zero_dim_field(param_el) and type_info.is_number(arg_el):
+            if _is_zero_dim_field(param_el) and (
+                type_info.is_number(arg_el) or type_info.is_logical(arg_el)
+            ):
                 if type_info.extract_dtype(param_el) == type_info.extract_dtype(arg_el):
                     return param_el
                 else:

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -298,14 +298,18 @@ def callable_type_info_cases():
             unary_tuple_arg_func_type,
             [ts.TupleType(types=[float_type, field_type])],
             {},
-            ["Expected 0-th argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `tuple\[float64, Field\[\[I\], float64\]\]`"],
+            [
+                "Expected 0-th argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `tuple\[float64, Field\[\[I\], float64\]\]`"
+            ],
             ts.VoidType(),
         ),
         (
             unary_tuple_arg_func_type,
             [int_type],
             {},
-            ["Expected 0-th argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `int64`"],
+            [
+                "Expected 0-th argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `int64`"
+            ],
             ts.VoidType(),
         ),
         # field operator

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -101,6 +101,7 @@ def callable_type_info_cases():
     float_type = ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
     int_type = ts.ScalarType(kind=ts.ScalarKind.INT64)
     field_type = ts.FieldType(dims=[Dimension("I")], dtype=float_type)
+    tuple_type = ts.TupleType(types=[bool_type, field_type])
     nullary_func_type = ts.FunctionType(
         pos_only_args=[], pos_or_kw_args={}, kw_only_args={}, returns=ts.VoidType()
     )
@@ -118,6 +119,9 @@ def callable_type_info_cases():
         pos_or_kw_args={"foo": int_type},
         kw_only_args={"bar": float_type},
         returns=ts.VoidType(),
+    )
+    unary_tuple_arg_func_type = ts.FunctionType(
+        pos_only_args=[tuple_type], pos_or_kw_args={}, kw_only_args={}, returns=ts.VoidType()
     )
     fieldop_type = gt4py.next.ffront.type_specifications.FieldOperatorType(
         definition=ts.FunctionType(
@@ -281,6 +285,27 @@ def callable_type_info_cases():
             [bool_type],
             {"bar": float_type, "foo": int_type},
             [],
+            ts.VoidType(),
+        ),
+        (
+            unary_tuple_arg_func_type,
+            [tuple_type],
+            {},
+            [],
+            ts.VoidType(),
+        ),
+        (
+            unary_tuple_arg_func_type,
+            [ts.TupleType(types=[float_type, field_type])],
+            {},
+            ["Expected 0-th argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `tuple\[float64, Field\[\[I\], float64\]\]`"],
+            ts.VoidType(),
+        ),
+        (
+            unary_tuple_arg_func_type,
+            [int_type],
+            {},
+            ["Expected 0-th argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `int64`"],
             ts.VoidType(),
         ),
         # field operator


### PR DESCRIPTION
Small fix to signature validation when calling a field-, scan-operator, program with a tuple parameter annotation, but a non-tuple argument in the call. E.g. something like:
```python
@field_operator
def foo_op(arg: tuple[...]):
  ...

foo_op(my_field)
```

__EDIT__:
While fixing this I stumbled upon another small bug that prevented scan operators to be called with boolean arguments. Since it is in the same function and only a couple of characters I put it into the same PR.