### PR TITLE
feature[next]: support for Python 3.11

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -14,7 +14,7 @@ jobs:
   daily-ci:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         tox-module-factor: ["cartesian", "eve", "next", "storage"]
         os: ["ubuntu-latest"]
         requirements-file: ["requirements-dev.txt", "min-requirements-test.txt", "min-extra-requirements-test.txt"]

--- a/.github/workflows/test-cartesian-fallback.yml
+++ b/.github/workflows/test-cartesian-fallback.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         backends: [internal-cpu, dace-cpu]
 
     steps:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         backends: [internal-cpu, dace-cpu]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-eve-fallback.yml
+++ b/.github/workflows/test-eve-fallback.yml
@@ -17,7 +17,7 @@ jobs:
   test-eve:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-eve.yml
+++ b/.github/workflows/test-eve.yml
@@ -20,7 +20,7 @@ jobs:
   test-eve:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest"]
       fail-fast: false
 
@@ -68,4 +68,3 @@ jobs:
     #   with:
     #     name: info-py${{ matrix.python-version }}-${{ matrix.os }}
     #     path: info.txt
-

--- a/.github/workflows/test-next-fallback.yml
+++ b/.github/workflows/test-next-fallback.yml
@@ -15,7 +15,7 @@ jobs:
   test-next:
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
         tox-env-factor: ["nomesh", "atlas"]
         os: ["ubuntu-latest"]
 

--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -18,7 +18,7 @@ jobs:
   test-next:
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
         tox-env-factor: ["nomesh", "atlas"]
         os: ["ubuntu-latest"]
       fail-fast: false

--- a/.github/workflows/test-storage-fallback.yml
+++ b/.github/workflows/test-storage-fallback.yml
@@ -18,7 +18,7 @@ jobs:
   test-storage:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         backends: [internal-cpu, dace-cpu]
         os: ["ubuntu-latest"]
 

--- a/.github/workflows/test-storage.yml
+++ b/.github/workflows/test-storage.yml
@@ -21,7 +21,7 @@ jobs:
   test-storage:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         backends: [internal-cpu, dace-cpu]
         os: ["ubuntu-latest"]
       fail-fast: false
@@ -70,4 +70,3 @@ jobs:
     #   with:
     #     name: info-py${{ matrix.python-version }}-${{ matrix.os }}
     #     path: info.txt
-

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -493,7 +493,7 @@ if _sys.version_info >= (3, 9):
     if isinstance(_typing.Any, type):  # Python >= 3.11
         _ArtefactTypes = (*_ArtefactTypes, _typing.Any)
 
-# `Any` is a class since typing_extensions >= 4.4
+# `Any` is a class since typing_extensions >= 4.4 and Python 3.11
 if (typing_exts_any := getattr(_typing_extensions, "Any", None)) is not _typing.Any and isinstance(
     typing_exts_any, type
 ):
@@ -504,11 +504,11 @@ def is_actual_type(obj: Any) -> TypeGuard[Type]:
     """Check if an object has an actual type and instead of a typing artefact like ``GenericAlias`` or ``Any``.
 
     This is needed because since Python 3.9:
-        ``isinstance(types.GenericAlias(),  type) is True``
+        ``isinstance(types.GenericAlias(), type) is True``
     and since Python 3.11:
-        ``isinstance(typing.Any,  type) is True``
+        ``isinstance(typing.Any, type) is True``
     """
