### PR TITLE
feat[next][dace]: use new LoopRegion construct for scan operator

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -18,6 +18,7 @@ from typing import Any, Mapping, Optional, Sequence
 import dace
 import numpy as np
 from dace.codegen.compiled_sdfg import CompiledSDFG
+from dace.sdfg import utils as sdutils
 from dace.transformation.auto import auto_optimize as autoopt
 
 import gt4py.next.allocators as next_allocators
@@ -264,6 +265,9 @@ def build_sdfg_from_itir(
     sdfg = sdfg_genenerator.visit(program)
     if sdfg is None:
         raise RuntimeError(f"Visit failed for program {program.id}.")
+    assert isinstance(sdfg, dace.SDFG)
+    # TODO(edopao): remove `inline_loop_blocks` when DaCe transformations support LoopRegion construct
+    sdutils.inline_loop_blocks(sdfg)
 
     # run DaCe transformations to simplify the SDFG
     sdfg.simplify()

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -263,12 +263,9 @@ def build_sdfg_from_itir(
     # visit ITIR and generate SDFG
     program = preprocess_program(program, offset_provider, lift_mode)
     sdfg_genenerator = ItirToSDFG(arg_types, offset_provider, column_axis)
-    sdfg = sdfg_genenerator.visit(program)
+    sdfg: dace.SDFG = sdfg_genenerator.visit(program)
     if sdfg is None:
         raise RuntimeError(f"Visit failed for program {program.id}.")
-    assert isinstance(sdfg, dace.SDFG)
-    # TODO(edopao): remove `inline_loop_blocks` when DaCe transformations support LoopRegion construct
-    sdutils.inline_loop_blocks(sdfg)
 
     for nested_sdfg in sdfg.all_sdfgs_recursive():
         if not nested_sdfg.debuginfo:
@@ -282,6 +279,9 @@ def build_sdfg_from_itir(
                 end_line=frameinfo.lineno,
                 filename=frameinfo.filename,
             )
+
+    # TODO(edopao): remove `inline_loop_blocks` when DaCe transformations support LoopRegion construct
+    sdutils.inline_loop_blocks(sdfg)
 
     # run DaCe transformations to simplify the SDFG
     sdfg.simplify()

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -559,10 +559,10 @@ class ItirToSDFG(eve.NodeVisitor):
                 dace.Memlet.simple(name, scan_loop_var),
             )
 
-        update_state.add_memlet_path(
+        update_state.add_nedge(
             update_state.add_access(output_name, debuginfo=lambda_context.body.debuginfo),
             update_state.add_access(scan_carry_name, debuginfo=lambda_context.body.debuginfo),
-            memlet=dace.Memlet.simple(output_names[0], scan_loop_var, other_subset_str="0"),
+            dace.Memlet.simple(output_names[0], scan_loop_var, other_subset_str="0"),
         )
 
         return scan_sdfg, map_ranges, scan_dim_index

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -449,12 +449,12 @@ class ItirToSDFG(eve.NodeVisitor):
             inverted=False,
         )
 
+        scan_sdfg.add_node(scan_loop)
         lambda_state = scan_loop.add_state("lambda_compute", is_start_block=True)
         lambda_update_state = scan_loop.add_state("lambda_update")
         scan_loop.add_edge(lambda_state, lambda_update_state, dace.InterstateEdge())
 
         start_state = scan_sdfg.add_state("start", is_start_block=True)
-        scan_sdfg.add_node(scan_loop)
         scan_sdfg.add_edge(start_state, scan_loop, dace.InterstateEdge())
 
         # tasklet for initialization of carry
@@ -552,9 +552,6 @@ class ItirToSDFG(eve.NodeVisitor):
                 None,
                 dace.Memlet.simple(name, f"i_{scan_dim}"),
             )
-
-        # add state to scan SDFG to update the carry value at each loop iteration
-        lambda_update_state = scan_sdfg.add_state_after(lambda_state, "lambda_update")
 
         lambda_update_state.add_memlet_path(
             lambda_update_state.add_access(output_name, debuginfo=lambda_context.body.debuginfo),


### PR DESCRIPTION
## Description

The lowering of scan operator to SDFG uses a state machine to represent a loop. This PR replaces the state machine with a `LoopRegion` construct introduced in dace v0.15. This construct is not yet supported by dace transformation, but it will in the future and it could open new optimization opportunities (e.g. K-caching).

## Requirements

- [x] All legacy test cases pass.