### PR TITLE
feature[next]: Add power unrolling functionality and respective unit tests.

### DIFF
--- a/src/gt4py/next/iterator/transforms/power_unrolling.py
+++ b/src/gt4py/next/iterator/transforms/power_unrolling.py
@@ -17,6 +17,23 @@ import math
 from gt4py.eve import NodeTranslator
 from gt4py.next.iterator import ir
 from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms.inline_lambdas import InlineLambdas
+
+
+def _is_power_call(
+    node: ir.FunCall,
+) -> bool:
+    return (
+        isinstance(node.fun, ir.SymRef)
+        and node.fun.id == "power"
+        and isinstance(node.args[1], ir.Literal)
+        and float(node.args[1].value) == int(node.args[1].value)
+        and node.args[1].value >= im.literal_from_value(0).value
+    )
+
+
+def _compute_integer_power_of_two(exp):
+    return math.floor(math.log2(exp))
 
 
 @dataclasses.dataclass
@@ -28,78 +45,39 @@ class PowerUnrolling(NodeTranslator):
         return cls(max_unroll=max_unroll).visit(node)
 
     def visit_FunCall(self, node: ir.FunCall):
-        def check_node(
-            node: ir.FunCall,
-        ) -> bool:
-            return (
-                isinstance(node.fun, ir.SymRef)
-                and node.fun.id == "power"
-                and isinstance(node.args[1], ir.Literal)
-                and float(node.args[1].value) == int(node.args[1].value)
-                and node.args[1].value >= im.literal_from_value(0).value
-            )
-
-        def check_node_args0_symref_funcall(
-            node: ir.FunCall,
-        ) -> bool:
-            if isinstance(node.args[0], ir.SymRef):
-                return True
-            elif isinstance(node.args[0], ir.FunCall):
-                return False
-            else:
-                raise TypeError("Power unrolling is only supported for ir.SymRef and ir.FunCall.")
-
-        def compute_integer_power_of_two(exp):
-            return math.floor(math.log2(exp))
-
         new_node = self.generic_visit(node)
 
-        if check_node(new_node):
+        if _is_power_call(new_node):
             assert len(new_node.args) == 2
             # Check if unroll should be performed or if exponent is too large
             base, exponent = new_node.args[0], int(new_node.args[1].value)
-            if exponent > self.max_unroll:
-                return new_node
-            else:
-                if exponent == 0:
-                    return im.literal_from_value(
-                        1
-                    )  # TODO: returned type of literal should be the same as the one of base
-                else:
-                    # Calculate and store powers of two of the base as long as they are smaller than the exponent.
-                    # Do the same (using the stored values) with the remainder and multiply computed values.
-                    pow_cur = compute_integer_power_of_two(exponent)
-                    pow_max = pow_cur
-                    remainder = exponent
-                    powers = [None] * (pow_max + 1)
+            if 1 <= exponent <= self.max_unroll:
+                # Calculate and store powers of two of the base as long as they are smaller than the exponent.
+                # Do the same (using the stored values) with the remainder and multiply computed values.
+                pow_cur = _compute_integer_power_of_two(exponent)
+                pow_max = pow_cur
+                remainder = exponent
 
-                    # Set up powers list
-                    for i in range(pow_max + 1):
-                        if check_node_args0_symref_funcall(new_node):
-                            if i == 0:  # power of one
-                                powers[i] = base
-                            else:
-                                powers[i] = im.multiplies_(powers[i - 1], powers[i - 1])
-                        else:
-                            powers[i] = f"power_{2 ** i}"
-
-                    # Build target expression
-                    ret = powers[pow_max]
+                # Build target expression
+                ret = im.ref(f"power_{2 ** pow_max}")
+                remainder -= 2**pow_cur
+                while remainder > 0:
+                    pow_cur = _compute_integer_power_of_two(remainder)
                     remainder -= 2**pow_cur
-                    while remainder > 0:
-                        pow_cur = compute_integer_power_of_two(remainder)
-                        remainder -= 2**pow_cur
 
-                        ret = im.multiplies_(ret, powers[pow_cur])
+                    ret = im.multiplies_(ret, f"power_{2 ** pow_cur}")
 
-                    # In case of FunCall: build nested expression to avoid multiple evaluations of base
-                    if not check_node_args0_symref_funcall(new_node):
-                        for i in range(pow_max, 0, -1):
-                            ret = im.let(
-                                f"power_{2 ** i}",
-                                im.multiplies_(f"power_{2**(i-1)}", f"power_{2**(i-1)}"),
-                            )(ret)
-                        ret = im.let("power_1", base)(ret)
+                # In case of FunCall: build nested expression to avoid multiple evaluations of base
+                for i in range(pow_max, 0, -1):
+                    ret = im.let(
+                        f"power_{2 ** i}",
+                        im.multiplies_(f"power_{2**(i-1)}", f"power_{2**(i-1)}"),
+                    )(ret)
+                ret = im.let("power_1", base)(ret)
 
