### PR TITLE
build: bump minimum version of typing_extensions requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   'pybind11>=2.10.1',
   'setuptools>=65.5.0',
   'tabulate>=0.8.10',
-  'typing-extensions>=4.2,<4.6.0',
+  'typing-extensions>=4.3.0,<4.6.0',
   'xxhash>=1.4.4,<3.1.0'
 ]
 description = 'Python library for generating high-performance implementations of stencil kernels for weather and climate modeling from a domain-specific language (DSL)'


### PR DESCRIPTION
typing_extensions 4.3.0 adds support for generic NamedTuples, which is now required in our codebase.
