### PR TITLE
feature[next]: Add argument types to ITIR when tracing

### DIFF
--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -1065,7 +1065,7 @@ class IndexField(LocatedField):
         return (self.axis,)
 
 
-def index_field(axis: common.Dimension, dtype: npt.DTypeLike = int) -> LocatedField:
+def index_field(axis: common.Dimension, dtype: npt.DTypeLike = np.int32) -> LocatedField:
     return IndexField(axis, dtype)
 
 

--- a/src/gt4py/next/iterator/runtime.py
+++ b/src/gt4py/next/iterator/runtime.py
@@ -66,17 +66,24 @@ class FendefDispatcher:
         self,
         *args,
         fendef_codegen: Optional[Callable[[types.FunctionType], FencilDefinition]] = None,
+        lift_mode=None,
         **kwargs,
     ):
         args, kwargs = self._rewrite_args(args, kwargs)
+
+        # For consistency with `__call__` we also allow these keyword arguments, but ignore them
+        # here, as they are not used for code generation.
+        for ignored_kwarg in ["offset_provider", "lift_mode", "column_axis"]:
+            kwargs.pop(ignored_kwarg, None)
+
         if fendef_codegen is None:
             # TODO(ricoh): refactor so that `tracing` does not import this module
             #   and can be imported top level. Then set `fendef_tracing` as a
             #   proper default value, instead of using `None` as a sentinel.
-            from .tracing import fendef_tracing
+            from gt4py.next.iterator.tracing import trace_fencil_definition
 
-            fendef_codegen = fendef_tracing
-        fencil_definition = fendef_codegen(self.function, *args, **kwargs)
+            fendef_codegen = trace_fencil_definition
+        fencil_definition = fendef_codegen(self.function, args, **kwargs)
         if "debug" in kwargs:
             debug(fencil_definition)
         return fencil_definition

--- a/src/gt4py/next/iterator/runtime.py
+++ b/src/gt4py/next/iterator/runtime.py
@@ -18,7 +18,7 @@ import types
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
-from devtools import debug
+import devtools
 
 from gt4py.next import common
 from gt4py.next.iterator import builtins
@@ -66,7 +66,7 @@ class FendefDispatcher:
         self,
         *args,
         fendef_codegen: Optional[Callable[[types.FunctionType], FencilDefinition]] = None,
-        lift_mode=None,
+        debug=False,
         **kwargs,
     ):
         args, kwargs = self._rewrite_args(args, kwargs)
@@ -84,8 +84,8 @@ class FendefDispatcher:
 
             fendef_codegen = trace_fencil_definition
         fencil_definition = fendef_codegen(self.function, args, **kwargs)
-        if "debug" in kwargs:
-            debug(fencil_definition)
+        if debug:
+            devtools.debug(fencil_definition)
         return fencil_definition
 
     def __call__(self, *args, backend: Optional[ProgramExecutor] = None, **kwargs):

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_builtins.py
@@ -319,16 +319,6 @@ def test_can_deref(program_processor, stencil):
 #     if validate:
 #         assert np.allclose(np.asarray(out), 1.0)
 
