### PR TITLE
feat[next]: Extend DaCe support for offset providers

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -196,7 +196,6 @@ class ItirToSDFG(eve.NodeVisitor):
         self, node: itir.StencilClosure, array_table: dict[str, dace.data.Array]
     ) -> tuple[dace.SDFG, list[str], list[str]]:
         assert ItirToSDFG._check_no_lifts(node)
-        assert ItirToSDFG._check_shift_offsets_are_literals(node)
 
         # Create the closure's nested SDFG and single state.
         closure_sdfg = dace.SDFG(name="closure")

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -698,7 +698,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             expr = f"{internals[0]} + {internals[1]}"
 
         shifted_value = self.add_expr_tasklet(
-            list(zip(args, internals)), expr, dace.dtypes.int64, "ind_addr"
+            list(zip(args, internals)), expr, dace.dtypes.int64, "shift"
         )[0].value
 
         shifted_index = {dim: value for dim, value in iterator.indices.items()}


### PR DESCRIPTION
## Description

Extend support in DaCe backend for offset providers, in order to generate the tasklet code in case of shift expressions with both direct and indirect addressing.

This allows to visit expressions like:

`⟪C2E2Cₒ, 0ₒ, Koffₒ, ·⟪C2CECₒ, 0ₒ⟫(zd_vertoffset)⟫(theta_v)`

which originates from user code:

`theta_v(as_offset(Koff, zd_vertoffset(C2CEC[0]) + int32(1)))`