### PR TITLE
fix[next]: ensure scan operator `init`, `carry`, return type is consistent

### DIFF
--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -312,12 +312,12 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as its return. "
                 f"Expected `{new_def_type.returns}`, but got `{new_init.type}`",
             )
-        elif new_init.type != state_type:
+        elif new_init.type != carry_type:
             carry_arg_name = list(new_def_type.pos_or_kw_args.keys())[0]
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as `{carry_arg_name}` argument. "
-                f"Expected `{state_type}`, but got `{new_init.type}`",
+                f"Expected `{carry_type}`, but got `{new_init.type}`",
             )
 
         new_type = ts_ffront.ScanOperatorType(

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -309,7 +309,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         if new_init.type != new_def_type.returns:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Argument `init` to scan operator `{node.id}` must have same type its return. "
+                msg=f"Argument `init` to scan operator `{node.id}` must have same type as its return. "
                 f"Expected {new_def_type.returns}, but got {new_init.type}",
             )
         elif new_init.type != state_type:

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -316,7 +316,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             carry_arg_name = list(new_def_type.pos_or_kw_args.keys())[0]
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Argument `init` to scan operator `{node.id}` must have same type as {list(new_def_type.pos_or_kw_args.keys())[0]}. "
+                msg=f"Argument `init` to scan operator `{node.id}` must have same type as `{carry_arg_name}` argument. "
                 f"Expected {state_type}, but got {new_init.type}",
             )
 

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -316,7 +316,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         elif new_init_type != state_type:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Argument `init` to scan operator `{node.id}` must have same type as {state_type}. "
+                msg=f"Argument `init` to scan operator `{node.id}` must have same type as {list(new_def_type.pos_or_kw_args.keys())[0]}. "
                 f"Expected {state_type}, but got {new_init_type}",
             )
 

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -317,7 +317,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as `{carry_arg_name}` argument. "
-                f"Expected {state_type}, but got {new_init.type}",
+                f"Expected `{state_type}`, but got `{new_init.type}`",
             )
 
         new_type = ts_ffront.ScanOperatorType(

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -310,7 +310,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as its return. "
-                f"Expected {new_def_type.returns}, but got {new_init.type}",
+                f"Expected `{new_def_type.returns}`, but got `{new_init.type}`",
             )
         elif new_init.type != state_type:
             carry_arg_name = list(new_def_type.pos_or_kw_args.keys())[0]

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -309,7 +309,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         if new_init.type != new_def_type.returns:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Argument `init` to scan operator `{node.id}` must have same type as return. "
+                msg=f"Argument `init` to scan operator `{node.id}` must have same type its return. "
                 f"Expected {new_def_type.returns}, but got {new_init.type}",
             )
         elif new_init.type != state_type:

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -294,10 +294,9 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 node, msg=f"Argument `forward` to scan operator `{node.id}` must be a boolean."
             )
         new_init = self.visit(node.init, **kwargs)
-        new_init_type = new_init.type
         if not all(
             type_info.is_arithmetic(type_) or type_info.is_logical(type_)
-            for type_ in type_info.primitive_constituents(new_init_type)
+            for type_ in type_info.primitive_constituents(new_init.type)
         ):
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
@@ -307,17 +306,17 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         new_definition = self.visit(node.definition, **kwargs)
         new_def_type = new_definition.type
         state_type = list(new_def_type.pos_or_kw_args.values())[0]
-        if new_init_type != new_def_type.returns:
+        if new_init.type != new_def_type.returns:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as return. "
-                f"Expected {new_def_type.returns}, but got {new_init_type}",
+                f"Expected {new_def_type.returns}, but got {new_init.type}",
             )
-        elif new_init_type != state_type:
+        elif new_init.type != state_type:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as {list(new_def_type.pos_or_kw_args.keys())[0]}. "
-                f"Expected {state_type}, but got {new_init_type}",
+                f"Expected {state_type}, but got {new_init.type}",
             )
 
         new_type = ts_ffront.ScanOperatorType(

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -304,9 +304,16 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 f"be an arithmetic type or a logical type or a composite of arithmetic and logical types.",
             )
         new_definition = self.visit(node.definition, **kwargs)
