### PR TITLE
refactor[next]: make function definition -> PAST into a workflow step

### DIFF
--- a/src/gt4py/next/backend.py
+++ b/src/gt4py/next/backend.py
@@ -26,7 +26,8 @@ from gt4py.next.program_processors import processor_interface as ppi
 
 DEFAULT_TRANSFORMS = recipes.ProgramTransformWorkflow(
     func_to_past=func_to_past.OptionalFuncToPast(),
-    past_to_itir=past_process_args.past_process_args.chain(past_to_itir.PastToItirFactory()),
+    past_transform_args=past_process_args.past_process_args,
+    past_to_itir=past_to_itir.PastToItirFactory(),
 )
 
 

--- a/src/gt4py/next/backend.py
+++ b/src/gt4py/next/backend.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Generic
+from typing import Any, Generic
 
 from gt4py._core import definitions as core_defs
 from gt4py.next import allocators as next_allocators
@@ -37,7 +37,9 @@ class Backend(Generic[core_defs.DeviceTypeT]):
     allocator: next_allocators.FieldBufferAllocatorProtocol[core_defs.DeviceTypeT]
     transformer: recipes.ProgramTransformWorkflow = DEFAULT_TRANSFORMS
 
-    def __call__(self, program: stages.ProgramDefinition, *args, **kwargs) -> None:
+    def __call__(
+        self, program: stages.ProgramDefinition, *args: tuple[Any], **kwargs: dict[str, Any]
+    ) -> None:
         transformer = self.transformer.replace(args=args, kwargs=kwargs)
         program_call = transformer(program)
         self.executor(program_call.program, *program_call.args, **program_call.kwargs)

--- a/src/gt4py/next/backend.py
+++ b/src/gt4py/next/backend.py
@@ -25,7 +25,7 @@ from gt4py.next.program_processors import processor_interface as ppi
 
 
 DEFAULT_TRANSFORMS = recipes.ProgramTransformWorkflow(
-    func_to_past=func_to_past.OptionalFuncToPast(),
+    func_to_past=func_to_past.OptionalFuncToPastFactory(cached=True),
     past_transform_args=past_process_args.past_process_args,
     past_to_itir=past_to_itir.PastToItirFactory(),
 )

--- a/src/gt4py/next/backend.py
+++ b/src/gt4py/next/backend.py
@@ -19,8 +19,8 @@ from typing import Any, Generic
 
 from gt4py._core import definitions as core_defs
 from gt4py.next import allocators as next_allocators
-from gt4py.next.ffront import func_to_past, past_process_args, past_to_itir
-from gt4py.next.otf import recipes, stages
+from gt4py.next.ffront import func_to_past, past_process_args, past_to_itir, stages as ffront_stages
+from gt4py.next.otf import recipes
 from gt4py.next.program_processors import processor_interface as ppi
 
 
@@ -38,7 +38,7 @@ class Backend(Generic[core_defs.DeviceTypeT]):
     transformer: recipes.ProgramTransformWorkflow = DEFAULT_TRANSFORMS
 
     def __call__(
-        self, program: stages.ProgramDefinition, *args: tuple[Any], **kwargs: dict[str, Any]
+        self, program: ffront_stages.ProgramDefinition, *args: tuple[Any], **kwargs: dict[str, Any]
     ) -> None:
         transformer = self.transformer.replace(args=args, kwargs=kwargs)
         program_call = transformer(program)

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -44,6 +44,7 @@ from gt4py.next.ffront import (
     past_process_args,
     past_to_itir,
     program_ast as past,
+    stages as ffront_stages,
     transform_utils,
     type_specifications as ts_ffront,
 )
