### PR TITLE
ci: uplift version of nvidia base image

### DIFF
--- a/ci/base.Dockerfile
+++ b/ci/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nvidia/cuda:11.2.0-devel-ubuntu20.04
+FROM docker.io/nvidia/cuda:11.2.2-devel-ubuntu20.04
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 


### PR DESCRIPTION
## Description

Uplift from nvidia/cuda:11.2.0-devel-ubuntu20.04 to nvidia/cuda:11.2.2-devel-ubuntu20.04
The previous image is no longer available on Nvidia dockerhub.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [x] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [x] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