-# TODO(tehrengruber): fix comment, check test fails if cast is missing
-# There is no straight-forward way to test cast, because when we define the
-# output buffer with the cast-to type an implicit conversion will happen even
-# if no explicit cast was done. To avoid
-# Therefore, we have to set up the test in a way that the explicit cast is required,
-# e.g. by a combination of explicit an implicit cast.
-# Test setup:
-# - Input buffer is setup with the dtype from `input_value`
-# - Output buffer is setup with the type of the `expected_value`
-
 
 @pytest.mark.parametrize(
     "input_value, dtype, np_dtype",
@@ -342,9 +332,6 @@ def test_can_deref(program_processor, stencil):
 @pytest.mark.parametrize("as_column", [False, True])
 def test_cast(program_processor, as_column, input_value, dtype, np_dtype):
     program_processor, validate = program_processor
-    if program_processor == run_dace_iterator:
-        pytest.xfail("Not supported in DaCe backend: implicit type cast")
-
     column_axis = IDim if as_column else None
 
     inp = asfield(np.array([input_value]))[0]

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_builtins.py
@@ -11,7 +11,7 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-
+import builtins
 import dataclasses
 import math
 from typing import Callable, Iterable
@@ -261,8 +261,8 @@ def test_can_deref(program_processor, stencil):
 
     Node = gtx.Dimension("Node")
 
-    inp = gtx.np_as_located_field(Node)(np.ones((1,)))
-    out = gtx.np_as_located_field(Node)(np.asarray([0]))
+    inp = gtx.np_as_located_field(Node)(np.ones((1,), dtype=np.int32))
+    out = gtx.np_as_located_field(Node)(np.asarray([0], dtype=inp.dtype))
 
     no_neighbor_tbl = gtx.NeighborTableOffsetProvider(np.array([[-1]]), Node, Node, 1)
     run_processor(
@@ -319,48 +319,53 @@ def test_can_deref(program_processor, stencil):
 #     if validate:
 #         assert np.allclose(np.asarray(out), 1.0)
 
-
+# TODO(tehrengruber): fix comment, check test fails if cast is missing
 # There is no straight-forward way to test cast, because when we define the
 # output buffer with the cast-to type an implicit conversion will happen even
-# if no explicit cast was done.
+# if no explicit cast was done. To avoid
 # Therefore, we have to set up the test in a way that the explicit cast is required,
 # e.g. by a combination of explicit an implicit cast.
 # Test setup:
 # - Input buffer is setup with the dtype from `input_value`
 # - Output buffer is setup with the type of the `expected_value`
-# `expected_value` should be chosen with a different type than the explict cast-to type `dtype`.
+
+
 @pytest.mark.parametrize(
-    "input_value, dtype, expected_value",
+    "input_value, dtype, np_dtype",
     [
-        (float64("0.1"), float32, float64(float32("0.1"))),
-        (int64(42), bool, int64(1)),
-        (int64(2147483648), int32, int64(-2147483648)),
-        (int64(2147483648), int64, int64(2147483648)),  # int64 does not accidentally down-cast
+        (float64("0.1"), float32, np.float32),
+        (int64(42), bool, builtins.bool),
+        (int64(2147483648), int32, np.int32),
+        (int64(2147483648), int64, np.int64),
     ],
 )
 @pytest.mark.parametrize("as_column", [False, True])
-def test_cast(program_processor, as_column, input_value, dtype, expected_value):
+def test_cast(program_processor, as_column, input_value, dtype, np_dtype):
     program_processor, validate = program_processor
     if program_processor == run_dace_iterator:
         pytest.xfail("Not supported in DaCe backend: implicit type cast")
 
     column_axis = IDim if as_column else None
 
-    inp = asfield(*asarray(input_value))[0]
-    out = asfield((np.zeros_like(*asarray(expected_value))))[0]
+    inp = asfield(np.array([input_value]))[0]
+
+    casted_valued = np_dtype(input_value)
 
     @fundef
-    def sten_cast(value):
-        return cast_(deref(value), dtype)
+    def sten_cast(it, casted_valued):
+        return eq(cast_(deref(it), dtype), deref(casted_valued))
 
+    out = asfield(np.zeros_like(inp, dtype=builtins.bool))[0]
     run_processor(
         sten_cast[{IDim: range(1)}],
         program_processor,
         inp,
+        casted_valued,
         out=out,
         offset_provider={},
         column_axis=column_axis,
+        debug=True,
     )
 
     if validate:
-        assert out[0] == expected_value
+        assert out[0] == True

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_constant.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_constant.py
@@ -30,7 +30,7 @@ def test_constant():
 
         return deref(inp) + deref(lift(constant_stencil)())
 
-    inp = gtx.np_as_located_field(IDim)(np.asarray([0, 42]))
+    inp = gtx.np_as_located_field(IDim)(np.asarray([0, 42], dtype=np.int32))
     res = gtx.np_as_located_field(IDim)(np.zeros_like(inp))
 
     add_constant[{IDim: range(2)}](inp, out=res, offset_provider={}, backend=roundtrip.executor)

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_horizontal_indirection.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_horizontal_indirection.py
@@ -69,10 +69,10 @@ def test_simple_indirection(program_processor):
         )  # TODO fix test or generalize itir?
 
     shape = [8]
-    inp = gtx.np_as_located_field(IDim, origin={IDim: 1})(np.asarray(range(shape[0] + 2)))
+    inp = gtx.np_as_located_field(IDim, origin={IDim: 1})(np.arange(0, shape[0] + 2))
     rng = np.random.default_rng()
     cond = gtx.np_as_located_field(IDim)(rng.normal(size=shape))
-    out = gtx.np_as_located_field(IDim)(np.zeros(shape))
+    out = gtx.np_as_located_field(IDim)(np.zeros(shape, dtype=inp.dtype))
 
     ref = np.zeros(shape)
     for i in range(shape[0]):
@@ -102,9 +102,9 @@ def test_direct_offset_for_indirection(program_processor):
         pytest.xfail("Not supported in DaCe backend: shift offsets not literals")
 
     shape = [4]
-    inp = gtx.np_as_located_field(IDim)(np.asarray(range(shape[0])))
+    inp = gtx.np_as_located_field(IDim)(np.asarray(range(shape[0]), dtype=np.float64))
     cond = gtx.np_as_located_field(IDim)(np.asarray([2, 1, -1, -2], dtype=np.int32))
-    out = gtx.np_as_located_field(IDim)(np.zeros(shape))
+    out = gtx.np_as_located_field(IDim)(np.zeros(shape, dtype=np.float64))
 
     ref = np.zeros(shape)
     for i in range(shape[0]):

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_horizontal_indirection.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_horizontal_indirection.py
@@ -46,7 +46,7 @@ I = offset("I")
 
 @fundef
 def compute_shift(cond):
-    return if_(deref(cond) < 0., shift(I, -1), shift(I, 1))
+    return if_(deref(cond) < 0.0, shift(I, -1), shift(I, 1))
 
 
 @fundef

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_horizontal_indirection.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_horizontal_indirection.py
@@ -46,7 +46,7 @@ I = offset("I")
 
 @fundef
 def compute_shift(cond):
-    return if_(deref(cond) < 0, shift(I, -1), shift(I, 1))
+    return if_(deref(cond) < 0., shift(I, -1), shift(I, 1))
 
 
 @fundef

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_implicit_fencil.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_implicit_fencil.py
@@ -34,7 +34,7 @@ def dom():
 
 
 def a_field():
-    return gtx.np_as_located_field(I)(np.asarray(range(_isize)))
+    return gtx.np_as_located_field(I)(np.arange(0, _isize, dtype=np.float64))
 
 
 def out_field():

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_scan.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_scan.py
@@ -33,7 +33,7 @@ def test_scan_in_stencil(program_processor, lift_mode):
     ksize = 3
     Koff = offset("Koff")
     inp = gtx.np_as_located_field(IDim, KDim)(
-        np.copy(np.broadcast_to(np.arange(0, ksize), (isize, ksize)))
+        np.copy(np.broadcast_to(np.arange(0, ksize, dtype=np.float64), (isize, ksize)))
     )
     out = gtx.np_as_located_field(IDim, KDim)(np.zeros((isize, ksize)))
 

--- a/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/anton_lap.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/anton_lap.py
@@ -17,7 +17,7 @@ import sys
 import gt4py.next as gtx
 from gt4py.next.iterator.builtins import *
 from gt4py.next.iterator.runtime import closure, fundef, offset
-from gt4py.next.iterator.tracing import trace
+from gt4py.next.iterator.tracing import trace_fencil_definition
 from gt4py.next.program_processors.codegens.gtfn.gtfn_backend import generate
 
 
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         raise RuntimeError(f"Usage: {sys.argv[0]} <output_file>")
     output_file = sys.argv[1]
 
-    prog = trace(lap_fencil, [None] * 8)
+    prog = trace_fencil_definition(lap_fencil, [None] * 8, use_arg_types=False)
     generated_code = generate(prog, offset_provider={"i": IDim, "j": JDim})
 
     with open(output_file, "w+") as output:

--- a/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/copy_stencil.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/copy_stencil.py
@@ -17,7 +17,7 @@ import sys
 import gt4py.next as gtx
 from gt4py.next.iterator.builtins import *
 from gt4py.next.iterator.runtime import closure, fundef
-from gt4py.next.iterator.tracing import trace
+from gt4py.next.iterator.tracing import trace_fencil_definition
 from gt4py.next.program_processors.codegens.gtfn.gtfn_backend import generate
 
 
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         raise RuntimeError(f"Usage: {sys.argv[0]} <output_file>")
     output_file = sys.argv[1]
 
-    prog = trace(copy_fencil, [None] * 5)
+    prog = trace_fencil_definition(copy_fencil, [None] * 5, use_arg_types=False)
     generated_code = generate(prog, offset_provider={})
 
     with open(output_file, "w+") as output:

--- a/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/fvm_nabla.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/fvm_nabla.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 import gt4py.next as gtx
 from gt4py.next.iterator.builtins import *
 from gt4py.next.iterator.runtime import closure, fundef, offset
-from gt4py.next.iterator.tracing import trace
+from gt4py.next.iterator.tracing import trace_fencil_definition
 from gt4py.next.program_processors.codegens.gtfn.gtfn_backend import generate
 
 
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     imperative = sys.argv[2].lower() == "true"
 
     # prog = trace(zavgS_fencil, [None] * 4) # TODO allow generating of 2 fencils
-    prog = trace(nabla_fencil, [None] * 7)
+    prog = trace_fencil_definition(nabla_fencil, [None] * 7, use_arg_types=False)
     offset_provider = {
         "V2E": DummyConnectivity(max_neighbors=6, has_skip_values=True),
         "E2V": DummyConnectivity(max_neighbors=2, has_skip_values=False),

--- a/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/tridiagonal_solve.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/cpp_backend_tests/tridiagonal_solve.py
@@ -17,7 +17,7 @@ import sys
 import gt4py.next as gtx
 from gt4py.next.iterator.builtins import *
 from gt4py.next.iterator.runtime import closure, fundef
-from gt4py.next.iterator.tracing import trace
+from gt4py.next.iterator.tracing import trace_fencil_definition
 from gt4py.next.iterator.transforms import LiftMode
 from gt4py.next.program_processors.codegens.gtfn.gtfn_backend import generate
 
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         raise RuntimeError(f"Usage: {sys.argv[0]} <output_file>")
     output_file = sys.argv[1]
 
-    prog = trace(tridiagonal_solve_fencil, [None] * 8)
+    prog = trace_fencil_definition(tridiagonal_solve_fencil, [None] * 8, use_arg_types=False)
     offset_provider = {"I": gtx.Dimension("IDim"), "J": gtx.Dimension("JDim")}
     generated_code = generate(
         prog,

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/fvm_nabla_setup.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/fvm_nabla_setup.py
@@ -84,10 +84,10 @@ class nabla_setup:
     def is_pole_edge_field(self):
         edge_flags = np.array(self.mesh.edges.flags())
 
-        pole_edge_field = np.zeros((self.edges_size,))
+        pole_edge_field = np.zeros((self.edges_size,), dtype=bool)
         for e in range(self.edges_size):
             pole_edge_field[e] = self._is_pole_edge(e, edge_flags)
-        return edge_flags
+        return pole_edge_field
 
     @property
     def sign_field(self):

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_column_stencil.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_column_stencil.py
@@ -298,9 +298,9 @@ def test_different_vertical_sizes(program_processor):
         )
 
     k_size = 10
-    inp0 = gtx.np_as_located_field(KDim)(np.asarray(list(range(k_size))))
-    inp1 = gtx.np_as_located_field(KDim)(np.asarray(list(range(k_size + 1))))
-    out = gtx.np_as_located_field(KDim)(np.zeros(k_size))
+    inp0 = gtx.np_as_located_field(KDim)(np.arange(0, k_size))
+    inp1 = gtx.np_as_located_field(KDim)(np.arange(0, k_size + 1))
+    out = gtx.np_as_located_field(KDim)(np.zeros(k_size, dtype=inp0.dtype))
     ref = inp0 + inp1[1:]
 
     run_processor(
@@ -338,9 +338,9 @@ def test_different_vertical_sizes_with_origin(program_processor):
         pytest.xfail("Not supported in DaCe backend: origin")
 
     k_size = 10
-    inp0 = gtx.np_as_located_field(KDim)(np.asarray(list(range(k_size))))
-    inp1 = gtx.np_as_located_field(KDim, origin={KDim: 1})(np.asarray(list(range(k_size + 1))))
-    out = gtx.np_as_located_field(KDim)(np.zeros(k_size))
+    inp0 = gtx.np_as_located_field(KDim)(np.arange(0, k_size))
+    inp1 = gtx.np_as_located_field(KDim, origin={KDim: 1})(np.arange(0, k_size + 1))
+    out = gtx.np_as_located_field(KDim)(np.zeros(k_size, dtype=np.int64))
     ref = inp0 + np.asarray(inp1)[:-1]
 
     run_processor(

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_with_toy_connectivity.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_with_toy_connectivity.py
@@ -39,6 +39,7 @@ from next_tests.toy_connectivity import (
     E2V,
     V2E,
     V2V,
+    C2EDim,
     Cell,
     E2VDim,
     Edge,
@@ -60,11 +61,11 @@ from next_tests.unit_tests.conftest import (
 
 
 def edge_index_field():  # TODO replace by gtx.index_field once supported in bindings
-    return gtx.np_as_located_field(Edge)(np.arange(e2v_arr.shape[0]))
+    return gtx.np_as_located_field(Edge)(np.arange(e2v_arr.shape[0], dtype=np.int32))
 
 
 def vertex_index_field():  # TODO replace by gtx.index_field once supported in bindings
-    return gtx.np_as_located_field(Vertex)(np.arange(v2e_arr.shape[0]))
+    return gtx.np_as_located_field(Vertex)(np.arange(v2e_arr.shape[0], dtype=np.int32))
 
 
 @fundef
@@ -95,7 +96,7 @@ def sum_edges_to_vertices_reduce(in_edges):
 def test_sum_edges_to_vertices(program_processor_no_dace_exec, lift_mode, stencil):
     program_processor, validate = program_processor_no_dace_exec
     inp = edge_index_field()
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
     ref = np.asarray(list(sum(row) for row in v2e_arr))
 
     run_processor(
@@ -119,9 +120,8 @@ def test_map_neighbors(program_processor_no_gtfn_exec, lift_mode):
     program_processor, validate = program_processor_no_gtfn_exec
     if program_processor == run_dace_iterator:
         pytest.xfail("Not supported in DaCe backend: map_ builtin, neighbors, reduce")
-
-    inp = gtx.index_field(Edge)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    inp = edge_index_field()
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
     ref = 2 * np.sum(v2e_arr, axis=1)
 
     run_processor(
@@ -147,9 +147,8 @@ def test_map_make_const_list(program_processor_no_gtfn_exec, lift_mode):
         pytest.xfail(
             "Not supported in DaCe backend: map_ builtin, neighbors, reduce, make_const_list"
         )
-
-    inp = gtx.index_field(Edge)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    inp = edge_index_field()
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], inp.dtype))
     ref = 2 * np.sum(v2e_arr, axis=1)
 
     run_processor(
@@ -174,7 +173,7 @@ def test_first_vertex_neigh_of_first_edge_neigh_of_cells_fencil(
 ):
     program_processor, validate = program_processor_no_dace_exec
     inp = vertex_index_field()
-    out = gtx.np_as_located_field(Cell)(np.zeros([9]))
+    out = gtx.np_as_located_field(Cell)(np.zeros([9], dtype=inp.dtype))
     ref = np.asarray(list(v2e_arr[c[0]][0] for c in c2e_arr))
 
     run_processor(
@@ -201,8 +200,8 @@ def test_sparse_input_field(program_processor_no_dace_exec, lift_mode):
     program_processor, validate = program_processor_no_dace_exec
 
     non_sparse = gtx.np_as_located_field(Edge)(np.zeros(18))
-    inp = gtx.np_as_located_field(Vertex, V2EDim)(np.asarray([[1, 2, 3, 4]] * 9))
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    inp = gtx.np_as_located_field(Vertex, V2EDim)(np.asarray([[1, 2, 3, 4]] * 9, dtype=np.int32))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     ref = np.ones([9]) * 10
 
@@ -225,7 +224,7 @@ def test_sparse_input_field_v2v(program_processor_no_dace_exec, lift_mode):
 
     non_sparse = gtx.np_as_located_field(Edge)(np.zeros(18))
     inp = gtx.np_as_located_field(Vertex, V2VDim)(v2v_arr)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     ref = np.asarray(list(sum(row) for row in v2v_arr))
 
@@ -254,7 +253,7 @@ def slice_sparse_stencil(sparse):
 def test_slice_sparse(program_processor_no_dace_exec, lift_mode):
     program_processor, validate = program_processor_no_dace_exec
     inp = gtx.np_as_located_field(Vertex, V2VDim)(v2v_arr)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     ref = v2v_arr[:, 1]
 
@@ -308,7 +307,7 @@ def shift_sliced_sparse_stencil(sparse):
 def test_shift_sliced_sparse(program_processor_no_dace_exec, lift_mode):
     program_processor, validate = program_processor_no_dace_exec
     inp = gtx.np_as_located_field(Vertex, V2VDim)(v2v_arr)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     ref = v2v_arr[:, 1][v2v_arr][:, 0]
 
@@ -335,7 +334,7 @@ def slice_shifted_sparse_stencil(sparse):
 def test_slice_shifted_sparse(program_processor_no_dace_exec, lift_mode):
     program_processor, validate = program_processor_no_dace_exec
     inp = gtx.np_as_located_field(Vertex, V2VDim)(v2v_arr)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     ref = v2v_arr[:, 1][v2v_arr][:, 0]
 
@@ -367,7 +366,7 @@ def lift_stencil(inp):
 def test_lift(program_processor_no_dace_exec, lift_mode):
     program_processor, validate = program_processor_no_dace_exec
     inp = vertex_index_field()
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
     ref = np.asarray(np.asarray(range(9)))
 
     run_processor(
@@ -390,7 +389,7 @@ def sparse_shifted_stencil(inp):
 def test_shift_sparse_input_field(program_processor_no_dace_exec, lift_mode):
     program_processor, validate = program_processor_no_dace_exec
     inp = gtx.np_as_located_field(Vertex, V2VDim)(v2v_arr)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
     ref = np.asarray(np.asarray(range(9)))
 
     run_processor(
@@ -422,10 +421,10 @@ def test_shift_sparse_input_field2(program_processor_no_dace_exec, lift_mode):
         pytest.xfail(
             "Bug in bindings/compilation/caching: only the first program seems to be compiled."
         )  # observed in `cache.Strategy.PERSISTENT` mode
-    inp = gtx.index_field(Vertex)
+    inp = vertex_index_field()
     inp_sparse = gtx.np_as_located_field(Edge, E2VDim)(e2v_arr)
-    out1 = gtx.np_as_located_field(Vertex)(np.zeros([9]))
-    out2 = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out1 = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
+    out2 = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     offset_provider = {
         "E2V": gtx.NeighborTableOffsetProvider(e2v_arr, Edge, Vertex, 2),
@@ -474,7 +473,7 @@ def test_sparse_shifted_stencil_reduce(program_processor_no_gtfn_exec, lift_mode
         pytest.xfail("shifted input arguments not supported for lift_mode != LiftMode.FORCE_INLINE")
 
     inp = gtx.np_as_located_field(Vertex, V2VDim)(v2v_arr)
-    out = gtx.np_as_located_field(Vertex)(np.zeros([9]))
+    out = gtx.np_as_located_field(Vertex)(np.zeros([9], dtype=inp.dtype))
 
     ref = []
     for row in v2v_arr:

--- a/tests/next_tests/toy_connectivity.py
+++ b/tests/next_tests/toy_connectivity.py
@@ -15,6 +15,7 @@
 import numpy as np
 
 import gt4py.next as gtx
+from gt4py.next.iterator import ir as itir
 
 
 Vertex = gtx.Dimension("Vertex")
@@ -50,7 +51,8 @@ c2e_arr = np.array(
         [6, 16, 0, 15],  # 6
         [7, 17, 1, 16],
         [8, 15, 2, 17],
-    ]
+    ],
+    dtype=np.dtype(itir.INTEGER_INDEX_BUILTIN),
 )
 
 v2v_arr = np.array(
@@ -64,7 +66,8 @@ v2v_arr = np.array(
         [7, 0, 8, 3],
         [8, 1, 6, 4],
         [6, 2, 7, 5],
-    ]
+    ],
+    dtype=np.dtype(itir.INTEGER_INDEX_BUILTIN),
 )
 
 e2v_arr = np.array(
@@ -87,7 +90,8 @@ e2v_arr = np.array(
         [6, 0],
         [7, 1],
         [8, 2],
-    ]
+    ],
+    dtype=np.dtype(itir.INTEGER_INDEX_BUILTIN),
 )
 
 
@@ -103,5 +107,6 @@ v2e_arr = np.array(
         [6, 12, 8, 15],  # 6
         [7, 13, 6, 16],
         [8, 14, 7, 17],
-    ]
+    ],
+    dtype=np.dtype(itir.INTEGER_INDEX_BUILTIN),
 )


### PR DESCRIPTION
Enhances the ITIR fencil tracer by populating the `dtype`, `kind` attributes of the fencil parameters (i.e. `itir.Sym`s) for all arguments that are fields. This is required by the Temporary pass in #1271. Since the ITIR type system is to be refactored only the minimal functionality needed is implemented here.