### PR TITLE
feat[next]: Extend astype to work with tuples

### DIFF
--- a/src/gt4py/next/ffront/fbuiltins.py
+++ b/src/gt4py/next/ffront/fbuiltins.py
@@ -175,7 +175,11 @@ def where(
 
 
 @builtin_function
-def astype(field: Field | gt4py_defs.ScalarT, type_: type, /) -> Field:
+def astype(
+    field: Field | gt4py_defs.ScalarT | Tuple[Field, ...],
+    type_: type,
+    /,
+) -> Field | Tuple[Field, ...]:
     raise NotImplementedError()
 
 

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -837,18 +837,12 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 f"Invalid call to `astype`. Second argument must be a scalar type, but got {new_type}.",
             )
 
-        if isinstance(value, foast.TupleExpr):
-            return_type = type_info.apply_to_primitive_constituents(
-                value.type,
-                lambda primitive_type: with_altered_scalar_kind(
-                    primitive_type, getattr(ts.ScalarKind, new_type.id.upper())
-                ),
-            )
-
-        else:
-            return_type = with_altered_scalar_kind(
-                value.type, getattr(ts.ScalarKind, new_type.id.upper())
-            )
+        return_type = type_info.apply_to_primitive_constituents(
+            value.type,
+            lambda primitive_type: with_altered_scalar_kind(
+                primitive_type, getattr(ts.ScalarKind, new_type.id.upper())
+            ),
+        )
 
         return foast.Call(
             func=node.func,

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -840,6 +840,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         if isinstance(value, foast.TupleExpr):
             element_types_new = []
             for element in value.elts:
+                assert isinstance(element.type, (ts.FieldType, ts.ScalarType))
                 element_types_new.append(
                     with_altered_scalar_kind(
                         element.type, getattr(ts.ScalarKind, new_type.id.upper())

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -838,15 +838,12 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
 
         if isinstance(value, foast.TupleExpr):
-            element_types_new = []
-            for element in value.elts:
-                assert isinstance(element.type, (ts.FieldType, ts.ScalarType))
-                element_types_new.append(
-                    with_altered_scalar_kind(
-                        element.type, getattr(ts.ScalarKind, new_type.id.upper())
-                    )
-                )
-            return_type = ts.TupleType(types=cast(list[ts.DataType], element_types_new))
+            return_type = type_info.apply_to_primitive_constituents(
+                value.type,
+                lambda primitive_type: with_altered_scalar_kind(
+                    primitive_type, getattr(ts.ScalarKind, new_type.id.upper())
+                ),
+            )
 
         else:
             return_type = with_altered_scalar_kind(

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -823,10 +823,12 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
         return self._visit_reduction(node, **kwargs)
 
     def _visit_astype(self, node: foast.Call, **kwargs) -> foast.Call:
+        return_type: ts.TupleType | ts.ScalarType | ts.FieldType
         value, new_type = node.args
         assert isinstance(
-            value.type, (ts.FieldType, ts.ScalarType)
+            value.type, (ts.FieldType, ts.ScalarType, ts.TupleType)
         )  # already checked using generic mechanism
+
         if not isinstance(new_type, foast.Name) or new_type.id.upper() not in [
             kind.name for kind in ts.ScalarKind
         ]:
@@ -835,9 +837,20 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 f"Invalid call to `astype`. Second argument must be a scalar type, but got {new_type}.",
             )
 
-        return_type = with_altered_scalar_kind(
-            value.type, getattr(ts.ScalarKind, new_type.id.upper())
-        )
+        if isinstance(value, foast.TupleExpr):
+            element_types_new = []
+            for element in value.elts:
+                element_types_new.append(
+                    with_altered_scalar_kind(
+                        element.type, getattr(ts.ScalarKind, new_type.id.upper())
+                    )
+                )
+            return_type = ts.TupleType(types=cast(list[ts.DataType], element_types_new))
+
+        else:
+            return_type = with_altered_scalar_kind(
+                value.type, getattr(ts.ScalarKind, new_type.id.upper())
+            )
 
         return foast.Call(
             func=node.func,

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -320,7 +320,7 @@ class FieldOperatorLowering(NodeTranslator):
         obj, dtype = node.args[0], node.args[1].id
         if isinstance(obj, foast.TupleExpr):
             casted_elements = []
-            for _, element in enumerate(obj.elts):
+            for element in obj.elts:
                 casted_element = self._map(
                     im.lambda_("it")(im.call("cast_")("it", str(dtype))), element
                 )

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -318,12 +318,22 @@ class FieldOperatorLowering(NodeTranslator):
     def _visit_astype(self, node: foast.Call, **kwargs) -> itir.FunCall:
         assert len(node.args) == 2 and isinstance(node.args[1], foast.Name)
         obj, dtype = node.args[0], node.args[1].id
-
-        # TODO check that we test astype that results in a itir.map_ operation
-        return self._map(
-            im.lambda_("it")(im.call("cast_")("it", str(dtype))),
-            obj,
-        )
+        if isinstance(obj, foast.TupleExpr):
+            casted_elements = []
+            for _, element in enumerate(obj.elts):
+                casted_element = self._map(
+                    im.lambda_("it")(im.call("cast_")("it", str(dtype))), element
+                )
+                casted_elements.append(casted_element)
+            args = [f"__arg{i}" for i in range(len(casted_elements))]
+            return im.lift(im.lambda_(*args)(im.make_tuple(*[im.deref(arg) for arg in args])))(
+                *casted_elements
+            )
+        else:
+            return self._map(
+                im.lambda_("it")(im.call("cast_")("it", str(dtype))),
+                obj,
+            )
 
     def _visit_where(self, node: foast.Call, **kwargs) -> itir.FunCall:
         return self._map("if_", *node.args)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -363,12 +363,8 @@ def test_astype_on_tuples(cartesian_case):  # noqa: F811 # fixtures
 
     a = cases.allocate(cartesian_case, cast_tuple, "a")()
     b = cases.allocate(cartesian_case, cast_tuple, "b")()
-    a_casted_to_int_outside_of_gt4py = cases.allocate(
-        cartesian_case, cast_tuple, "a", dtype=int32
-    )()
-    b_casted_to_int_outside_of_gt4py = cases.allocate(
-        cartesian_case, cast_tuple, "b", dtype=int32
-    )()
+    a_casted_to_int_outside_of_gt4py = gtx.np_as_located_field(IDim)(np.asarray(a).astype(int32))
+    b_casted_to_int_outside_of_gt4py = gtx.np_as_located_field(IDim)(np.asarray(b).astype(int32))
     out_tuple = cases.allocate(cartesian_case, cast_tuple, cases.RETURN)()
     out_nested_tuple = cases.allocate(cartesian_case, cast_nested_tuple, cases.RETURN)()
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -329,14 +329,17 @@ def test_astype_int(cartesian_case):  # noqa: F811 # fixtures
 
 def test_astype_on_tuples(cartesian_case):
     @gtx.field_operator
-    def testee(
+    def cast_tuple(
         a: cases.IFloatField, b: cases.IFloatField
     ) -> tuple[gtx.Field[[IDim], int64], gtx.Field[[IDim], int64]]:
         return astype((a, b), int64)
 
-    cases.verify_with_default_data(
-        cartesian_case, testee, ref=lambda a, b: (a.astype(int64), b.astype(int64))
-    )
+    @gtx.field_operator
+    def combine(a: cases.IFloatField, b: cases.IFloatField) -> gtx.Field[[IDim], int64]:
+        packed_tuple = cast_tuple(a, b)
+        return packed_tuple[0] + packed_tuple[1]
+
+    cases.verify_with_default_data(cartesian_case, combine, ref=lambda a, b: a + b)
 
 
 def test_astype_on_nested_tuples(cartesian_case):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -327,6 +327,33 @@ def test_astype_int(cartesian_case):  # noqa: F811 # fixtures
     )
 
 
+def test_astype_on_tuples(cartesian_case):
+    @gtx.field_operator
+    def testee(
+        a: cases.IFloatField, b: cases.IFloatField
+    ) -> tuple[gtx.Field[[IDim], int64], gtx.Field[[IDim], int64]]:
+        return astype((a, b), int64)
+
+    cases.verify_with_default_data(
+        cartesian_case, testee, ref=lambda a, b: (a.astype(int64), b.astype(int64))
+    )
+
+
+def test_astype_on_nested_tuples(cartesian_case):
+    @gtx.field_operator
+    def cast_nested_tuple(
+        a: cases.IField, b: cases.IField
+    ) -> tuple[gtx.Field[[IDim], int64], tuple[gtx.Field[[IDim], int64], gtx.Field[[IDim], int64]]]:
+        return astype((a, (a, b)), int64)
+
+    @gtx.field_operator
+    def combine(a: cases.IField, b: cases.IField) -> gtx.Field[[IDim], int64]:
+        nested_tuple = cast_nested_tuple(a, b)
+        return nested_tuple[0] + nested_tuple[1][0] + nested_tuple[1][1]
+
+    cases.verify_with_default_data(cartesian_case, combine, ref=lambda a, b: a + a + b)
+
+
 def test_astype_bool_field(cartesian_case):  # noqa: F811 # fixtures
     @gtx.field_operator
     def testee(a: cases.IFloatField) -> gtx.Field[[IDim], bool]:

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -327,34 +327,59 @@ def test_astype_int(cartesian_case):  # noqa: F811 # fixtures
     )
 
 
-def test_astype_on_tuples(cartesian_case):
+@pytest.mark.uses_tuple_returns
+def test_astype_on_tuples(cartesian_case):  # noqa: F811 # fixtures
+    @gtx.field_operator
+    def field_op_returning_a_tuple(
+        a: cases.IFloatField, b: cases.IFloatField
+    ) -> tuple[gtx.Field[[IDim], float], gtx.Field[[IDim], float]]:
+        tup = (a, b)
+        return tup
+
     @gtx.field_operator
     def cast_tuple(
         a: cases.IFloatField, b: cases.IFloatField
-    ) -> tuple[gtx.Field[[IDim], int64], gtx.Field[[IDim], int64]]:
-        return astype((a, b), int64)
+    ) -> tuple[gtx.Field[[IDim], int32], gtx.Field[[IDim], int32]]:
+        return astype(field_op_returning_a_tuple(a, b), int32)
 
-    @gtx.field_operator
-    def combine(a: cases.IFloatField, b: cases.IFloatField) -> gtx.Field[[IDim], int64]:
-        packed_tuple = cast_tuple(a, b)
-        return packed_tuple[0] + packed_tuple[1]
-
-    cases.verify_with_default_data(cartesian_case, combine, ref=lambda a, b: a + b)
-
-
-def test_astype_on_nested_tuples(cartesian_case):
     @gtx.field_operator
     def cast_nested_tuple(
-        a: cases.IField, b: cases.IField
-    ) -> tuple[gtx.Field[[IDim], int64], tuple[gtx.Field[[IDim], int64], gtx.Field[[IDim], int64]]]:
-        return astype((a, (a, b)), int64)
+        a: cases.IFloatField, b: cases.IFloatField
+    ) -> tuple[gtx.Field[[IDim], int32], tuple[gtx.Field[[IDim], int32], gtx.Field[[IDim], int32]]]:
+        return astype((a, field_op_returning_a_tuple(a, b)), int32)
 
-    @gtx.field_operator
-    def combine(a: cases.IField, b: cases.IField) -> gtx.Field[[IDim], int64]:
-        nested_tuple = cast_nested_tuple(a, b)
-        return nested_tuple[0] + nested_tuple[1][0] + nested_tuple[1][1]
+    a = cases.allocate(cartesian_case, cast_tuple, "a")()
+    b = cases.allocate(cartesian_case, cast_tuple, "b")()
+    out_tuple = cases.allocate(cartesian_case, cast_tuple, cases.RETURN)()
+    out_nested_tuple = cases.allocate(cartesian_case, cast_nested_tuple, cases.RETURN)()
 
-    cases.verify_with_default_data(cartesian_case, combine, ref=lambda a, b: a + a + b)
+    def unpack_and_compare(ref, out):
+        if isinstance(ref, tuple) and isinstance(out, tuple):
+            return all(
+                unpack_and_compare(ref_item, out_item) for ref_item, out_item in zip(ref, out)
+            )
+        else:
+            return ref.dtype == out.dtype and np.array_equal(ref, out)
+
+    cases.verify(
+        cartesian_case,
+        cast_tuple,
+        a,
+        b,
+        out=out_tuple,
+        ref=(int32(a), int32(b)),
+        comparison=lambda ref, out: unpack_and_compare(ref, out),
+    )
+
+    cases.verify(
+        cartesian_case,
+        cast_nested_tuple,
+        a,
+        b,
+        out=out_nested_tuple,
+        ref=(int32(a), (int32(a), int32(b))),
+        comparison=lambda ref, out: unpack_and_compare(ref, out),
+    )
 
 
 def test_astype_bool_field(cartesian_case):  # noqa: F811 # fixtures

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -785,8 +785,8 @@ def test_astype_wrong_dtype():
 
 def test_astype_wrong_value_type():
     def simple_astype(a: Field[[TDim], float64]):
-        # we just use a tuple here but anything that is not a field or scalar works
-        return astype((1, 2), bool)
+        # we just use broadcast here but anything that is not a field, scalar or tuple works
+        return astype(broadcast, bool)
 
     with pytest.raises(errors.DSLError) as exc_info:
         _ = FieldOperatorParser.apply_to_function(simple_astype)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -785,7 +785,7 @@ def test_astype_wrong_dtype():
 
 def test_astype_wrong_value_type():
     def simple_astype(a: Field[[TDim], float64]):
-        # we just use broadcast here but anything that is not a field, scalar or tuple works
+        # we just use broadcast here but anything that is not a field, scalar or tuple thereof works
         return astype(broadcast, bool)
 
     with pytest.raises(errors.DSLError) as exc_info:

--- a/tests/next_tests/unit_tests/ffront_tests/foast_passes_tests/test_type_alias_replacement.py
+++ b/tests/next_tests/unit_tests/ffront_tests/foast_passes_tests/test_type_alias_replacement.py
@@ -19,9 +19,13 @@ from typing import TypeAlias
 import pytest
 
 import gt4py.next as gtx
+from gt4py.eve import SymbolRef
 from gt4py.next import float32, float64
 from gt4py.next.ffront.fbuiltins import astype
+from gt4py.next.ffront.foast_to_itir import FieldOperatorLowering
 from gt4py.next.ffront.func_to_foast import FieldOperatorParser
+from gt4py.next.iterator import ir as itir, ir_makers as im
+from gt4py.next.type_system import type_specifications as ts
 
 
 TDim = gtx.Dimension("TDim")  # Meaningless dimension, used for tests.
@@ -42,3 +46,22 @@ def test_type_alias_replacement(test_input, expected):
         foast_tree.body.stmts[0].value.left.func.id == expected
         and foast_tree.body.stmts[0].value.right.args[1].id == expected
     )
