### PR TITLE
[bug]: Fix neighbor table type error in icon4py

### DIFF
--- a/src/gt4py/next/program_processors/codegens/gtfn/gtfn_module.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/gtfn_module.py
@@ -118,7 +118,7 @@ class GTFNTranslationStep(
 
         for name, connectivity in offset_provider.items():
             if isinstance(connectivity, Connectivity):
-                if connectivity.index_type not in [np.int32, np.int64]:
+                if connectivity.index_type not in [np.dtypes.Int64DType(), np.dtypes.Int32DType()]:
                     raise ValueError(
                         "Neighbor table indices must be of type `np.int32` or `np.int64`."
                     )


### PR DESCRIPTION
## Description

A PR to fix 

```python
ValueError("Neighbor table indices must be of type `np.int32` or `np.int64`.")
```

which occurs when attempting to run icon4py stencils with the gtfn cpu executor.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
