### PR TITLE
fix[next]: Detection of ROCM vs CUDA gpu runtime

### DIFF
--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -44,7 +44,7 @@ except ImportError:
 CUPY_DEVICE: Final[Literal[None, core_defs.DeviceType.CUDA, core_defs.DeviceType.ROCM]] = (
     None
     if not cp
-    else (core_defs.DeviceType.ROCM if cp.cuda.get_hipcc_path() else core_defs.DeviceType.CUDA)
+    else (core_defs.DeviceType.ROCM if cp.cuda.runtime.is_hip else core_defs.DeviceType.CUDA)
 )
 
 


### PR DESCRIPTION
Call to `cp.cuda.get_hipcc_path()` seems not to work on Clariden to detect the gpu runtime used by CUPy. It returns ROCm on an Nvidia A100 node. Therefore, the allocator code was updated to use `cp.cuda.runtime.is_hip`.