### PR TITLE
feat[cartesian]: gtc `cuda` backend deprecation

### DIFF
--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -450,6 +450,8 @@ def disabled(message: str, *, enabled_env_var: str) -> Callable[[Backend], Backe
             # Flag that it got disabled for register lookup
             cls.disabled = True  # type: ignore
             # Replace generate method with raise
+            if not hasattr(cls, "generate"):
+                raise ValueError(f"Coding error. Expected a generate method on {cls}")
             cls.generate = _no_generate  # type: ignore
             return cls
 

--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -228,6 +228,7 @@ class CLIBackendMixin(Backend):
 
 class BaseBackend(Backend):
     MODULE_GENERATOR_CLASS: ClassVar[Type["BaseModuleGenerator"]]
+    deprecated: bool = False
 
     def load(self) -> Optional[Type["StencilObject"]]:
         build_info = self.builder.options.build_info

--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -441,7 +441,7 @@ def disabled(message: str, *, enabled_env_var: str) -> Callable[[Backend], Backe
     else:
 
         def _decorator(cls: Backend) -> Backend:
-            def _no_generate() -> Type["StencilObject"]:
+            def _no_generate(obj) -> Type["StencilObject"]:
                 raise NotImplementedError(
                     f"Disabled '{cls.name}' backend: 'f{message}'\n",
                     f"You can still enable the backend by hand using the environment variable '{enabled_env_var}=1'",

--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -53,7 +53,7 @@ def from_name(name: str) -> Optional[Type["Backend"]]:
     return REGISTRY.get(name, None)
 
 
-def register(backend_cls: Type["Backend"]) -> "Backend":
+def register(backend_cls: Type["Backend"]) -> Type["Backend"]:
     assert issubclass(backend_cls, Backend) and backend_cls.name is not None
 
     if isinstance(backend_cls.name, str):
@@ -433,25 +433,25 @@ class BasePyExtBackend(BaseBackend):
         return module_name, file_path
 
 
-def disabled(message: str, *, enabled_env_var: str) -> Callable[[Backend], Backend]:
+def disabled(message: str, *, enabled_env_var: str) -> Callable[[Type[Backend]], Type[Backend]]:
     # We push for hard deprecation here by raising by default and warning if enabling has been forced.
     enabled = bool(int(os.environ.get(enabled_env_var, "0")))
     if enabled:
         return deprecated(message)
     else:
 
-        def _decorator(cls: Backend) -> Backend:
+        def _decorator(cls: Type[Backend]) -> Type[Backend]:
             def _no_generate(obj) -> Type["StencilObject"]:
                 raise NotImplementedError(
                     f"Disabled '{cls.name}' backend: 'f{message}'\n",
                     f"You can still enable the backend by hand using the environment variable '{enabled_env_var}=1'",
                 )
 
-            # Flag that it got disabled for register lookup
-            cls.disabled = True  # type: ignore
             # Replace generate method with raise
             if not hasattr(cls, "generate"):
                 raise ValueError(f"Coding error. Expected a generate method on {cls}")
+            # Flag that it got disabled for register lookup
+            cls.disabled = True  # type: ignore
             cls.generate = _no_generate  # type: ignore
             return cls
 

--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -19,7 +19,21 @@ import os
 import pathlib
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Protocol, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    Union,
+)
+
+from typing_extensions import deprecated
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian import definitions as gt_definitions, utils as gt_utils
@@ -39,7 +53,7 @@ def from_name(name: str) -> Optional[Type["Backend"]]:
     return REGISTRY.get(name, None)
 
 
-def register(backend_cls: Type["Backend"]) -> None:
+def register(backend_cls: Type["Backend"]) -> "Backend":
     assert issubclass(backend_cls, Backend) and backend_cls.name is not None
 
     if isinstance(backend_cls.name, str):
@@ -228,7 +242,6 @@ class CLIBackendMixin(Backend):
 
 class BaseBackend(Backend):
     MODULE_GENERATOR_CLASS: ClassVar[Type["BaseModuleGenerator"]]
-    deprecated: bool = False
 
     def load(self) -> Optional[Type["StencilObject"]]:
         build_info = self.builder.options.build_info
@@ -418,3 +431,26 @@ class BasePyExtBackend(BaseBackend):
         })
 
         return module_name, file_path