-                return ret
+                # Simplify expression in case of SymRef by resolving let statements
+                if isinstance(base, ir.SymRef):
+                    return InlineLambdas.apply(ret)
+                else:
+                    return ret
         return new_node

--- a/src/gt4py/next/iterator/transforms/power_unrolling.py
+++ b/src/gt4py/next/iterator/transforms/power_unrolling.py
@@ -33,7 +33,7 @@ def _is_power_call(
     )
 
 
-def _compute_integer_power_of_two(exp) -> int:
+def _compute_integer_power_of_two(exp: int) -> int:
     return math.floor(math.log2(exp))
 
 

--- a/src/gt4py/next/iterator/transforms/power_unrolling.py
+++ b/src/gt4py/next/iterator/transforms/power_unrolling.py
@@ -61,7 +61,7 @@ class PowerUnrolling(NodeTranslator):
             if exponent > self.max_unroll:
                 return new_node
             else:
-                if exponent == int(im.literal_from_value(0).value):
+                if exponent == 0:
                     return im.literal_from_value(
                         1
                     )  # TODO: returned type of literal should be the same as the one of base
@@ -73,11 +73,8 @@ class PowerUnrolling(NodeTranslator):
                     remainder = exponent
                     powers = [None] * (pow_max + 1)
 
-                    # Account for two base being either an ir.SymRef or an ir.FunCall
-                    if check_node_args0_symref_funcall(new_node):
-                        powers[0] = base.id
-                    else:
-                        powers[0] = base
+                    powers[0] = base
+
                     for i in range(1, pow_max + 1):
                         if check_node_args0_symref_funcall(new_node):
                             powers[i] = im.multiplies_(powers[i - 1], powers[i - 1])

