### PR TITLE
feature[next]: Collect shifts for all nodes in TraceShift pass

### DIFF
--- a/src/gt4py/next/iterator/transforms/trace_shifts.py
+++ b/src/gt4py/next/iterator/transforms/trace_shifts.py
@@ -32,11 +32,11 @@ class ShiftRecorder:
         default_factory=dict
     )
 
-    def register_node(self, inp: ir.Expr | ir.Sym):
+    def register_node(self, inp: ir.Expr | ir.Sym) -> None:
         self.recorded_shifts.setdefault(id(inp), set())
 
     def __call__(self, inp: ir.Expr | ir.Sym, offsets: tuple[ir.OffsetLiteral, ...]) -> None:
-        self.recorded_shifts.setdefault(id(inp), set()).add(offsets)
+        self.recorded_shifts[id(inp)].add(offsets)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -272,6 +272,7 @@ class TraceShifts(NodeTranslator):
         def fun(*args):
             new_args = []
             for param, arg in zip(node.params, args, strict=True):
+                self.shift_recorder.register_node(param)
                 new_args.append(
                     IteratorArgTracer(
                         arg=param, shift_recorder=ForwardingShiftRecorder(arg, self.shift_recorder)

--- a/src/gt4py/next/iterator/transforms/trace_shifts.py
+++ b/src/gt4py/next/iterator/transforms/trace_shifts.py
@@ -272,12 +272,16 @@ class TraceShifts(NodeTranslator):
         def fun(*args):
             new_args = []
             for param, arg in zip(node.params, args, strict=True):
-                self.shift_recorder.register_node(param)
-                new_args.append(
-                    IteratorArgTracer(
-                        arg=param, shift_recorder=ForwardingShiftRecorder(arg, self.shift_recorder)
+                if isinstance(arg, IteratorTracer):
+                    self.shift_recorder.register_node(param)
+                    new_args.append(
+                        IteratorArgTracer(
+                            arg=param,
+                            shift_recorder=ForwardingShiftRecorder(arg, self.shift_recorder),
+                        )
                     )
-                )
+                else:
+                    new_args.append(arg)
 
             return self.visit(
                 node.expr, ctx=ctx | {p.id: a for p, a in zip(node.params, new_args, strict=True)}

--- a/src/gt4py/next/iterator/transforms/trace_shifts.py
+++ b/src/gt4py/next/iterator/transforms/trace_shifts.py
@@ -11,9 +11,9 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+import dataclasses
 import enum
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any, Final, Iterable, Literal
 
 from gt4py.eve import NodeTranslator
@@ -26,6 +26,30 @@ class Sentinel(enum.Enum):
     TYPE = object()
 
 
+@dataclasses.dataclass(frozen=True)
+class ShiftRecorder:
+    recorded_shifts: dict[int, set[tuple[ir.OffsetLiteral, ...]]] = dataclasses.field(
+        default_factory=dict
+    )
+
+    def register_node(self, inp: ir.Expr | ir.Sym):
+        self.recorded_shifts.setdefault(id(inp), set())
+
+    def __call__(self, inp: ir.Expr | ir.Sym, offsets: tuple[ir.OffsetLiteral, ...]) -> None:
+        self.recorded_shifts.setdefault(id(inp), set()).add(offsets)
+
+
+@dataclasses.dataclass(frozen=True)
+class ForwardingShiftRecorder:
+    wrapped_tracer: Any
+    shift_recorder: ShiftRecorder
+
+    def __call__(self, inp: ir.Expr | ir.Sym, offsets: tuple[ir.OffsetLiteral, ...]):
+        self.shift_recorder(inp, offsets)
+        # Forward shift to wrapped tracer such it can record the shifts of the parent nodes
+        self.wrapped_tracer.shift(offsets).deref()
+
+
 # for performance reasons (`isinstance` is slow otherwise) we don't use abc here
 class IteratorTracer:
     def deref(self):
@@ -35,29 +59,27 @@ class IteratorTracer:
         raise NotImplementedError()
 
 
-@dataclass(frozen=True)
-class InputTracer(IteratorTracer):
-    inp: str
-    register_deref: Callable[[str, tuple[ir.OffsetLiteral, ...]], None]
+@dataclasses.dataclass(frozen=True)
+class IteratorArgTracer(IteratorTracer):
+    arg: ir.Expr | ir.Sym
+    register_deref: Callable[[ir.Sym, tuple[ir.OffsetLiteral, ...]], None]
     offsets: tuple[ir.OffsetLiteral, ...] = ()
-    lift_level: int = 0
 
     def shift(self, offsets: tuple[ir.OffsetLiteral, ...]):
-        return InputTracer(
-            inp=self.inp,
+        return IteratorArgTracer(
+            arg=self.arg,
             register_deref=self.register_deref,
             offsets=self.offsets + tuple(offsets),
-            lift_level=self.lift_level,
         )
 
     def deref(self):
-        self.register_deref(self.inp, self.offsets)
+        self.register_deref(self.arg, self.offsets)
         return Sentinel.VALUE
 
 
 # This class is only needed because we currently allow conditionals on iterators. Since this is
 # not supported in the C++ backend it can likely be removed again in the future.
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class CombinedTracer(IteratorTracer):
     its: tuple[IteratorTracer, ...]
 
@@ -98,13 +120,13 @@ def _shift(*offsets):
     return apply
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class AppliedLift(IteratorTracer):
     stencil: Callable
     its: tuple[IteratorTracer, ...]
 
     def shift(self, offsets):
-        return AppliedLift(self.stencil, tuple(_shift(it) for it in self.its))
+        return AppliedLift(self.stencil, tuple(_shift(*offsets)(it) for it in self.its))
 
     def deref(self):
         return self.stencil(*self.its)
@@ -211,7 +233,10 @@ _START_CTX: Final = {
 }
 
 
+@dataclasses.dataclass(frozen=True)
 class TraceShifts(NodeTranslator):
+    shift_recorder: ShiftRecorder = dataclasses.field(default_factory=ShiftRecorder)
+
     def visit_Literal(self, node: ir.SymRef, *, ctx: dict[str, Any]) -> Any:
         return Sentinel.VALUE
 
@@ -232,30 +257,57 @@ class TraceShifts(NodeTranslator):
         args = self.visit(node.args, ctx=ctx)
         return fun(*args)
 
+    def visit(self, node, **kwargs):
+        result = super().visit(node, **kwargs)
+        if isinstance(result, IteratorTracer):
+            assert isinstance(node, (ir.Sym, ir.Expr))
+
+            self.shift_recorder.register_node(node)
+            result = IteratorArgTracer(
+                arg=node, register_deref=ForwardingShiftRecorder(result, self.shift_recorder)
+            )
+        return result
+
     def visit_Lambda(self, node: ir.Lambda, *, ctx: dict[str, Any]) -> Callable:
         def fun(*args):
+            new_args = []
+            for param, arg in zip(node.params, args, strict=True):
+                new_args.append(
+                    IteratorArgTracer(
+                        arg=param, register_deref=ForwardingShiftRecorder(arg, self.shift_recorder)
+                    )
+                )
+
             return self.visit(
-                node.expr, ctx=ctx | {p.id: a for p, a in zip(node.params, args, strict=True)}
+                node.expr, ctx=ctx | {p.id: a for p, a in zip(node.params, new_args, strict=True)}
             )
 
         return fun
 
-    def visit_StencilClosure(
-        self, node: ir.StencilClosure, *, shifts: dict[str, list[tuple[ir.OffsetLiteral, ...]]]
-    ):
-        def register_deref(inp: str, offsets: tuple[ir.OffsetLiteral, ...]):
-            shifts[inp].append(offsets)
-
+    def visit_StencilClosure(self, node: ir.StencilClosure):
         tracers = []
         for inp in node.inputs:
-            shifts.setdefault(inp.id, [])
-            tracers.append(InputTracer(inp=inp.id, register_deref=register_deref))
+            self.shift_recorder.register_node(inp)
+            tracers.append(IteratorArgTracer(arg=inp, register_deref=self.shift_recorder))
 
         result = self.visit(node.stencil, ctx=_START_CTX)(*tracers)
         assert all(el is Sentinel.VALUE for el in _primitive_constituents(result))
 
     @classmethod
-    def apply(cls, node: ir.StencilClosure) -> dict[str, list[tuple[ir.OffsetLiteral, ...]]]:
-        shifts = dict[str, list[tuple[ir.OffsetLiteral, ...]]]()
-        cls().visit(node, shifts=shifts)
-        return shifts
+    def apply(
+        cls, node: ir.StencilClosure, *, inputs_only=True
+    ) -> (
+        dict[int, set[tuple[ir.OffsetLiteral, ...]]] | dict[str, set[tuple[ir.OffsetLiteral, ...]]]
+    ):
+        instance = cls()
+        instance.visit(node)
+
+        recorded_shifts = instance.shift_recorder.recorded_shifts
+
+        if inputs_only:
+            inputs_shifts = {}
+            for inp in node.inputs:
+                inputs_shifts[str(inp.id)] = recorded_shifts[id(inp)]
+            return inputs_shifts
+
+        return recorded_shifts

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_trace_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_trace_shifts.py
@@ -320,3 +320,20 @@ def test_if_of_tuples_of_iterators():
 
     actual = TraceShifts.apply(testee)
     assert actual == expected
+
+
+def test_non_derefed_iterator():
+    """
+    Test that even if an iterator is not derefed the resulting dict has an (empty) entry for it.
+    """
+    non_derefed_it = im.shift("I", 1)("x")
+    testee = ir.StencilClosure(
+        # λ(x) → (λ(non_derefed_it) → ·x)(⟪Iₒ, 1ₒ⟫(x))
+        stencil=im.lambda_("x")(im.let("non_derefed_it", non_derefed_it)(im.deref("x"))),
+        inputs=[ir.SymRef(id="inp")],
+        output=ir.SymRef(id="out"),
+        domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
+    )
+
+    actual = TraceShifts.apply(testee, inputs_only=False)
+    assert actual[id(non_derefed_it)] == set()

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_trace_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_trace_shifts.py
@@ -23,10 +23,9 @@ def test_trivial():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp": [()]}
+    expected = {"inp": {()}}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -51,10 +50,9 @@ def test_shift():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp": [(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))]}
+    expected = {"inp": {(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))}}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -84,10 +82,9 @@ def test_lift():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp": [(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))]}
+    expected = {"inp": {(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))}}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -105,16 +102,15 @@ def test_neighbors():
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
     expected = {
-        "inp": [
+        "inp": {
             (
                 ir.OffsetLiteral(value="O"),
                 ALL_NEIGHBORS,
             )
-        ]
+        }
     }
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -134,10 +130,9 @@ def test_reduce():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp": [()]}
+    expected = {"inp": {()}}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -150,10 +145,9 @@ def test_shifted_literal():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp": []}
+    expected = {"inp": set()}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -165,11 +159,50 @@ def test_tuple_get():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp1": [], "inp2": [()]}  # never derefed  # once derefed
+    expected = {"inp1": set(), "inp2": {()}}  # never derefed  # once derefed
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
+
+
+def test_trace_non_closure_input_arg():
+    x, y = im.sym("x"), im.sym("y")
+    testee = ir.StencilClosure(
+        # λ(x) → (λ(y) → ·⟪Iₒ, 1ₒ⟫(y))(⟪Iₒ, 2ₒ⟫(x))
+        stencil=im.lambda_(x)(
+            im.call(im.lambda_(y)(im.deref(im.shift("I", 1)("y"))))(im.shift("I", 2)("x"))
+        ),
+        inputs=[ir.SymRef(id="inp")],
+        output=ir.SymRef(id="out"),
+        domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
+    )
+
+    actual = TraceShifts.apply(testee, inputs_only=False)
+
+    assert actual[id(x)] == {
+        (
+            ir.OffsetLiteral(value="I"),
+            ir.OffsetLiteral(value=2),
+            ir.OffsetLiteral(value="I"),
+            ir.OffsetLiteral(value=1),
+        )
+    }
+    assert actual[id(y)] == {(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))}
+
+
+def test_inner_iterator():
+    inner_shift = im.shift("I", 1)("x")
+    testee = ir.StencilClosure(
+        # λ(x) → ·⟪Iₒ, 1ₒ⟫(⟪Iₒ, 1ₒ⟫(x))
+        stencil=im.lambda_("x")(im.deref(im.shift("I", 1)(inner_shift))),
+        inputs=[ir.SymRef(id="inp")],
+        output=ir.SymRef(id="out"),
+        domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
+    )
+    expected = {(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))}
+
+    actual = TraceShifts.apply(testee, inputs_only=False)
+    assert actual[id(inner_shift)] == expected
 
 
 def test_tuple_get_on_closure_input():
@@ -180,10 +213,9 @@ def test_tuple_get_on_closure_input():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"inp": [(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))]}
+    expected = {"inp": {(ir.OffsetLiteral(value="I"), ir.OffsetLiteral(value=1))}}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -204,10 +236,9 @@ def test_if_tuple_branch_broadcasting():
         output=ir.SymRef(id="out"),
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
-    expected = {"cond": [()], "inp": [()]}
+    expected = {"cond": {()}, "inp": {()}}
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -226,8 +257,8 @@ def test_if_of_iterators():
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
     expected = {
-        "cond": [()],
-        "inp": [
+        "cond": {()},
+        "inp": {
             (
                 ir.OffsetLiteral(value="I"),
                 ir.OffsetLiteral(value=2),
@@ -240,11 +271,10 @@ def test_if_of_iterators():
                 ir.OffsetLiteral(value="I"),
                 ir.OffsetLiteral(value=1),
             ),
-        ],
+        },
     }
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected
 
 
@@ -271,8 +301,8 @@ def test_if_of_tuples_of_iterators():
         domain=ir.FunCall(fun=ir.SymRef(id="cartesian_domain"), args=[]),
     )
     expected = {
-        "cond": [()],
-        "inp": [
+        "cond": {()},
+        "inp": {
             (
                 ir.OffsetLiteral(value="I"),
                 ir.OffsetLiteral(value=2),
@@ -285,9 +315,8 @@ def test_if_of_tuples_of_iterators():
                 ir.OffsetLiteral(value="I"),
                 ir.OffsetLiteral(value=1),
             ),
-        ],
+        },
     }
 
-    actual = dict()
-    TraceShifts().visit(testee, shifts=actual)
+    actual = TraceShifts.apply(testee)
     assert actual == expected


### PR DESCRIPTION
- Shifts are collected not only for the closure inputs, but for every iterator expression in the tree (including iterator arguments to lambdas).
- The collected shifts are now represented as a set.

This PR is a prerequisite for the temporary extraction heuristics.