+
+
+def disabled(message: str, *, enabled_env_var: str) -> Callable[[Backend], Backend]:
+    # We push for hard deprecation here by raising by default and warning if enabling has been forced.
+    enabled = bool(int(os.environ.get(enabled_env_var, "0")))
+    if enabled:
+        return deprecated(message)
+    else:
+
+        def _decorator(cls: Backend) -> Backend:
+            def _no_generate() -> Type["StencilObject"]:
+                raise NotImplementedError(
+                    f"Disabled '{cls.name}' backend: 'f{message}'\n",
+                    f"You can still enable the backend by hand using the environment variable '{enabled_env_var}=1'",
+                )
+
+            # Flag that it got disabled for register lookup
+            cls.disabled = True  # type: ignore
+            # Replace generate method with raise
+            cls.generate = _no_generate  # type: ignore
+            return cls
+
+        return _decorator

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -12,6 +12,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
 
 from gt4py import storage as gt_storage
@@ -21,6 +22,7 @@ from gt4py.cartesian.backend.gtc_common import (
     bindings_main_template,
     pybuffer_to_sid,
 )
+from gt4py.cartesian.config import GT4PY_GTC_CUDA_USE
 from gt4py.cartesian.gtc import gtir
 from gt4py.cartesian.gtc.common import DataType
 from gt4py.cartesian.gtc.cuir import cuir, cuir_codegen, extent_analysis, kernel_fusion
@@ -136,7 +138,10 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     """CUDA backend using gtc."""
 
     name = "cuda"
-    options = {**BaseGTBackend.GT_BACKEND_OPTS, "device_sync": {"versioning": True, "type": bool}}
+    options = {
+        **BaseGTBackend.GT_BACKEND_OPTS,
+        "device_sync": {"versioning": True, "type": bool},
+    }
     languages = {"computation": "cuda", "bindings": ["python"]}
     storage_info = gt_storage.layout.CUDALayout
     PYEXT_GENERATOR_CLASS = CudaExtGenerator  # type: ignore
@@ -147,6 +152,18 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
         return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=True)
 
     def generate(self) -> Type["StencilObject"]:
