### PR TITLE
fix[next]: DaCe backend - set gpu storage after SDFG transformations

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -210,7 +210,7 @@ def run_dace_iterator(program: itir.FencilDefinition, *args, **kwargs) -> None:
     else:
         # visit ITIR and generate SDFG
         program = preprocess_program(program, offset_provider, lift_mode)
-        sdfg_genenerator = ItirToSDFG(arg_types, offset_provider, column_axis, run_on_gpu)
+        sdfg_genenerator = ItirToSDFG(arg_types, offset_provider, column_axis)
         sdfg = sdfg_genenerator.visit(program)
         sdfg.simplify()
 
@@ -220,6 +220,9 @@ def run_dace_iterator(program: itir.FencilDefinition, *args, **kwargs) -> None:
             #      in which case the cache table should take the symbols map into account.
             symbols: dict[str, int] = {}
             sdfg = autoopt.auto_optimize(sdfg, device, symbols=symbols, use_gpu_storage=run_on_gpu)
+
+        if run_on_gpu:
+            sdfg.apply_gpu_transformations()
 
         # compile SDFG and retrieve SDFG program
         sdfg.build_folder = cache._session_cache_dir_path / ".dacecache"

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -97,20 +97,17 @@ class ItirToSDFG(eve.NodeVisitor):
     offset_provider: dict[str, Any]
     node_types: dict[int, next_typing.Type]
     unique_id: int
-    use_gpu_storage: bool
 
     def __init__(
         self,
         param_types: list[ts.TypeSpec],
         offset_provider: dict[str, NeighborTableOffsetProvider],
         column_axis: Optional[Dimension] = None,
-        use_gpu_storage: bool = False,
     ):
         self.param_types = param_types
         self.column_axis = column_axis
         self.offset_provider = offset_provider
         self.storage_types = {}
-        self.use_gpu_storage = use_gpu_storage
 
     def add_storage(self, sdfg: dace.SDFG, name: str, type_: ts.TypeSpec, has_offset: bool = True):
         if isinstance(type_, ts.FieldType):
@@ -122,14 +119,7 @@ class ItirToSDFG(eve.NodeVisitor):
                 else None
             )
             dtype = as_dace_type(type_.dtype)
-            storage = (
-                dace.dtypes.StorageType.GPU_Global
-                if self.use_gpu_storage
-                else dace.dtypes.StorageType.Default
-            )
-            sdfg.add_array(
-                name, shape=shape, strides=strides, offset=offset, dtype=dtype, storage=storage
-            )
+            sdfg.add_array(name, shape=shape, strides=strides, offset=offset, dtype=dtype)
         elif isinstance(type_, ts.ScalarType):
             sdfg.add_symbol(name, as_dace_type(type_))
         else:
@@ -238,7 +228,6 @@ class ItirToSDFG(eve.NodeVisitor):
                     shape=array_table[name].shape,
                     strides=array_table[name].strides,
                     dtype=array_table[name].dtype,
-                    storage=array_table[name].storage,
                     transient=True,
                 )
                 closure_init_state.add_nedge(
@@ -253,7 +242,6 @@ class ItirToSDFG(eve.NodeVisitor):
                     shape=array_table[name].shape,
                     strides=array_table[name].strides,
                     dtype=array_table[name].dtype,
-                    storage=array_table[name].storage,
                 )
             else:
                 assert isinstance(self.storage_types[name], ts.ScalarType)


### PR DESCRIPTION
For generation of DaCe SDFGs targeting GPU execution, the GPU storage should be set on arrays after all transformation passes. Otherwise, CUDA code generation will fail.