### PR TITLE
fix[next]: Disable collapse tuple `if` propagation

### DIFF
--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -116,6 +116,8 @@ def apply_common_transforms(
             inlined,
             # to limit number of times global type inference is executed, only in the last iterations.
             use_global_type_inference=inlined == ir,
+            # TODO(tehrengruber): disabled since it increases compile-time too much right now
+            flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES
         )
         # This pass is required such that a deref outside of a
         # `tuple_get(make_tuple(let(...), ...))` call is propagated into the let after the
@@ -159,7 +161,12 @@ def apply_common_transforms(
     # larger than the number of closure outputs as given by the unconditional collapse, we can
     # only run the unconditional version here instead of in the loop above.
     if unconditionally_collapse_tuples:
-        ir = CollapseTuple.apply(ir, ignore_tuple_size=unconditionally_collapse_tuples)
+        ir = CollapseTuple.apply(
+            ir,
+            ignore_tuple_size=unconditionally_collapse_tuples,
+            # TODO(tehrengruber): disabled since it increases compile-time too much right now
+            flags = ~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES
+        )
 
     if lift_mode == LiftMode.FORCE_INLINE:
         ir = _inline_into_scan(ir)

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -117,7 +117,7 @@ def apply_common_transforms(
             # to limit number of times global type inference is executed, only in the last iterations.
             use_global_type_inference=inlined == ir,
             # TODO(tehrengruber): disabled since it increases compile-time too much right now
-            flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES
+            flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
         )
         # This pass is required such that a deref outside of a
         # `tuple_get(make_tuple(let(...), ...))` call is propagated into the let after the
@@ -165,7 +165,7 @@ def apply_common_transforms(
             ir,
             ignore_tuple_size=unconditionally_collapse_tuples,
             # TODO(tehrengruber): disabled since it increases compile-time too much right now
-            flags = ~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES
+            flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
         )
 
     if lift_mode == LiftMode.FORCE_INLINE:


### PR DESCRIPTION
We observed some increase in compile time due to the `PROPAGATE_TO_IF_ON_TUPLES` option of the `CollapseTuple` pass. This option is needed for `if` statements to work properly, which is not fully functional yet anyway and will be taken care of separately. We disable the option for now until #1414 is merged.