### PR TITLE
refactor[next]: use __gt_dims__ in LocatedField

### DIFF
--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -174,7 +174,7 @@ class LocatedField(Protocol):
 
     @property
     @abc.abstractmethod
-    def axes(self) -> tuple[common.Dimension, ...]:
+    def __gt_dims__(self) -> tuple[common.Dimension, ...]:
         ...
 
     # TODO(havogt): define generic Protocol to provide a concrete return type
@@ -184,7 +184,7 @@ class LocatedField(Protocol):
 
     @property
     def __gt_origin__(self) -> tuple[int, ...]:
-        return tuple([0] * len(self.axes))
+        return tuple([0] * len(self.__gt_dims__))
 
 
 class MutableLocatedField(LocatedField, Protocol):
@@ -685,7 +685,9 @@ def _get_axes(
     field_or_tuple: LocatedField | tuple,
 ) -> Sequence[common.Dimension | runtime.Offset]:  # arbitrary nesting of tuples of LocatedField
     return (
-        _get_axes(field_or_tuple[0]) if isinstance(field_or_tuple, tuple) else field_or_tuple.axes
+        _get_axes(field_or_tuple[0])
+        if isinstance(field_or_tuple, tuple)
+        else field_or_tuple.__gt_dims__
     )
 
 
@@ -880,7 +882,7 @@ class LocatedFieldImpl(MutableLocatedField):
     """A Field with named dimensions/axes."""
 
     @property