@@ -91,7 +92,7 @@ class Program:
             it will be deduced from actually occurring dimensions.
     """
 
-    definition_stage: stages.ProgramDefinition
+    definition_stage: ffront_stages.ProgramDefinition
     backend: Optional[next_backend.Backend]
 
     @classmethod
@@ -101,7 +102,7 @@ class Program:
         backend: Optional[next_backend],
         grid_type: Optional[GridType] = None,
     ) -> Program:
-        program_def = stages.ProgramDefinition(definition=definition, grid_type=grid_type)
+        program_def = ffront_stages.ProgramDefinition(definition=definition, grid_type=grid_type)
         return cls(
             definition_stage=program_def,
             backend=backend,

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -107,6 +107,11 @@ class Program:
             backend=backend,
         )
 
+    # needed in testing
+    @property
+    def definition(self):
+        return self.definition_stage.definition
+
     @functools.cached_property
     def past_stage(self):
         if self.backend is not None and self.backend.transformer is not None:

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -64,7 +64,6 @@ from gt4py.next.iterator.ir_utils.ir_makers import (
     ref,
     sym,
 )
-from gt4py.next.otf import stages
 from gt4py.next.program_processors import processor_interface as ppi
 from gt4py.next.type_system import type_info, type_specifications as ts, type_translation
 
@@ -239,7 +238,7 @@ class Program:
 
     @functools.cached_property
     def itir(self) -> itir.FencilDefinition:
-        no_args_past = stages.PastClosure(
+        no_args_past = ffront_stages.PastClosure(
             past_node=self.past_stage.past_node,
             closure_vars=self.past_stage.closure_vars,
             grid_type=self.definition_stage.grid_type,

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -277,7 +277,7 @@ class Program:
 
 @dataclasses.dataclass(frozen=True)
 class ProgramFromPast(Program):
-    past_stage: ffront_stages.ProgramPast
+    past_stage: ffront_stages.PastProgramDefinition
 
     def __call__(self, *args, offset_provider: dict[str, Dimension], **kwargs):
         if self.backend is None:
@@ -586,7 +586,7 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
 
         self._program_cache[hash_] = ProgramFromPast(
             definition_stage=None,
-            past_stage=ffront_stages.ProgramPast(
+            past_stage=ffront_stages.PastProgramDefinition(
                 past_node=past_node,
                 closure_vars=closure_vars,
                 grid_type=self.grid_type,

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -107,51 +107,11 @@ class Program:
             backend=backend,
         )
 
-    # TODO(ricoh): remove when ready
-    @property
-    def definition(self):
-        warnings.warn(
-            "The 'Program.definition' attribute is deprecated. Use 'Program.definition_stage.definition' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.definition_stage.definition
-
-    # TODO(ricoh): remove when ready
-    @property
-    def grid_type(self):
-        warnings.warn(
-            "The 'Program.grid_type' attribute is deprecated. Use 'Program.definition_stage.grid_type' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.definition_stage.grid_type
-
     @functools.cached_property
     def past_stage(self):
         if self.backend is not None and self.backend.transformer is not None:
             return self.backend.transformer.func_to_past(self.definition_stage)
         return next_backend.DEFAULT_TRANSFORMS.func_to_past(self.definition_stage)
-
-    # TODO(ricoh): remove when ready
-    @property
-    def past_node(self):
-        warnings.warn(
-            "The 'Program.past_node' attribute is deprecated. Use 'Program.past_stage.past_node' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.past_stage.past_node
-
-    # TODO(ricoh): remove when ready
-    @property
-    def closure_vars(self):
-        warnings.warn(
-            "The 'Program.closure_vars' attribute is deprecated. Use 'Program.past_stage.closure_vars' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.past_stage.closure_vars
 
     def __post_init__(self):
         function_closure_vars = transform_utils._filter_closure_vars_by_type(

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -233,15 +233,16 @@ class Program:
 
     @functools.cached_property
     def itir(self) -> itir.FencilDefinition:
-        return past_to_itir.PastToItirFactory()(
-            stages.PastClosure(
-                past_node=self.past_node,
-                closure_vars=self.closure_vars,
-                grid_type=self.grid_type,
-                args=[],
-                kwargs={},
-            )
-        ).program
+        no_args_past = stages.PastClosure(
+            past_node=self.past_node,
+            closure_vars=self.closure_vars,
+            grid_type=self.grid_type,
+            args=[],
+            kwargs={},
+        )
+        if self.backend is not None and self.backend.transformer is not None:
+            return self.backend.transformer.past_to_itir(no_args_past)
+        return past_to_itir.PastToItirFactory()(no_args_past).program
 
     def __call__(self, *args, offset_provider: dict[str, Dimension], **kwargs) -> None:
         if self.backend is None:

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -277,7 +277,7 @@ class Program:
 
 @dataclasses.dataclass(frozen=True)
 class ProgramFromPast(Program):
-    past_stage: stages.ProgramPast
+    past_stage: ffront_stages.ProgramPast
 
     def __call__(self, *args, offset_provider: dict[str, Dimension], **kwargs):
         if self.backend is None:
@@ -586,7 +586,7 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
 
         self._program_cache[hash_] = ProgramFromPast(
             definition_stage=None,
-            past_stage=stages.ProgramPast(
+            past_stage=ffront_stages.ProgramPast(
                 past_node=past_node,
                 closure_vars=closure_vars,
                 grid_type=self.grid_type,

--- a/src/gt4py/next/ffront/func_to_past.py
+++ b/src/gt4py/next/ffront/func_to_past.py
@@ -38,11 +38,11 @@ from gt4py.next.type_system import type_specifications as ts, type_translation
 
 
 @workflow.make_step
-def func_to_past(inp: ffront_stages.ProgramDefinition) -> ffront_stages.ProgramPast:
+def func_to_past(inp: ffront_stages.ProgramDefinition) -> ffront_stages.PastProgramDefinition:
     source_def = source_utils.SourceDefinition.from_function(inp.definition)
     closure_vars = source_utils.get_closure_vars_from_function(inp.definition)
     annotations = typing.get_type_hints(inp.definition)
-    return ffront_stages.ProgramPast(
+    return ffront_stages.PastProgramDefinition(
         past_node=ProgramParser.apply(source_def, closure_vars, annotations),
         closure_vars=closure_vars,
         grid_type=inp.grid_type,
@@ -51,17 +51,17 @@ def func_to_past(inp: ffront_stages.ProgramDefinition) -> ffront_stages.ProgramP
 
 @dataclasses.dataclass(frozen=True)
 class OptionalFuncToPast(workflow.SkippableStep):
-    step: workflow.Workflow[ffront_stages.ProgramDefinition, ffront_stages.ProgramPast] = (
-        func_to_past
-    )
+    step: workflow.Workflow[
+        ffront_stages.ProgramDefinition, ffront_stages.PastProgramDefinition
+    ] = func_to_past
 
     def skip_condition(
-        self, inp: ffront_stages.ProgramPast | ffront_stages.ProgramDefinition
+        self, inp: ffront_stages.PastProgramDefinition | ffront_stages.ProgramDefinition
     ) -> bool:
         match inp:
             case ffront_stages.ProgramDefinition():
                 return False
-            case ffront_stages.ProgramPast():
+            case ffront_stages.PastProgramDefinition():
                 return True
 
 

--- a/src/gt4py/next/ffront/func_to_past.py
+++ b/src/gt4py/next/ffront/func_to_past.py
@@ -27,6 +27,7 @@ from gt4py.next.ffront import (
     dialect_ast_enums,
     program_ast as past,
     source_utils,
+    stages as ffront_stages,
     type_specifications as ts_ffront,
 )
 from gt4py.next.ffront.dialect_parser import DialectParser
@@ -37,7 +38,7 @@ from gt4py.next.type_system import type_specifications as ts, type_translation
 
 
 @workflow.make_step
-def func_to_past(inp: stages.ProgramDefinition) -> stages.ProgramPast:
+def func_to_past(inp: ffront_stages.ProgramDefinition) -> stages.ProgramPast:
     source_def = source_utils.SourceDefinition.from_function(inp.definition)
     closure_vars = source_utils.get_closure_vars_from_function(inp.definition)
     annotations = typing.get_type_hints(inp.definition)
@@ -50,11 +51,11 @@ def func_to_past(inp: stages.ProgramDefinition) -> stages.ProgramPast:
 
 @dataclasses.dataclass(frozen=True)
 class OptionalFuncToPast(workflow.SkippableStep):
-    step: workflow.Workflow[stages.ProgramDefinition, stages.ProgramPast] = func_to_past
+    step: workflow.Workflow[ffront_stages.ProgramDefinition, stages.ProgramPast] = func_to_past
 
-    def skip_condition(self, inp: stages.ProgramPast | stages.ProgramDefinition) -> bool:
+    def skip_condition(self, inp: stages.ProgramPast | ffront_stages.ProgramDefinition) -> bool:
         match inp:
-            case stages.ProgramDefinition():
+            case ffront_stages.ProgramDefinition():
                 return False
             case stages.ProgramPast():
                 return True

--- a/src/gt4py/next/ffront/func_to_past.py
+++ b/src/gt4py/next/ffront/func_to_past.py
@@ -33,16 +33,16 @@ from gt4py.next.ffront import (
 from gt4py.next.ffront.dialect_parser import DialectParser
 from gt4py.next.ffront.past_passes.closure_var_type_deduction import ClosureVarTypeDeduction
 from gt4py.next.ffront.past_passes.type_deduction import ProgramTypeDeduction
-from gt4py.next.otf import stages, workflow
+from gt4py.next.otf import workflow
 from gt4py.next.type_system import type_specifications as ts, type_translation
 
 
 @workflow.make_step
-def func_to_past(inp: ffront_stages.ProgramDefinition) -> stages.ProgramPast:
+def func_to_past(inp: ffront_stages.ProgramDefinition) -> ffront_stages.ProgramPast:
     source_def = source_utils.SourceDefinition.from_function(inp.definition)
     closure_vars = source_utils.get_closure_vars_from_function(inp.definition)
     annotations = typing.get_type_hints(inp.definition)
-    return stages.ProgramPast(
+    return ffront_stages.ProgramPast(
         past_node=ProgramParser.apply(source_def, closure_vars, annotations),
         closure_vars=closure_vars,
         grid_type=inp.grid_type,
@@ -51,13 +51,17 @@ def func_to_past(inp: ffront_stages.ProgramDefinition) -> stages.ProgramPast:
 
 @dataclasses.dataclass(frozen=True)
 class OptionalFuncToPast(workflow.SkippableStep):
-    step: workflow.Workflow[ffront_stages.ProgramDefinition, stages.ProgramPast] = func_to_past
+    step: workflow.Workflow[ffront_stages.ProgramDefinition, ffront_stages.ProgramPast] = (
+        func_to_past
+    )
 
-    def skip_condition(self, inp: stages.ProgramPast | ffront_stages.ProgramDefinition) -> bool:
+    def skip_condition(
+        self, inp: ffront_stages.ProgramPast | ffront_stages.ProgramDefinition
+    ) -> bool:
         match inp:
             case ffront_stages.ProgramDefinition():
                 return False
-            case stages.ProgramPast():
+            case ffront_stages.ProgramPast():
                 return True
 
 

--- a/src/gt4py/next/ffront/func_to_past.py
+++ b/src/gt4py/next/ffront/func_to_past.py
@@ -19,6 +19,9 @@ import dataclasses
 import typing
 from typing import Any, cast
 
+import factory
+
+from gt4py.eve import utils as eve_utils
 from gt4py.next import errors
 from gt4py.next.ffront import (
     dialect_ast_enums,
@@ -55,6 +58,21 @@ class OptionalFuncToPast(workflow.SkippableStep):
                 return False
             case stages.ProgramPast():
                 return True
+
+
+class OptionalFuncToPastFactory(factory.Factory):
+    class Meta:
+        model = OptionalFuncToPast
+
+    class Params:
+        workflow = func_to_past
+        cached = factory.Trait(
+            step=factory.LazyAttribute(
+                lambda o: workflow.CachedStep(step=o.workflow, hash_function=eve_utils.content_hash)
+            )
+        )
+
+        step = factory.LazyAttribute(lambda o: o.workflow)
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/src/gt4py/next/ffront/past_process_args.py
+++ b/src/gt4py/next/ffront/past_process_args.py
@@ -15,20 +15,24 @@
 from typing import Any, Iterator, Optional
 
 from gt4py.next import common, errors
-from gt4py.next.ffront import program_ast as past, type_specifications as ts_ffront
-from gt4py.next.otf import stages, workflow
+from gt4py.next.ffront import (
+    program_ast as past,
+    stages as ffront_stages,
+    type_specifications as ts_ffront,
+)
+from gt4py.next.otf import workflow
 from gt4py.next.type_system import type_info, type_specifications as ts, type_translation
 
 
 @workflow.make_step
-def past_process_args(inp: stages.PastClosure) -> stages.PastClosure:
+def past_process_args(inp: ffront_stages.PastClosure) -> ffront_stages.PastClosure:
     extra_kwarg_names = ["offset_provider", "column_axis"]
     extra_kwargs = {k: v for k, v in inp.kwargs.items() if k in extra_kwarg_names}
     kwargs = {k: v for k, v in inp.kwargs.items() if k not in extra_kwarg_names}
     rewritten_args, size_args, kwargs = _process_args(
         past_node=inp.past_node, args=list(inp.args), kwargs=kwargs
     )
-    return stages.PastClosure(
+    return ffront_stages.PastClosure(
         past_node=inp.past_node,
         closure_vars=inp.closure_vars,
         grid_type=inp.grid_type,

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -27,6 +27,7 @@ from gt4py.next.ffront import (
     gtcallable,
     lowering_utils,
     program_ast as past,
+    stages as ffront_stages,
     transform_utils,
     type_specifications as ts_ffront,
 )
@@ -38,7 +39,7 @@ from gt4py.next.type_system import type_info, type_specifications as ts
 
 @dataclasses.dataclass(frozen=True)
 class PastToItir(workflow.ChainableWorkflowMixin):
-    def __call__(self, inp: stages.PastClosure) -> stages.ProgramCall:
+    def __call__(self, inp: ffront_stages.PastClosure) -> stages.ProgramCall:
         all_closure_vars = transform_utils._get_closure_vars_recursively(inp.closure_vars)
         offsets_and_dimensions = transform_utils._filter_closure_vars_by_type(
             all_closure_vars, fbuiltins.FieldOffset, common.Dimension

--- a/src/gt4py/next/ffront/stages.py
+++ b/src/gt4py/next/ffront/stages.py
@@ -29,7 +29,7 @@ class ProgramDefinition:
 
 
 @dataclasses.dataclass(frozen=True)
-class ProgramPast:
+class PastProgramDefinition:
     past_node: past.Program
     closure_vars: dict[str, Any]
     grid_type: Optional[common.GridType] = None

--- a/src/gt4py/next/ffront/stages.py
+++ b/src/gt4py/next/ffront/stages.py
@@ -16,12 +16,20 @@ from __future__ import annotations
 
 import dataclasses
 import types
-from typing import Optional
+from typing import Any, Optional
 
 from gt4py.next import common
+from gt4py.next.ffront import program_ast as past
 
 
 @dataclasses.dataclass(frozen=True)
 class ProgramDefinition:
     definition: types.FunctionType
+    grid_type: Optional[common.GridType] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ProgramPast:
+    past_node: past.Program
+    closure_vars: dict[str, Any]
     grid_type: Optional[common.GridType] = None

--- a/src/gt4py/next/ffront/stages.py
+++ b/src/gt4py/next/ffront/stages.py
@@ -1,0 +1,27 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2023, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import dataclasses
+import types
+from typing import Optional
+
+from gt4py.next import common
+
+
+@dataclasses.dataclass(frozen=True)
+class ProgramDefinition:
+    definition: types.FunctionType
+    grid_type: Optional[common.GridType] = None

--- a/src/gt4py/next/ffront/stages.py
+++ b/src/gt4py/next/ffront/stages.py
@@ -33,3 +33,12 @@ class PastProgramDefinition:
     past_node: past.Program
     closure_vars: dict[str, Any]
     grid_type: Optional[common.GridType] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class PastClosure:
+    closure_vars: dict[str, Any]
+    past_node: past.Program
+    grid_type: Optional[common.GridType]
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+from gt4py.next.ffront import stages as ffront_stages
 from gt4py.next.otf import stages, step_types, workflow
 
 
@@ -25,7 +26,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
 
     # TODO(ricoh): consider wrapping this in a CachedStep.
     func_to_past: workflow.SkippableStep[
-        stages.ProgramDefinition | stages.ProgramPast, stages.ProgramPast
+        ffront_stages.ProgramDefinition | stages.ProgramPast, stages.ProgramPast
     ]
     past_transform_args: workflow.Workflow[stages.PastClosure, stages.PastClosure]
     past_to_itir: workflow.Workflow[stages.PastClosure, stages.ProgramCall]
@@ -33,7 +34,9 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
     args: tuple[Any, ...] = dataclasses.field(default_factory=tuple)
     kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
 
-    def __call__(self, inp: stages.ProgramDefinition | stages.ProgramPast) -> stages.ProgramCall:
+    def __call__(
+        self, inp: ffront_stages.ProgramDefinition | stages.ProgramPast
+    ) -> stages.ProgramCall:
         past_stage = self.func_to_past(inp)
         return self.past_to_itir(
             self.past_transform_args(

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -29,8 +29,8 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
         ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
         ffront_stages.PastProgramDefinition,
     ]
-    past_transform_args: workflow.Workflow[stages.PastClosure, stages.PastClosure]
-    past_to_itir: workflow.Workflow[stages.PastClosure, stages.ProgramCall]
+    past_transform_args: workflow.Workflow[ffront_stages.PastClosure, ffront_stages.PastClosure]
+    past_to_itir: workflow.Workflow[ffront_stages.PastClosure, stages.ProgramCall]
 
     args: tuple[Any, ...] = dataclasses.field(default_factory=tuple)
     kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -42,7 +42,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
         past_stage = self.func_to_past(inp)
         return self.past_to_itir(
             self.past_transform_args(
-                stages.PastClosure(
+                ffront_stages.PastClosure(
                     past_node=past_stage.past_node,
                     closure_vars=past_stage.closure_vars,
                     grid_type=past_stage.grid_type,

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -23,6 +23,7 @@ from gt4py.next.otf import stages, step_types, workflow
 class ProgramTransformWorkflow(workflow.NamedStepSequence):
     """Modular workflow for transformations with access to intermediates."""
 
+    # TODO(ricoh): consider wrapping this in a CachedStep.
     func_to_past: workflow.SkippableStep[
         stages.ProgramDefinition | stages.ProgramPast, stages.ProgramPast
     ]

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -26,7 +26,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
 
     # TODO(ricoh): consider wrapping this in a CachedStep.
     func_to_past: workflow.SkippableStep[
-        ffront_stages.ProgramDefinition | stages.ProgramPast, stages.ProgramPast
+        ffront_stages.ProgramDefinition | ffront_stages.ProgramPast, ffront_stages.ProgramPast
     ]
     past_transform_args: workflow.Workflow[stages.PastClosure, stages.PastClosure]
     past_to_itir: workflow.Workflow[stages.PastClosure, stages.ProgramCall]
@@ -35,7 +35,8 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
     kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     def __call__(
-        self, inp: ffront_stages.ProgramDefinition | stages.ProgramPast
+        self,
+        inp: ffront_stages.ProgramDefinition | ffront_stages.ProgramPast,
     ) -> stages.ProgramCall:
         past_stage = self.func_to_past(inp)
         return self.past_to_itir(

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -26,7 +26,8 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
 
     # TODO(ricoh): consider wrapping this in a CachedStep.
     func_to_past: workflow.SkippableStep[
-        ffront_stages.ProgramDefinition | ffront_stages.ProgramPast, ffront_stages.ProgramPast
+        ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
+        ffront_stages.PastProgramDefinition,
     ]
     past_transform_args: workflow.Workflow[stages.PastClosure, stages.PastClosure]
     past_to_itir: workflow.Workflow[stages.PastClosure, stages.ProgramCall]
@@ -36,7 +37,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
 
     def __call__(
         self,
-        inp: ffront_stages.ProgramDefinition | ffront_stages.ProgramPast,
+        inp: ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
     ) -> stages.ProgramCall:
         past_stage = self.func_to_past(inp)
         return self.past_to_itir(

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -24,7 +24,6 @@ from gt4py.next.otf import stages, step_types, workflow
 class ProgramTransformWorkflow(workflow.NamedStepSequence):
     """Modular workflow for transformations with access to intermediates."""
 
-    # TODO(ricoh): consider wrapping this in a CachedStep.
     func_to_past: workflow.SkippableStep[
         ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
         ffront_stages.PastProgramDefinition,

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -26,6 +26,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
     func_to_past: workflow.SkippableStep[
         stages.ProgramDefinition | stages.ProgramPast, stages.ProgramPast
     ]
+    past_transform_args: workflow.Workflow[stages.PastClosure, stages.PastClosure]
     past_to_itir: workflow.Workflow[stages.PastClosure, stages.ProgramCall]
 
     args: tuple[Any, ...] = dataclasses.field(default_factory=tuple)
@@ -34,12 +35,14 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
     def __call__(self, inp: stages.ProgramDefinition | stages.ProgramPast) -> stages.ProgramCall:
         past_stage = self.func_to_past(inp)
         return self.past_to_itir(
-            stages.PastClosure(
-                past_node=past_stage.past_node,
-                closure_vars=past_stage.closure_vars,
-                grid_type=past_stage.grid_type,
-                args=self.args,
-                kwargs=self.kwargs,
+            self.past_transform_args(
+                stages.PastClosure(
+                    past_node=past_stage.past_node,
+                    closure_vars=past_stage.closure_vars,
+                    grid_type=past_stage.grid_type,
+                    args=self.args,
+                    kwargs=self.kwargs,
+                )
             )
         )
 

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -14,8 +14,34 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import Any
 
 from gt4py.next.otf import stages, step_types, workflow
+
+
+@dataclasses.dataclass(frozen=True)
+class ProgramTransformWorkflow(workflow.NamedStepSequence):
+    """Modular workflow for transformations with access to intermediates."""
+
+    func_to_past: workflow.SkippableStep[
+        stages.ProgramDefinition | stages.ProgramPast, stages.ProgramPast
+    ]
+    past_to_itir: workflow.Workflow[stages.PastClosure, stages.ProgramCall]
+
+    args: tuple[Any, ...] = dataclasses.field(default_factory=tuple)
+    kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def __call__(self, inp: stages.ProgramDefinition | stages.ProgramPast) -> stages.ProgramCall:
+        past_stage = self.func_to_past(inp)
+        return self.past_to_itir(
+            stages.PastClosure(
+                past_node=past_stage.past_node,
+                closure_vars=past_stage.closure_vars,
+                grid_type=past_stage.grid_type,
+                args=self.args,
+                kwargs=self.kwargs,
+            )
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/gt4py/next/otf/stages.py
+++ b/src/gt4py/next/otf/stages.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import dataclasses
-import types
 from typing import Any, Generic, Optional, Protocol, TypeVar
 
 from gt4py.next import common
@@ -31,12 +30,6 @@ SettingT = TypeVar("SettingT", bound=languages.LanguageSettings)
 SrcL_co = TypeVar("SrcL_co", bound=languages.LanguageTag, covariant=True)
 TgtL_co = TypeVar("TgtL_co", bound=languages.LanguageTag, covariant=True)
 SettingT_co = TypeVar("SettingT_co", bound=languages.LanguageSettings, covariant=True)
-
-
-@dataclasses.dataclass(frozen=True)
-class ProgramDefinition:
-    definition: types.FunctionType
-    grid_type: Optional[common.GridType] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/gt4py/next/otf/stages.py
+++ b/src/gt4py/next/otf/stages.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
+import types
 from typing import Any, Generic, Optional, Protocol, TypeVar
 
 from gt4py.next import common
@@ -33,10 +34,23 @@ SettingT_co = TypeVar("SettingT_co", bound=languages.LanguageSettings, covariant
 
 
 @dataclasses.dataclass(frozen=True)
+class ProgramDefinition:
+    definition: types.FunctionType
+    grid_type: Optional[common.GridType] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ProgramPast:
+    past_node: past.Program
+    closure_vars: dict[str, Any]
+    grid_type: Optional[common.GridType] = None
+
+
+@dataclasses.dataclass(frozen=True)
 class PastClosure:
     closure_vars: dict[str, Any]
     past_node: past.Program
-    grid_type: common.GridType
+    grid_type: Optional[common.GridType]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
 

--- a/src/gt4py/next/otf/stages.py
+++ b/src/gt4py/next/otf/stages.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Generic, Optional, Protocol, TypeVar
 
-from gt4py.next import common
-from gt4py.next.ffront import program_ast as past
 from gt4py.next.iterator import ir as itir
 from gt4py.next.otf import languages
 from gt4py.next.otf.binding import interface
@@ -30,15 +28,6 @@ SettingT = TypeVar("SettingT", bound=languages.LanguageSettings)
 SrcL_co = TypeVar("SrcL_co", bound=languages.LanguageTag, covariant=True)
 TgtL_co = TypeVar("TgtL_co", bound=languages.LanguageTag, covariant=True)
 SettingT_co = TypeVar("SettingT_co", bound=languages.LanguageSettings, covariant=True)
-
-
-@dataclasses.dataclass(frozen=True)
-class PastClosure:
-    closure_vars: dict[str, Any]
-    past_node: past.Program
-    grid_type: Optional[common.GridType]
-    args: tuple[Any, ...]
-    kwargs: dict[str, Any]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/gt4py/next/otf/stages.py
+++ b/src/gt4py/next/otf/stages.py
@@ -33,13 +33,6 @@ SettingT_co = TypeVar("SettingT_co", bound=languages.LanguageSettings, covariant
 
 
 @dataclasses.dataclass(frozen=True)
-class ProgramPast:
-    past_node: past.Program
-    closure_vars: dict[str, Any]
-    grid_type: Optional[common.GridType] = None
-
-
-@dataclasses.dataclass(frozen=True)
 class PastClosure:
     closure_vars: dict[str, Any]
     past_node: past.Program

--- a/src/gt4py/next/otf/workflow.py
+++ b/src/gt4py/next/otf/workflow.py
@@ -249,3 +249,19 @@ class CachedStep(
         except KeyError:
             result = self._cache[hash_] = self.step(inp)
         return result
+
+
+@dataclasses.dataclass(frozen=True)
+class SkippableStep(
+    ChainableWorkflowMixin[StartT, EndT],
+    ReplaceEnabledWorkflowMixin[StartT, EndT],
+):
+    step: Workflow[StartT, EndT]
+
+    def __call__(self, inp: StartT) -> EndT:
+        if not self.skip_condition(inp):
+            return self.step(inp)
+        return inp  # type: ignore[return-value]  # up to the implementer to make sure StartT == EndT
+
+    def skip_condition(self, inp: StartT) -> bool:
+        raise NotImplementedError()

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
@@ -45,7 +45,7 @@ def no_exec(program: itir.FencilDefinition, *args: Any, **kwargs: Any) -> None:
 
 
 class NoBackend(next_backend.Backend):
-    def __call__(self, program) -> None:
+    def __call__(self, program, *args, **kwargs) -> None:
         raise ValueError("No backend selected! Backend selection is mandatory in tests.")
 
 


### PR DESCRIPTION
## Description

### New:

- `recipes.ProgramTransformWorkflow`, a transform workflow with support for partial transforms by giving access to steps.
- `ffront.func_to_past.func_to_past`, a transform workflow step `stages.ProgramDefinition` -> `stages.ProgramPast`
- workflow stages:
  - `ProgramDefinition`: function object + grid type
  - `ProgramPast`: PAST node + closure vars + grid type

### Changed:

- `backend.Backend`:
  - `.transformer` is now specifically expected to be a `recipes.ProgramTransformWorkflow`, to allow partial transformations 
- `decorator.Program`:
  - data attributes: packed into `.definition_stage`, except for `.backend`.
  - properties: `.definition`, `.grid_type`, `.past_node`, `.closure_vars` provide access to the same data as before
  - new property: `.past_stage` (cached) does (argument-less) function -> PAST lowering on demand, using the backend's transform workflow if it exists.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
