### PR TITLE
bug[next]: Fix gtfn code generation for negative literals

### DIFF
--- a/src/gt4py/next/program_processors/codegens/gtfn/codegen.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/codegen.py
@@ -109,14 +109,14 @@ class GTFNCodegen(codegen.TemplatedGenerator):
             case _:
                 result = node.value
         if node.type in ["bool", "int32", "int64", "float32", "float64"]:
-            # wrap into parenthesis such that `minus(1, -1)` does not get translated into `1--1`,
-            # but `(1)-(-1)`
-            result = f"({result})"
+            # add an extra space in the beginning such that `minus(1, -1)` does not get
+            # translated into `1--1`, but `1 - -1`
+            result = f" {result}"
         elif node.type == "axis_literal":
             pass
         else:
             raise NotImplementedError(
-                f"Literal type '{node.type}' is not supported in the code " f"generator"
+                f"Literal type '{node.type}' is not supported in the code generator"
             )
         return result
 

--- a/src/gt4py/next/program_processors/codegens/gtfn/codegen.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/codegen.py
@@ -101,29 +101,20 @@ class GTFNCodegen(codegen.TemplatedGenerator):
         # TODO(tehrengruber): isn't this wrong and int32 should be casted to an actual int32?
         match pytype_to_cpptype(node.type):
             case "float":
-                result = self.asfloat(node.value) + "f"
+                return self.asfloat(node.value) + "f"
             case "double":
-                result = self.asfloat(node.value)
+                return self.asfloat(node.value)
             case "bool":
-                result = node.value.lower()
+                return node.value.lower()
             case _:
-                result = node.value
-        if node.type in ["bool", "int32", "int64", "float32", "float64"]:
-            # add an extra space in the beginning such that `minus(1, -1)` does not get
-            # translated into `1--1`, but `1 - -1`
-            result = f" {result}"
-        elif node.type == "axis_literal":
-            pass
-        else:
-            raise NotImplementedError(
-                f"Literal type '{node.type}' is not supported in the code generator"
-            )
-        return result
+                return node.value
 
     IntegralConstant = as_fmt("{value}_c")
 
     UnaryExpr = as_fmt("{op}({expr})")
-    BinaryExpr = as_fmt("({lhs}{op}{rhs})")
+    # add an extra space between the operators is needed such that `minus(1, -1)` does not get
+    # translated into `1--1`, but `1 - -1`
+    BinaryExpr = as_fmt("({lhs} {op} {rhs})")
     TernaryExpr = as_fmt("({cond}?{true_expr}:{false_expr})")
     CastExpr = as_fmt("static_cast<{new_dtype}>({obj_expr})")
 


### PR DESCRIPTION
Add an extra space between the operators of BinOp such that `minus(1, -1)` does not get translated into `1--1`, but `1 - -1`.

While looking at that part of the code I was wondering whether there is another bug in that function namely that we don't case int32 literals to the respective C++ type.

I would add tests, but there seems to be no infrastructure for this. Should we leave it like that for now?