### PR TITLE
feat[next]: new domain slice syntax

### DIFF
--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -276,7 +276,7 @@ NamedRange: TypeAlias = tuple[Dimension, UnitRange]  # TODO: convert to NamedTup
 FiniteNamedRange: TypeAlias = tuple[Dimension, FiniteUnitRange]  # TODO: convert to NamedTuple
 RelativeIndexElement: TypeAlias = IntIndex | slice | types.EllipsisType
 NamedSlice: TypeAlias = (
-    slice  # once slice is generic we should do: slice[NamedIndex, NamedIndex, Literal[1]]
+    slice  # once slice is generic we should do: slice[NamedIndex, NamedIndex, Literal[1]], see https://peps.python.org/pep-0696/
 )
 AbsoluteIndexElement: TypeAlias = NamedIndex | NamedRange | NamedSlice
 AnyIndexElement: TypeAlias = RelativeIndexElement | AbsoluteIndexElement

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -79,7 +79,7 @@ class Dimension:
         return self, val
 
     def __name__(self) -> str:
-        return getattr(self.value, "__name__", None) or repr(self)
+        return repr(self)
 
 
 class Infinity(enum.Enum):

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -275,7 +275,10 @@ NamedIndex: TypeAlias = tuple[Dimension, IntIndex]  # TODO: convert to NamedTupl
 NamedRange: TypeAlias = tuple[Dimension, UnitRange]  # TODO: convert to NamedTuple
 FiniteNamedRange: TypeAlias = tuple[Dimension, FiniteUnitRange]  # TODO: convert to NamedTuple
 RelativeIndexElement: TypeAlias = IntIndex | slice | types.EllipsisType
