### PR TITLE
fix[next]: DaCe scalar argument in stencil closure

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -95,7 +95,7 @@ def run_dace_iterator(program: itir.FencilDefinition, *args, **kwargs) -> None:
     sdfg: dace.SDFG = sdfg_genenerator.visit(program)
 
     dace_args = get_args(program.params, args)
-    dace_field_args = {n: v for n, v in dace_args.items() if hasattr(v, "shape")}
+    dace_field_args = {n: v for n, v in dace_args.items() if not np.isscalar(v)}
     dace_conn_args = get_connectivity_args(neighbor_tables)
     dace_shapes = get_shape_args(sdfg.arrays, dace_field_args)
     dace_conn_shapes = get_shape_args(sdfg.arrays, dace_conn_args)

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -545,7 +545,7 @@ class ItirToSDFG(eve.NodeVisitor):
         # Create an SDFG for the tasklet that computes a single item of the output domain.
         index_domain = {dim: f"i_{dim}" for dim, _ in closure_domain}
 
-        input_arrays = [(array_table[name], name, self.storage_types[name]) for name in input_names]
+        input_arrays = [(name, self.storage_types[name]) for name in input_names]
         conn_arrays = [(array_table[name], name) for name in conn_names]
 
         context, _, results = closure_to_tasklet_sdfg(

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -291,7 +291,6 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
 
         # Translate the function's body
         result: ValueExpr | SymbolExpr = self.visit(node.expr)[0]
-        # Forwarding result through a tasklet needed because empty SDFG states don't properly forward connectors
         if isinstance(result, SymbolExpr):
             result = self.add_expr_tasklet([], result.value, result.dtype, "forward")[0]
         self.context.body.arrays[result.value.data].transient = False

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -292,15 +292,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
         # Translate the function's body
         result: ValueExpr | SymbolExpr = self.visit(node.expr)[0]
         # Forwarding result through a tasklet needed because empty SDFG states don't properly forward connectors
-        if isinstance(result, ValueExpr):
-            result_name = unique_var_name()
-            self.context.body.add_scalar(result_name, result.dtype, transient=True)
-            result_access = self.context.state.add_access(result_name)
-            self.context.state.add_edge(
-                result.value, None, result_access, None, dace.Memlet(f"{result.value.data}[0]")
-            )
-            result = ValueExpr(value=result_access, dtype=result.dtype)
-        else:
+        if isinstance(result, SymbolExpr):
             result = self.add_expr_tasklet([], result.value, result.dtype, "forward")[0]
         self.context.body.arrays[result.value.data].transient = False
         self.context = prev_context

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -291,7 +291,16 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
 
         # Translate the function's body
         result: ValueExpr | SymbolExpr = self.visit(node.expr)[0]
-        if isinstance(result, SymbolExpr):
+        # Forwarding result through a tasklet needed because empty SDFG states don't properly forward connectors
+        if isinstance(result, ValueExpr):
+            result_name = unique_var_name()
+            self.context.body.add_scalar(result_name, result.dtype, transient=True)
+            result_access = self.context.state.add_access(result_name)
+            self.context.state.add_edge(
+                result.value, None, result_access, None, dace.Memlet(f"{result.value.data}[0]")
+            )
+            result = ValueExpr(value=result_access, dtype=result.dtype)
+        else:
             result = self.add_expr_tasklet([], result.value, result.dtype, "forward")[0]
         self.context.body.arrays[result.value.data].transient = False
         self.context = prev_context

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -178,8 +178,6 @@ def test_tuples(cartesian_case):  # noqa: F811 # fixtures
 
 def test_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
     """Test scalar argument being turned into 0-dim field."""
-    if unstructured_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
 
     @gtx.field_operator
     def testee(a: int32) -> cases.VField:
@@ -198,9 +196,6 @@ def test_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
 
 
 def test_nested_scalar_arg(unstructured_case):  # noqa: F811 # fixtures
-    if unstructured_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
-
     @gtx.field_operator
     def testee_inner(a: int32) -> cases.VField:
         return broadcast(a + 1, (Vertex,))
@@ -587,9 +582,6 @@ def test_solve_triag(cartesian_case):
 
 @pytest.mark.parametrize("left, right", [(2, 3), (3, 2)])
 def test_ternary_operator(cartesian_case, left, right):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
-
     @gtx.field_operator
     def testee(a: cases.IField, b: cases.IField, left: int32, right: int32) -> cases.IField:
         return a if left < right else b
@@ -917,7 +909,7 @@ def test_undefined_symbols(cartesian_case):
 
 def test_zero_dims_fields(cartesian_case):
     if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
+        pytest.xfail("Not supported in DaCe backend: zero-dimensional fields")
 
     @gtx.field_operator
     def implicit_broadcast_scalar(inp: cases.EmptyField):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -208,9 +208,6 @@ def test_conditional_nested_tuple(cartesian_case):
 
 
 def test_broadcast_simple(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
-
     @gtx.field_operator
     def simple_broadcast(inp: cases.IField) -> cases.IJField:
         return broadcast(inp, (IDim, JDim))
@@ -221,8 +218,6 @@ def test_broadcast_simple(cartesian_case):
 
 
 def test_broadcast_scalar(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
     size = cartesian_case.default_sizes[IDim]
 
     @gtx.field_operator
@@ -233,9 +228,6 @@ def test_broadcast_scalar(cartesian_case):
 
 
 def test_broadcast_two_fields(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
-
     @gtx.field_operator
     def broadcast_two_fields(inp1: cases.IField, inp2: gtx.Field[[JDim], int32]) -> cases.IJField:
         a = broadcast(inp1, (IDim, JDim))
@@ -248,9 +240,6 @@ def test_broadcast_two_fields(cartesian_case):
 
 
 def test_broadcast_shifted(cartesian_case):
-    if cartesian_case.backend == dace_iterator.run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: broadcast")
-
     @gtx.field_operator
     def simple_broadcast(inp: cases.IField) -> cases.IJField:
         bcasted = broadcast(inp, (IDim, JDim))


### PR DESCRIPTION
## Description

Add support for argument of stencil closure with `ScalarType`. Baseline only supported `FieldType` arguments.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
