### PR TITLE
fix[next][dace]: accept runtime lift_mode as argument to dace backend

### DIFF
--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -111,6 +111,8 @@ def compilation_hash(otf_closure: stages.ProgramCall) -> int:
         content_hash(tuple(from_value(arg) for arg in otf_closure.args)),
         id(offset_provider) if offset_provider else None,
         otf_closure.kwargs.get("column_axis", None),
+        # TODO(tehrengruber): Remove `lift_mode` from call interface.
+        otf_closure.kwargs.get("lift_mode", None),
     ))
 
 


### PR DESCRIPTION
Fix previous PR #1477. Like for gtfn backend, we still need to accept the runtime `lift_mode` passed as keyword argument to  the backend.
