### PR TITLE
feat[next][dace]: Remove array offsets

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -22,7 +22,6 @@ import numpy as np
 from dace.codegen.compiled_sdfg import CompiledSDFG
 from dace.sdfg import utils as sdutils
 from dace.transformation.auto import auto_optimize as autoopt
-from dace.transformation.interstate import RefineNestedAccess
 
 import gt4py.next.allocators as next_allocators
 import gt4py.next.iterator.ir as itir
@@ -287,9 +286,6 @@ def build_sdfg_from_itir(
     sdfg = sdfg_genenerator.visit(program)
     if sdfg is None:
         raise RuntimeError(f"Visit failed for program {program.id}.")
-    elif tmps:
-        # This pass is needed to avoid transformation errors in SDFG inlining, because temporaries are using offsets
-        sdfg.apply_transformations_repeated(RefineNestedAccess)
 
     for nested_sdfg in sdfg.all_sdfgs_recursive():
         if not nested_sdfg.debuginfo:

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -55,7 +55,8 @@ _build_type = "Release"
 def convert_arg(arg: Any):
     if common.is_field(arg):
         # field domain offsets are not supported
-        assert all(drange.start == 0 for drange in arg.domain.ranges)
+        if any(dim_range.start != 0 for dim_range in arg.domain.ranges):
+            raise RuntimeError("Sliced fields not supported as program arguments.")
         sorted_dims = get_sorted_dims(arg.domain.dims)
         ndim = len(sorted_dims)
         dim_indices = [dim_index for dim_index, _ in sorted_dims]

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -259,10 +259,8 @@ class ItirToSDFG(eve.NodeVisitor):
             ):
                 # instead of using the actual size `end.value - begin.value` we allocate space for indexing from 0
                 # in order to avoid using dace array offsets
-                if begin.value != 0:
-                    warnings.warn(
-                        f"Array for temporary {tmp_name} allocated with size larger than the domain shape."
-                    )
+                if not (isinstance(begin, SymbolExpr) and begin.value == "0"):
+                    warnings.warn(f"Domain start offset for temporary {tmp_name} is ignored.")
                 tmp_symbols[str(shape_sym)] = end.value
 
         return tmp_symbols
@@ -767,7 +765,7 @@ class ItirToSDFG(eve.NodeVisitor):
 
     def _visit_domain(
         self, node: itir.FunCall, context: Context
-    ) -> tuple[tuple[str, tuple[ValueExpr, ValueExpr]], ...]:
+    ) -> tuple[tuple[str, tuple[SymbolExpr | ValueExpr, SymbolExpr | ValueExpr]], ...]:
         assert isinstance(node.fun, itir.SymRef)
         assert node.fun.id == "cartesian_domain" or node.fun.id == "unstructured_domain"
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -11,6 +11,7 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+import warnings
 from typing import Any, Mapping, Optional, Sequence, cast
 
 import dace
