### PR TITLE
feature[next]: Fix caching stability

### DIFF
--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -105,10 +105,12 @@ def process_elements(
     if isinstance(objs, itir.Expr):
         objs = [objs]
 
-    _current_el_exprs = [im.ref(f"__val_{eve_utils.content_hash(obj)[0:12]}") for i, obj in enumerate(objs)]
+    _current_el_exprs = [
+        im.ref(f"__val_{eve_utils.content_hash(obj)[0:12]}") for i, obj in enumerate(objs)
+    ]
     body = _process_elements_impl(process_func, _current_el_exprs, current_el_type)
 
-    return im.let(*((f"__val_{_expr_hash(obj)}", obj) for i, obj in enumerate(objs)))(  # type: ignore[arg-type]  # mypy not smart enough
+    return im.let(*((f"__val_{eve_utils.content_hash(obj)[0:12]}", obj) for i, obj in enumerate(objs)))(  # type: ignore[arg-type]  # mypy not smart enough
         body
     )
 

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -15,17 +15,11 @@ import hashlib
 import pickle
 from typing import Callable, TypeVar
 
+from gt4py.eve import utils as eve_utils
 from gt4py.next.ffront import type_info as ti_ffront
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.type_system import type_info, type_specifications as ts
-
-
-def _expr_hash(expr: itir.Expr | str) -> str:
-    """Small utility function that returns a string hash of an expression."""
-    m = hashlib.sha1()
-    m.update(pickle.dumps(expr))
-    return m.hexdigest()[0:12]
 
 
 def to_tuples_of_iterator(expr: itir.Expr | str, arg_type: ts.TypeSpec):
@@ -38,7 +32,7 @@ def to_tuples_of_iterator(expr: itir.Expr | str, arg_type: ts.TypeSpec):
     ...   dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32))])))   # doctest: +ELLIPSIS
     (λ(__toi_...) → {(↑(λ(it) → (·it)[0]))(__toi_...)})(arg)
     """
-    param = f"__toi_{_expr_hash(expr)}"
+    param = f"__toi_{eve_utils.content_hash(expr)[:12]}"
 
     def fun(primitive_type, path):
         inner_expr = im.deref("it")
@@ -64,7 +58,7 @@ def to_iterator_of_tuples(expr: itir.Expr | str, arg_type: ts.TypeSpec):
     ...   dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32))])))  # doctest: +ELLIPSIS
     (λ(__iot_...) → (↑(λ(__iot_el_0) → {·__iot_el_0}))(__iot_...[0]))(arg)
     """
-    param = f"__iot_{_expr_hash(expr)}"
+    param = f"__iot_{eve_utils.content_hash(expr)[:12]}"
 
     type_constituents = [
         ti_ffront.promote_scalars_to_zero_dim_field(type_)

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -30,7 +30,7 @@ def to_tuples_of_iterator(expr: itir.Expr | str, arg_type: ts.TypeSpec):
     ...   dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32))])))   # doctest: +ELLIPSIS
     (λ(__toi_...) → {(↑(λ(it) → (·it)[0]))(__toi_...)})(arg)
     """
-    param = f"__toi_{eve_utils.content_hash(expr)[:12]}"
+    param = f"__toi_{eve_utils.content_hash(expr)}"
 
     def fun(primitive_type, path):
         inner_expr = im.deref("it")
@@ -56,7 +56,7 @@ def to_iterator_of_tuples(expr: itir.Expr | str, arg_type: ts.TypeSpec):
     ...   dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32))])))  # doctest: +ELLIPSIS
     (λ(__iot_...) → (↑(λ(__iot_el_0) → {·__iot_el_0}))(__iot_...[0]))(arg)
     """
-    param = f"__iot_{eve_utils.content_hash(expr)[:12]}"
+    param = f"__iot_{eve_utils.content_hash(expr)}"
 
     type_constituents = [
         ti_ffront.promote_scalars_to_zero_dim_field(type_)
@@ -106,11 +106,11 @@ def process_elements(
         objs = [objs]
 
     _current_el_exprs = [
-        im.ref(f"__val_{eve_utils.content_hash(obj)[0:12]}") for i, obj in enumerate(objs)
+        im.ref(f"__val_{eve_utils.content_hash(obj)}") for i, obj in enumerate(objs)
     ]
     body = _process_elements_impl(process_func, _current_el_exprs, current_el_type)
 
-    return im.let(*((f"__val_{eve_utils.content_hash(obj)[0:12]}", obj) for i, obj in enumerate(objs)))(  # type: ignore[arg-type]  # mypy not smart enough
+    return im.let(*((f"__val_{eve_utils.content_hash(obj)}", obj) for i, obj in enumerate(objs)))(  # type: ignore[arg-type]  # mypy not smart enough
         body
     )
 

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -11,14 +11,14 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+import hashlib
+import pickle
 from typing import Callable, TypeVar
 
 from gt4py.next.ffront import type_info as ti_ffront
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.type_system import type_info, type_specifications as ts
-import pickle
-import hashlib
 
 
 def _expr_hash(expr: itir.Expr | str) -> str:

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -11,8 +11,6 @@
 # distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-import hashlib
-import pickle
 from typing import Callable, TypeVar
 
 from gt4py.eve import utils as eve_utils

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -105,7 +105,7 @@ def process_elements(
     if isinstance(objs, itir.Expr):
         objs = [objs]
 
-    _current_el_exprs = [im.ref(f"__val_{_expr_hash(obj)}") for i, obj in enumerate(objs)]
+    _current_el_exprs = [im.ref(f"__val_{eve_utils.content_hash(obj)[0:12]}") for i, obj in enumerate(objs)]
     body = _process_elements_impl(process_func, _current_el_exprs, current_el_type)
 
     return im.let(*((f"__val_{_expr_hash(obj)}", obj) for i, obj in enumerate(objs)))(  # type: ignore[arg-type]  # mypy not smart enough

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -17,11 +17,15 @@ from gt4py.next.ffront import type_info as ti_ffront
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.type_system import type_info, type_specifications as ts
+import pickle
+import hashlib
 
 
 def _expr_hash(expr: itir.Expr | str) -> str:
     """Small utility function that returns a string hash of an expression."""
-    return str(abs(hash(expr)) % (10**12)).zfill(12)
+    m = hashlib.sha1()
+    m.update(pickle.dumps(expr))
+    return m.hexdigest()[0:12]
 
 
 def to_tuples_of_iterator(expr: itir.Expr | str, arg_type: ts.TypeSpec):


### PR DESCRIPTION
#1449 introduced a hashing function for expressions that relied on Python's builtin `hash`. As `hash` is not stable across interpreter runs this broke caching in some cases. This PR fixes that.