### PR TITLE
build: add ruff to the automated requirement generation workflow 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
+# -----------------------------------------------------------------------
 # This file contains 'cog' snippets (https://nedbatchelder.com/code/cog/) 
 # to keep version numbers in sync with 'constraints.txt'
+# -----------------------------------------------------------------------
 
 default_language_version:
   python: python3.10
@@ -42,7 +44,13 @@ repos:
   - id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
+  ##[[[cog
+  ## import re
+  ## version = re.search('ruff==([0-9\.]*)', open("constraints.txt").read())[1]
+  ## print(f"rev: v{version}")
+  ##]]]
   rev: v0.2.0
+  ##[[[end]]]
   hooks:
     # Run the linter.
     # TODO: include tests here


### PR DESCRIPTION
Add cog snippet to precommit-config to grab ruff version from constraints file as usual.