+
+
+def test_type_alias_replacement_astype_with_tuples():
+    def fieldop_with_typealias_with_tuples(
+        a: gtx.Field[[TDim], vpfloat], b: gtx.Field[[TDim], vpfloat]
+    ) -> tuple[gtx.Field[[TDim], wpfloat], gtx.Field[[TDim], wpfloat]]:
+        return astype((a, b), wpfloat)
+
+    parsed = FieldOperatorParser.apply_to_function(fieldop_with_typealias_with_tuples)
+    lowered = FieldOperatorLowering.apply(parsed)
+
+    # Check that the type of the first arg of "astype" is a tuple
+    assert isinstance(parsed.body.stmts[0].value.args[0].type, ts.TupleType)
+    # Check that the return type of "astype" is a tuple
+    assert isinstance(parsed.body.stmts[0].value.type, ts.TupleType)
+    # Check inside the lift function that make_tuple is applied to return a tuple
+    assert lowered.expr.fun.args[0].expr.fun == itir.SymRef(id=SymbolRef("make_tuple"))
+    # Check that the elements that form the tuple called the cast_ function individually
+    assert lowered.expr.args[0].fun.args[0].expr.fun.expr.fun == itir.SymRef(id=SymbolRef("cast_"))

--- a/tests/next_tests/unit_tests/ffront_tests/foast_passes_tests/test_type_alias_replacement.py
+++ b/tests/next_tests/unit_tests/ffront_tests/foast_passes_tests/test_type_alias_replacement.py
@@ -19,13 +19,9 @@ from typing import TypeAlias
 import pytest
 
 import gt4py.next as gtx
