### PR TITLE
fix[next][dace]: Fix for GPU illegal memory access

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -221,7 +221,7 @@ def _visit_lift_in_neighbors_reduction(
 
     input_nodes = {}
     iterator_index_nodes = {}
-    lifted_index_connectors = []
+    lifted_index_connectors = set()
 
     for x, y in inner_inputs:
         if isinstance(y, IteratorExpr):
@@ -229,7 +229,7 @@ def _visit_lift_in_neighbors_reduction(
             input_nodes[field_connector] = y.field
             for dim, connector in inner_index_table.items():
                 if dim == neighbor_dim:
-                    lifted_index_connectors.append(connector)
+                    lifted_index_connectors.add(connector)
                 iterator_index_nodes[connector] = y.indices[dim]
         else:
             assert isinstance(y, ValueExpr)

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -302,14 +302,12 @@ def _visit_lift_in_neighbors_reduction(
     check_full_iterator_index = True
     if offset_provider.has_skip_values or check_full_iterator_index:
         # check neighbor validity on if/else inter-state edge
-        valid_index_expr = " and ".join([
-            f"{connector} != {neighbor_skip_value}"
-            for connector in iterator_index_nodes.keys()
-        ])
-        invalid_index_expr = " or ".join([
-            f"{connector} == {neighbor_skip_value}"
-            for connector in iterator_index_nodes.keys()
-        ])
+        valid_index_expr = " and ".join(
+            [f"{connector} != {neighbor_skip_value}" for connector in iterator_index_nodes.keys()]
+        )
+        invalid_index_expr = " or ".join(
+            [f"{connector} == {neighbor_skip_value}" for connector in iterator_index_nodes.keys()]
+        )
         start_state = lift_context.body.add_state("start", is_start_block=True)
         skip_neighbor_state = lift_context.body.add_state("skip_neighbor")
         skip_neighbor_state.add_edge(


### PR DESCRIPTION
Add check for all iterator indices when performing shift inside lift expression in neighbor reduction. Baseline was only checking the index in the neighbor dimension, which caused an illegal memory access in GPU execution.

For example, provided this ITIR:
`neighbors(C2Eₒ, (↑(λ(__arg0) → cast_(·__arg0, float64)))(⟪Koffₒ, -1ₒ⟫(__stencil_arg2))))`

we now check validity of both neighbor index (C2E) and cartesian shift (Koff). The unrolled ITIR (which was working) is actually doing the same.
