### PR TITLE
feat[next][dace]: Filter unused connectivity tables

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -109,7 +109,7 @@ def _get_scan_dim(
 def _make_array_shape_and_strides(
     name: str,
     dims: Sequence[Dimension],
-    neighbor_tables: Mapping[str, NeighborTable],
+    offset_provider: Mapping[str, Any],
     sort_dims: bool,
 ) -> tuple[list[dace.symbol], list[dace.symbol]]:
     """
@@ -125,6 +125,7 @@ def _make_array_shape_and_strides(
     """
     dtype = dace.int32
     sorted_dims = get_sorted_dims(dims) if sort_dims else list(enumerate(dims))
+    neighbor_tables = {n: v for n, v in offset_provider.items() if isinstance(v, NeighborTable)}
     shape = [
         (
             neighbor_tables[dim.value].max_neighbors
@@ -185,12 +186,11 @@ class ItirToSDFG(eve.NodeVisitor):
         sdfg: dace.SDFG,
         name: str,
         type_: ts.TypeSpec,
-        neighbor_tables: Mapping[str, NeighborTable],
         sort_dimensions: bool,
     ):
         if isinstance(type_, ts.FieldType):
             shape, strides = _make_array_shape_and_strides(
-                name, type_.dims, neighbor_tables, sort_dimensions
+                name, type_.dims, self.offset_provider, sort_dimensions
             )
             dtype = as_dace_type(type_.dtype)
             sdfg.add_array(
@@ -316,7 +316,7 @@ class ItirToSDFG(eve.NodeVisitor):
         self.node_types = itir_typing.infer_all(node)
 
         # Filter neighbor tables from offset providers.
-        neighbor_tables = filter_neighbor_tables(self.offset_provider)
+        neighbor_tables = filter_neighbor_tables(node, self.offset_provider)
 
         # Add program parameters as SDFG storages.
         for param, type_ in zip(node.params, self.param_types):
@@ -324,7 +324,6 @@ class ItirToSDFG(eve.NodeVisitor):
                 program_sdfg,
                 str(param.id),
                 type_,
-                neighbor_tables,
                 self.use_field_canonical_representation,
             )
 
@@ -353,7 +352,6 @@ class ItirToSDFG(eve.NodeVisitor):
                 program_sdfg,
                 connectivity_identifier(offset),
                 type_,
-                neighbor_tables,
                 sort_dimensions=False,
             )
 
@@ -418,7 +416,7 @@ class ItirToSDFG(eve.NodeVisitor):
         closure_init_state = closure_sdfg.add_state_before(closure_state, "closure_init", True)
 
         input_names = [str(inp.id) for inp in node.inputs]
-        neighbor_tables = filter_neighbor_tables(self.offset_provider)
+        neighbor_tables = filter_neighbor_tables(node, self.offset_provider)
         connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 
         output_nodes = self.get_output_nodes(node, closure_sdfg, closure_state)
@@ -610,7 +608,7 @@ class ItirToSDFG(eve.NodeVisitor):
         )
 
         assert isinstance(node.output, SymRef)
-        neighbor_tables = filter_neighbor_tables(self.offset_provider)
+        neighbor_tables = filter_neighbor_tables(node, self.offset_provider)
         input_names = [str(inp.id) for inp in node.inputs]
         connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 
@@ -773,7 +771,7 @@ class ItirToSDFG(eve.NodeVisitor):
             tuple[str, tuple[ValueExpr | SymbolExpr, ValueExpr | SymbolExpr]], ...
         ],
     ) -> tuple[dace.SDFG, dict[str, str | dace.subsets.Subset], list[str]]:
-        neighbor_tables = filter_neighbor_tables(self.offset_provider)
+        neighbor_tables = filter_neighbor_tables(node, self.offset_provider)
         input_names = [str(inp.id) for inp in node.inputs]
         connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -1101,7 +1101,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                         store, self.context.body.arrays[store]
                     )
 
-        neighbor_tables = filter_neighbor_tables(node, self.offset_provider)
+        neighbor_tables = filter_neighbor_tables(node.fun, self.offset_provider)
         for offset in neighbor_tables.keys():
             var = connectivity_identifier(offset)
             nsdfg_inputs[var] = dace.Memlet.from_array(var, self.context.body.arrays[var])

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -35,8 +35,8 @@ from .utility import (
     as_dace_type,
     connectivity_identifier,
     dace_debuginfo,
-    filter_neighbor_tables,
     flatten_list,
+    get_used_neighbor_tables,
     map_nested_sdfg_symbols,
     new_array_symbols,
     unique_name,
@@ -234,7 +234,7 @@ def _visit_lift_in_neighbors_reduction(
             assert isinstance(y, ValueExpr)
             input_nodes[x] = y.value
 
-    neighbor_tables = filter_neighbor_tables(node.args[0], transformer.offset_provider)
+    neighbor_tables = get_used_neighbor_tables(node.args[0], transformer.offset_provider)
     connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 
     parent_sdfg = transformer.context.body
@@ -946,7 +946,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
     ]:
         func_name = f"lambda_{abs(hash(node)):x}"
         neighbor_tables = (
-            filter_neighbor_tables(node, self.offset_provider) if use_neighbor_tables else {}
+            get_used_neighbor_tables(node, self.offset_provider) if use_neighbor_tables else {}
         )
         connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 
@@ -1101,7 +1101,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                         store, self.context.body.arrays[store]
                     )
 