+        if GT4PY_GTC_CUDA_USE:
+            warnings.warn(
+                "cuda backend is deprecated, feature developed after February 2024 will not be available",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            raise NotImplementedError(
+                "cuda backend is no longer maintained (February 2024)."
+                "You can still force the use of the backend by defining GT4PY_GTC_CUDA_USE=1"
+            )
+
         self.check_options(self.builder.options)
 
         pyext_module_name: Optional[str]

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -50,18 +50,14 @@ class CudaExtGenerator(BackendCodegen):
         base_oir = GTIRToOIR().visit(stencil_ir)
         oir_pipeline = self.backend.builder.options.backend_opts.get(
             "oir_pipeline",
-            DefaultPipeline(
-                skip=[NoFieldAccessPruning], add_steps=[FillFlushToLocalKCaches]
-            ),
+            DefaultPipeline(skip=[NoFieldAccessPruning], add_steps=[FillFlushToLocalKCaches]),
         )
         oir_node = oir_pipeline.run(base_oir)
         cuir_node = OIRToCUIR().visit(oir_node)
         cuir_node = kernel_fusion.FuseKernels().visit(cuir_node)
         cuir_node = extent_analysis.CacheExtents().visit(cuir_node)
         format_source = self.backend.builder.options.format_source
-        implementation = cuir_codegen.CUIRCodegen.apply(
-            cuir_node, format_source=format_source
-        )
+        implementation = cuir_codegen.CUIRCodegen.apply(cuir_node, format_source=format_source)
         bindings = CudaBindingsCodegen.apply_codegen(
             cuir_node,
             module_name=self.module_name,
@@ -109,13 +105,9 @@ class CudaBindingsCodegen(codegen.TemplatedGenerator):
     def visit_ScalarDecl(self, node: cuir.ScalarDecl, **kwargs):
         if "external_arg" in kwargs:
             if kwargs["external_arg"]:
-                return "{dtype} {name}".format(
-                    name=node.name, dtype=self.visit(node.dtype)
-                )
+                return "{dtype} {name}".format(name=node.name, dtype=self.visit(node.dtype))
             else:
-                return "gridtools::stencil::global_parameter({name})".format(
-                    name=node.name
-                )
+                return "gridtools::stencil::global_parameter({name})".format(name=node.name)
 
     def visit_Program(self, node: cuir.Program, **kwargs):
         assert "module_name" in kwargs

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -147,12 +147,14 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     PYEXT_GENERATOR_CLASS = CudaExtGenerator  # type: ignore
     MODULE_GENERATOR_CLASS = CUDAPyExtModuleGenerator
     GT_BACKEND_T = "gpu"
+    deprecated = not GT4PY_GTC_CUDA_USE
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
         return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=True)
 
     def generate(self) -> Type["StencilObject"]:
-        if GT4PY_GTC_CUDA_USE:
+        # We push for hard deprecation here by raising by default and warning if use has been forced.
+        if not self.deprecated:
             warnings.warn(
                 "cuda backend is deprecated, feature developed after February 2024 will not be available",
                 DeprecationWarning,
@@ -161,7 +163,7 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
         else:
             raise NotImplementedError(
                 "cuda backend is no longer maintained (February 2024)."
-                "You can still force the use of the backend by defining GT4PY_GTC_CUDA_USE=1"
+                "You can still force the use of the backend by defining GT4PY_GTC_CUDA_USE=1."
             )
 
         self.check_options(self.builder.options)

--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -286,7 +286,10 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
         gt_pyext_sources: Dict[str, Any]
         if not self.builder.options._impl_opts.get("disable-code-generation", False):
             gt_pyext_files = self.make_extension_sources(stencil_ir=stencil_ir)
-            gt_pyext_sources = {**gt_pyext_files["computation"], **gt_pyext_files["bindings"]}
+            gt_pyext_sources = {
+                **gt_pyext_files["computation"],
+                **gt_pyext_files["bindings"],
+            }
         else:
             # Pass NOTHING to the self.builder means try to reuse the source code files
             gt_pyext_files = {}

--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -86,3 +86,7 @@ code_settings: Dict[str, Any] = {"root_package_name": "_GT_"}
 os.environ.setdefault("DACE_CONFIG", os.path.join(os.path.abspath("."), ".dace.conf"))
 
 DACE_DEFAULT_BLOCK_SIZE: str = os.environ.get("DACE_DEFAULT_BLOCK_SIZE", "64,8,1")
+
+# Deerecate by default the gtc `cuda` backend. Use GT4PY_GTC_CUDA_USE=1 to turn it on
+# at user own risks.
+GT4PY_GTC_CUDA_USE = bool(int(os.environ.get("GT4PY_GTC_CUDA_USE", "0")))

--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -64,9 +64,7 @@ build_settings: Dict[str, Any] = {
     "extra_compile_args": {"cxx": extra_compile_args, "cuda": extra_compile_args},
     "extra_link_args": [],
     "parallel_jobs": multiprocessing.cpu_count(),
-    "cpp_template_depth": os.environ.get(
-        "GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH
-    ),
+    "cpp_template_depth": os.environ.get("GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH),
 }
 if GT4PY_USE_HIP:
     build_settings["cuda_library_path"] = os.path.join(CUDA_ROOT, "lib")
@@ -80,9 +78,7 @@ cache_settings: Dict[str, Any] = {
     "dir_name": os.environ.get("GT_CACHE_DIR_NAME", ".gt_cache"),
     "root_path": os.environ.get("GT_CACHE_ROOT", os.path.abspath(".")),
     "load_retries": int(os.environ.get("GT_CACHE_LOAD_RETRIES", 3)),
-    "load_retry_delay": int(
-        os.environ.get("GT_CACHE_LOAD_RETRY_DELAY", 100)
-    ),  # unit milliseconds
+    "load_retry_delay": int(os.environ.get("GT_CACHE_LOAD_RETRY_DELAY", 100)),  # unit milliseconds
 }
 
 code_settings: Dict[str, Any] = {"root_package_name": "_GT_"}

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -43,7 +43,7 @@ def _get_backends_with_storage_info(storage_info_kind: str):
     res = []
     for name in _ALL_BACKEND_NAMES:
         backend = gt4pyc.backend.from_name(name)
-        if not hasattr(backend, "disabled") or not backend.disabled:
+        if not getattr(backend, "disabled", False):
             if backend.storage_info["device"] == storage_info_kind:
                 res.append(_backend_name_as_param(name))
     return res

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -44,7 +44,7 @@ def _get_backends_with_storage_info(storage_info_kind: str):
     for name in _ALL_BACKEND_NAMES:
         backend = gt4pyc.backend.from_name(name)
         if backend is not None:
-            if backend.storage_info["device"] == storage_info_kind:
+            if backend.storage_info["device"] == storage_info_kind and not backend.deprecated:
                 res.append(_backend_name_as_param(name))
     return res
 

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -43,9 +43,8 @@ def _get_backends_with_storage_info(storage_info_kind: str):
     res = []
     for name in _ALL_BACKEND_NAMES:
         backend = gt4pyc.backend.from_name(name)
-        if backend is not None:
-            if backend.storage_info["device"] == storage_info_kind and not backend.deprecated:
-                res.append(_backend_name_as_param(name))
+        if not hasattr(backend, "disabled") or not backend.disabled:
+            res.append(_backend_name_as_param(name))
     return res
 
 

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -44,7 +44,8 @@ def _get_backends_with_storage_info(storage_info_kind: str):
     for name in _ALL_BACKEND_NAMES:
         backend = gt4pyc.backend.from_name(name)
         if not hasattr(backend, "disabled") or not backend.disabled:
-            res.append(_backend_name_as_param(name))
+            if backend.storage_info["device"] == storage_info_kind:
+                res.append(_backend_name_as_param(name))
     return res
 
 

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
@@ -48,7 +48,11 @@ def stencil_def(
             out = pa * fa + pb * fb - pc * fc  # type: ignore  # noqa
 
 
-field_info_val = {0: ("out", "fa"), 1: ("out", "fa", "fb"), 2: ("out", "fa", "fb", "fc")}
+field_info_val = {
+    0: ("out", "fa"),
+    1: ("out", "fa", "fb"),
+    2: ("out", "fa", "fb", "fc"),
+}
 parameter_info_val = {0: ("pa",), 1: ("pa", "pb"), 2: ("pa", "pb", "pc")}
 unreferenced_val = {0: ("pb", "fb", "pc", "fc"), 1: ("pc", "fc"), 2: ()}
 
@@ -166,6 +170,24 @@ def test_toolchain_profiling(backend_name: str, mode: int, rebuild: bool):
             assert build_info["build_time"] > 0.0
     else:
         assert build_info["load_time"] > 0.0
+
+
+@pytest.mark.parametrize("backend_name", ["cuda"])
+def test_deprecation_gtc_cuda(backend_name: str):
+    # Default deprecation, raise an error
+    build_info: Dict[str, Any] = {}
+    builder = (
+        StencilBuilder(cast(StencilFunc, stencil_def))
+        .with_backend(backend_name)
+        .with_externals({"MODE": 2})
+        .with_options(
+            name=stencil_def.__name__,
+            module=stencil_def.__module__,
+            build_info=build_info,
+        )
+    )
+    with pytest.raises(NotImplementedError):
+        builder.build()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

GTC `cuda` backend was made available a few years ago for AI2 team research. It has been kept updated but a recent poll shows that it is not in use. Recent new features break the backend and we propose here to hard deprecate it rather than keep spending time maintaining it.

`GT4PY_GTC_CUDA_USE=1` can be used to force the use of the backend, but will warn that any feature from February 2024 are not available/not tested.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
