### PR TITLE
fix[next-dace]: Preserve ITIR data layout

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -31,11 +31,7 @@ from .utility import connectivity_identifier, filter_neighbor_tables
 
 def convert_arg(arg: Any):
     if common.is_field(arg):
-        sorted_dims = sorted(enumerate(arg.__gt_dims__), key=lambda v: v[1].value)
-        ndim = len(sorted_dims)
-        dim_indices = [dim[0] for dim in sorted_dims]
-        assert isinstance(arg.ndarray, np.ndarray)
-        return np.moveaxis(arg.ndarray, range(ndim), dim_indices)
+        return arg.ndarray
     return arg
 
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -31,7 +31,11 @@ from .utility import connectivity_identifier, filter_neighbor_tables
 
 def convert_arg(arg: Any):
     if common.is_field(arg):
-        return arg.ndarray
+        sorted_dims = sorted(enumerate(arg.__gt_dims__), key=lambda v: v[1].value)
+        ndim = len(sorted_dims)
+        dim_indices = [dim[0] for dim in sorted_dims]
+        assert isinstance(arg.ndarray, np.ndarray)
+        return np.moveaxis(arg.ndarray, range(ndim), dim_indices)
     return arg
 
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -38,6 +38,7 @@ from .utility import (
     create_memlet_at,
     create_memlet_full,
     filter_neighbor_tables,
+    get_sorted_dims,
     map_nested_sdfg_symbols,
     unique_var_name,
 )
