### PR TITLE
fix[cartesian]: Add missing cstdint header in gtcpp codegen

### DIFF
--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
@@ -288,6 +288,7 @@ class GTCppCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
 
     Program = as_mako(
         """
+        #include <cstdint>
         #include <gridtools/stencil/${gt_backend_t}.hpp>
         #include <gridtools/stencil/cartesian.hpp>
         #include <gridtools/common/array.hpp>


### PR DESCRIPTION
Fixes some compilation errors I got on my machine with gcc `13.2.1`
```
error: ‘int64_t’ in namespace ‘std’ does not name a type
```