+        new_def_type = new_definition.type
+        if new_def_type.returns != new_init.type:
+            raise FieldOperatorTypeDeductionError.from_foast_node(
+                node,
+                msg=f"Argument `init` to scan operator `{node.id}` must have same type as return. "
+                f"Expected {new_def_type.returns}, but got {new_init.type}",
+            )
         new_type = ts_ffront.ScanOperatorType(
             axis=new_axis.type.dim,
-            definition=new_definition.type,
+            definition=new_def_type,
         )
         return foast.ScanOperator(
             id=node.id,

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -313,6 +313,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 f"Expected {new_def_type.returns}, but got {new_init.type}",
             )
         elif new_init.type != state_type:
+            carry_arg_name = list(new_def_type.pos_or_kw_args.keys())[0]
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as {list(new_def_type.pos_or_kw_args.keys())[0]}. "

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -305,7 +305,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         new_definition = self.visit(node.definition, **kwargs)
         new_def_type = new_definition.type
-        state_type = list(new_def_type.pos_or_kw_args.values())[0]
+        carry_type = list(new_def_type.pos_or_kw_args.values())[0]
         if new_init.type != new_def_type.returns:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -306,17 +306,18 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         new_definition = self.visit(node.definition, **kwargs)
         new_def_type = new_definition.type
+        state_type = list(new_def_type.pos_or_kw_args.values())[0]
         if new_init_type != new_def_type.returns:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
                 msg=f"Argument `init` to scan operator `{node.id}` must have same type as return. "
                 f"Expected {new_def_type.returns}, but got {new_init_type}",
             )
-        elif new_init_type != list(new_def_type.pos_or_kw_args.values())[0]:
+        elif new_init_type != state_type:
             raise FieldOperatorTypeDeductionError.from_foast_node(
                 node,
-                msg=f"Argument `init` to scan operator `{node.id}` must have same type as {list(new_def_type.pos_or_kw_args.keys())[0]}. "
-                f"Expected {list(new_def_type.pos_or_kw_args.values())[0]}, but got {new_init_type}",
+                msg=f"Argument `init` to scan operator `{node.id}` must have same type as {state_type}. "
+                f"Expected {state_type}, but got {new_init_type}",
             )
 
         new_type = ts_ffront.ScanOperatorType(

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -247,16 +247,11 @@ def test_scan_wrong_return_type(cartesian_case):
         match=(r"Argument `init` to scan operator `testee_scan` must have same type as return"),
     ):
 
-        @scan_operator(axis=KDim, forward=True, init=(0.0, 0, 0.0))
+        @scan_operator(axis=KDim, forward=True, init=0)
         def testee_scan(
-            state: tuple[float, int32, float],
-            qc_in: float,
-            param_1: int32,
-            param_2: float,
-            scalar: float,
-        ) -> tuple[float, int32]:
-            qc = qc_in + state[0] + scalar
-            return (qc, param_1)
+            state: int32,
+        ) -> float:
+            return 1.
 
         @program
         def testee(qc: cases.IKFloatField, param_1: int32, param_2: float, scalar: float):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -20,7 +20,8 @@ import pytest
 
 from gt4py.next.common import Field
 from gt4py.next.ffront.decorator import field_operator, program, scan_operator
-from gt4py.next.ffront.fbuiltins import int64
+from gt4py.next.ffront.fbuiltins import int32, int64
+from gt4py.next.ffront.foast_passes.type_deduction import FieldOperatorTypeDeductionError
 from gt4py.next.program_processors.runners import dace_iterator, gtfn_cpu
 
 from next_tests.integration_tests import cases
@@ -235,3 +236,49 @@ def test_call_scan_operator_from_program(cartesian_case):
         ref=(ref, ref, ref, ref),
         comparison=lambda out, ref: all(map(np.allclose, zip(out, ref))),
     )
