### PR TITLE
test[next]: Fix warnings that cause Spack to crash

### DIFF
--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_program.py
@@ -228,8 +228,8 @@ def test_wrong_argument_type(cartesian_case, copy_program_def):
         copy_program(inp, out, offset_provider={})
 
     msgs = [
-        "- Expected argument `in_field` to be of type `Field\[\[IDim], float64\]`,"
-        " but got `Field\[\[JDim\], float64\]`.",
+        r"- Expected argument `in_field` to be of type `Field\[\[IDim], float64\]`,"
+        r" but got `Field\[\[JDim\], float64\]`.",
     ]
     for msg in msgs:
         assert re.search(msg, exc_info.value.__cause__.args[0]) is not None

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_type_deduction.py
@@ -299,7 +299,7 @@ def callable_type_info_cases():
             [ts.TupleType(types=[float_type, field_type])],
             {},
             [
-                "Expected 1st argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `tuple\[float64, Field\[\[I\], float64\]\]`"
+                r"Expected 1st argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `tuple\[float64, Field\[\[I\], float64\]\]`"
             ],
             ts.VoidType(),
         ),
@@ -308,7 +308,7 @@ def callable_type_info_cases():
             [int_type],
             {},
             [
-                "Expected 1st argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `int64`"
+                r"Expected 1st argument to be of type `tuple\[bool, Field\[\[I\], float64\]\]`, but got `int64`"
             ],
             ts.VoidType(),
         ),

--- a/tests/next_tests/unit_tests/ffront_tests/test_func_to_past.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_func_to_past.py
@@ -206,7 +206,9 @@ def test_domain_exception_3(identity_def):
     assert exc_info.match("Invalid call to `domain_format_3`")
 
     assert (
-        re.search("Missing required keyword argument\(s\) `out`.", exc_info.value.__cause__.args[0])
+        re.search(
+            r"Missing required keyword argument\(s\) `out`.", exc_info.value.__cause__.args[0]
+        )
         is not None
     )
 

--- a/tests/next_tests/unit_tests/ffront_tests/test_past_to_itir.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_past_to_itir.py
@@ -187,6 +187,6 @@ def test_invalid_call_sig_program(invalid_call_sig_program_def):
     #    is not None
     # )
     assert (
-        re.search("Missing required keyword argument\(s\) `out`", exc_info.value.__cause__.args[0])
+        re.search(r"Missing required keyword argument\(s\) `out`", exc_info.value.__cause__.args[0])
         is not None
     )


### PR DESCRIPTION
## Description

Solves warning about invalid escape sequence in some regex strings. These warnings cause spack build to crash.