### PR TITLE
feat[next-dace]: support for field arguments with domain offset

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -15,7 +15,6 @@
 from typing import Any, Mapping, Sequence
 
 import dace
-import numpy as np
 
 import gt4py.next.iterator.ir as itir
 from gt4py.next import common
@@ -31,8 +30,8 @@ from .utility import connectivity_identifier, filter_neighbor_tables
 
 def convert_arg(arg: Any):
     if common.is_field(arg):
-        return arg.ndarray
-    return arg
+        return (arg.ndarray, arg.domain)
+    return (arg, None)
 
 
 def preprocess_program(program: itir.FencilDefinition, offset_provider: Mapping[str, Any]):
@@ -45,8 +44,25 @@ def preprocess_program(program: itir.FencilDefinition, offset_provider: Mapping[
     return program
 
 
+def expand_tuple_arg(name: str, arg: tuple) -> dict[str, Any]:
+    t = {}
+    for idx, member_arg in enumerate(arg):
+        member_name = f"{name}_{idx}"
+        if isinstance(member_arg, tuple):
+            t.update(expand_tuple_arg(member_name, member_arg))
+        else:
+            t[member_name] = convert_arg(member_arg)
+    return t
+
+
 def get_args(params: Sequence[itir.Sym], args: Sequence[Any]) -> dict[str, Any]:
-    return {name.id: convert_arg(arg) for name, arg in zip(params, args)}
+    t = {}
+    for param, arg in zip(params, args):
+        if isinstance(arg, tuple):
+            t.update(expand_tuple_arg(param.id, arg))
+        else:
+            t[param.id] = convert_arg(arg)
+    return t
 
 
 def get_connectivity_args(
@@ -66,13 +82,12 @@ def get_shape_args(
 
 
 def get_offset_args(
-    arrays: Mapping[str, dace.data.Array], params: Sequence[itir.Sym], args: Sequence[Any]
+    arrays: Mapping[str, dace.data.Array], field_domains: Mapping[str, Any]
 ) -> Mapping[str, int]:
     return {
         str(sym): -drange.start
-        for param, arg in zip(params, args)
-        if common.is_field(arg)
-        for sym, drange in zip(arrays[param.id].offset, arg.domain.ranges)
+        for name, domain in field_domains.items()
+        for sym, drange in zip(arrays[name].offset, domain.ranges)
     }
 
 
@@ -105,18 +120,22 @@ def run_dace_iterator(program: itir.FencilDefinition, *args, **kwargs) -> None:
     sdfg.simplify()
 
     dace_args = get_args(program.params, args)
-    dace_field_args = {n: v for n, v in dace_args.items() if not np.isscalar(v)}
+    # domain is only set for field arguments
+    dace_field_args = {n: v for n, (v, d) in dace_args.items() if d}
+    dace_field_domains = {n: d for n, (v, d) in dace_args.items() if d}
+    dace_scalar_args = {n: v for n, (v, d) in dace_args.items() if d is None}
     dace_conn_args = get_connectivity_args(neighbor_tables)
     dace_shapes = get_shape_args(sdfg.arrays, dace_field_args)
     dace_conn_shapes = get_shape_args(sdfg.arrays, dace_conn_args)
     dace_strides = get_stride_args(sdfg.arrays, dace_field_args)
     dace_conn_strides = get_stride_args(sdfg.arrays, dace_conn_args)
-    dace_offsets = get_offset_args(sdfg.arrays, program.params, args)
+    dace_offsets = get_offset_args(sdfg.arrays, dace_field_domains)
 
     sdfg.build_folder = cache._session_cache_dir_path / ".dacecache"
 
     all_args = {
-        **dace_args,
+        **dace_field_args,
+        **dace_scalar_args,
         **dace_conn_args,
         **dace_shapes,
         **dace_conn_shapes,

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -29,11 +29,20 @@ from .itir_to_sdfg import ItirToSDFG
 from .utility import connectivity_identifier, filter_neighbor_tables
 
 
+def get_sorted_dims(dims: Sequence[common.Dimension]) -> Sequence[tuple[int, common.Dimension]]:
+    return sorted(enumerate(dims), key=lambda v: v[1].value)
+
+
+def get_sorted_dim_ranges(domain: common.Domain) -> Sequence[common.UnitRange]:
+    sorted_dims = get_sorted_dims(domain.dims)
+    return [domain.ranges[dim_index] for dim_index, _ in sorted_dims]
+
+
 def convert_arg(arg: Any):
     if common.is_field(arg):
-        sorted_dims = sorted(enumerate(arg.__gt_dims__), key=lambda v: v[1].value)
+        sorted_dims = get_sorted_dims(arg.domain.dims)
         ndim = len(sorted_dims)
-        dim_indices = [dim[0] for dim in sorted_dims]
+        dim_indices = [dim_index for dim_index, _ in sorted_dims]
         assert isinstance(arg.ndarray, np.ndarray)
         return np.moveaxis(arg.ndarray, range(ndim), dim_indices)
     return arg
@@ -76,7 +85,7 @@ def get_offset_args(
         str(sym): -drange.start
         for param, arg in zip(params, args)
         if common.is_field(arg)
-        for sym, drange in zip(arrays[param.id].offset, arg.domain.ranges)
+        for sym, drange in zip(arrays[param.id].offset, get_sorted_dim_ranges(arg.domain))
     }
 
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -31,7 +31,11 @@ from .utility import connectivity_identifier, filter_neighbor_tables
 
 def convert_arg(arg: Any):
     if common.is_field(arg):
-        return arg.ndarray
+        sorted_dims = sorted(enumerate(arg.__gt_dims__), key=lambda v: v[1].value)
+        ndim = len(sorted_dims)
+        dim_indices = [dim[0] for dim in sorted_dims]
+        assert isinstance(arg.ndarray, np.ndarray)
+        return np.moveaxis(arg.ndarray, range(ndim), dim_indices)
     return arg
 
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -18,7 +18,7 @@ import dace
 import numpy as np
 
 import gt4py.next.iterator.ir as itir
-from gt4py.next import common
+from gt4py.next.common import Domain, UnitRange, is_field
 from gt4py.next.iterator.embedded import NeighborTableOffsetProvider
 from gt4py.next.iterator.transforms import LiftMode, apply_common_transforms
 from gt4py.next.otf.compilation import cache
@@ -26,20 +26,16 @@ from gt4py.next.program_processors.processor_interface import program_executor
 from gt4py.next.type_system import type_translation
 
 from .itir_to_sdfg import ItirToSDFG
-from .utility import connectivity_identifier, filter_neighbor_tables
+from .utility import connectivity_identifier, filter_neighbor_tables, get_sorted_dims
 
 
-def get_sorted_dims(dims: Sequence[common.Dimension]) -> Sequence[tuple[int, common.Dimension]]:
-    return sorted(enumerate(dims), key=lambda v: v[1].value)
-
-
-def get_sorted_dim_ranges(domain: common.Domain) -> Sequence[common.UnitRange]:
+def get_sorted_dim_ranges(domain: Domain) -> Sequence[UnitRange]:
     sorted_dims = get_sorted_dims(domain.dims)
     return [domain.ranges[dim_index] for dim_index, _ in sorted_dims]
 
 
 def convert_arg(arg: Any):
-    if common.is_field(arg):
+    if is_field(arg):
         sorted_dims = get_sorted_dims(arg.domain.dims)
         ndim = len(sorted_dims)
         dim_indices = [dim_index for dim_index, _ in sorted_dims]
@@ -84,7 +80,7 @@ def get_offset_args(
     return {
         str(sym): -drange.start
         for param, arg in zip(params, args)
-        if common.is_field(arg)
+        if is_field(arg)
         for sym, drange in zip(arrays[param.id].offset, get_sorted_dim_ranges(arg.domain))
     }
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -290,21 +290,15 @@ class ItirToSDFG(eve.NodeVisitor):
             _, (scan_lb, scan_ub) = closure_domain[scan_dim_index]
             output_subset = f"{scan_lb.value}:{scan_ub.value}"
 
-            closure_sdfg.add_array(
-                nsdfg_output_name,
-                dtype=output_descriptor.dtype,
-                shape=(array_table[output_name].shape[scan_dim_index],),
-                strides=(array_table[output_name].strides[scan_dim_index],),
-                transient=True,
-            )
-
+            scan_offset = output_descriptor.offset[scan_dim_index]
+            scan_shape = output_descriptor.shape[scan_dim_index]
             output_memlet = create_memlet_at(
                 output_name,
                 self.storage_types[output_name],
                 {
                     dim: f"i_{dim}"
                     if f"i_{dim}" in map_ranges
-                    else f"0:{output_descriptor.shape[scan_dim_index]}"
+                    else f"{scan_offset}:{scan_offset}+{scan_shape}"
                     for dim, _ in closure_domain
                 },
             )
@@ -315,12 +309,6 @@ class ItirToSDFG(eve.NodeVisitor):
             assert len(results) == 1
 
             output_subset = "0"
-
-            closure_sdfg.add_scalar(
-                nsdfg_output_name,
-                dtype=output_descriptor.dtype,
-                transient=True,
-            )
 
             output_memlet = create_memlet_at(
                 output_name,

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -236,7 +236,6 @@ class ItirToSDFG(eve.NodeVisitor):
                     name,
                     shape=array_table[name].shape,
                     strides=array_table[name].strides,
-                    offset=array_table[name].offset,
                     dtype=array_table[name].dtype,
                 )
 
@@ -293,8 +292,8 @@ class ItirToSDFG(eve.NodeVisitor):
             closure_sdfg.add_array(
                 nsdfg_output_name,
                 dtype=output_descriptor.dtype,
-                shape=(array_table[output_name].shape[scan_dim_index],),
-                strides=(array_table[output_name].strides[scan_dim_index],),
+                shape=(output_descriptor.shape[scan_dim_index],),
+                strides=(output_descriptor.strides[scan_dim_index],),
                 transient=True,
             )
 
@@ -441,7 +440,6 @@ class ItirToSDFG(eve.NodeVisitor):
                     name,
                     shape=array_table[name].shape,
                     strides=array_table[name].strides,
-                    offset=array_table[name].offset,
                     dtype=array_table[name].dtype,
                 )
             else:

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -290,15 +290,21 @@ class ItirToSDFG(eve.NodeVisitor):
             _, (scan_lb, scan_ub) = closure_domain[scan_dim_index]
             output_subset = f"{scan_lb.value}:{scan_ub.value}"
 
-            scan_offset = output_descriptor.offset[scan_dim_index]
-            scan_shape = output_descriptor.shape[scan_dim_index]
+            closure_sdfg.add_array(
+                nsdfg_output_name,
+                dtype=output_descriptor.dtype,
+                shape=(array_table[output_name].shape[scan_dim_index],),
+                strides=(array_table[output_name].strides[scan_dim_index],),
+                transient=True,
+            )
+
             output_memlet = create_memlet_at(
                 output_name,
                 self.storage_types[output_name],
                 {
                     dim: f"i_{dim}"
                     if f"i_{dim}" in map_ranges
-                    else f"{scan_offset}:{scan_offset}+{scan_shape}"
+                    else f"0:{output_descriptor.shape[scan_dim_index]}"
                     for dim, _ in closure_domain
                 },
             )
@@ -309,6 +315,12 @@ class ItirToSDFG(eve.NodeVisitor):
             assert len(results) == 1
 
             output_subset = "0"
+
+            closure_sdfg.add_scalar(
+                nsdfg_output_name,
+                dtype=output_descriptor.dtype,
+                transient=True,
+            )
 
             output_memlet = create_memlet_at(
                 output_name,

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -987,12 +987,9 @@ def closure_to_tasklet_sdfg(
             stride = [
                 dace.symbol(f"{unique_var_name()}_strd{i}", dtype=dace.int64) for i in range(ndim)
             ]
-            offset = [
-                dace.symbol(f"{unique_var_name()}_offset{i}", dtype=dace.int64) for i in range(ndim)
-            ]
             dims = [dim.value for dim in ty.dims]
             dtype = as_dace_type(ty.dtype)
-            body.add_array(name, shape=shape, strides=stride, offset=offset, dtype=dtype)
+            body.add_array(name, shape=shape, strides=stride, dtype=dtype)
             field = state.add_access(name)
             indices = {dim: idx_accesses[dim] for dim in domain.keys()}
             symbol_map[name] = IteratorExpr(field, indices, dtype, dims)

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -990,9 +990,12 @@ def closure_to_tasklet_sdfg(
             stride = [
                 dace.symbol(f"{unique_var_name()}_strd{i}", dtype=dace.int64) for i in range(ndim)
             ]
+            offset = [
+                dace.symbol(f"{unique_var_name()}_offset{i}", dtype=dace.int64) for i in range(ndim)
+            ]
             dims = [dim.value for dim in ty.dims]
             dtype = as_dace_type(ty.dtype)
-            body.add_array(name, shape=shape, strides=stride, dtype=dtype)
+            body.add_array(name, shape=shape, strides=stride, offset=offset, dtype=dtype)
             field = state.add_access(name)
             indices = {dim: idx_accesses[dim] for dim in domain.keys()}
             symbol_map[name] = IteratorExpr(field, indices, dtype, dims)

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -47,7 +47,10 @@ def connectivity_identifier(name: str):
 
 
 def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
-    bounds = [(0, size) for size in source_array.shape]
+    bounds = [
+        (f"-{offset}", f"{size}-{offset}")
+        for offset, size in zip(source_array.offset, source_array.shape)
+    ]
     subset = ", ".join(f"{lb}:{ub}" for lb, ub in bounds)
     return dace.Memlet(data=source_identifier, subset=subset)
 
@@ -73,6 +76,10 @@ def map_nested_sdfg_symbols(
             for arg_stride, param_stride in zip(arg_array.strides, param_array.strides):
                 if isinstance(param_stride, dace.symbol):
                     symbol_mapping[str(param_stride)] = str(arg_stride)
+            assert len(arg_array.offset) == len(param_array.offset)
+            for arg_offset, param_offset in zip(arg_array.offset, param_array.offset):
+                if isinstance(param_offset, dace.symbol):
+                    symbol_mapping[str(param_offset)] = str(arg_offset)
         else:
             assert arg.subset.num_elements() == 1
     for sym in nested_sdfg.free_symbols:

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -46,10 +46,7 @@ def connectivity_identifier(name: str):
 
 
 def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
-    bounds = [
-        (f"-{offset}", f"{size}-{offset}")
-        for offset, size in zip(source_array.offset, source_array.shape)
-    ]
+    bounds = [(0, size) for size in source_array.shape]
     subset = ", ".join(f"{lb}:{ub}" for lb, ub in bounds)
     return dace.Memlet.simple(source_identifier, subset)
 
@@ -77,10 +74,6 @@ def map_nested_sdfg_symbols(
             for arg_stride, param_stride in zip(arg_array.strides, param_array.strides):
                 if isinstance(param_stride, dace.symbol):
                     symbol_mapping[str(param_stride)] = str(arg_stride)
-            assert len(arg_array.offset) == len(param_array.offset)
-            for arg_offset, param_offset in zip(arg_array.offset, param_array.offset):
-                if isinstance(param_offset, dace.symbol):
-                    symbol_mapping[str(param_offset)] = str(arg_offset)
         else:
             assert arg.subset.num_elements() == 1
     for sym in nested_sdfg.free_symbols:

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -11,7 +11,8 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from typing import Any, cast
+
+from typing import Any
 
 import dace
 
@@ -48,14 +49,12 @@ def connectivity_identifier(name: str):
 def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
     bounds = [(0, size) for size in source_array.shape]
     subset = ", ".join(f"{lb}:{ub}" for lb, ub in bounds)
-    return dace.Memlet.simple(source_identifier, subset)
+    return dace.Memlet(data=source_identifier, subset=subset)
 
 
-def create_memlet_at(source_identifier: str, storage_type: ts.TypeSpec, index: dict[str, str]):
-    field_type = cast(ts.FieldType, storage_type)
-    field_index = [index[dim.value] for dim in field_type.dims]
-    subset = ", ".join(field_index)
-    return dace.Memlet.simple(source_identifier, subset)
+def create_memlet_at(source_identifier: str, index: tuple[str, ...]):
+    subset = ", ".join(index)
+    return dace.Memlet(data=source_identifier, subset=subset)
 
 
 def map_nested_sdfg_symbols(

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -12,10 +12,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Any
+from typing import Any, Sequence
 
 import dace
 
+from gt4py.next import Dimension
 from gt4py.next.iterator.embedded import NeighborTableOffsetProvider
 from gt4py.next.type_system import type_specifications as ts
 
@@ -55,6 +56,10 @@ def create_memlet_full(source_identifier: str, source_array: dace.data.Array):
 def create_memlet_at(source_identifier: str, index: tuple[str, ...]):
     subset = ", ".join(index)
     return dace.Memlet(data=source_identifier, subset=subset)
+
+
+def get_sorted_dims(dims: Sequence[Dimension]) -> Sequence[tuple[int, Dimension]]:
+    return sorted(enumerate(dims), key=lambda v: v[1].value)
 
 
 def map_nested_sdfg_symbols(


### PR DESCRIPTION
## Description

Adding support in DaCe backend for field arguments with domain offset. This feature is required by following icon4py stencils:
- [mo_velocity_advection_stencil_02](https://github.com/C2SM/icon4py/blob/main/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/mo_velocity_advection_stencil_02.py)
- [mo_velocity_advection_stencil_03](https://github.com/C2SM/icon4py/blob/main/model/atmosphere/dycore/src/icon4py/model/atmosphere/dycore/mo_velocity_advection_stencil_03.py)

N.B. The solution has been updated to be consistent with the alphabetical order of dimensions in the field domain (see discussion in #1346).