@@ -104,7 +105,7 @@ def _make_array_shape_and_strides(
     dims: Sequence[Dimension],
     neighbor_tables: Mapping[str, NeighborTable],
     sort_dims: bool,
-) -> tuple[list[dace.symbol], list[dace.symbol], list[dace.symbol]]:
+) -> tuple[list[dace.symbol], list[dace.symbol]]:
     """
     Parse field dimensions and allocate symbols for array shape and strides.
 
@@ -127,9 +128,8 @@ def _make_array_shape_and_strides(
         )
         for i, dim in sorted_dims
     ]
-    offset = [dace.symbol(unique_name(f"{name}_offset{i}"), dtype) for i, _ in sorted_dims]
     strides = [dace.symbol(unique_name(f"{name}_stride{i}"), dtype) for i, _ in sorted_dims]
-    return shape, offset, strides
+    return shape, strides
 
 
 def _check_no_lifts(node: itir.StencilClosure):
@@ -177,11 +177,10 @@ class ItirToSDFG(eve.NodeVisitor):
         name: str,
         type_: ts.TypeSpec,
         neighbor_tables: Mapping[str, NeighborTable],
-        has_offset: bool = True,
         sort_dimensions: bool = True,
     ):
         if isinstance(type_, ts.FieldType):
-            shape, offset, strides = _make_array_shape_and_strides(
+            shape, strides = _make_array_shape_and_strides(
                 name, type_.dims, neighbor_tables, sort_dimensions
             )
             dtype = as_dace_type(type_.dtype)
@@ -189,7 +188,6 @@ class ItirToSDFG(eve.NodeVisitor):
                 name,
                 shape=shape,
                 strides=strides,
-                offset=(offset if has_offset else None),
                 dtype=dtype,
             )
 
@@ -249,22 +247,23 @@ class ItirToSDFG(eve.NodeVisitor):
             # Another option, in the future, is to use symbolic strides and apply auto-tuning or some heuristics
             # to assign optimal stride values.
             tmp_shape, _ = new_array_symbols(tmp_name, len(dims))
-            tmp_offset = [
-                dace.symbol(unique_name(f"{tmp_name}_offset{i}")) for i in range(len(dims))
-            ]
             _, tmp_array = program_sdfg.add_array(
-                tmp_name, tmp_shape, as_dace_type(type_.dtype), offset=tmp_offset, transient=True
+                tmp_name, tmp_shape, as_dace_type(type_.dtype), transient=True
             )
 
             # Loop through all dimensions to visit the symbolic expressions for array shape and offset.
             # These expressions are later mapped to interstate symbols.
-            for (_, (begin, end)), offset_sym, shape_sym in zip(
+            for (_, (begin, end)), shape_sym in zip(
                 tmp_domain,
-                tmp_array.offset,
                 tmp_array.shape,
             ):
-                tmp_symbols[str(offset_sym)] = f"0 - {begin.value}"
-                tmp_symbols[str(shape_sym)] = f"{end.value} - {begin.value}"
+                # instead of using the actual size `end.value - begin.value` we allocate space for indexing from 0
+                # in order to avoid using dace array offsets
+                if begin.value != 0:
+                    warnings.warn(
+                        f"Array for temporary {tmp_name} allocated with size larger than the domain shape."
+                    )
+                tmp_symbols[str(shape_sym)] = end.value
 
         return tmp_symbols
 
@@ -319,7 +318,6 @@ class ItirToSDFG(eve.NodeVisitor):
                 connectivity_identifier(offset),
                 type_,
                 neighbor_tables,
-                has_offset=False,
                 sort_dimensions=False,
             )
 
@@ -663,7 +661,6 @@ class ItirToSDFG(eve.NodeVisitor):
             output_name,
             shape=(array_table[node.output.id].shape[scan_dim_index],),
             strides=(array_table[node.output.id].strides[scan_dim_index],),
-            offset=(array_table[node.output.id].offset[scan_dim_index],),
             dtype=array_table[node.output.id].dtype,
         )
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -257,8 +257,14 @@ class ItirToSDFG(eve.NodeVisitor):
                 tmp_domain,
                 tmp_array.shape,
             ):
-                # instead of using the actual size `end.value - begin.value` we allocate space for indexing from 0
-                # in order to avoid using dace array offsets
+                """
+                The temporary field has a dimension range defined by `begin` and `end` values.
+                Therefore, the actual size is given by the difference `end.value - begin.value`.
+                Instead of allocating the actual size, we allocate space to enable indexing from 0
+                because we want to avoid using dace array offsets (which will be deprecated soon).
+                The result should still be valid, but the stencil will be using only a subset
+                of the array.
+                """
                 if not (isinstance(begin, SymbolExpr) and begin.value == "0"):
                     warnings.warn(f"Domain start offset for temporary {tmp_name} is ignored.")
                 tmp_symbols[str(shape_sym)] = end.value

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -1071,7 +1071,7 @@ def test_where_k_offset(cartesian_case):
 
     @gtx.program
     def prog(inp: cases.IKField, k_index: gtx.Field[[KDim], gtx.IndexType], out: cases.IKField):
-        fieldop_where_k_offset(inp, k_index, out=out, domain={IDim: (0, 10), KDim: (1, 10)})
+        fieldop_where_k_offset(inp, k_index, out=out)
 
     inp = cases.allocate(cartesian_case, fieldop_where_k_offset, "inp")()
     k_index = cases.allocate(
@@ -1081,7 +1081,7 @@ def test_where_k_offset(cartesian_case):
 
     ref = np.where(k_index.asnumpy() > 0, np.roll(inp.asnumpy(), 1, axis=1), 2)
 
-    cases.verify(cartesian_case, prog, inp, k_index, out=out[:, 1:], ref=ref[:, 1:])
+    cases.verify(cartesian_case, prog, inp, k_index, out=out, ref=ref)
 
 
 def test_undefined_symbols(cartesian_case):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -1071,7 +1071,7 @@ def test_where_k_offset(cartesian_case):
 
     @gtx.program
     def prog(inp: cases.IKField, k_index: gtx.Field[[KDim], gtx.IndexType], out: cases.IKField):
-        fieldop_where_k_offset(inp, k_index, out=out)
+        fieldop_where_k_offset(inp, k_index, out=out, domain={IDim: (0, 10), KDim: (1, 10)})
 
     inp = cases.allocate(cartesian_case, fieldop_where_k_offset, "inp")()
     k_index = cases.allocate(
@@ -1081,7 +1081,16 @@ def test_where_k_offset(cartesian_case):
 
     ref = np.where(k_index.asnumpy() > 0, np.roll(inp.asnumpy(), 1, axis=1), 2)
 
-    cases.verify(cartesian_case, prog, inp, k_index, out=out, ref=ref)
+    cases.verify(
+        cartesian_case,
+        prog,
+        inp,
+        k_index,
+        out=out,
+        ref=ref,
+        # only compare the intersection of `inp` and `out` domain
+        comparison=lambda ref, out: (out == ref)[:, 1:].all(),
+    )
 
 
 def test_undefined_symbols(cartesian_case):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -1079,18 +1079,9 @@ def test_where_k_offset(cartesian_case):
     )()
     out = cases.allocate(cartesian_case, fieldop_where_k_offset, "inp")()
 
-    ref = np.where(k_index.asnumpy() > 0, np.roll(inp.asnumpy(), 1, axis=1), 2)
+    ref = np.where(k_index.asnumpy() > 0, np.roll(inp.asnumpy(), 1, axis=1), out.asnumpy())
 
-    cases.verify(
-        cartesian_case,
-        prog,
-        inp,
-        k_index,
-        out=out,
-        ref=ref,
-        # only compare the intersection of `inp` and `out` domain
-        comparison=lambda ref, out: (out == ref)[:, 1:].all(),
-    )
+    cases.verify(cartesian_case, prog, inp, k_index, out=out, ref=ref)
 
 
 def test_undefined_symbols(cartesian_case):


### PR DESCRIPTION
Remove dace array offsets since they are deprecated in DaCe.

N.B. This PR adopts a simplistic approach to allocation of transient arrays for temporaries: the array shape is dimensioned for indexing from 0, although only a subset of the temporary field is actually used.