### PR TITLE
style: Fix leftovers of moving lint infrastructure to ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,26 +94,6 @@ Homepage = 'https://gridtools.github.io/'
 Source = 'https://github.com/GridTools/gt4py'
 
 # ---- Other tools ----
-# -- black --
-[tool.black]
-exclude = '''
-/(
-    \.git
-  | \.gt_cache
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-include = '\.pyi?$'
-line-length = 100
-target-version = ['py310']
-
 # -- coverage --
 [tool.coverage]
 
@@ -136,99 +116,6 @@ ignore_errors = true
 [tool.coverage.run]
 branch = true
 source_pkgs = ['gt4py']
-
-# -- flake8  --
-# flake8-pyproject plugin is used to load configuration settings
-# from this file, since flake8 doesn't support it natively.
-[tool.flake8]
-count = true
-doctests = true
-exclude = [
-  '.eggs',
-  '.gt_cache',
-  '.ipynb_checkpoints',
-  '.tox',
-  '_local/',
-  'build',
-  'dist',
-  'docs',
-  'tests/_disabled',
-  'setup.py'
-]
-ignore = [
-  'B008',  # Do not perform function calls in argument defaults
-  'B028',  # Consider replacing f"'{foo}'" with f"{foo!r}"  # TODO: review this ignore
-  'D1',  # Public code object needs docstring
-  'DAR',  # Disable dargling errors by default
-  'E203',  # Whitespace before ':' (black formatter breaks this sometimes)
-  'E501',  # Line too long (using Bugbear's B950 warning)
-  'W503',  # Line break occurred before a binary operator
-  'E701',  # Multiple statements on one line, see https://github.com/psf/black/issues/3887
-  'E704'  # Multiple statements on one line, see https://github.com/psf/black/issues/3887
-]
-max-complexity = 15
-max-line-length = 100  # It should be the same as in `tool.black.line-length` above
-per-file-ignores = [
-  'src/gt4py/eve/extended_typing.py:F401,F405',
-  'src/gt4py/next/__init__.py:F401'  # We import stuff there in order to reexport.
-]
-rst-roles = [
-  'py:mod, mod',
-  'py:func, func',
-  'py:data, data',
-  'py:const, const',
-  'py:class, class',
-  'py:meth, meth',
-  'py:attr, attr',
-  'py:exc, exc',
-  'py:obj, obj'
-]
-
-# -- isort --
-[tool.isort]
-combine_as_imports = true
-group_by_package = true
-known_first_party = ['gt4py', '__externals__', '__gtscript__']
-known_tests = ['cartesian_tests', 'eve_tests', 'next_tests', 'storage_tests']
-known_third_party = [
-  'attr',
-  'black',
-  'boltons',
-  'cached_property',
-  'click',
-  'cupy',
-  'dace',
-  'devtools',
-  'factory',
-  'hypothesis',
-  'importlib_resources',
-  'jinja2',
-  'mako',
-  'networkx',
-  'numpy',
-  'packaging',
-  'pybind11',
-  'pytest',
-  'pytest_factoryboy',
-  'setuptools',
-  'tabulate',
-  'typing_extensions',
-  'xxhash'
-]
-lexicographical = true
-line_length = 100  # It should be the same as in `tool.black.line-length` above
-lines_after_imports = 2
-profile = 'black'
-sections = [
-  'FUTURE',
-  'STDLIB',
-  'THIRDPARTY',
-  'FIRSTPARTY',
-  'TESTS',
-  'LOCALFOLDER'
-]
-skip_gitignore = true
-skip_glob = ['*.venv/**', '_local/**']
 
 # -- mypy  --
 [tool.mypy]
@@ -451,7 +338,7 @@ split-on-trailing-comma = false
 max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
-"src/gt4py/cartesian/*" = ["RUF012"]
+'src/gt4py/cartesian/*' = ['RUF012']
 'src/gt4py/eve/extended_typing.py' = ['F401', 'F405']
 'src/gt4py/next/__init__.py' = ['F401']
 

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1887,9 +1887,7 @@ class GTScriptParser(ast.NodeVisitor):
                         "{}.{}".format(value._gtscript_["qualified_name"], item_name): item_value
                         for item_name, item_value in value._gtscript_["nonlocals"].items()
                     }
-                    resolved_values_list.extend(  # noqa[B038] #editing a loop's mutable iterable (probably intended here)
-                        nested_inlined_values.items()
-                    )
+                    resolved_values_list.extend(nested_inlined_values.items())
 
                     for imported_name, imported_name_accesses in value._gtscript_[
                         "imported"

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_stencil_object.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_stencil_object.py
@@ -81,4 +81,4 @@ def test_warning_for_unsupported_backend_option(backend):
         @gtscript.stencil(backend=backend, **{"this_option_is_not_supported": "foo"})
         def foo(f: Field[float]):
             with computation(PARALLEL), interval(...):  # type: ignore
-                f = 42.0  # noqa F841
+                f = 42.0  # noqa: F841 [unused-variable]

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
@@ -30,7 +30,7 @@ from cartesian_tests.utils import OriginWrapper
 
 
 dace = pytest.importorskip("dace")
-from gt4py.cartesian.backend.dace_lazy_stencil import (  # noqa: E402 (needs to be guarded by above importorskip)
+from gt4py.cartesian.backend.dace_lazy_stencil import (  # noqa: E402 [import-shadowed-by-loop-var]  'importorskip' is needed
     DaCeLazyStencil,
 )
 
@@ -76,7 +76,7 @@ def test_basic(decorator, backend):
     @decorator(backend=backend)
     def defn(outp: gtscript.Field[np.float64], par: np.float64):
         with computation(PARALLEL), interval(...):
-            outp = par  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = par  # noqa: F841 [unused-variable]
 
     outp = OriginWrapper(
         array=gt_storage.zeros(
@@ -105,7 +105,7 @@ def test_origin_offsetting_frozen(domain, outp_origin):
     @gtscript.stencil(backend=backend)
     def dace_stencil(inp: gtscript.Field[np.float64], outp: gtscript.Field[np.float64]):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     frozen_stencil = dace_stencil.freeze(
         domain=domain, origin={"inp": (0, 0, 0), "outp": outp_origin}
@@ -156,7 +156,7 @@ def test_origin_offsetting_nofrozen(domain, outp_origin):
     @gtscript.stencil(backend=backend)
     def dace_stencil(inp: gtscript.Field[np.float64], outp: gtscript.Field[np.float64]):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     inp = OriginWrapper(
         array=gt_storage.full(
@@ -204,7 +204,7 @@ def test_origin_offsetting_nofrozen_default_origin(domain, outp_origin):
     @gtscript.stencil(backend=backend)
     def dace_stencil(inp: gtscript.Field[np.float64], outp: gtscript.Field[np.float64]):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     inp = OriginWrapper(
         array=gt_storage.full(
@@ -252,7 +252,7 @@ def test_optional_arg_noprovide():
         unused_par: float,
     ):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     frozen_stencil = stencil.freeze(
         domain=(3, 3, 10),
@@ -298,7 +298,7 @@ def test_optional_arg_provide(decorator):
         unused_par: float,
     ):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     inp = OriginWrapper(
         array=gt_storage.full(
@@ -352,7 +352,7 @@ def test_optional_arg_provide_aot(decorator):
         unused_par: float,
     ):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     inp = OriginWrapper(
         array=gt_storage.full(
@@ -405,7 +405,7 @@ def test_nondace_raises(decorator):
     @decorator(backend="numpy")
     def numpy_stencil(inp: gtscript.Field[np.float64], outp: gtscript.Field[np.float64]):
         with computation(PARALLEL), interval(...):
-            outp = inp  # noqa F841: local variable 'outp' is assigned to but never used
+            outp = inp  # noqa: F841 [unused-variable]
 
     inp = OriginWrapper(
         array=gt_storage.full(
@@ -445,7 +445,7 @@ def test_nondace_raises(decorator):
 @typing.no_type_check
 def simple_stencil_defn(outp: gtscript.Field[np.float64], par: np.float64):
     with computation(PARALLEL), interval(...):
-        outp = par  # noqa F841: local variable 'outp' is assigned to but never used
+        outp = par  # noqa: F841 [unused-variable]
 
 
 def test_lazy_sdfg():

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend_api.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend_api.py
@@ -31,7 +31,7 @@ def backend(request):
 def init_1(input_field: Field[float]):  # type: ignore
     """Implement simple stencil."""
     with computation(PARALLEL), interval(...):  # type: ignore
-        input_field = 1  # noqa - unused var is in/out field
+        input_field = 1  # noqa  # unused var is in/out field
 
 
 def test_generate_computation(backend, tmp_path):

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_bound_args.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_bound_args.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_scalar_if.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_fix_missing_locations.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_fix_missing_locations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_simple_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_simple_assign.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich

--- a/tests/next_tests/unit_tests/type_system_tests/test_type_translation.py
+++ b/tests/next_tests/unit_tests/type_system_tests/test_type_translation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # GT4Py - GridTools Framework
 #
 # Copyright (c) 2014-2023, ETH Zurich


### PR DESCRIPTION
Changes:
- Remove unneeded configuration for `black`, `isort` and `flake8` in pyproject.toml
- Fixes in `noqa` comments in several files
- Remove line with text-encoding from some headers