@@ -79,9 +80,10 @@ def get_scan_dim(
             - scan_dim_dtype: data type along the scan dimension
     """
     output_type = cast(ts.FieldType, storage_types[output.id])
+    sorted_dims = [dim for _, dim in get_sorted_dims(output_type.dims)]
     return (
         column_axis.value,
-        output_type.dims.index(column_axis),
+        sorted_dims.index(column_axis),
         output_type.dtype,
     )
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -246,7 +246,7 @@ class ItirToSDFG(eve.NodeVisitor):
                     )
                     access = closure_init_state.add_access(out_name)
                     value = ValueExpr(access, dtype)
-                    memlet = create_memlet_at(out_name, ("0",))
+                    memlet = dace.Memlet.simple(out_name, "0")
                     closure_init_state.add_edge(out_tasklet, "__result", access, None, memlet)
                     program_arg_syms[name] = value
                 else:
@@ -274,7 +274,7 @@ class ItirToSDFG(eve.NodeVisitor):
         transient_to_arg_name_mapping[nsdfg_output_name] = output_name
         # scan operator should always be the first function call in a closure
         if is_scan(node.stencil):
-            nsdfg, map_domain, scan_dim_index = self._visit_scan_stencil_closure(
+            nsdfg, map_ranges, scan_dim_index = self._visit_scan_stencil_closure(
                 node, closure_sdfg.arrays, closure_domain, nsdfg_output_name
             )
             results = [nsdfg_output_name]
@@ -292,15 +292,16 @@ class ItirToSDFG(eve.NodeVisitor):
 
             output_memlet = create_memlet_at(
                 output_name,
-                tuple(
-                    f"i_{dim}"
-                    if f"i_{dim}" in map_domain
+                self.storage_types[output_name],
+                {
+                    dim: f"i_{dim}"
+                    if f"i_{dim}" in map_ranges
                     else f"0:{output_descriptor.shape[scan_dim_index]}"
                     for dim, _ in closure_domain
-                ),
+                },
             )
         else:
-            nsdfg, map_domain, results = self._visit_parallel_stencil_closure(
+            nsdfg, map_ranges, results = self._visit_parallel_stencil_closure(
                 node, closure_sdfg.arrays, closure_domain
             )
             assert len(results) == 1
@@ -313,7 +314,11 @@ class ItirToSDFG(eve.NodeVisitor):
                 transient=True,
             )
 
-            output_memlet = create_memlet_at(output_name, tuple(idx for idx in map_domain.keys()))
+            output_memlet = create_memlet_at(
+                output_name,
+                self.storage_types[output_name],
+                {dim: f"i_{dim}" for dim, _ in closure_domain},
+            )
 
         input_mapping = {param: arg for param, arg in zip(input_names, input_memlets)}
         output_mapping = {param: arg_memlet for param, arg_memlet in zip(results, [output_memlet])}
@@ -325,7 +330,7 @@ class ItirToSDFG(eve.NodeVisitor):
         nsdfg_node, map_entry, map_exit = add_mapped_nested_sdfg(
             closure_state,
             sdfg=nsdfg,
-            map_ranges=map_domain or {"__dummy": "0"},
+            map_ranges=map_ranges or {"__dummy": "0"},
             inputs=array_mapping,
             outputs=output_mapping,
             symbol_mapping=symbol_mapping,
@@ -341,10 +346,10 @@ class ItirToSDFG(eve.NodeVisitor):
                 edge.src_conn,
                 transient_access,
                 None,
-                dace.Memlet(data=memlet.data, subset=output_subset),
+                dace.Memlet.simple(memlet.data, output_subset),
             )
-            inner_memlet = dace.Memlet(
-                data=memlet.data, subset=output_subset, other_subset=memlet.subset
+            inner_memlet = dace.Memlet.simple(
+                memlet.data, output_subset, other_subset_str=memlet.subset
             )
             closure_state.add_edge(transient_access, None, map_exit, edge.dst_conn, inner_memlet)
             closure_state.remove_edge(edge)
@@ -360,7 +365,7 @@ class ItirToSDFG(eve.NodeVisitor):
                     None,
                     map_entry,
                     b.value.data,
-                    create_memlet_at(b.value.data, ("0",)),
+                    dace.Memlet.simple(b.value.data, "0"),
                 )
         return closure_sdfg
 
@@ -390,12 +395,12 @@ class ItirToSDFG(eve.NodeVisitor):
         connectivity_names = [connectivity_identifier(offset) for offset, _ in neighbor_tables]
 
         # find the scan dimension, same as output dimension, and exclude it from the map domain
-        map_domain = {}
+        map_ranges = {}
         for dim, (lb, ub) in closure_domain:
             lb_str = lb.value.data if isinstance(lb, ValueExpr) else lb.value
             ub_str = ub.value.data if isinstance(ub, ValueExpr) else ub.value
             if not dim == scan_dim:
-                map_domain[f"i_{dim}"] = f"{lb_str}:{ub_str}"
+                map_ranges[f"i_{dim}"] = f"{lb_str}:{ub_str}"
             else:
                 scan_lb_str = lb_str
                 scan_ub_str = ub_str
@@ -481,29 +486,29 @@ class ItirToSDFG(eve.NodeVisitor):
             "__result",
             carry_node1,
             None,
-            dace.Memlet(data=f"{scan_carry_name}", subset="0"),
+            dace.Memlet.simple(scan_carry_name, "0"),
         )
 
         carry_node2 = lambda_state.add_access(scan_carry_name)
         lambda_state.add_memlet_path(
             carry_node2,
             scan_inner_node,
-            memlet=dace.Memlet(data=f"{scan_carry_name}", subset="0"),
+            memlet=dace.Memlet.simple(scan_carry_name, "0"),
             src_conn=None,
             dst_conn=lambda_carry_name,
         )
 
         # connect access nodes to lambda inputs
         for (inner_name, _), data_name in zip(lambda_inputs[1:], input_names):
-            data_subset = (
-                ", ".join([f"i_{dim}" for dim, _ in closure_domain])
-                if isinstance(self.storage_types[data_name], ts.FieldType)
-                else "0"
-            )
+            if isinstance(self.storage_types[data_name], ts.FieldType):
+                index = {dim: f"i_{dim}" for dim, _ in closure_domain}
+                memlet = create_memlet_at(data_name, self.storage_types[data_name], index)
+            else:
+                memlet = dace.Memlet.simple(data_name, "0")
             lambda_state.add_memlet_path(
                 lambda_state.add_access(data_name),
                 scan_inner_node,
-                memlet=dace.Memlet(data=f"{data_name}", subset=data_subset),
+                memlet=memlet,
                 src_conn=None,
                 dst_conn=inner_name,
             )
@@ -532,7 +537,7 @@ class ItirToSDFG(eve.NodeVisitor):
             lambda_state.add_memlet_path(
                 scan_inner_node,
                 lambda_state.add_access(data_name),
-                memlet=dace.Memlet(data=data_name, subset=f"i_{scan_dim}"),
+                memlet=dace.Memlet.simple(data_name, f"i_{scan_dim}"),
                 src_conn=lambda_connector.value.label,
                 dst_conn=None,
             )
@@ -544,10 +549,10 @@ class ItirToSDFG(eve.NodeVisitor):
         lambda_update_state.add_memlet_path(
             result_node,
             carry_node3,
-            memlet=dace.Memlet(data=f"{output_names[0]}", subset=f"i_{scan_dim}", other_subset="0"),
+            memlet=dace.Memlet.simple(output_names[0], f"i_{scan_dim}", other_subset_str="0"),
         )
 
-        return scan_sdfg, map_domain, scan_dim_index
+        return scan_sdfg, map_ranges, scan_dim_index
 
     def _visit_parallel_stencil_closure(
         self,
@@ -562,11 +567,11 @@ class ItirToSDFG(eve.NodeVisitor):
         conn_names = [connectivity_identifier(offset) for offset, _ in neighbor_tables]
 
         # find the scan dimension, same as output dimension, and exclude it from the map domain
-        map_domain = {}
+        map_ranges = {}
         for dim, (lb, ub) in closure_domain:
             lb_str = lb.value.data if isinstance(lb, ValueExpr) else lb.value
             ub_str = ub.value.data if isinstance(ub, ValueExpr) else ub.value
-            map_domain[f"i_{dim}"] = f"{lb_str}:{ub_str}"
+            map_ranges[f"i_{dim}"] = f"{lb_str}:{ub_str}"
 
         # Create an SDFG for the tasklet that computes a single item of the output domain.
         index_domain = {dim: f"i_{dim}" for dim, _ in closure_domain}
@@ -583,7 +588,7 @@ class ItirToSDFG(eve.NodeVisitor):
             self.node_types,
         )
 
-        return context.body, map_domain, [r.value.data for r in results]
+        return context.body, map_ranges, [r.value.data for r in results]
 
     def _visit_domain(
         self, node: itir.FunCall, context: Context
@@ -606,7 +611,7 @@ class ItirToSDFG(eve.NodeVisitor):
             ub = translator.visit(upper_bound)[0]
             bounds.append((dimension.value, (lb, ub)))
 
-        return tuple(sorted(bounds, key=lambda item: item[0]))
+        return tuple(bounds)
 
     @staticmethod
     def _check_no_lifts(node: itir.StencilClosure):

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -596,7 +596,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             # if dim is not found in iterator indices, we take the neighbor index over the reduction domain
             flat_index = [
                 f"{iterator.indices[dim].data}_v" if dim in iterator.indices else index_name
-                for dim in iterator.dimensions
+                for dim in sorted(iterator.dimensions)
             ]
             args = [ValueExpr(iterator.field, iterator.dtype)] + [
                 ValueExpr(iterator.indices[dim], iterator.dtype) for dim in iterator.indices
@@ -629,8 +629,9 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             return [ValueExpr(value=result_access, dtype=iterator.dtype)]
 
         else:
+            sorted_index = sorted(iterator.indices.items(), key=lambda x: x[0])
             flat_index = [
-                ValueExpr(iterator.indices[dim], iterator.dtype) for dim in iterator.dimensions
+                ValueExpr(x[1], iterator.dtype) for x in sorted_index if x[0] in iterator.dimensions
             ]
             args = [ValueExpr(iterator.field, iterator.dtype), *flat_index]
             internals = [f"{arg.value.data}_v" for arg in args]

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -34,7 +34,6 @@ from .utility import (
     add_mapped_nested_sdfg,
     as_dace_type,
     connectivity_identifier,
-    create_memlet_at,
     create_memlet_full,
     filter_neighbor_tables,
     map_nested_sdfg_symbols,
@@ -595,9 +594,9 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             )
 
             # if dim is not found in iterator indices, we take the neighbor index over the reduction domain
-            array_index = [
+            flat_index = [
                 f"{iterator.indices[dim].data}_v" if dim in iterator.indices else index_name
-                for dim in sorted(iterator.dimensions)
+                for dim in iterator.dimensions
             ]
             args = [ValueExpr(iterator.field, iterator.dtype)] + [
                 ValueExpr(iterator.indices[dim], iterator.dtype) for dim in iterator.indices
@@ -608,7 +607,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                 name="deref",
                 inputs=set(internals),
                 outputs={"__result"},
-                code=f"__result = {args[0].value.data}_v[{', '.join(array_index)}]",
+                code=f"__result = {args[0].value.data}_v[{', '.join(flat_index)}]",
             )
 
             for arg, internal in zip(args, internals):
@@ -630,12 +629,10 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             return [ValueExpr(value=result_access, dtype=iterator.dtype)]
 
         else:
-            sorted_index = sorted(iterator.indices.items(), key=lambda x: x[0])
             flat_index = [
-                ValueExpr(x[1], iterator.dtype) for x in sorted_index if x[0] in iterator.dimensions
+                ValueExpr(iterator.indices[dim], iterator.dtype) for dim in iterator.dimensions
             ]
-
-            args = [ValueExpr(iterator.field, int), *flat_index]
+            args = [ValueExpr(iterator.field, iterator.dtype), *flat_index]
             internals = [f"{arg.value.data}_v" for arg in args]
             expr = f"{internals[0]}[{', '.join(internals[1:])}]"
             return self.add_expr_tasklet(list(zip(args, internals)), expr, iterator.dtype, "deref")
@@ -849,7 +846,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             p.apply_pass(lambda_context.body, {})
 
             input_memlets = [
-                create_memlet_at(expr.value.data, ("__idx",)) for arg, expr in zip(node.args, args)
+                dace.Memlet.simple(expr.value.data, "__idx") for arg, expr in zip(node.args, args)
             ]
             output_memlet = dace.Memlet.simple(result_name, "0")
 
@@ -928,7 +925,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                 )
                 self.context.state.add_edge(arg.value, None, expr_tasklet, internal, memlet)
 
-        memlet = create_memlet_at(result_access.data, ("0",))
+        memlet = dace.Memlet.simple(result_access.data, "0")
         self.context.state.add_edge(expr_tasklet, "__result", result_access, None, memlet)
 
         return [ValueExpr(result_access, result_type)]

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -11,10 +11,12 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from typing import Any, cast
+
+from typing import Any, Sequence, cast
 
 import dace
 
+from gt4py.next import Dimension
 from gt4py.next.iterator.embedded import NeighborTableOffsetProvider
 from gt4py.next.type_system import type_specifications as ts
 
@@ -53,9 +55,13 @@ def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
 
 def create_memlet_at(source_identifier: str, storage_type: ts.TypeSpec, index: dict[str, str]):
     field_type = cast(ts.FieldType, storage_type)
-    field_index = [index[dim.value] for dim in field_type.dims]
-    subset = ", ".join(field_index)
+    sorted_index = [index[dim.value] for _, dim in get_sorted_dims(field_type.dims)]
+    subset = ", ".join(sorted_index)
     return dace.Memlet.simple(source_identifier, subset)
+
+
+def get_sorted_dims(dims: Sequence[Dimension]) -> Sequence[tuple[int, Dimension]]:
+    return sorted(enumerate(dims), key=lambda v: v[1].value)
 
 
 def map_nested_sdfg_symbols(

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Any, Sequence, cast
+from typing import Any, Sequence
 
 import dace
 
@@ -53,11 +53,9 @@ def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
     return dace.Memlet.simple(source_identifier, subset)
 
 
-def create_memlet_at(source_identifier: str, storage_type: ts.TypeSpec, index: dict[str, str]):
-    field_type = cast(ts.FieldType, storage_type)
-    sorted_index = [index[dim.value] for _, dim in get_sorted_dims(field_type.dims)]
-    subset = ", ".join(sorted_index)
-    return dace.Memlet.simple(source_identifier, subset)
+def create_memlet_at(source_identifier: str, index: tuple[str, ...]):
+    subset = ", ".join(index)
+    return dace.Memlet(data=source_identifier, subset=subset)
 
 
 def get_sorted_dims(dims: Sequence[Dimension]) -> Sequence[tuple[int, Dimension]]:

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -11,8 +11,7 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-from typing import Any
+from typing import Any, cast
 
 import dace
 
@@ -49,12 +48,14 @@ def connectivity_identifier(name: str):
 def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
     bounds = [(0, size) for size in source_array.shape]
     subset = ", ".join(f"{lb}:{ub}" for lb, ub in bounds)
-    return dace.Memlet(data=source_identifier, subset=subset)
+    return dace.Memlet.simple(source_identifier, subset)
 
 
-def create_memlet_at(source_identifier: str, index: tuple[str, ...]):
-    subset = ", ".join(index)
-    return dace.Memlet(data=source_identifier, subset=subset)
+def create_memlet_at(source_identifier: str, storage_type: ts.TypeSpec, index: dict[str, str]):
+    field_type = cast(ts.FieldType, storage_type)
+    field_index = [index[dim.value] for dim in field_type.dims]
+    subset = ", ".join(field_index)
+    return dace.Memlet.simple(source_identifier, subset)
 
 
 def map_nested_sdfg_symbols(


### PR DESCRIPTION
## Description

The DaCe backend is reordering the dimensions of field domain based on alphabetical order - we call this the _canonical order_ of dimensions. This PR corrects indexing of field domain in `get_scan_dim` which was not consistent with the canonical order.

Additional minor edit:
- rename `map_domain` -> `map_ranges`
- replace `dace.Memlet()` with `dace.Memlet.simple()`