--- a/src/gt4py/next/iterator/transforms/power_unrolling.py
+++ b/src/gt4py/next/iterator/transforms/power_unrolling.py
@@ -1,0 +1,93 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2023, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+import dataclasses
+import math
+
+from gt4py.eve import NodeTranslator
+from gt4py.next.iterator import ir
+from gt4py.next.iterator.ir_utils import ir_makers as im
+
+
+@dataclasses.dataclass
+class PowerUnrolling(NodeTranslator):
+    max_unroll: int
+
+    @classmethod
+    def apply(cls, node: ir.Node, max_unroll=5) -> ir.Node:
+        return cls(max_unroll=max_unroll).visit(node)
+
+    def visit_FunCall(self, node: ir.FunCall):
+        def check_node(
+            node: ir.FunCall,
+        ) -> bool:
+            return (
+                isinstance(node.fun, ir.SymRef)
+                and node.fun.id == "power"
+                and isinstance(node.args[1], ir.Literal)
+                and float(node.args[1].value) == int(node.args[1].value)
+                and node.args[1].value >= im.literal_from_value(0).value
+            )
+
+        def check_node_args0_symref_funcall(
+            node: ir.FunCall,
+        ) -> bool:
+            if isinstance(node.args[0], ir.SymRef):
+                return True
+            elif isinstance(node.args[0], ir.FunCall):
+                return False
+            else:
+                raise TypeError("Power unrolling is only supported for ir.SymRef and ir.FunCall.")
+
+        def compute_integer_power_of_two(exp):
+            return math.floor(math.log2(int(exp)))
+
+        new_node = self.generic_visit(node)
+
+        if check_node(new_node):
+            assert len(new_node.args) == 2
+            # Check if unroll should be performed or if exponent is too large
+            if int(new_node.args[1].value) > self.max_unroll:
+                return new_node
+            else:
+                if new_node.args[1].value == im.literal_from_value(0).value:
+                    return im.literal_from_value(
+                        1
+                    )  # TODO: returned type of literal should be the same as the one of base
+                else:
+                    # Calculate and store powers of two of the base as long as they are smaller than the exponent.
+                    # Do the same (using the stored values) with the remainder and multiply computed values.
+                    pow_cur = compute_integer_power_of_two(new_node.args[1].value)
+                    pow_max = pow_cur
+                    remainder = int(new_node.args[1].value)
+                    powers = [None] * (pow_max + 1)
+
+                    # Account for two new_node.args[0] being either an ir.SymRef or an ir.FunCall
+                    if check_node_args0_symref_funcall(new_node):
+                        powers[0] = new_node.args[0].id
+                    else:
+                        powers[0] = new_node.args[0]
+                    for i in range(1, pow_max + 1):
+                        if check_node_args0_symref_funcall(new_node):
+                            powers[i] = im.multiplies_(powers[i - 1], powers[i - 1])
+                        else:
+                            powers[i] = im.let("tmp", powers[i - 1])(im.multiplies_("tmp", "tmp"))
+                    ret = powers[pow_max]
+                    remainder -= 2**pow_cur
+                    while remainder > 0:
+                        pow_cur = compute_integer_power_of_two(remainder)
+                        remainder -= 2**pow_cur
+                        ret = im.multiplies_(ret, powers[pow_cur])
+
+                return ret
+        return new_node

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
@@ -1,0 +1,118 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2023, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms.power_unrolling import PowerUnrolling
+
+
+def test_power_unrolling_zero():
+    testee = im.call("power")("x", 0)
+    expected = im.literal_from_value(1)
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_one():
+    testee = im.call("power")("x", 1)
+    expected = "x"
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_two():
+    testee = im.call("power")("x", 2)
+    expected = im.multiplies_("x", "x")
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_three():
+    testee = im.call("power")("x", 3)
+    expected = im.multiplies_(im.multiplies_("x", "x"), "x")
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_four():
+    testee = im.call("power")("x", 4)
+    tmp = im.multiplies_("x", "x")
+    expected = im.multiplies_(tmp, tmp)
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_five():
+    testee = im.call("power")("x", 5)
+    tmp2 = im.multiplies_("x", "x")
+    expected = im.multiplies_(im.multiplies_(tmp2, tmp2), "x")
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_x_plus_two():
+    testee = im.call("power")(im.plus("x", 2), 2)
+    tmp = im.plus("x", 2)
+    expected = im.let("tmp", tmp)(im.multiplies_("tmp", "tmp"))
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_x_plus_one_times_three():
+    testee = im.call("power")(im.multiplies_(im.plus("x", 1), 3), 2)
+    tmp = im.multiplies_(im.plus("x", 1), 3)
+    expected = im.let("tmp", tmp)(im.multiplies_("tmp", "tmp"))
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_seven():
+    testee = im.call("power")("x", 7)
+    expected = im.call("power")("x", 7)
+
+    actual = PowerUnrolling.apply(testee, max_unroll=5)
+    assert actual == expected
+
+
+def test_power_unrolling_seven_unrolled():
+    testee = im.call("power")("x", 7)
+    tmp2 = im.multiplies_("x", "x")
+    tmp4 = im.multiplies_(tmp2, tmp2)
+    expected = im.multiplies_(im.multiplies_(tmp4, tmp2), "x")
+
+    actual = PowerUnrolling.apply(testee, max_unroll=7)
+    assert actual == expected
+
+
+def test_power_unrolling_eight():
+    testee = im.call("power")("x", 8)
+    expected = im.call("power")("x", 8)
+
+    actual = PowerUnrolling.apply(testee, max_unroll=5)
+    assert actual == expected
+
+
+def test_power_unrolling_eight_unrolled():
+    testee = im.call("power")("x", 8)
+    tmp2 = im.multiplies_("x", "x")
+    tmp4 = im.multiplies_(tmp2, tmp2)
+    expected = im.multiplies_(tmp4, tmp4)
+
+    actual = PowerUnrolling.apply(testee, max_unroll=8)
+    assert actual == expected

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
@@ -12,8 +12,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from gt4py.next.iterator import ir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.iterator.transforms.power_unrolling import PowerUnrolling
+from src.gt4py.eve import SymbolRef
 
 
 def test_power_unrolling_zero():
@@ -26,7 +28,7 @@ def test_power_unrolling_zero():
 
 def test_power_unrolling_one():
     testee = im.call("power")("x", 1)
-    expected = "x"
+    expected = ir.SymRef(id=SymbolRef("x"))
 
     actual = PowerUnrolling.apply(testee)
     assert actual == expected
@@ -98,6 +100,16 @@ def test_power_unrolling_seven_unrolled():
 
     actual = PowerUnrolling.apply(testee, max_unroll=7)
     assert actual == expected
+
+
+# def test_power_unrolling_x_plus_one_seven_unrolled():
+#     testee = im.call("power")(im.plus("x", 1), 7)
+#     tmp2 = im.multiplies_(im.plus("x", 1), im.plus("x", 1))
+#     tmp4 = im.multiplies_(tmp2, tmp2)
+#     expected = im.multiplies_(im.multiplies_(tmp4, tmp2), im.plus("x", 1))
+#
+#     actual = PowerUnrolling.apply(testee, max_unroll=7)
+#     assert actual == expected
 
 
 def test_power_unrolling_eight():

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
@@ -12,13 +12,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import pytest
+
+from gt4py.eve import SymbolRef
 from gt4py.next.iterator import ir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.iterator.transforms.power_unrolling import PowerUnrolling