+
+
+def test_scan_wrong_return_type(cartesian_case):
+    if cartesian_case.backend == dace_iterator.run_dace_iterator:
+        pytest.xfail("Not supported in DaCe backend: scan")
+
+    with pytest.raises(
+        FieldOperatorTypeDeductionError,
+        match=(r"Argument `init` to scan operator `testee_scan` must have same type as return"),
+    ):
+
+        @scan_operator(axis=KDim, forward=True, init=(0.0, 0, 0.0))
+        def testee_scan(
+            state: tuple[float, int32, float],
+            qc_in: float,
+            param_1: int32,
+            param_2: float,
+            scalar: float,
+        ) -> tuple[float, int32]:
+            qc = qc_in + state[0] + scalar
+            return (qc, param_1)
+
+        @program
+        def testee(qc: cases.IKFloatField, param_1: int32, param_2: float, scalar: float):
+            testee_scan(qc, param_1, param_2, scalar, out=(qc, param_1, param_2))
+
+
+def test_scan_wrong_state_type(cartesian_case):
+    if cartesian_case.backend == dace_iterator.run_dace_iterator:
+        pytest.xfail("Not supported in DaCe backend: scan")
+
+    with pytest.raises(
+        FieldOperatorTypeDeductionError,
+        match=(r"Argument `init` to scan operator `testee_scan` must have same type as state"),
+    ):
+
+        @scan_operator(axis=KDim, forward=True, init=(0.0, 0, 0.0))
+        def testee_scan(
+            state: tuple[float, float], qc_in: float, param_1: int32, param_2: float, scalar: float
+        ) -> tuple[float, int32, float]:
+            qc = qc_in + state[0] + scalar
+            return (qc, param_1, param_2)
+
+        @program
+        def testee(qc: cases.IKFloatField, param_1: int32, param_2: float, scalar: float):
+            testee_scan(qc, param_1, param_2, scalar, out=(qc, param_1, param_2))

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -272,12 +272,11 @@ def test_scan_wrong_state_type(cartesian_case):
         match=(r"Argument `init` to scan operator `testee_scan` must have same type as state"),
     ):
 
