### PR TITLE
fix[cartesian]: DaceIR bridge for DaCe v0.15

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -451,7 +451,7 @@ class DaCeComputationCodegen:
                 const int __I = domain[0];
                 const int __J = domain[1];
                 const int __K = domain[2];
-                ${name}_{state_prefix} dace_handle;
+                ${name}_${state_prefix} dace_handle;
                 ${backend_specifics}
                 auto allocator = gt::sid::cached_allocator(&${allocator}<char[]>);
                 ${"\\n".join(tmp_allocs)}

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -575,7 +575,7 @@ class DaCeComputationCodegen:
             functor_args=self.generate_functor_args(sdfg),
             tmp_allocs=self.generate_tmp_allocs(sdfg),
             allocator="gt::cuda_util::cuda_malloc" if is_gpu else "std::make_unique",
-            state_prefix=dace_state_suffix,
+            state_suffix=dace_state_suffix,
         )
         generated_code = textwrap.dedent(
             f"""#include <gridtools/sid/sid_shift_origin.hpp>

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -451,7 +451,7 @@ class DaCeComputationCodegen:
                 const int __I = domain[0];
                 const int __J = domain[1];
                 const int __K = domain[2];
-                ${name}_t dace_handle;
+                ${name}_{state_prefix} dace_handle;
                 ${backend_specifics}
                 auto allocator = gt::sid::cached_allocator(&${allocator}<char[]>);
                 ${"\\n".join(tmp_allocs)}
@@ -561,6 +561,13 @@ class DaCeComputationCodegen:
         else:
             omp_threads = ""
             omp_header = ""
+
+        # Backward compatible state struct name change in dave >=0.15.x
+        try:
+            dace_state_prefix = dace.Config.get("compiler.codegen_state_struct_suffix")
+        except (KeyError, TypeError):
+            dace_state_prefix = "t"  # old structure name
+
         interface = cls.template.definition.render(
             name=sdfg.name,
             backend_specifics=omp_threads,
@@ -568,6 +575,7 @@ class DaCeComputationCodegen:
             functor_args=self.generate_functor_args(sdfg),
             tmp_allocs=self.generate_tmp_allocs(sdfg),
             allocator="gt::cuda_util::cuda_malloc" if is_gpu else "std::make_unique",
+            state_prefix=dace_state_prefix,
         )
         generated_code = textwrap.dedent(
             f"""#include <gridtools/sid/sid_shift_origin.hpp>

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -451,7 +451,7 @@ class DaCeComputationCodegen:
                 const int __I = domain[0];
                 const int __J = domain[1];
                 const int __K = domain[2];
-                ${name}_${state_prefix} dace_handle;
+                ${name}_${state_suffix} dace_handle;
                 ${backend_specifics}
                 auto allocator = gt::sid::cached_allocator(&${allocator}<char[]>);
                 ${"\\n".join(tmp_allocs)}
@@ -562,11 +562,11 @@ class DaCeComputationCodegen:
             omp_threads = ""
             omp_header = ""
 
-        # Backward compatible state struct name change in dave >=0.15.x
+        # Backward compatible state struct name change in DaCe >=0.15.x
         try:
-            dace_state_prefix = dace.Config.get("compiler.codegen_state_struct_suffix")
+            dace_state_suffix = dace.Config.get("compiler.codegen_state_struct_suffix")
         except (KeyError, TypeError):
-            dace_state_prefix = "t"  # old structure name
+            dace_state_suffix = "t"  # old structure name
 
         interface = cls.template.definition.render(
             name=sdfg.name,
@@ -575,7 +575,7 @@ class DaCeComputationCodegen:
             functor_args=self.generate_functor_args(sdfg),
             tmp_allocs=self.generate_tmp_allocs(sdfg),
             allocator="gt::cuda_util::cuda_malloc" if is_gpu else "std::make_unique",
-            state_prefix=dace_state_prefix,
+            state_prefix=dace_state_suffix,
         )
         generated_code = textwrap.dedent(
             f"""#include <gridtools/sid/sid_shift_origin.hpp>

--- a/src/gt4py/cartesian/gtc/daceir.py
+++ b/src/gt4py/cartesian/gtc/daceir.py
@@ -101,6 +101,7 @@ class MapSchedule(eve.IntEnum):
             dace.ScheduleType.Default: MapSchedule.Default,
             dace.ScheduleType.Sequential: MapSchedule.Sequential,
             dace.ScheduleType.CPU_Multicore: MapSchedule.CPU_Multicore,
+            dace.ScheduleType.GPU_Default: MapSchedule.GPU_Device,
             dace.ScheduleType.GPU_Device: MapSchedule.GPU_Device,
             dace.ScheduleType.GPU_ThreadBlock: MapSchedule.GPU_ThreadBlock,
         }[schedule]


### PR DESCRIPTION
## Description

Going to the next major version of DaCe (v15) has led a couple of breakage.
The current codegen used a static naming for state struct. The default has changed and an option has been introduce in the dace config, we replicate those changes here.
Missing DaCe schedule to GT4Py schedule mapping.

Those changes will _not_ affect `next`.
Those changes were tested internally at NASA on the GEOS model.