### PR TITLE
feature[next]: Improve ITIR constant folding

### DIFF
--- a/src/gt4py/next/iterator/transforms/constant_folding.py
+++ b/src/gt4py/next/iterator/transforms/constant_folding.py
@@ -28,6 +28,13 @@ class ConstantFolding(PreserveLocationVisitor, NodeTranslator):
 
         if (
             isinstance(new_node.fun, ir.SymRef)
+            and new_node.fun.id in ["minimum", "maximum"]
+            and new_node.args[0] == new_node.args[1]
+        ):  # minimum(a, a) -> a
+            return new_node.args[0]
+
+        if (
+            isinstance(new_node.fun, ir.SymRef)
             and new_node.fun.id == "if_"
             and isinstance(new_node.args[0], ir.Literal)
         ):  # `if_(True, true_branch, false_branch)` -> `true_branch`

--- a/src/gt4py/next/iterator/transforms/constant_folding.py
+++ b/src/gt4py/next/iterator/transforms/constant_folding.py
@@ -30,7 +30,7 @@ class ConstantFolding(PreserveLocationVisitor, NodeTranslator):
             isinstance(new_node.fun, ir.SymRef)
             and new_node.fun.id in ["minimum", "maximum"]
             and new_node.args[0] == new_node.args[1]
-        ):  # minimum(a, a) -> a
+        ):  # `minimum(a, a)` -> `a`
             return new_node.args[0]
 
         if (

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_constant_folding.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_constant_folding.py
@@ -45,3 +45,10 @@ def test_constant_folding_if():
     )
     actual = ConstantFolding.apply(testee)
     assert actual == expected
+
+
+def test_constant_folding_minimum():
+    testee = im.call("minimum")("a", "a")
+    expected = im.ref("a")
+    actual = ConstantFolding.apply(testee)
+    assert actual == expected


### PR DESCRIPTION
Improves constant folding in ITIR such that mimimum and maximum are eliminated in case the arguments are equal. This greatly simplifies the domain bounds expressions in ITIR that are computed by the temporary pass.