-    return isinstance(obj, type) and type(obj) not in _ArtefactTypes
+    return isinstance(obj, type) and obj not in _ArtefactTypes
 
 
 if hasattr(_typing_extensions, "Any") and _typing.Any is not _typing_extensions.Any:  # type: ignore[attr-defined] # _typing_extensions.Any only from >= 4.4

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -508,7 +508,9 @@ def is_actual_type(obj: Any) -> TypeGuard[Type]:
     and since Python 3.11:
         ``isinstance(typing.Any, type) is True``
     """
-    return isinstance(obj, type) and obj not in _ArtefactTypes
+    return (
+        isinstance(obj, type) and (obj not in _ArtefactTypes) and (type(obj) not in _ArtefactTypes)
+    )
 
 
 if hasattr(_typing_extensions, "Any") and _typing.Any is not _typing_extensions.Any:  # type: ignore[attr-defined] # _typing_extensions.Any only from >= 4.4

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -646,8 +646,9 @@ def get_partial_type_hints(
             hints[name] = resolved_hints[name]
         except NameError as error:
             if isinstance(hint, str):
-                # This conversion could be probably skipped after the fix applied in bpo-41370.
-                # Check: https://github.com/python/cpython/commit/b465b606049f6f7dd0711cb031fdaa251818741a#diff-ddb987fca5f5df0c9a2f5521ed687919d70bb3d64eaeb8021f98833a2a716887R344
+                # This conversion could be probably skipped in Python versions containing
+                # the fix applied in bpo-41370. Check:
+                # https://github.com/python/cpython/commit/b465b606049f6f7dd0711cb031fdaa251818741a#diff-ddb987fca5f5df0c9a2f5521ed687919d70bb3d64eaeb8021f98833a2a716887R344
                 hints[name] = ForwardRef(hint)
             elif isinstance(hint, (ForwardRef, _typing.ForwardRef)):
                 hints[name] = hint

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -643,9 +643,11 @@ def get_partial_type_hints(
             resolved_hints = get_type_hints(  # type: ignore[call-arg]  # Python 3.8 does not define `include-extras`
                 obj, globalns=globalns, localns=localns, include_extras=include_extras
             )
-            hints.update(resolved_hints)
+            hints[name] = resolved_hints[name]
         except NameError as error:
             if isinstance(hint, str):
+                # This conversion could be probably skipped after the fix applied in bpo-41370.
+                # Check: https://github.com/python/cpython/commit/b465b606049f6f7dd0711cb031fdaa251818741a#diff-ddb987fca5f5df0c9a2f5521ed687919d70bb3d64eaeb8021f98833a2a716887R344
                 hints[name] = ForwardRef(hint)
             elif isinstance(hint, (ForwardRef, _typing.ForwardRef)):
                 hints[name] = hint

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -358,6 +358,8 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         """Create an ``FixedTypeValidator`` validator for a specific type."""
 
         def _is_instance_of(value: Any, **kwargs: Any) -> None:
+            if type_ is Any:
+                return
             if not isinstance(value, type_):
                 raise TypeError(
                     f"'{name}' must be {type_} (got '{value}' which is a {type(value)})."

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -358,8 +358,6 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         """Create an ``FixedTypeValidator`` validator for a specific type."""
 
         def _is_instance_of(value: Any, **kwargs: Any) -> None:
-            if type_ is Any:
-                return
             if not isinstance(value, type_):
                 raise TypeError(
                     f"'{name}' must be {type_} (got '{value}' which is a {type(value)})."

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import enum
+import numbers
 import types
 import typing
 from typing import Set  # noqa: F401 # imported but unused (used in exec() context)
@@ -1150,66 +1151,80 @@ class TestGenericModelValidation:
         with pytest.raises(TypeError, match="'PartialGenericModel__int.value'"):
             PartialGenericModel__int(value=["1"])
 
-    def test_partial_specialization(self):
-        class PartialGenericModel(datamodels.GenericDataModel, Generic[T, U]):
+    def test_partial_concretization(self):
+        class BaseGenericModel(datamodels.GenericDataModel, Generic[T, U]):
             value: List[Tuple[T, U]]
 
-        PartialGenericModel(value=[])
-        PartialGenericModel(value=[("value", 3)])
-        PartialGenericModel(value=[(1, "value")])
-        PartialGenericModel(value=[(-1.0, "value")])
-        with pytest.raises(TypeError, match="'PartialGenericModel.value'"):
-            PartialGenericModel(value=1)
-        with pytest.raises(TypeError, match="'PartialGenericModel.value'"):
-            PartialGenericModel(value=(1, 2))
-        with pytest.raises(TypeError, match="'PartialGenericModel.value'"):
-            PartialGenericModel(value=[()])
-        with pytest.raises(TypeError, match="'PartialGenericModel.value'"):
-            PartialGenericModel(value=[(1,)])
+        BaseGenericModel(value=[])
+        BaseGenericModel(value=[("value", 3)])
+        BaseGenericModel(value=[(1, "value")])
+        BaseGenericModel(value=[(-1.0, "value")])
+        with pytest.raises(TypeError, match="'BaseGenericModel.value'"):
+            BaseGenericModel(value=1)
+        with pytest.raises(TypeError, match="'BaseGenericModel.value'"):
+            BaseGenericModel(value=(1, 2))
+        with pytest.raises(TypeError, match="'BaseGenericModel.value'"):
+            BaseGenericModel(value=[()])
+        with pytest.raises(TypeError, match="'BaseGenericModel.value'"):
+            BaseGenericModel(value=[(1,)])
 
-        print(f"{PartialGenericModel.__parameters__=}")
-        print(f"{hasattr(PartialGenericModel ,'__args__')=}")
+        assert len(BaseGenericModel.__parameters__) == 2
 
-        PartiallySpecializedGenericModel = PartialGenericModel[int, U]
-        print(f"{PartiallySpecializedGenericModel.__datamodel_fields__=}")
-        print(f"{PartiallySpecializedGenericModel.__parameters__=}")
-        print(f"{PartiallySpecializedGenericModel.__args__=}")
+        PartiallyConcretizedGenericModel = BaseGenericModel[int, U]
 
-        PartiallySpecializedGenericModel(value=[])
-        PartiallySpecializedGenericModel(value=[(1, 2)])
-        PartiallySpecializedGenericModel(value=[(1, "value")])
-        PartiallySpecializedGenericModel(value=[(1, (11, 12))])
+        assert len(PartiallyConcretizedGenericModel.__parameters__) == 1
+
+        PartiallyConcretizedGenericModel(value=[])
+        PartiallyConcretizedGenericModel(value=[(1, 2)])
+        PartiallyConcretizedGenericModel(value=[(1, "value")])
+        PartiallyConcretizedGenericModel(value=[(1, (11, 12))])
         with pytest.raises(TypeError, match=".value'"):
-            PartiallySpecializedGenericModel(value=1)
+            PartiallyConcretizedGenericModel(value=1)
         with pytest.raises(TypeError, match=".value'"):
-            PartiallySpecializedGenericModel(value=(1, 2))
+            PartiallyConcretizedGenericModel(value=(1, 2))
         with pytest.raises(TypeError, match=".value'"):
-            PartiallySpecializedGenericModel(value=[1.0])
+            PartiallyConcretizedGenericModel(value=[1.0])
         with pytest.raises(TypeError, match=".value'"):
-            PartiallySpecializedGenericModel(value=["1"])
+            PartiallyConcretizedGenericModel(value=["1"])
 
-        # TODO(egparedes): after fixing partial nested datamodel specialization
-        # noqa: e800 FullySpecializedGenericModel = PartiallySpecializedGenericModel[str]
-        # noqa: e800 print(f"{FullySpecializedGenericModel.__datamodel_fields__=}")
-        # noqa: e800 print(f"{FullySpecializedGenericModel.__parameters__=}")
-        # noqa: e800 print(f"{FullySpecializedGenericModel.__args__=}")
+        FullySpecializedGenericModel = PartiallyConcretizedGenericModel[str]
 
-        # noqa: e800 FullySpecializedGenericModel(value=[])
-        # noqa: e800 FullySpecializedGenericModel(value=[(1, "value")])
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=1)
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=(1, 2))
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=[1.0])
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=["1"])
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=1)
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=[(1, 2)])
-        # noqa: e800 with pytest.raises(TypeError, match=".value'"):
-        # noqa: e800     FullySpecializedGenericModel(value=[(1, (11, 12))])
+        assert len(FullySpecializedGenericModel.__parameters__) == 0
+
+        FullySpecializedGenericModel(value=[])
+        FullySpecializedGenericModel(value=[(1, "value")])
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=1)
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=(1, 2))
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=[1.0])
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=["1"])
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=1)
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=[(1, 2)])
+        with pytest.raises(TypeError, match=".value'"):
+            FullySpecializedGenericModel(value=[(1, (11, 12))])
+
+    def test_partial_concretization_with_typevar(self):
+        class PartialGenericModel(datamodels.GenericDataModel, Generic[T]):
+            a: T
+            values: List[T]
+
+        B = TypeVar("B", bound=numbers.Number)
+        PartiallyConcretizedGenericModel = PartialGenericModel[B]
+
+        PartiallyConcretizedGenericModel(a=1, values=[2, 3])
+        PartiallyConcretizedGenericModel(a=-1.32, values=[2.2, 3j])
+
+        with pytest.raises(TypeError, match=".a'"):
+            PartiallyConcretizedGenericModel(a="1", values=[2, 3])
+        with pytest.raises(TypeError, match=".values'"):
+            PartiallyConcretizedGenericModel(a=1, values=[1, "2"])
+        with pytest.raises(TypeError, match=".values'"):
+            PartiallyConcretizedGenericModel(a=1, values=(1, 2))
 
     # Reuse sample_type_data from test_field_type_hint
     @pytest.mark.parametrize(["type_hint", "valid_values", "wrong_values"], SAMPLE_TYPE_DATA)

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -1187,26 +1187,26 @@ class TestGenericModelValidation:
         with pytest.raises(TypeError, match=".value'"):
             PartiallyConcretizedGenericModel(value=["1"])
 
-        FullySpecializedGenericModel = PartiallyConcretizedGenericModel[str]
+        FullyConcretizedGenericModel = PartiallyConcretizedGenericModel[str]
 
-        assert len(FullySpecializedGenericModel.__parameters__) == 0
+        assert len(FullyConcretizedGenericModel.__parameters__) == 0
 
-        FullySpecializedGenericModel(value=[])
-        FullySpecializedGenericModel(value=[(1, "value")])
+        FullyConcretizedGenericModel(value=[])
+        FullyConcretizedGenericModel(value=[(1, "value")])
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=1)
+            FullyConcretizedGenericModel(value=1)
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=(1, 2))
+            FullyConcretizedGenericModel(value=(1, 2))
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=[1.0])
+            FullyConcretizedGenericModel(value=[1.0])
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=["1"])
+            FullyConcretizedGenericModel(value=["1"])
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=1)
+            FullyConcretizedGenericModel(value=1)
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=[(1, 2)])
+            FullyConcretizedGenericModel(value=[(1, 2)])
         with pytest.raises(TypeError, match=".value'"):
-            FullySpecializedGenericModel(value=[(1, (11, 12))])
+            FullyConcretizedGenericModel(value=[(1, (11, 12))])
 
     def test_partial_concretization_with_typevar(self):
         class PartialGenericModel(datamodels.GenericDataModel, Generic[T]):

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -28,6 +28,7 @@ from gt4py.eve import (
 )
 from gt4py.eve.extended_typing import (
     Any,
+    Callable,
     Dict,
     Final,
     ForwardRef,
@@ -41,8 +42,8 @@ from gt4py.eve.extended_typing import (
 )
 
 
-VALIDATORS: Final = [type_val.simple_type_validator]
-FACTORIES: Final = [type_val.simple_type_validator_factory]
+VALIDATORS: Final[list[Callable]] = [type_val.simple_type_validator]
+FACTORIES: Final[list[Callable]] = [type_val.simple_type_validator_factory]
 
 
 class SampleEnum(enum.Enum):

--- a/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_icon_like_scan.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_icon_like_scan.py
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from dataclasses import dataclass
+import dataclasses
 
 import numpy as np
 import pytest
@@ -201,22 +201,26 @@ def test_setup(fieldview_backend):
         grid_type=common.GridType.UNSTRUCTURED,
     )
 
-    @dataclass(frozen=True)
+    @dataclasses.dataclass(frozen=True)
     class setup:
-        case: cases.Case = test_case
-        cell_size = case.default_sizes[Cell]
-        k_size = case.default_sizes[KDim]
-        z_alpha = case.as_field(
+        case: cases.Case = dataclasses.field(default_factory=lambda: test_case)
+        cell_size = test_case.default_sizes[Cell]
+        k_size = test_case.default_sizes[KDim]
+        z_alpha = test_case.as_field(
             [Cell, KDim], np.random.default_rng().uniform(size=(cell_size, k_size + 1))
         )
-        z_beta = case.as_field(
+        z_beta = test_case.as_field(
             [Cell, KDim], np.random.default_rng().uniform(size=(cell_size, k_size))
         )
-        z_q = case.as_field([Cell, KDim], np.random.default_rng().uniform(size=(cell_size, k_size)))
-        w = case.as_field([Cell, KDim], np.random.default_rng().uniform(size=(cell_size, k_size)))
+        z_q = test_case.as_field(
+            [Cell, KDim], np.random.default_rng().uniform(size=(cell_size, k_size))
+        )
+        w = test_case.as_field(
+            [Cell, KDim], np.random.default_rng().uniform(size=(cell_size, k_size))
+        )
         z_q_ref, w_ref = reference(z_alpha.ndarray, z_beta.ndarray, z_q.ndarray, w.ndarray)
-        dummy = case.as_field([Cell, KDim], np.zeros((cell_size, k_size), dtype=bool))
-        z_q_out = case.as_field([Cell, KDim], np.zeros((cell_size, k_size)))
+        dummy = test_case.as_field([Cell, KDim], np.zeros((cell_size, k_size), dtype=bool))
+        z_q_out = test_case.as_field([Cell, KDim], np.zeros((cell_size, k_size)))
 
     return setup()
 

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
@@ -108,7 +108,10 @@ def test_unpacking_swap():
     lines = ast.unparse(ssa_ast).split("\n")
     assert lines[0] == f"a{SEP}0 = 5"
     assert lines[1] == f"b{SEP}0 = 1"
-    assert lines[2] == f"(b{SEP}1, a{SEP}1) = (a{SEP}0, b{SEP}0)"
+    assert lines[2] in [
+        f"(b{SEP}1, a{SEP}1) = (a{SEP}0, b{SEP}0)",
+        f"b{SEP}1, a{SEP}1 = (a{SEP}0, b{SEP}0)",
+    ]  # unparse produces different parentheses in different Python versions
 
 
 def test_annotated_assign():

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ labels =
     cartesian-py311-internal-cpu, cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu, \
     cartesian-py311-dace-cpu, \
     eve-py38, eve-py39, eve-py310, eve-py311, \
-    next-py310-nomesh, next-py311-nomesh, next-py310-atlas, next-py311-atlas\
-    storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, storage-py311-internal-cpu \
+    next-py310-nomesh, next-py311-nomesh, next-py310-atlas, next-py311-atlas, \
+    storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, storage-py311-internal-cpu, \
     storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu, storage-py311-dace-cpu
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -11,21 +11,24 @@ envlist =
 #    docs
 labels =
     test-cartesian-cpu = cartesian-py38-internal-cpu, cartesian-py39-internal-cpu, cartesian-py310-internal-cpu, \
-    cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu
+    cartesian-py311-internal-cpu, cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu, \
+    cartesian-py311-dace-cpu
 
-    test-eve-cpu = eve-py38, eve-py39, eve-py310
+    test-eve-cpu = eve-py38, eve-py39, eve-py310, eve-py311
 
-    test-next-cpu = next-py310-nomesh, next-py310-atlas
+    test-next-cpu = next-py310-nomesh, next-py311-nomesh, next-py310-atlas, next-py311-atlas
 
     test-storage-cpu = storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, \
-    storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu
+    storage-py311-internal-cpu, storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu, \
+    storage-py311-dace-cpu
 
     test-cpu = cartesian-py38-internal-cpu, cartesian-py39-internal-cpu, cartesian-py310-internal-cpu, \
-    cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu, \
-    eve-py38, eve-py39, eve-py310, \
-    next-py310-nomesh, next-py310-atlas, \
-    storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, \
-    storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu
+    cartesian-py311-internal-cpu, cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu, \
+    cartesian-py311-dace-cpu, \
+    eve-py38, eve-py39, eve-py310, eve-py311, \
+    next-py310-nomesh, next-py311-nomesh, next-py310-atlas, next-py311-atlas\
+    storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, storage-py311-internal-cpu \
+    storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu, storage-py311-dace-cpu
 
 [testenv]
 deps = -r {tox_root}{/}{env:ENV_REQUIREMENTS_FILE:requirements-dev.txt}
@@ -44,7 +47,7 @@ pass_env = NUM_PROCESSES
 set_env =
     PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning}
 
-[testenv:cartesian-py{38,39,310}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
+[testenv:cartesian-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.cartesian' tests
 pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH, CXX, CC, OPENMP_CPPFLAGS, OPENMP_LDFLAGS, PIP_USER, PYTHONUSERBASE
 allowlist_externals =
@@ -65,13 +68,13 @@ commands =
 ;    coverage json --rcfile=setup.cfg
 ;    coverage html --rcfile=setup.cfg --show-contexts
 
-[testenv:eve-py{38,39,310}]
+[testenv:eve-py{38,39,310,311}]
 description = Run 'gt4py.eve' tests
 commands =
     python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} {posargs} tests{/}eve_tests
     python -m pytest --doctest-modules src{/}gt4py{/}eve
 
-[testenv:next-py{310}-{nomesh,atlas}-{cpu,cuda,cuda11x,cuda12x}]
+[testenv:next-py{310,311}-{nomesh,atlas}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.next' tests
 pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH
 deps =
@@ -87,14 +90,14 @@ commands =
     # atlas-{cuda,cuda11x,cuda12x}: python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "requires_atlas and requires_gpu" {posargs} tests{/}next_tests   # TODO(ricoh): activate when such tests exist
     pytest --doctest-modules src{/}gt4py{/}next
 
-[testenv:storage-py{38,39,310}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
+[testenv:storage-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.storage' tests
 commands =
     cpu: python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "not requires_gpu" {posargs} tests{/}storage_tests
     {cuda,cuda11x,cuda12x}: python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "requires_gpu" {posargs} tests{/}storage_tests
     #pytest doctest-modules {posargs} src{/}gt4py{/}storage
 
-[testenv:linters-py{38,39,310}]
+[testenv:linters-py{38,39,310,311}]
 description = Run linters
 commands =
     flake8 .{/}src
@@ -134,11 +137,13 @@ description =
     py38: Update requirements for testing a specific python version
     py39: Update requirements for testing a specific python version
     py310: Update requirements for testing a specific python version
+    py311: Update requirements for testing a specific python version
 base_python =
     common: py38
     py38: py38
     py39: py39
     py310: py310
+    py311: py311
 deps =
     cogapp>=3.3
     pip-tools>=6.10
@@ -178,7 +183,7 @@ commands =
     # Run cog to update .pre-commit-config.yaml with new versions
     common: cog -r -P .pre-commit-config.yaml
 
-[testenv:dev-py{38,39,310}{-atlas,}]
+[testenv:dev-py{38,39,310,311}{-atlas,}]
 description = Initialize development environment for gt4py
 deps =
     -r {tox_root}{/}requirements-dev.txt


### PR DESCRIPTION
Fixes hidden bugs in datamodels and extended_typing to support Python 3.11.

Actual bug fixes:
- Previous fix to support `typing.Any` implementation as a class (https://github.com/python/cpython/commit/5a4973e29f2f5c4ee8c086f40325786c62381540) didn't work in 3.11. 
- Partially concretization of generic datamodels replacing typevars was broken.
- Partially concretization of generic datamodels leaving some parameters as typevars was broken.

Other changes:
- Add python 3.11 as supported version.
- Remove dead code in comments.
- Fix some imports style to comply with our coding guidelines.

