### PR TITLE
bug[next]: fix field_operator caching

### DIFF
--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -562,7 +562,9 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
     backend: Optional[ppi.ProgramExecutor]
     grid_type: Optional[GridType]
     operator_attributes: Optional[dict[str, Any]] = None
-    _program_cache: dict = dataclasses.field(default_factory=dict)
+    _program_cache: dict = dataclasses.field(
+        init=False, default_factory=dict
+    )  # init=False ensure the cache is not copied in calls to replace
 
     @classmethod
     def from_function(


### PR DESCRIPTION
The cache was copied in `with_backend`, but backend is not part of the hash. Now the cache will be empty after `with_backend`.