-        neighbor_tables = filter_neighbor_tables(node.fun, self.offset_provider)
+        neighbor_tables = get_used_neighbor_tables(node.fun, self.offset_provider)
         for offset in neighbor_tables.keys():
             var = connectivity_identifier(offset)
             nsdfg_inputs[var] = dace.Memlet.from_array(var, self.context.body.arrays[var])

--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_tasklet.py
@@ -234,7 +234,7 @@ def _visit_lift_in_neighbors_reduction(
             assert isinstance(y, ValueExpr)
             input_nodes[x] = y.value
 
-    neighbor_tables = filter_neighbor_tables(transformer.offset_provider)
+    neighbor_tables = filter_neighbor_tables(node.args[0], transformer.offset_provider)
     connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 
     parent_sdfg = transformer.context.body
@@ -946,7 +946,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
     ]:
         func_name = f"lambda_{abs(hash(node)):x}"
         neighbor_tables = (
-            filter_neighbor_tables(self.offset_provider) if use_neighbor_tables else {}
+            filter_neighbor_tables(node, self.offset_provider) if use_neighbor_tables else {}
         )
         connectivity_names = [connectivity_identifier(offset) for offset in neighbor_tables.keys()]
 
@@ -1101,7 +1101,7 @@ class PythonTaskletCodegen(gt4py.eve.codegen.TemplatedGenerator):
                         store, self.context.body.arrays[store]
                     )
 
-        neighbor_tables = filter_neighbor_tables(self.offset_provider)
+        neighbor_tables = filter_neighbor_tables(node, self.offset_provider)
         for offset in neighbor_tables.keys():
             var = connectivity_identifier(offset)
             nsdfg_inputs[var] = dace.Memlet.from_array(var, self.context.body.arrays[var])

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 import itertools
-from typing import Any, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 import dace
 
@@ -60,15 +60,20 @@ def as_scalar_type(typestr: str) -> ts.ScalarType:
     return ts.ScalarType(kind)
 
 
-def filter_neighbor_tables(
-    node: itir.Node, offset_provider: dict[str, Any]
-) -> dict[str, NeighborTable]:
-    offset_dims = set(eve.walk_values(node).if_isinstance(itir.OffsetLiteral).getattr("value"))
+def filter_neighbor_tables(offset_provider: Mapping[str, Any]) -> dict[str, NeighborTable]:
     return {
         offset: table
         for offset, table in offset_provider.items()
-        if isinstance(table, NeighborTable) and offset in offset_dims
+        if isinstance(table, NeighborTable)
     }
+
+
+def get_used_neighbor_tables(
+    node: itir.Node, offset_provider: Mapping[str, Any]
+) -> dict[str, NeighborTable]:
+    neighbor_tables = filter_neighbor_tables(offset_provider)
+    offset_dims = set(eve.walk_values(node).if_isinstance(itir.OffsetLiteral).getattr("value"))
+    return {offset: neighbor_tables[offset] for offset in offset_dims if offset in neighbor_tables}
 
 
 def connectivity_identifier(name: str) -> str:

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -16,14 +16,15 @@ from typing import Any, Optional, Sequence
 
 import dace
 
+import gt4py.next.iterator.ir as itir
+from gt4py import eve
 from gt4py.next import Dimension
 from gt4py.next.common import NeighborTable
-from gt4py.next.iterator.ir import Node
 from gt4py.next.type_system import type_specifications as ts
 
 
 def dace_debuginfo(
-    node: Node, debuginfo: Optional[dace.dtypes.DebugInfo] = None
+    node: itir.Node, debuginfo: Optional[dace.dtypes.DebugInfo] = None
 ) -> Optional[dace.dtypes.DebugInfo]:
     location = node.location
     if location:
@@ -59,11 +60,14 @@ def as_scalar_type(typestr: str) -> ts.ScalarType:
     return ts.ScalarType(kind)
 
 
-def filter_neighbor_tables(offset_provider: dict[str, Any]) -> dict[str, NeighborTable]:
+def filter_neighbor_tables(
+    node: itir.Node, offset_provider: dict[str, Any]
+) -> dict[str, NeighborTable]:
+    offset_dims = set(eve.walk_values(node).if_isinstance(itir.OffsetLiteral).getattr("value"))
     return {
         offset: table
         for offset, table in offset_provider.items()
-        if isinstance(table, NeighborTable)
+        if isinstance(table, NeighborTable) and offset in offset_dims
     }
 
 


### PR DESCRIPTION
During SDFG construction, only include the connectivity tables that are used by the stencil program. By convention, DaCe will not remove unnecessary data dependencies from program arguments.

Before this PR:
![Screenshot 2024-03-20 at 08 50 30](https://github.com/GridTools/gt4py/assets/25990065/f83ab684-0337-4b5b-bedb-d1a8a2eae57f)

with this PR:
![Screenshot 2024-03-20 at 08 50 49](https://github.com/GridTools/gt4py/assets/25990065/9fd776d8-9247-4f17-bad7-1a9ff7655c0a)
