### PR TITLE
test[next][dace]: Enable some GPU tests

### DIFF
--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
@@ -30,16 +30,6 @@ pytestmark = pytest.mark.uses_unstructured_shift
 
 
 def test_external_local_field(unstructured_case):
-    # TODO(edopao): remove try/catch after uplift of dace module to version > 0.15
-    try:
-        from gt4py.next.program_processors.runners.dace_iterator import run_dace_gpu
-
-        if unstructured_case.backend == run_dace_gpu:
-            # see https://github.com/spcl/dace/pull/1442
-            pytest.xfail("requires fix in dace module for cuda codegen")
-    except ImportError:
-        pass
-
     @gtx.field_operator
     def testee(
         inp: gtx.Field[[Vertex, V2EDim], int32], ones: gtx.Field[[Edge], int32]

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -46,16 +46,6 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
     ids=["positive_values", "negative_values"],
 )
 def test_maxover_execution_(unstructured_case, strategy):
-    # TODO(edopao): remove try/catch after uplift of dace module to version > 0.15
-    try:
-        from gt4py.next.program_processors.runners.dace_iterator import run_dace_gpu
-
-        if unstructured_case.backend == run_dace_gpu:
-            # see https://github.com/spcl/dace/pull/1442
-            pytest.xfail("requires fix in dace module for cuda codegen")
-    except ImportError:
-        pass
-
     if unstructured_case.backend in [
         gtfn.run_gtfn,
         gtfn.run_gtfn_gpu,
@@ -79,16 +69,6 @@ def test_maxover_execution_(unstructured_case, strategy):
 
 @pytest.mark.uses_unstructured_shift
 def test_minover_execution(unstructured_case):
-    # TODO(edopao): remove try/catch after uplift of dace module to version > 0.15
-    try:
-        from gt4py.next.program_processors.runners.dace_iterator import run_dace_gpu
-
-        if unstructured_case.backend == run_dace_gpu:
-            # see https://github.com/spcl/dace/pull/1442
-            pytest.xfail("requires fix in dace module for cuda codegen")
-    except ImportError:
-        pass
-
     @gtx.field_operator
     def minover(edge_f: cases.EField) -> cases.VField:
         out = min_over(edge_f(V2E), axis=V2EDim)
@@ -102,16 +82,6 @@ def test_minover_execution(unstructured_case):
 
 @pytest.mark.uses_unstructured_shift
 def test_reduction_execution(unstructured_case):
-    # TODO(edopao): remove try/catch after uplift of dace module to version > 0.15
-    try:
-        from gt4py.next.program_processors.runners.dace_iterator import run_dace_gpu
-
-        if unstructured_case.backend == run_dace_gpu:
-            # see https://github.com/spcl/dace/pull/1442
-            pytest.xfail("requires fix in dace module for cuda codegen")
-    except ImportError:
-        pass
-
     @gtx.field_operator
     def reduction(edge_f: cases.EField) -> cases.VField:
         return neighbor_sum(edge_f(V2E), axis=V2EDim)
@@ -150,16 +120,6 @@ def test_reduction_expression_in_call(unstructured_case):
 
 @pytest.mark.uses_unstructured_shift
 def test_reduction_with_common_expression(unstructured_case):
-    # TODO(edopao): remove try/catch after uplift of dace module to version > 0.15
-    try:
-        from gt4py.next.program_processors.runners.dace_iterator import run_dace_gpu
-
-        if unstructured_case.backend == run_dace_gpu:
-            # see https://github.com/spcl/dace/pull/1442
-            pytest.xfail("requires fix in dace module for cuda codegen")
-    except ImportError:
-        pass
-
     @gtx.field_operator
     def testee(flux: cases.EField) -> cases.VField:
         return neighbor_sum(flux(V2E) + flux(V2E), axis=V2EDim)


### PR DESCRIPTION
## Description

Some GPU tests were disabled on DaCe backend because of [CUDA-codegen bug](https://github.com/spcl/dace/issues/1388) in DaCe.

In #1383 the memlet WCR for reduction was replaced with a library node. This change to the generated SDFG, although functionally equivalent, seems to not hit the same lowering path to CUDA code, and not hit the above-mentioned issue in DaCe. Therefore, some tests can be re-enabled.