### PR TITLE
fix[next][dace]: Bugfix for nested neighbor reduction

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -458,7 +458,7 @@ def builtin_neighbors(
         neighbor_valid_node = state.add_access(neighbor_valid_var, debuginfo=di)
 
         neighbor_valid_tasklet = state.add_tasklet(
-            "check_valid_neighbor",
+            f"check_valid_neighbor_{offset_dim}",
             {"__idx"},
             {"__valid"},
             f"__valid = True if __idx != {neighbor_skip_value} else False",
@@ -1214,7 +1214,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
             nreduce_shape = args_shape[0]
 
             input_args = [arg[0] for arg in args]
-            input_valid = [arg[1] for arg in args if len(arg) == 2]
+            input_valid_args = [arg[1] for arg in args if len(arg) == 2]
 
             nreduce_index = tuple(f"_i{i}" for i in range(len(nreduce_shape)))
             nreduce_domain = {idx: f"0:{size}" for idx, size in zip(nreduce_index, nreduce_shape)}
@@ -1246,7 +1246,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                 self.context.body, lambda_context.body, input_mapping
             )
 
-            if input_valid:
+            if input_valid_args:
                 """
                 The neighbors builtin returns an array of booleans in case the connectivity table
                 contains skip values. These boolean values indicate whether the neighbor value is present or not,
@@ -1254,8 +1254,8 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                 If the neighbor table has full connectivity (no skip values by type definition), the input_valid node
                 is not built, and the construction of the if/else branch below is also skipped.
                 """
-                input_args.append(input_valid[0])
-                input_valid_node = input_valid[0].value
+                input_args.append(input_valid_args[0])
+                input_valid_node = input_valid_args[0].value
                 # add input connector to nested sdfg
                 input_mapping["is_valid"] = create_memlet_at(input_valid_node.data, nreduce_index)
                 # check neighbor validity on if/else inter-state edge

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -1288,7 +1288,11 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                     input_valid_node.data, nreduce_index
                 )
                 # add select tasklet before writing to output node
+                # TODO: consider replacing it with a select-memlet once it is supported by DaCe SDFG API
                 output_edge = lambda_context.state.in_edges(lambda_output_node)[0]
+                assert isinstance(
+                    lambda_context.body.arrays[output_edge.src.data], dace.data.Scalar
+                )
                 select_tasklet = lambda_context.state.add_tasklet(
                     "neighbor_select",
                     {"_inp", "_valid"},

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -515,9 +515,9 @@ def test_nested_tuple_return(cartesian_case):
 @pytest.mark.uses_reduction_over_lift_expressions
 def test_nested_reduction(unstructured_case):
     @gtx.field_operator
-    def testee(a: cases.EField) -> cases.EField:
-        tmp = neighbor_sum(a(V2E), axis=V2EDim)
-        tmp_2 = neighbor_sum(tmp(E2V), axis=E2VDim)
+    def testee(a: cases.VField) -> cases.VField:
+        tmp = neighbor_sum(a(E2V), axis=E2VDim)
+        tmp_2 = neighbor_sum(tmp(V2E), axis=V2EDim)
         return tmp_2
 
     cases.verify_with_default_data(
@@ -525,12 +525,12 @@ def test_nested_reduction(unstructured_case):
         testee,
         ref=lambda a: np.sum(
             np.sum(
-                a[unstructured_case.offset_provider["V2E"].table],
+                a[unstructured_case.offset_provider["E2V"].table],
                 axis=1,
                 initial=0,
-                where=unstructured_case.offset_provider["V2E"].table != common.SKIP_VALUE,
-            )[unstructured_case.offset_provider["E2V"].table],
+            )[unstructured_case.offset_provider["V2E"].table],
             axis=1,
+            where=unstructured_case.offset_provider["V2E"].table != common.SKIP_VALUE,
         ),
         comparison=lambda a, tmp_2: np.all(a == tmp_2),
     )


### PR DESCRIPTION
In case of nested neighbor reduction with lift expression on inner node, the DaCe backend should generate a conditional state transition to field access, based on the value of neighbor index provided by the outer connectivity table.

The test case `test_nested_reduction` was modified by swapping the inner and outer connectivity tables, in order to have V2E on the outer neighbor expression. This because V2E is setup with skip values in `skip_value_mesh` tests.

Additional change. The previous selection of valid neighbors implemented as conditional inter-state edge is replaced by a select tasklet, which makes the SDFG easier to read.