### PR TITLE
build: Remove duplicated factory-boy dependency.

### DIFF
--- a/docs/development/tools/requirements.md
+++ b/docs/development/tools/requirements.md
@@ -5,7 +5,7 @@ The specification of required third-party packages is scattered and partially du
 The following files in this repository contain information about required third-party packages:
 
 - `pyproject.toml`: GT4Py [package configuration](https://peps.python.org/pep-0621/) used by the build backend (`setuptools`). Install dependencies are specified in the _project.dependencies_ and _project.optional-dependencies_ tables.
-- `requirements-dev.in`: [requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/) used by **pip**. It contains a list of packages required for the development of GT4Py.
+- `requirements-dev.in`: [requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/) used by **pip**. It contains a list of packages required only for the development of GT4Py.
 - `requirements-dev.txt`: requirements file used by **pip**. It contains a completely frozen list of all packages required for installing and developing GT4Py. It is used by **pip** and **tox** to initialize the standard development and testing environments. It is automatically generated automatically from `requirements-dev.in` by **pip-compile**, when running the **tox** environment to update requirements.
 - `constraints.txt`: [constraints file](https://pip.pypa.io/en/stable/user_guide/#constraints-files) used by **pip** and **tox** to initialize a subset of the standard development environment making sure that if other packages are installed, transitive dependencies are taken from the frozen package list. It is generated automatically from `requirements-dev.in` using **pip-compile**.
 - `min-requirements-test.txt`: requirements file used by **pip**. It contains the minimum list of requirements to run GT4Py tests with the oldest compatible versions of all dependencies. It is generated automatically from `pyproject.toml` using **cog**.
@@ -16,7 +16,7 @@ The expected workflow to update GT4Py requirements is as follows:
 
 1. For changes in the GT4Py package dependencies, update the relevant table in `pyproject.toml`. When adding new tables to the _project.optional-dependencies_ section, make sure to add the new table as a dependency of the `all-` extra tables when possible.
 
-2. For changes in the development tools, update the `requirements-dev.in` file.
+2. For changes in the development tools, update the `requirements-dev.in` file. Note that required project packages already appearing in `pyproject.toml` should not be duplicated here.
 
 3. Run the **tox** _requirements-base_ environment to update all files automatically with **pip-compile** and **cog**. Note that **pip-compile** will most likely update the versions of some unrelated tools if new versions are available in PyPI.
 

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -64,7 +64,6 @@ dace==0.15.1
 darglint==1.6
 deepdiff==5.6.0
 devtools==0.6
-factory-boy==3.1
 factory-boy==3.3.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -60,7 +60,6 @@ cytoolz==0.12.1
 darglint==1.6
 deepdiff==5.6.0
 devtools==0.6
-factory-boy==3.1
 factory-boy==3.3.0
 flake8-bugbear==20.11.1
 flake8-builtins==1.5.3

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -9,7 +9,6 @@ clang-format>=9.0
 cogapp>=3.3
 coverage[toml]>=5.0
 darglint>=1.6
-factory-boy>=3.1
 flake8>=5.0.4
 flake8-bugbear>=20.11.1
 flake8-builtins>=1.5.3


### PR DESCRIPTION
Remove `factory-boy` as development dependency since it has been added as a core gt4py dependency.

