### PR TITLE
feature[next]: Improve temporary extraction heuristics

### DIFF
--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -203,6 +203,7 @@ class SimpleTemporaryExtractionHeuristics:
                 contains_reduction = True
         if not contains_reduction and isinstance(expr, ir.FunCall) and len(expr.args) == 1:
             return False
+
         # extract if more than one shift
         shifts = self.closure_shifts[id(expr)]
         if len(shifts) > 1:


### PR DESCRIPTION
Improves the temporary extraction heuristics so that simple expression like `(↑(λ(it) → cast_(·it, float64)))(outer_it)` are inlined.

Blocked by some other problem fixed in #1414.