### PR TITLE
feat[next]: Limit use of global type inference in CollapseTuple pass 

### DIFF
--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -40,7 +40,7 @@ class CollapseTuple(eve.NodeTranslator):
     collapse_make_tuple_tuple_get: bool
     collapse_tuple_get_make_tuple: bool
     collapse_tuple_inference: bool
-    node_types: Optional[dict[int, type_inference.Type]] = None
+    _node_types: Optional[dict[int, type_inference.Type]] = None
 
     @classmethod
     def apply(

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -39,8 +39,6 @@ class CollapseTuple(eve.NodeTranslator):
     collapse_make_tuple_tuple_get: bool
     collapse_tuple_get_make_tuple: bool
 
-    _node_types: dict[int, type_inference.Type]
-
     @classmethod
     def apply(
         cls,
@@ -57,13 +55,8 @@ class CollapseTuple(eve.NodeTranslator):
         If `ignore_tuple_size`, apply the transformation even if length of the inner tuple
         is greater than the length of the outer tuple.
         """
-        node_types = it_type_inference.infer_all(node)
-
         return cls(
-            ignore_tuple_size,
-            collapse_make_tuple_tuple_get,
-            collapse_tuple_get_make_tuple,
-            node_types,
+            ignore_tuple_size, collapse_make_tuple_tuple_get, collapse_tuple_get_make_tuple
         ).visit(node)
 
     def visit_FunCall(self, node: ir.FunCall, **kwargs) -> ir.Node:
@@ -86,9 +79,7 @@ class CollapseTuple(eve.NodeTranslator):
                     # tuple argument differs, just continue with the rest of the tree
                     return self.generic_visit(node)
 
-            if self.ignore_tuple_size or _get_tuple_size(self._node_types[id(first_expr)]) == len(
-                node.args
-            ):
+            if self.ignore_tuple_size or _get_tuple_size(first_expr) == len(node.args):
                 return first_expr
         if (
             self.collapse_tuple_get_make_tuple

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -51,7 +51,7 @@ class CollapseTuple(eve.NodeTranslator):
         # the following options are mostly for allowing separate testing of the modes
         collapse_make_tuple_tuple_get: bool = True,
         collapse_tuple_get_make_tuple: bool = True,
-        collapse_tuple_inference: bool = False,
+        use_global_type_inferrence: bool = False,
     ) -> ir.Node:
         """
         Simplifies `make_tuple`, `tuple_get` calls.

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -29,10 +29,12 @@ def _get_tuple_size(
         assert isinstance(elem_or_type, ir.Node)
         type_ = it_type_inference.infer(elem_or_type)
 
-    assert isinstance(type_, it_type_inference.Val) and isinstance(
-        type_.dtype, it_type_inference.Tuple
-    )
-    return len(type_.dtype)
+    assert isinstance(type_, it_type_inference.Val)
+    if isinstance(type_.dtype, it_type_inference.Tuple):
+        return len(type_.dtype)
+    else:
+        # in case of TypeVar
+        return 1
 
 
 @dataclass(frozen=True)

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -103,10 +103,7 @@ class CollapseTuple(eve.NodeTranslator):
                     # tuple argument differs, just continue with the rest of the tree
                     return self.generic_visit(node)
 
-            tuple_expr: type_inference.Type | ir.Node = (
-                self.node_types[id(first_expr)] if self.node_types is not None else first_expr
-            )
-            if self.ignore_tuple_size or _get_tuple_size(tuple_expr) == len(node.args):
+            if self.ignore_tuple_size or _get_tuple_size(first_expr, self.node_types) == len(node.args):
                 return first_expr
         if (
             self.collapse_tuple_get_make_tuple

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -59,15 +59,14 @@ class CollapseTuple(eve.NodeTranslator):
         If `ignore_tuple_size`, apply the transformation even if length of the inner tuple
         is greater than the length of the outer tuple.
         """
-        if collapse_tuple_inference:
-            node_types = it_type_inference.infer_all(node)
-            return cls(
-                ignore_tuple_size,
-                collapse_make_tuple_tuple_get,
-                collapse_tuple_get_make_tuple,
-                collapse_tuple_inference,
-                node_types,
-            ).visit(node)
+        node_types = it_type_inference.infer_all(node) if use_global_type_inferrence else None
+        return cls(
+            ignore_tuple_size,
+            collapse_make_tuple_tuple_get,
+            collapse_tuple_get_make_tuple,
+            collapse_tuple_inference,
+            node_types
+        ).visit(node)
 
         return cls(
             ignore_tuple_size,

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -19,7 +19,15 @@ from gt4py.next import type_inference
 from gt4py.next.iterator import ir, type_inference as it_type_inference
 
 
-def _get_tuple_size(elem: type_inference.Type | ir.Node) -> int:
+def _get_tuple_size(elem_or_type: type_inference.Type | ir.Node) -> int:
+    if isinstance(elem, ir.Node):
+        type_ = it_type_inference.infer(elem)  # use local type inference
+    else:
+        type_ = elem_or_type
+    assert isinstance(type_, it_type_inference.Val) and isinstance(
+        type_.dtype, it_type_inference.Tuple
+    )
+    return len(type_.dtype)
     infered_type = it_type_inference.infer(elem) if isinstance(elem, ir.Node) else elem
     assert isinstance(infered_type, it_type_inference.Val) and isinstance(
         infered_type.dtype, it_type_inference.Tuple

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -29,12 +29,10 @@ def _get_tuple_size(
         assert isinstance(elem_or_type, ir.Node)
         type_ = it_type_inference.infer(elem_or_type)
 
-    assert isinstance(type_, it_type_inference.Val)
-    if isinstance(type_.dtype, it_type_inference.Tuple):
-        return len(type_.dtype)
-    else:
-        assert isinstance(type_.size, type_inference.TypeVar)
-        return type_.size.idx
+    assert isinstance(type_, it_type_inference.Val) and isinstance(
+        type_.dtype, it_type_inference.Tuple
+    )
+    return len(type_.dtype)
 
 
 @dataclass(frozen=True)

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -76,13 +76,13 @@ class CollapseTuple(eve.NodeTranslator):
         If `ignore_tuple_size`, apply the transformation even if length of the inner tuple
         is greater than the length of the outer tuple.
         """
-        _node_types = it_type_inference.infer_all(node) if use_global_type_inference else None
+        node_types = it_type_inference.infer_all(node) if use_global_type_inference else None
         return cls(
             ignore_tuple_size,
             collapse_make_tuple_tuple_get,
             collapse_tuple_get_make_tuple,
             use_global_type_inference,
-            _node_types,
+            node_types,
         ).visit(node)
 
         return cls(

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -33,8 +33,8 @@ def _get_tuple_size(
     if isinstance(type_.dtype, it_type_inference.Tuple):
         return len(type_.dtype)
     else:
-        # in case of TypeVar
-        return 1
+        assert isinstance(type_.size, type_inference.TypeVar)
+        return type_.size.idx
 
 
 @dataclass(frozen=True)

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -26,7 +26,7 @@ class UnknownLength:
 def _get_tuple_size(elem: ir.Node, node_types: Optional[dict] = None) -> int | type[UnknownLength]:
     if node_types:
         type_ = node_types[id(elem)]
-        # Global inference should always give a length, function should fail otherwise
+        # global inference should always give a length, function should fail otherwise
         assert isinstance(type_, it_type_inference.Val) and isinstance(
             type_.dtype, it_type_inference.Tuple
         )

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -90,7 +90,7 @@ def apply_common_transforms(
     ir = PropagateDeref.apply(ir)
     ir = NormalizeShifts().visit(ir)
 
-    for i in range(10):
+    for _ in range(10):
         inlined = ir
 
         inlined = _inline_lifts(inlined, lift_mode)
@@ -106,7 +106,7 @@ def apply_common_transforms(
         inlined = ConstantFolding.apply(inlined)
         # This pass is required to be in the loop such that when an `if_` call with tuple arguments
         # is constant-folded the surrounding tuple_get calls can be removed.
-        if i == 0:
+        if inlined == ir:
             inlined = CollapseTuple.apply(inlined, use_global_type_inference=True)
         else:
             inlined = CollapseTuple.apply(inlined, use_global_type_inference=False)

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -82,7 +82,7 @@ def apply_common_transforms(
     unconditionally_collapse_tuples=False,
 ):
     if lift_mode is None:
-        lift_mode = LiftMode.FORCE_TEMPORARIES
+        lift_mode = LiftMode.FORCE_INLINE
     assert isinstance(lift_mode, LiftMode)
     ir = MergeLet().visit(ir)
     ir = InlineFundefs().visit(ir)

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -106,10 +106,11 @@ def apply_common_transforms(
         inlined = ConstantFolding.apply(inlined)
         # This pass is required to be in the loop such that when an `if_` call with tuple arguments
         # is constant-folded the surrounding tuple_get calls can be removed.
-        if inlined == ir:
-            inlined = CollapseTuple.apply(inlined, use_global_type_inference=True)
-        else:
-            inlined = CollapseTuple.apply(inlined, use_global_type_inference=False)
+        inlined = CollapseTuple.apply(
+            inlined,
+            # to limit number of times global type inference is executed, only in the last iteration
+            use_global_type_inference=inlined == ir,
+        )
 
         if inlined == ir:
             break

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -107,9 +107,9 @@ def apply_common_transforms(
         # This pass is required to be in the loop such that when an `if_` call with tuple arguments
         # is constant-folded the surrounding tuple_get calls can be removed.
         if i == 1:
-            inlined = CollapseTuple.apply(inlined, collapse_tuple_inference=True)
+            inlined = CollapseTuple.apply(inlined, use_global_type_inference=True)
         else:
-            inlined = CollapseTuple.apply(inlined, collapse_tuple_inference=False)
+            inlined = CollapseTuple.apply(inlined, use_global_type_inference=False)
 
         if inlined == ir:
             break

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -106,7 +106,7 @@ def apply_common_transforms(
         inlined = ConstantFolding.apply(inlined)
         # This pass is required to be in the loop such that when an `if_` call with tuple arguments
         # is constant-folded the surrounding tuple_get calls can be removed.
-        if i == 1:
+        if i == 0:
             inlined = CollapseTuple.apply(inlined, use_global_type_inference=True)
         else:
             inlined = CollapseTuple.apply(inlined, use_global_type_inference=False)

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -108,7 +108,7 @@ def apply_common_transforms(
         # is constant-folded the surrounding tuple_get calls can be removed.
         inlined = CollapseTuple.apply(
             inlined,
-            # to limit number of times global type inference is executed, only in the last iteration
+            # to limit number of times global type inference is executed, only in the last iterations.
             use_global_type_inference=inlined == ir,
         )
 


### PR DESCRIPTION
Make `CollapseTuple` pass configurable such that whether the global ITIR type inference is used to get the tuple size or the simple local inference can be configured using a boolean flag.

Execute with global ITIR type inference once in loop in pass manager and in all subsequent runs use the local inference. This significantly improves the performance of the toolchain.