-from gt4py.eve import SymbolRef
 from gt4py.next import float32, float64
 from gt4py.next.ffront.fbuiltins import astype
-from gt4py.next.ffront.foast_to_itir import FieldOperatorLowering
 from gt4py.next.ffront.func_to_foast import FieldOperatorParser
-from gt4py.next.iterator import ir as itir, ir_makers as im
-from gt4py.next.type_system import type_specifications as ts
 
 
 TDim = gtx.Dimension("TDim")  # Meaningless dimension, used for tests.
@@ -46,22 +42,3 @@ def test_type_alias_replacement(test_input, expected):
         foast_tree.body.stmts[0].value.left.func.id == expected
         and foast_tree.body.stmts[0].value.right.args[1].id == expected
     )
-
-
-def test_type_alias_replacement_astype_with_tuples():
-    def fieldop_with_typealias_with_tuples(
-        a: gtx.Field[[TDim], vpfloat], b: gtx.Field[[TDim], vpfloat]
-    ) -> tuple[gtx.Field[[TDim], wpfloat], gtx.Field[[TDim], wpfloat]]:
-        return astype((a, b), wpfloat)
-
-    parsed = FieldOperatorParser.apply_to_function(fieldop_with_typealias_with_tuples)
-    lowered = FieldOperatorLowering.apply(parsed)
-
-    # Check that the type of the first arg of "astype" is a tuple
-    assert isinstance(parsed.body.stmts[0].value.args[0].type, ts.TupleType)
-    # Check that the return type of "astype" is a tuple
-    assert isinstance(parsed.body.stmts[0].value.type, ts.TupleType)
-    # Check inside the lift function that make_tuple is applied to return a tuple
-    assert lowered.expr.fun.args[0].expr.fun == itir.SymRef(id=SymbolRef("make_tuple"))
-    # Check that the elements that form the tuple called the cast_ function individually
-    assert lowered.expr.args[0].fun.args[0].expr.fun.expr.fun == itir.SymRef(id=SymbolRef("cast_"))


### PR DESCRIPTION
This pull request extends the functionality of the built-in `astype` function in the `ffront` module such that we can write `field_float32, field_float32 = astype((field_float64, field_float64), float32)`. The changes specifically impact the `foast_to_itir.py` file. Here's an overview of the modifications:

- The `astype` function's argument and return types have been extended to accept tuples of fields in addition to individual fields.
- In the `foast_to_itir.py` file, when casting tuples, each element is processed individually. The casted elements are then combined into a new tuple using `make_tuple`.
- The code also includes test cases to ensure that the modified `astype` function correctly handles tuples of fields.

The motivation for these changes is to simplify and enhance code readability when performing operations that mix different types. In such scenarios, explicit type promotion is required, resulting in cluttered stencils with casting operations. This update makes the type conversion explicit and visible, reducing the need for extensive casting operations and improving code clarity.