-AbsoluteIndexElement: TypeAlias = NamedIndex | NamedRange
+NamedSlice: TypeAlias = (
+    slice  # once slice is generic we should do: slice[NamedIndex, NamedIndex, Literal[1]]
+)
+AbsoluteIndexElement: TypeAlias = NamedIndex | NamedRange | NamedSlice
 AnyIndexElement: TypeAlias = RelativeIndexElement | AbsoluteIndexElement
 AbsoluteIndexSequence: TypeAlias = Sequence[NamedRange | NamedIndex]
 RelativeIndexSequence: TypeAlias = tuple[
@@ -308,6 +311,10 @@ def is_named_index(v: AnyIndexSpec) -> TypeGuard[NamedRange]:
     return (
         isinstance(v, tuple) and len(v) == 2 and isinstance(v[0], Dimension) and is_int_index(v[1])
     )
+
+
+def is_named_slice(obj: AnyIndexSpec) -> TypeGuard[NamedRange]:
+    return isinstance(obj, slice) and (is_named_index(obj.start) and is_named_index(obj.stop))
 
 
 def is_any_index_element(v: AnyIndexSpec) -> TypeGuard[AnyIndexElement]:

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -75,7 +75,7 @@ class Dimension:
     def __str__(self):
         return f"{self.value}[{self.kind}]"
 
-    def __call__(self, val: int):
+    def __call__(self, val: int) -> common.NamedIndex:
         return self, val
 
     def __name__(self) -> str:

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -78,9 +78,6 @@ class Dimension:
     def __call__(self, val: int) -> NamedIndex:
         return self, val
 
-    def __name__(self) -> str:
-        return repr(self)
-
 
 class Infinity(enum.Enum):
     """Describes an unbounded `UnitRange`."""

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -78,6 +78,10 @@ class Dimension:
     def __call__(self, val: int):
         return self, val
 
+    @property
+    def __name__(self) -> str:
+        return repr(self)
+
 
 class Infinity(enum.Enum):
     """Describes an unbounded `UnitRange`."""

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -78,7 +78,6 @@ class Dimension:
     def __call__(self, val: int):
         return self, val
 
-    @property
     def __name__(self) -> str:
         return getattr(self.value, "__name__", None) or repr(self)
 

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -75,6 +75,9 @@ class Dimension:
     def __str__(self):
         return f"{self.value}[{self.kind}]"
 
+    def __call__(self, val: int):
+        return self, val
+
 
 class Infinity(enum.Enum):
     """Describes an unbounded `UnitRange`."""

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -75,7 +75,7 @@ class Dimension:
     def __str__(self):
         return f"{self.value}[{self.kind}]"
 
-    def __call__(self, val: int) -> common.NamedIndex:
+    def __call__(self, val: int) -> NamedIndex:
         return self, val
 
     def __name__(self) -> str:

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -80,7 +80,7 @@ class Dimension:
 
     @property
     def __name__(self) -> str:
-        return repr(self)
+        return getattr(self.value, "__name__", None) or repr(self)
 
 
 class Infinity(enum.Enum):

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -153,14 +153,14 @@ def canonicalize_any_index_sequence(
 ) -> common.AnyIndexSpec:
     # TODO: instead of canonicalizing to `NamedRange`, we should canonicalize to `NamedSlice`
     new_index: common.AnyIndexSpec = (index,) if isinstance(index, slice) else index
-    if isinstance(index, slice):
-        new_index = _named_slice_to_named_range(index)
     if isinstance(index, tuple) and all(isinstance(i, slice) for i in index):
         new_index = tuple([_named_slice_to_named_range(i) for i in index])  # type: ignore[arg-type, assignment] # all i's are slices as per if statement
     return new_index
 
 
-def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange:
+def _named_slice_to_named_range(
+    idx: common.NamedSlice,
+) -> common.NamedRange | common.NamedSlice:
     assert hasattr(idx, "start") and hasattr(idx, "stop")
     if common.is_named_slice(idx):
         idx_start_0, idx_start_1, idx_stop_0, idx_stop_1 = idx.start[0], idx.start[1], idx.stop[0], idx.stop[1]  # type: ignore[attr-defined]

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -151,6 +151,7 @@ def _find_index_of_dim(
 def canonicalize_any_index_sequence(
     index: common.AnyIndexSpec,
 ) -> common.AnyIndexSpec:
+    # TODO: instead of canonicalizing to `NamedRange`, we should canonicalize to `NamedSlice`
     new_index: common.AnyIndexSpec = (index,) if isinstance(index, slice) else index
     if isinstance(index, slice):
         new_index = _named_slice_to_named_range(index)

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -151,22 +151,25 @@ def _find_index_of_dim(
 def canonicalize_any_index_sequence(
     index: common.AnyIndexSpec,
 ) -> common.AnyIndexSpec:
-    new_index = index
+    new_index: common.AnyIndexSpec = (index,) if isinstance(index, slice) else index
     if isinstance(index, slice):
-        new_index = _refactor_slice(index)
+        new_index = _named_slice_to_named_range(index)
     if isinstance(index, tuple) and all(isinstance(i, slice) for i in index):
-        new_index = tuple([_refactor_slice(i) for i in index])  # type: ignore[arg-type, assignment] # all i's are slices as per if statement
+        new_index = tuple([_named_slice_to_named_range(i) for i in index])  # type: ignore[arg-type, assignment] # all i's are slices as per if statement
     return new_index
 
 
-def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange:
-    if common.is_named_index(idx.start) and common.is_named_index(idx.stop):
-        if idx.start[0] != idx.stop[0]:
+def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange | common.NamedSlice:
+    assert hasattr(idx, "start") and hasattr(idx, "stop")
+    if common.is_named_slice(idx):
+        idx_start_0, idx_start_1 = idx.start[0], idx.stop[1]  # type: ignore[attr-defined]
+        idx_stop_0, idx_stop_1 = idx.stop[0], idx.stop[1]  # type: ignore[attr-defined]
+        if idx_start_0 != idx_stop_0:
             raise IndexError(
-                f"Dimensions slicing mismatch between '{idx.start[0].value}' and '{idx.stop[0].value}'."
+                f"Dimensions slicing mismatch between '{idx_start_0.value}' and '{idx_stop_0.value}'."
             )
-        assert isinstance(idx.start[1], int) and isinstance(idx.stop[1], int)
-        return (idx.start[0], common.UnitRange(idx.start[1], idx.stop[1]))
+        assert isinstance(idx_start_1, int) and isinstance(idx_stop_1, int)
+        return (idx_start_0, common.UnitRange(idx_start_1, idx_stop_1))
     if common.is_named_index(idx.start) and idx.stop is None:
         raise IndexError(f"Upper bound needs to be specified for {idx}.")
     if common.is_named_index(idx.stop) and idx.start is None:

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -159,7 +159,7 @@ def canonicalize_any_index_sequence(
     return new_index
 
 
-def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange | common.NamedSlice:
+def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange:
     assert hasattr(idx, "start") and hasattr(idx, "stop")
     if common.is_named_slice(idx):
         idx_start_0, idx_start_1, idx_stop_0, idx_stop_1 = idx.start[0], idx.start[1], idx.stop[0], idx.stop[1]  # type: ignore[attr-defined]

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -159,7 +159,7 @@ def canonicalize_any_index_sequence(
     return new_index
 
 
-def _refactor_slice(idx: slice) -> common.NamedRange | slice:
+def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange:
     if common.is_named_index(idx.start) and common.is_named_index(idx.stop):
         if idx.start[0] != idx.stop[0]:
             raise IndexError(

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -147,26 +147,28 @@ def _find_index_of_dim(
             return i
     return None
 
-def canonicalize_any_index_sequence(dims, index: common.AnyIndexSpec) -> common.AnyIndexSpec:
+
+def canonicalize_any_index_sequence(
+    index: common.AnyIndexSpec,
+) -> common.AnyIndexSpec:
     new_index = index
     if isinstance(index, slice):
-        new_index = _refactor_slice(dims, index)
+        new_index = _refactor_slice(index)
     if isinstance(index, tuple) and all(isinstance(i, slice) for i in index):
-        new_index = tuple(
-            [_refactor_slice(dims, i) for i in index])  # type: ignore[arg-type] # all i's are slices as per if statement
+        new_index = tuple([_refactor_slice(i) for i in index])  # type: ignore[arg-type, assignment] # all i's are slices as per if statement
     return new_index
 
-def _refactor_slice(dims, idx: slice) -> common.NamedRange | slice:
-    if common.is_named_index(idx.start) or common.is_named_index(idx.stop):
-        dim_idx = list(dims).index(
-            idx.stop[0] if idx.start is None else idx.start[0]
-        )
-        if idx.start is not None and idx.stop is not None:
-            if idx.start[0] != idx.stop[0]:
-                raise ValueError(
-                    f"Dimensions slicing mismatch between '{idx.start[0].value}' and '{idx.stop[0].value}'."
-                )
-        start = common.Infinity.NEGATIVE if idx.start is None else idx.start[1]
-        stop = common.Infinity.POSITIVE if idx.stop is None else idx.stop[1]
-        return (dims[dim_idx], common.UnitRange(start, stop))
+
+def _refactor_slice(idx: slice) -> common.NamedRange | slice:
+    if common.is_named_index(idx.start) and common.is_named_index(idx.stop):
+        if idx.start[0] != idx.stop[0]:
+            raise IndexError(
+                f"Dimensions slicing mismatch between '{idx.start[0].value}' and '{idx.stop[0].value}'."
+            )
+        assert isinstance(idx.start[1], int) and isinstance(idx.stop[1], int)
+        return (idx.start[0], common.UnitRange(idx.start[1], idx.stop[1]))
+    if common.is_named_index(idx.start) and idx.stop is None:
+        raise IndexError(f"Upper bound needs to be specified for {idx}.")
+    if common.is_named_index(idx.stop) and idx.start is None:
+        raise IndexError(f"Lower bound needs to be specified for {idx}.")
     return idx

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -162,8 +162,7 @@ def canonicalize_any_index_sequence(
 def _named_slice_to_named_range(idx: common.NamedSlice) -> common.NamedRange | common.NamedSlice:
     assert hasattr(idx, "start") and hasattr(idx, "stop")
     if common.is_named_slice(idx):
-        idx_start_0, idx_start_1 = idx.start[0], idx.stop[1]  # type: ignore[attr-defined]
-        idx_stop_0, idx_stop_1 = idx.stop[0], idx.stop[1]  # type: ignore[attr-defined]
+        idx_start_0, idx_start_1, idx_stop_0, idx_stop_1 = idx.start[0], idx.start[1], idx.stop[0], idx.stop[1]  # type: ignore[attr-defined]
         if idx_start_0 != idx_stop_0:
             raise IndexError(
                 f"Dimensions slicing mismatch between '{idx_start_0.value}' and '{idx_stop_0.value}'."

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -153,8 +153,8 @@ def canonicalize_any_index_sequence(
 ) -> common.AnyIndexSpec:
     # TODO: instead of canonicalizing to `NamedRange`, we should canonicalize to `NamedSlice`
     new_index: common.AnyIndexSpec = (index,) if isinstance(index, slice) else index
-    if isinstance(index, tuple) and all(isinstance(i, slice) for i in index):
-        new_index = tuple([_named_slice_to_named_range(i) for i in index])  # type: ignore[arg-type, assignment] # all i's are slices as per if statement
+    if isinstance(new_index, tuple) and all(isinstance(i, slice) for i in new_index):
+        new_index = tuple([_named_slice_to_named_range(i) for i in new_index])  # type: ignore[arg-type, assignment] # all i's are slices as per if statement
     return new_index
 
 

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -316,7 +316,7 @@ class NdArrayField(
     def _refactor_slice(
         self, idx: slice
     ) -> tuple[common.Dimension, common.UnitRange] | common.AnyIndexSpec:
-        if isinstance(idx.start, tuple) or isinstance(idx.stop, tuple):
+        if common.is_named_index(idx.start) or common.is_named_index(idx.stop):
             is_start_none: bool = idx.start is None
             is_stop_none: bool = idx.stop is None
             dim_idx = list(self.domain.dims).index(idx.stop[0] if is_start_none else idx.start[0])

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -24,7 +24,7 @@ import numpy as np
 from numpy import typing as npt
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve.extended_typing import Any, Never, Optional, ParamSpec, Tuple, TypeAlias, TypeVar
+from gt4py.eve.extended_typing import Any, Never, Optional, ParamSpec, TypeAlias, TypeVar
 from gt4py.next import common
 from gt4py.next.embedded import common as embedded_common
 from gt4py.next.ffront import fbuiltins
@@ -297,7 +297,7 @@ class NdArrayField(
     def _slice(
         self, index: common.AnyIndexSpec
     ) -> tuple[common.Domain, common.RelativeIndexSequence]:
-        index = embedded_common.canonicalize_any_index_sequence(self.domain.dims, index)
+        index = embedded_common.canonicalize_any_index_sequence(index)
         new_domain = embedded_common.sub_domain(self.domain, index)
 
         index_sequence = common.as_any_index_sequence(index)
@@ -308,21 +308,6 @@ class NdArrayField(
         )
         assert common.is_relative_index_sequence(slice_)
         return new_domain, slice_
-
-    # def _refactor_slice(self, idx: slice) -> common.NamedRange | slice:
-    #     if common.is_named_index(idx.start) or common.is_named_index(idx.stop):
-    #         dim_idx = list(self.domain.dims).index(
-    #             idx.stop[0] if idx.start is None else idx.start[0]
-    #         )
-    #         if idx.start is not None and idx.stop is not None:
-    #             if idx.start[0] != idx.stop[0]:
-    #                 raise ValueError(
-    #                     f"Dimensions slicing mismatch between '{idx.start[0].value}' and '{idx.stop[0].value}'."
-    #                 )
-    #         start = self.domain.ranges[dim_idx].start if idx.start is None else idx.start[1]
-    #         stop = self.domain.ranges[dim_idx].stop if idx.stop is None else idx.stop[1]
-    #         return (self.domain.dims[dim_idx], common.UnitRange(start, stop))
-    #     return idx
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -320,7 +320,7 @@ class NdArrayField(
             is_start_none: bool = idx.start is None
             is_stop_none: bool = idx.stop is None
             dim_idx = list(self.domain.dims).index(idx.stop[0] if is_start_none else idx.start[0])
-            if not (is_start_none and is_stop_none):
+            if not is_start_none and not is_stop_none:
                 # assert dimension in upper and lower bounds are the same
                 assert idx.start[0] == idx.stop[0]
             start = self.domain.ranges[dim_idx].start if is_start_none else idx.start[1]

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -313,18 +313,18 @@ class NdArrayField(
         assert common.is_relative_index_sequence(slice_)
         return new_domain, slice_
 
-    def _refactor_slice(
-        self, idx: slice
-    ) -> common.NamedRange | slice:
+    def _refactor_slice(self, idx: slice) -> common.NamedRange | slice:
         if common.is_named_index(idx.start) or common.is_named_index(idx.stop):
-            is_start_none: bool = idx.start is None
-            is_stop_none: bool = idx.stop is None
-            dim_idx = list(self.domain.dims).index(idx.stop[0] if is_start_none else idx.start[0])
-            if not is_start_none and not is_stop_none:
-                # assert dimension in upper and lower bounds are the same
-                assert idx.start[0] == idx.stop[0]
-            start = self.domain.ranges[dim_idx].start if is_start_none else idx.start[1]
-            stop = self.domain.ranges[dim_idx].stop if is_stop_none else idx.stop[1]
+            dim_idx = list(self.domain.dims).index(
+                idx.stop[0] if idx.start is None else idx.start[0]
+            )
+            if idx.start is not None and idx.stop is not None:
+                if idx.start[0] != idx.stop[0]:
+                    raise ValueError(
+                        f"Dimensions slicing mismatch between '{idx.start[0].value}' and '{idx.stop[0].value}'."
+                    )
+            start = self.domain.ranges[dim_idx].start if idx.start is None else idx.start[1]
+            stop = self.domain.ranges[dim_idx].stop if idx.stop is None else idx.stop[1]
             return (self.domain.dims[dim_idx], common.UnitRange(start, stop))
         return idx
 

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -315,7 +315,7 @@ class NdArrayField(
 
     def _refactor_slice(
         self, idx: slice
-    ) -> tuple[common.Dimension, common.UnitRange] | common.AnyIndexSpec:
+    ) -> common.NamedRange | slice:
         if common.is_named_index(idx.start) or common.is_named_index(idx.stop):
             is_start_none: bool = idx.start is None
             is_stop_none: bool = idx.stop is None

--- a/src/gt4py/next/iterator/tracing.py
+++ b/src/gt4py/next/iterator/tracing.py
@@ -147,6 +147,8 @@ for builtin_name in builtins.BUILTINS:
 def make_node(o):
     if isinstance(o, Node):
         return o
+    if isinstance(o, common.Dimension):
+        return AxisLiteral(value=o.value)
     if callable(o):
         if o.__name__ == "<lambda>":
             return lambdadef(o)
@@ -155,9 +157,7 @@ def make_node(o):
     if isinstance(o, iterator.runtime.Offset):
         return OffsetLiteral(value=o.value)
     if isinstance(o, core_defs.Scalar):
-        return im.literal_from_value(o)
-    if isinstance(o, common.Dimension):
-        return AxisLiteral(value=o.value)
+        return im.literal_from_value(o
     if isinstance(o, tuple):
         return _f("make_tuple", *(make_node(arg) for arg in o))
     if o is None:

--- a/src/gt4py/next/iterator/tracing.py
+++ b/src/gt4py/next/iterator/tracing.py
@@ -157,7 +157,7 @@ def make_node(o):
     if isinstance(o, iterator.runtime.Offset):
         return OffsetLiteral(value=o.value)
     if isinstance(o, core_defs.Scalar):
-        return im.literal_from_value(o
+        return im.literal_from_value(o)
     if isinstance(o, tuple):
         return _f("make_tuple", *(make_node(arg) for arg in o))
     if o is None:

--- a/tests/next_tests/unit_tests/embedded_tests/test_common.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_common.py
@@ -19,7 +19,12 @@ import pytest
 from gt4py.next import common
 from gt4py.next.common import UnitRange
 from gt4py.next.embedded import exceptions as embedded_exceptions
-from gt4py.next.embedded.common import _slice_range, iterate_domain, sub_domain
+from gt4py.next.embedded.common import (
+    _slice_range,
+    canonicalize_any_index_sequence,
+    iterate_domain,
+    sub_domain,
+)
 
 
 @pytest.mark.parametrize(
@@ -147,3 +152,31 @@ def test_iterate_domain():
     testee = list(iterate_domain(domain))
 
     assert testee == ref
+
+
+@pytest.mark.parametrize(
+    "slices, expected",
+    [
+        [slice(I(3), I(4)), (I, common.UnitRange(3, 4))],
+        [
+            (slice(J(3), J(6)), slice(I(3), I(5))),
+            ((J, common.UnitRange(3, 6)), (I, common.UnitRange(3, 5))),
+        ],
+        [slice(I(1), J(7)), IndexError],
+        [
+            slice(I(1), None),
+            IndexError,
+        ],
+        [
+            slice(None, K(8)),
+            IndexError,
+        ],
+    ],
+)
+def test_slicing(slices, expected):
+    if expected is IndexError:
+        with pytest.raises(IndexError):
+            canonicalize_any_index_sequence(slices)
+    else:
+        testee = canonicalize_any_index_sequence(slices)
+        assert testee == expected

--- a/tests/next_tests/unit_tests/embedded_tests/test_common.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_common.py
@@ -157,7 +157,7 @@ def test_iterate_domain():
 @pytest.mark.parametrize(
     "slices, expected",
     [
-        [slice(I(3), I(4)), (I, common.UnitRange(3, 4))],
+        [slice(I(3), I(4)), ((I, common.UnitRange(3, 4)),)],
         [
             (slice(J(3), J(6)), slice(I(3), I(5))),
             ((J, common.UnitRange(3, 6)), (I, common.UnitRange(3, 5))),

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -468,7 +468,7 @@ def test_absolute_indexing_dim_sliced():
         dims=(IDim, JDim, KDim), ranges=(UnitRange(5, 10), UnitRange(5, 15), UnitRange(10, 25))
     )
     field = common._field(np.ones((5, 10, 15)), domain=domain)
-    indexed_field_1 = field[JDim(8) : JDim(10), : IDim(9)]
+    indexed_field_1 = field[JDim(8) : JDim(10), IDim(5) : IDim(9)]
     expected = field[(IDim, UnitRange(5, 9)), (JDim, UnitRange(8, 10))]
 
     assert common.is_field(indexed_field_1)
@@ -493,8 +493,17 @@ def test_absolute_indexing_wrong_dim_sliced():
     )
     field = common._field(np.ones((5, 10, 15)), domain=domain)
 
-    with pytest.raises(ValueError, match="Dimensions slicing mismatch between 'JDim' and 'IDim'."):
+    with pytest.raises(IndexError, match="Dimensions slicing mismatch between 'JDim' and 'IDim'."):
         field[JDim(8) : IDim(10)]
+
+
+def test_absolute_indexing_empty_dim_sliced():
+    domain = common.Domain(
+        dims=(IDim, JDim, KDim), ranges=(UnitRange(5, 10), UnitRange(5, 15), UnitRange(10, 25))
+    )
+    field = common._field(np.ones((5, 10, 15)), domain=domain)
+    with pytest.raises(IndexError, match="Lower bound needs to be specified"):
+        field[: IDim(10)]
 
 
 def test_absolute_indexing_value_return():

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -463,6 +463,30 @@ def test_absolute_indexing(domain_slice, expected_dimensions, expected_shape):
     assert indexed_field.domain.dims == expected_dimensions
 
 
+def test_absolute_indexing_dim_sliced():
+    domain = common.Domain(
+        dims=(IDim, JDim, KDim), ranges=(UnitRange(5, 10), UnitRange(5, 15), UnitRange(10, 25))
+    )
+    field = common._field(np.ones((5, 10, 15)), domain=domain)
+    indexed_field_1 = field[JDim(8) : JDim(10), : IDim(9)]
+    indexed_field_2 = field[(IDim, UnitRange(5, 9)), (JDim, UnitRange(8, 10))]
+
+    assert common.is_field(indexed_field_1)
+    assert indexed_field_1 == indexed_field_2
+
+
+def test_absolute_indexing_dim_sliced_single_slice():
+    domain = common.Domain(
+        dims=(IDim, JDim, KDim), ranges=(UnitRange(5, 10), UnitRange(5, 15), UnitRange(10, 25))
+    )
+    field = common._field(np.ones((5, 10, 15)), domain=domain)
+    indexed_field_1 = field[KDim(11)]
+    indexed_field_2 = field[(KDim, 11)]
+
+    assert common.is_field(indexed_field_1)
+    assert indexed_field_1 == indexed_field_2
+
+
 def test_absolute_indexing_value_return():
     domain = common.Domain(dims=(IDim, JDim), ranges=(UnitRange(10, 20), UnitRange(5, 15)))
     field = common._field(np.reshape(np.arange(100, dtype=np.int32), (10, 10)), domain=domain)

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -469,7 +469,7 @@ def test_absolute_indexing_dim_sliced():
     )
     field = common._field(np.ones((5, 10, 15)), domain=domain)
     indexed_field_1 = field[JDim(8) : JDim(10), : IDim(9)]
-    indexed_field_2 = field[(IDim, UnitRange(5, 9)), (JDim, UnitRange(8, 10))]
+    expected = field[(IDim, UnitRange(5, 9)), (JDim, UnitRange(8, 10))]
 
     assert common.is_field(indexed_field_1)
     assert indexed_field_1 == indexed_field_2

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -472,7 +472,7 @@ def test_absolute_indexing_dim_sliced():
     expected = field[(IDim, UnitRange(5, 9)), (JDim, UnitRange(8, 10))]
 
     assert common.is_field(indexed_field_1)
-    assert indexed_field_1 == indexed_field_2
+    assert indexed_field_1 == expected
 
 
 def test_absolute_indexing_dim_sliced_single_slice():
@@ -485,6 +485,16 @@ def test_absolute_indexing_dim_sliced_single_slice():
 
     assert common.is_field(indexed_field_1)
     assert indexed_field_1 == indexed_field_2
+
+
+def test_absolute_indexing_wrong_dim_sliced():
+    domain = common.Domain(
+        dims=(IDim, JDim, KDim), ranges=(UnitRange(5, 10), UnitRange(5, 15), UnitRange(10, 25))
+    )
+    field = common._field(np.ones((5, 10, 15)), domain=domain)
+
+    with pytest.raises(ValueError, match="Dimensions slicing mismatch between 'JDim' and 'IDim'."):
+        field[JDim(8) : IDim(10)]
 
 
 def test_absolute_indexing_value_return():


### PR DESCRIPTION
New domain slice syntax: f[I(-1):I(5)].

E.g. going from:
```python
f[(named_range(I, unit_range(5,10)), ...)]
```
To:
```python
f[I(5):I(10), ...]
```