-from src.gt4py.eve import SymbolRef
 
 
 def test_power_unrolling_zero():
+    pytest.xfail("Not implemented.")
     testee = im.call("power")("x", 0)
     expected = im.literal_from_value(1)
 

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_power_unrolling.py
@@ -42,6 +42,26 @@ def test_power_unrolling_two():
     assert actual == expected
 
 
+def test_power_unrolling_two_x_plus_two():
+    testee = im.call("power")(im.plus("x", 2), 2)
+    expected = im.let("power_1", im.plus("x", 2))(
+        im.let("power_2", im.multiplies_("power_1", "power_1"))("power_2")
+    )
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
+def test_power_unrolling_two_x_plus_one_times_three():
+    testee = im.call("power")(im.multiplies_(im.plus("x", 1), 3), 2)
+    expected = im.let("power_1", im.multiplies_(im.plus("x", 1), 3))(
+        im.let("power_2", im.multiplies_("power_1", "power_1"))("power_2")
+    )
+
+    actual = PowerUnrolling.apply(testee)
+    assert actual == expected
+
+
 def test_power_unrolling_three():
     testee = im.call("power")("x", 3)
     expected = im.multiplies_(im.multiplies_("x", "x"), "x")
@@ -68,22 +88,6 @@ def test_power_unrolling_five():
     assert actual == expected
 
 
-def test_power_unrolling_x_plus_two():
-    testee = im.call("power")(im.plus("x", 2), 2)
-    tmp = im.plus("x", 2)
-    expected = im.let("tmp", tmp)(im.multiplies_("tmp", "tmp"))
-    actual = PowerUnrolling.apply(testee)
-    assert actual == expected
-
-
-def test_power_unrolling_x_plus_one_times_three():
-    testee = im.call("power")(im.multiplies_(im.plus("x", 1), 3), 2)
-    tmp = im.multiplies_(im.plus("x", 1), 3)
-    expected = im.let("tmp", tmp)(im.multiplies_("tmp", "tmp"))
-    actual = PowerUnrolling.apply(testee)
-    assert actual == expected
-
-
 def test_power_unrolling_seven():
     testee = im.call("power")("x", 7)
     expected = im.call("power")("x", 7)
@@ -102,14 +106,18 @@ def test_power_unrolling_seven_unrolled():
     assert actual == expected
 
 
-# def test_power_unrolling_x_plus_one_seven_unrolled():
-#     testee = im.call("power")(im.plus("x", 1), 7)
-#     tmp2 = im.multiplies_(im.plus("x", 1), im.plus("x", 1))
-#     tmp4 = im.multiplies_(tmp2, tmp2)
-#     expected = im.multiplies_(im.multiplies_(tmp4, tmp2), im.plus("x", 1))
-#
-#     actual = PowerUnrolling.apply(testee, max_unroll=7)
-#     assert actual == expected
+def test_power_unrolling_seven_x_plus_one_unrolled():
+    testee = im.call("power")(im.plus("x", 1), 7)
+    expected = im.let("power_1", im.plus("x", 1))(
+        im.let("power_2", im.multiplies_("power_1", "power_1"))(
+            im.let("power_4", im.multiplies_("power_2", "power_2"))(
+                im.multiplies_(im.multiplies_("power_4", "power_2"), "power_1")
+            )
+        )
+    )
+
+    actual = PowerUnrolling.apply(testee, max_unroll=7)
+    assert actual == expected
 
 
 def test_power_unrolling_eight():
@@ -125,6 +133,20 @@ def test_power_unrolling_eight_unrolled():
     tmp2 = im.multiplies_("x", "x")
     tmp4 = im.multiplies_(tmp2, tmp2)
     expected = im.multiplies_(tmp4, tmp4)
+
+    actual = PowerUnrolling.apply(testee, max_unroll=8)
+    assert actual == expected
+
+
+def test_power_unrolling_eight_x_plus_one_unrolled():
+    testee = im.call("power")(im.plus("x", 1), 8)
+    expected = im.let("power_1", im.plus("x", 1))(
+        im.let("power_2", im.multiplies_("power_1", "power_1"))(
+            im.let("power_4", im.multiplies_("power_2", "power_2"))(
+                im.let("power_8", im.multiplies_("power_4", "power_4"))("power_8")
+            )
+        )
+    )
 
     actual = PowerUnrolling.apply(testee, max_unroll=8)
     assert actual == expected


### PR DESCRIPTION



## PR Title: Add power unrolling functionality and respective unit tests.

    <type>:
        - powers of SymRefs and FunCalls until order 5 are unrolled per default
        - powers with higher exponent are still computed by the built-in functions.
        - test: add respective tests

    <scope>: next 

