### PR TITLE
feature[next]: Validate no dynamic offsets

### DIFF
--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -642,6 +642,15 @@ def collect_tmps_info(node: FencilWithTemporaries, *, offset_provider) -> Fencil
     )
 
 
+def validate_no_dynamic_offsets(node: ir.Node):
+    """Vaidate we have no dynamic offsets, e.g. `shift(Ioff, deref(...))(...)`"""
+    for call_node in node.walk_values().if_isinstance(ir.FunCall):
+        assert isinstance(call_node, ir.FunCall)
+        if call_node.fun == im.ref("shift"):
+            if any(not isinstance(arg, ir.OffsetLiteral) for arg in call_node.args):
+                raise NotImplementedError("Dynamic offsets not supported in temporary pass.")
+
+
 # TODO(tehrengruber): Add support for dynamic shifts (e.g. the distance is a symbol). This can be
 #  tricky: For every lift statement that is dynamically shifted we can not compute bounds anymore
 #  and hence also not extract as a temporary.
@@ -661,6 +670,8 @@ class CreateGlobalTmps(PreserveLocationVisitor, NodeTranslator):
         ] = None,
         symbolic_sizes: Optional[dict[str, str]],
     ) -> FencilWithTemporaries:
+        # Vaidate we have no dynamic offsets, e.g. `shift(Ioff, deref(...))(...)`
+        validate_no_dynamic_offsets(node)
         # Split closures on lifted function calls and introduce temporaries
         res = split_closures(
             node, offset_provider=offset_provider, extraction_heuristics=extraction_heuristics


### PR DESCRIPTION
Just a small PR that improves the error message of the temporary pass when there are dynamic offsets alla `shift(Ioff, deref(...))(...)`. This allows catching the error in Icon4Py and failing the respective codegen test gracefully.