-    def axes(self) -> tuple[common.Dimension, ...]:
+    def __gt_dims__(self) -> tuple[common.Dimension, ...]:
         return self._axes
 
     def __init__(
@@ -920,9 +922,10 @@ class LocatedFieldImpl(MutableLocatedField):
     @property
     def __gt_origin__(self) -> tuple[int, ...]:
         if not self.origin:
-            return tuple([0] * len(self.axes))
+            return tuple([0] * len(self.__gt_dims__))
         return cast(
-            tuple[int], get_ordered_indices(self.axes, {k.value: v for k, v in self.origin.items()})
+            tuple[int],
+            get_ordered_indices(self.__gt_dims__, {k.value: v for k, v in self.origin.items()}),
         )
 
     @property
@@ -1060,7 +1063,7 @@ class IndexField(LocatedField):
             return self.dtype.type(index[0])
 
     @property
-    def axes(self) -> tuple[common.Dimension]:
+    def __gt_dims__(self) -> tuple[common.Dimension]:
         return (self.axis,)
 
 
@@ -1077,7 +1080,7 @@ class ConstantField(LocatedField):
         return self.dtype(self.value)
 
     @property
-    def axes(self) -> tuple[()]:
+    def __gt_dims__(self) -> tuple[()]:
         return ()
 
 
@@ -1260,7 +1263,7 @@ def _get_axeses(field):
         return tuple(itertools.chain(*tuple(_get_axeses(f) for f in field)))
     else:
         assert is_located_field(field)
-        return (field.axes,)
+        return (_get_axes(field),)
 
 
 def _build_tuple_result(field, indices):
@@ -1290,7 +1293,7 @@ class TupleOfFields(TupleField):
             raise TypeError("Can only be instantiated with a tuple of fields")
         self.data = data
         axeses = _get_axeses(data)
-        self.axes = axeses[0]
+        self.__gt_dims__ = axeses[0]
 
     def field_getitem(self, indices):
         return _build_tuple_result(self.data, indices)
@@ -1398,14 +1401,14 @@ def fendef_embedded(fun: Callable[..., None], *args: Any, **kwargs: Any):
 
                 if column is None:
                     assert _is_concrete_position(pos)
-                    ordered_indices = get_ordered_indices(out.axes, pos)
+                    ordered_indices = get_ordered_indices(_get_axes(out), pos)
                     out.field_setitem(ordered_indices, res)
                 else:
                     col_pos = pos.copy()
                     for k in column.col_range:
                         col_pos[column.axis] = k
                         assert _is_concrete_position(col_pos)
-                        ordered_indices = get_ordered_indices(out.axes, col_pos)
+                        ordered_indices = get_ordered_indices(_get_axes(out), col_pos)
                         out.field_setitem(ordered_indices, res[k])
 
         ctx = cvars.copy_context()

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -1263,7 +1263,7 @@ def _get_axeses(field):
         return tuple(itertools.chain(*tuple(_get_axeses(f) for f in field)))
     else:
         assert is_located_field(field)
-        return (_get_axes(field),)
+        return (field.__gt_dims__,)
 
 
 def _build_tuple_result(field, indices):

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -30,7 +30,7 @@ from .utility import connectivity_identifier, filter_neighbor_tables
 
 def convert_arg(arg: Any):
     if isinstance(arg, LocatedField):
-        sorted_dims = sorted(enumerate(arg.axes), key=lambda v: v[1].value)
+        sorted_dims = sorted(enumerate(arg.__gt_dims__), key=lambda v: v[1].value)
         ndim = len(sorted_dims)
         dim_indices = [dim[0] for dim in sorted_dims]
         return np.moveaxis(np.asarray(arg), range(ndim), dim_indices)

--- a/src/gt4py/next/program_processors/runners/gtfn_cpu.py
+++ b/src/gt4py/next/program_processors/runners/gtfn_cpu.py
@@ -32,7 +32,7 @@ from gt4py.next.type_system.type_translation import from_value
 def convert_arg(arg: Any) -> Any:
     if isinstance(arg, tuple):
         return tuple(convert_arg(a) for a in arg)
-    if hasattr(arg, "__array__") and hasattr(arg, "axes"):
+    if hasattr(arg, "__array__") and hasattr(arg, "__gt_dims__"):
         arr = np.asarray(arg)
         origin = getattr(arg, "__gt_origin__", tuple([0] * arr.ndim))
         return arr, origin

--- a/src/gt4py/next/type_system/type_translation.py
+++ b/src/gt4py/next/type_system/type_translation.py
@@ -186,7 +186,7 @@ def from_value(value: Any) -> ts.TypeSpec:
     elif isinstance(value, common.Dimension):
         symbol_type = ts.DimensionType(dim=value)
     elif isinstance(value, LocatedField):
-        dims = list(value.axes)
+        dims = list(value.__gt_dims__)
         dtype = from_type_hint(value.dtype.type)
         symbol_type = ts.FieldType(dims=dims, dtype=dtype)
     elif isinstance(value, tuple):

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_field.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_field.py
@@ -28,7 +28,7 @@ def test_located_field_1d():
 
     foo[0] = 42
 
-    assert foo.axes[0] == "foo"
+    assert foo.__gt_dims__[0] == "foo"
     assert foo[0] == 42
 
 
@@ -37,7 +37,7 @@ def test_located_field_2d():
 
     foo[0, 0] = 42
 
-    assert foo.axes[0] == "foo"
+    assert foo.__gt_dims__[0] == "foo"
     assert foo[0, 0] == 42
     assert foo.dtype == np.float64
 
@@ -74,7 +74,6 @@ def test_tuple_of_tuple_of_field():
         (make_located_field(), make_located_field()),
         (make_located_field(), make_located_field()),
     )
-    print(embedded._get_axeses(tup))
     testee = embedded.TupleOfFields(tup)
     assert isinstance(testee, embedded.TupleField)
 

--- a/tests/next_tests/unit_tests/iterator_tests/test_embedded_field.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_embedded_field.py
@@ -49,12 +49,6 @@ def test_tuple_field_concept():
     field_of_tuples = make_located_field(dtype="f8,f8")
     assert embedded.can_be_tuple_field(field_of_tuples)
 
-    # TODO think about if that makes sense
-    # field_with_unnamed_dimensions = gtx.np_as_located_field("foo", unnamed_as_tuple=True)(
-    #     np.zeros((1, 2))
-    # )
-    # assert embedded.is_tuple_field(field_with_unnamed_dimensions)
-
 
 def test_field_of_tuple():
     field_of_tuples = make_located_field(dtype="f8,f8")


### PR DESCRIPTION
Rename `LocatedField.axes` to `LocatedField.__gt_dims__` to make it compatible with the Cartesian and as preparation to switch to the new field implementation.

Note that gt4py.cartesian requires returning a tuple of `str`, for gt4py.next we require `tuple[Dimension]`. I propose to relax the cartesian requirement to convertible to `str`, which should already work as the documentation demands to go through `gt4py.storage.utils.get_dims()` which has string conversion.