-        @scan_operator(axis=KDim, forward=True, init=(0.0, 0, 0.0))
+        @scan_operator(axis=KDim, forward=True, init=0)
         def testee_scan(
-            state: tuple[float, float], qc_in: float, param_1: int32, param_2: float, scalar: float
-        ) -> tuple[float, int32, float]:
-            qc = qc_in + state[0] + scalar
-            return (qc, param_1, param_2)
+            state: float,
+        ) -> int32:
+            return 1
 
         @program
         def testee(qc: cases.IKFloatField, param_1: int32, param_2: float, scalar: float):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -239,19 +239,16 @@ def test_call_scan_operator_from_program(cartesian_case):
 
 
 def test_scan_wrong_return_type(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: scan")
-
     with pytest.raises(
         FieldOperatorTypeDeductionError,
-        match=(r"Argument `init` to scan operator `testee_scan` must have same type as return"),
+        match=(r"Argument `init` to scan operator `testee_scan` must have same type as its return"),
     ):
 
         @scan_operator(axis=KDim, forward=True, init=0)
         def testee_scan(
             state: int32,
         ) -> float:
-            return 1.
+            return 1.0
 
         @program
         def testee(qc: cases.IKFloatField, param_1: int32, param_2: float, scalar: float):
@@ -259,12 +256,11 @@ def test_scan_wrong_return_type(cartesian_case):
 
 
 def test_scan_wrong_state_type(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: scan")
-
     with pytest.raises(
         FieldOperatorTypeDeductionError,
-        match=(r"Argument `init` to scan operator `testee_scan` must have same type as state"),
+        match=(
+            r"Argument `init` to scan operator `testee_scan` must have same type as `state` argument"
+        ),
     ):
 
         @scan_operator(axis=KDim, forward=True, init=0)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -1015,6 +1015,25 @@ def test_tuple_unpacking_star_multi(cartesian_case):
     )
 
 
+def test_scan_wrong_init_type(cartesian_case):
+    if cartesian_case.backend == dace_iterator.run_dace_iterator:
+        pytest.xfail("Not supported in DaCe backend: scan")
+
+    with pytest.raises(
+        FieldOperatorTypeDeductionError,
+        match=(r"Argument `init` to scan operator `testee_scan` must have same type as return"),
+    ):
+
+        @gtx.scan_operator(axis=KDim, forward=True, init=(0.0, 0))
+        def testee_scan(state: float, qc_in: float, scalar: float) -> tuple[float, int32]:
+            qc = qc_in + state + scalar
+            return qc, 2
+
+        @gtx.program
+        def testee(qc: cases.IKFloatField, scalar: float):
+            testee_scan(qc, scalar, out=(qc, 2))
+
+
 def test_tuple_unpacking_too_many_values(cartesian_case):
     with pytest.raises(
         FieldOperatorTypeDeductionError,

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -1015,25 +1015,6 @@ def test_tuple_unpacking_star_multi(cartesian_case):
     )
 
 
-def test_scan_wrong_init_type(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: scan")
-
-    with pytest.raises(
-        FieldOperatorTypeDeductionError,
-        match=(r"Argument `init` to scan operator `testee_scan` must have same type as return"),
-    ):
-
-        @gtx.scan_operator(axis=KDim, forward=True, init=(0.0, 0))
-        def testee_scan(state: float, qc_in: float, scalar: float) -> tuple[float, int32]:
-            qc = qc_in + state + scalar
-            return qc, 2
-
-        @gtx.program
-        def testee(qc: cases.IKFloatField, scalar: float):
-            testee_scan(qc, scalar, out=(qc, 2))
-
-
 def test_tuple_unpacking_too_many_values(cartesian_case):
     with pytest.raises(
         FieldOperatorTypeDeductionError,

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -75,14 +75,14 @@ def test_fieldop():
 def test_scanop():
     KDim = Dimension("KDim", kind=DimensionKind.VERTICAL)
 
-    @scan_operator(axis=KDim, forward=False, init=1.0)
+    @scan_operator(axis=KDim, forward=False, init=int64(1))
     def scan(inp: int64) -> int64:
         foo = inp
         return inp
 
     expected = textwrap.dedent(
         f"""
-        @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1.0)
+        @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1)
         def scan(inp: int64) -> int64:
           {ssa.unique_name("foo", 0)} = inp
           return inp

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -17,7 +17,7 @@ import textwrap
 
 import pytest
 
-from gt4py.next import Dimension, DimensionKind, Field, field_operator, int64, scan_operator
+from gt4py.next import Dimension, DimensionKind, Field, field_operator, int32, int64, scan_operator
 from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.ffront.foast_pretty_printer import pretty_format
 from gt4py.next.ffront.func_to_foast import FieldOperatorParser
@@ -82,8 +82,8 @@ def test_scanop():
 
     expected = textwrap.dedent(
         f"""
-        @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1.)
-        def scan(inp: int64) -> int64:
+        @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1)
+        def scan(inp: int32) -> int32:
           {ssa.unique_name("foo", 0)} = inp
           return inp
         """

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -75,8 +75,8 @@ def test_fieldop():
 def test_scanop():
     KDim = Dimension("KDim", kind=DimensionKind.VERTICAL)
 
-    @scan_operator(axis=KDim, forward=False, init=int64(1))
-    def scan(inp: int64) -> int64:
+    @scan_operator(axis=KDim, forward=False, init=1)
+    def scan(inp: int32) -> int32:
         foo = inp
         return inp
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -82,7 +82,7 @@ def test_scanop():
 
     expected = textwrap.dedent(
         f"""
-        @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1)
+        @scan_operator(axis=Dimension(value="KDim", kind=DimensionKind.VERTICAL), forward=False, init=1.)
         def scan(inp: int64) -> int64:
           {ssa.unique_name("foo", 0)} = inp
           return inp


### PR DESCRIPTION
type check such that init, state, and return all have the same type. Such example should return an error message:
```python
@scan_operator(axis=KDim, forward=True, init=(0.0, 0, 0.0))
def testee_scan(
    state: tuple[float, float], qc_in: float, param_1: int32, param_2: float, scalar: float
) -> tuple[float, int32, float]:
    qc = qc_in + state[0] + scalar
    return (qc, param_1, param_2)
```

```python
@scan_operator(axis=KDim, forward=True, init=(0.0, 0, 0.0))
def testee_scan(state: tuple[float, int32, float], qc_in: float, param_1: int32, param_2: float, scalar: float
) -> tuple[float, int32]:
    qc = qc_in + state[0] + scalar
    return (qc, param_1)
```