### PR TITLE
fix[cartesian]: use distutils from setuptools instead of the standard library

### DIFF
--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -14,8 +14,6 @@
 
 import contextlib
 import copy
-import distutils
-import distutils.sysconfig
 import io
 import os
 import shutil
@@ -24,6 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast, overload
 import pybind11
 import setuptools
 from setuptools.command.build_ext import build_ext
+from setuptools import distutils
 
 from gt4py.cartesian import config as gt_config
 

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -21,8 +21,8 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
 import pybind11
 import setuptools
-from setuptools.command.build_ext import build_ext
 from setuptools import distutils
+from setuptools.command.build_ext import build_ext
 
 from gt4py.cartesian import config as gt_config
 


### PR DESCRIPTION
This PR fixes the imports in the module used to compile python extensions to use the `distutils` versions packaged into `setuptools` instead of the version from the standard library, which is deprecated and causes some warnings at compilation which can break other tools (e.g.  spack).