### PR TITLE
refactor[next]: workflowify step3

### DIFF
--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -119,28 +119,9 @@ class Program:
         return next_backend.DEFAULT_TRANSFORMS.func_to_past(self.definition_stage)
 
     def __post_init__(self):
-        function_closure_vars = transform_utils._filter_closure_vars_by_type(
-            self.past_stage.closure_vars, GTCallable
-        )
-        misnamed_functions = [
-            f"{name} vs. {func.id}"
-            for name, func in function_closure_vars.items()
-            if name != func.__gt_itir__().id
-        ]
-        if misnamed_functions:
-            raise RuntimeError(
-                f"The following symbols resolve to a function with a mismatching name: {','.join(misnamed_functions)}."
-            )
-
-        undefined_symbols = [
-            symbol.id
-            for symbol in self.past_stage.past_node.closure_vars
-            if symbol.id not in self.past_stage.closure_vars
-        ]
-        if undefined_symbols:
-            raise RuntimeError(
-                f"The following closure variables are undefined: {', '.join(undefined_symbols)}."
-            )
+        if self.backend is not None and self.backend.transformer is not None:
+            self.backend.transformer.past_lint(self.past_stage)
+        return next_backend.DEFAULT_TRANSFORMS.past_lint(self.past_stage)
 
     @property
     def __name__(self) -> str:

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Any, Optional, cast
+from typing import Any, Optional, TypeVar, cast
 
 import gt4py.next.ffront.field_operator_ast as foast
 from gt4py.eve import NodeTranslator, NodeVisitor, traits
@@ -27,6 +27,9 @@ from gt4py.next.ffront import (  # noqa
 )
 from gt4py.next.ffront.foast_passes.utils import compute_assign_indices
 from gt4py.next.type_system import type_info, type_specifications as ts, type_translation
+
+
+OperatorNodeT = TypeVar("OperatorNodeT", bound=foast.LocatedNode)
 
 
 def with_altered_scalar_kind(
@@ -250,7 +253,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
     """
 
     @classmethod
-    def apply(cls, node: foast.FunctionDefinition) -> foast.FunctionDefinition:
+    def apply(cls, node: OperatorNodeT) -> OperatorNodeT:
         typed_foast_node = cls().visit(node)
 
         FieldOperatorTypeDeductionCompletnessValidator.apply(typed_foast_node)

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -23,6 +23,7 @@ from gt4py.next.ffront import (
     fbuiltins,
     field_operator_ast as foast,
     lowering_utils,
+    stages as ffront_stages,
     type_specifications as ts_ffront,
 )
 from gt4py.next.ffront.experimental import EXPERIMENTAL_FUN_BUILTIN_NAMES
@@ -31,6 +32,10 @@ from gt4py.next.ffront.foast_introspection import StmtReturnKind, deduce_stmt_re
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.type_system import type_info, type_specifications as ts
+
+
+def foast_to_itir(inp: ffront_stages.FoastOperatorDefinition) -> itir.Expr:
+    return FieldOperatorLowering.apply(inp.foast_node)
 
 
 def promote_to_list(

--- a/src/gt4py/next/ffront/func_to_foast.py
+++ b/src/gt4py/next/ffront/func_to_foast.py
@@ -16,11 +16,21 @@ from __future__ import annotations
 
 import ast
 import builtins
-from typing import Any, Callable, Iterable, Mapping, Type, cast
+import dataclasses
+import typing
+from typing import Any, Callable, Iterable, Mapping, Type
+
+import factory
 
 import gt4py.eve as eve
 from gt4py.next import errors
-from gt4py.next.ffront import dialect_ast_enums, fbuiltins, field_operator_ast as foast
+from gt4py.next.ffront import (
+    dialect_ast_enums,
+    fbuiltins,
+    field_operator_ast as foast,
+    source_utils,
+    stages as ffront_stages,
+)
 from gt4py.next.ffront.ast_passes import (
     SingleAssignTargetPass,
     SingleStaticAssignPass,
@@ -35,7 +45,72 @@ from gt4py.next.ffront.foast_passes.dead_closure_var_elimination import DeadClos
 from gt4py.next.ffront.foast_passes.iterable_unpack import UnpackedAssignPass
 from gt4py.next.ffront.foast_passes.type_alias_replacement import TypeAliasReplacement
 from gt4py.next.ffront.foast_passes.type_deduction import FieldOperatorTypeDeduction
+from gt4py.next.otf import workflow
 from gt4py.next.type_system import type_info, type_specifications as ts, type_translation
+
+
+@workflow.make_step
+def func_to_foast(
+    inp: ffront_stages.FieldOperatorDefinition[ffront_stages.OperatorNodeT],
+) -> ffront_stages.FoastOperatorDefinition[ffront_stages.OperatorNodeT]:
+    source_def = source_utils.SourceDefinition.from_function(inp.definition)
+    closure_vars = source_utils.get_closure_vars_from_function(inp.definition)
+    annotations = typing.get_type_hints(inp.definition)
+    foast_definition_node = FieldOperatorParser.apply(source_def, closure_vars, annotations)
+    loc = foast_definition_node.location
+    operator_attribute_nodes = {
+        key: foast.Constant(value=value, type=type_translation.from_value(value), location=loc)
+        for key, value in inp.attributes.items()
+    }
+    untyped_foast_node = inp.node_class(
+        id=foast_definition_node.id,
+        definition=foast_definition_node,
+        location=loc,
+        **operator_attribute_nodes,
+    )
+    foast_node = FieldOperatorTypeDeduction.apply(untyped_foast_node)
+    return ffront_stages.FoastOperatorDefinition(
+        foast_node=foast_node,
+        closure_vars=closure_vars,
+        grid_type=inp.grid_type,
+        attributes=inp.attributes,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class OptionalFuncToFoast(workflow.SkippableStep):
+    step: workflow.Workflow[
+        ffront_stages.FieldOperatorDefinition, ffront_stages.FoastOperatorDefinition
+    ] = func_to_foast
+
+    def skip_condition(
+        self, inp: ffront_stages.FieldOperatorDefinition | ffront_stages.FoastOperatorDefinition
+    ) -> bool:
+        match inp:
+            case ffront_stages.FieldOperatorDefinition():
+                return False
+            case ffront_stages.FoastOperatorDefinition():
+                return True
+
+
+@dataclasses.dataclass(frozen=True)
+class OptionalFuncToFoastFactory(factory.Factory):
+    class Meta:
+        model = OptionalFuncToFoast
+
+    class Params:
+        workflow: workflow.Workflow[
+            ffront_stages.FieldOperatorDefinition, ffront_stages.FoastOperatorDefinition
+        ] = func_to_foast
+        cached = factory.Trait(
+            step=factory.LazyAttribute(
+                lambda o: workflow.CachedStep(
+                    step=o.workflow, hash_function=ffront_stages.hash_field_operator_definition
+                )
+            )
+        )
+
+    step = factory.LazyAttribute(lambda o: o.workflow)
 
 
 class FieldOperatorParser(DialectParser[foast.FunctionDefinition]):
@@ -141,7 +216,7 @@ class FieldOperatorParser(DialectParser[foast.FunctionDefinition]):
                         ],  # this is a constraint type that will not be inferred (as the function is polymorphic)
                         pos_or_kw_args={},
                         kw_only_args={},
-                        returns=cast(ts.DataType, type_translation.from_type_hint(value)),
+                        returns=typing.cast(ts.DataType, type_translation.from_type_hint(value)),
                     ),
                     namespace=dialect_ast_enums.Namespace.CLOSURE,
                     location=location,

--- a/src/gt4py/next/ffront/past_passes/linters.py
+++ b/src/gt4py/next/ffront/past_passes/linters.py
@@ -26,7 +26,7 @@ def lint_misnamed_functions(
         inp.closure_vars, gtcallable.GTCallable
     )
     misnamed_functions = [
-        f"{name} vs. {func.id}"
+        f"{name} vs. {func.__gt_itir__().id}"
         for name, func in function_closure_vars.items()
         if name != func.__gt_itir__().id
     ]

--- a/src/gt4py/next/ffront/past_passes/linters.py
+++ b/src/gt4py/next/ffront/past_passes/linters.py
@@ -1,0 +1,59 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2023, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import factory
+
+from gt4py.next.ffront import gtcallable, stages as ffront_stages, transform_utils
+from gt4py.next.otf import workflow
+
+
+@workflow.make_step
+def lint_misnamed_functions(
+    inp: ffront_stages.PastProgramDefinition,
+) -> ffront_stages.PastProgramDefinition:
+    function_closure_vars = transform_utils._filter_closure_vars_by_type(
+        inp.closure_vars, gtcallable.GTCallable
+    )
+    misnamed_functions = [
+        f"{name} vs. {func.id}"
+        for name, func in function_closure_vars.items()
+        if name != func.__gt_itir__().id
+    ]
+    if misnamed_functions:
+        raise RuntimeError(
+            f"The following symbols resolve to a function with a mismatching name: {','.join(misnamed_functions)}."
+        )
+    return inp
+
+
+@workflow.make_step
+def lint_undefined_symbols(
+    inp: ffront_stages.PastProgramDefinition,
+) -> ffront_stages.PastProgramDefinition:
+    undefined_symbols = [
+        symbol.id for symbol in inp.past_node.closure_vars if symbol.id not in inp.closure_vars
+    ]
+    if undefined_symbols:
+        raise RuntimeError(
+            f"The following closure variables are undefined: {', '.join(undefined_symbols)}."
+        )
+    return inp
+
+
+class LinterFactory(factory.Factory):
+    class Meta:
+        model = workflow.CachedStep
+
+    step = lint_misnamed_functions.chain(lint_undefined_symbols)
+    hash_function = ffront_stages.hash_past_program_definition

--- a/src/gt4py/next/ffront/stages.py
+++ b/src/gt4py/next/ffront/stages.py
@@ -18,6 +18,7 @@ import dataclasses
 import types
 from typing import Any, Optional
 
+from gt4py.eve import utils as eve_utils
 from gt4py.next import common
 from gt4py.next.ffront import program_ast as past
 
@@ -42,3 +43,7 @@ class PastClosure:
     grid_type: Optional[common.GridType]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
+
+
+def hash_past_program_definition(past_definition: PastProgramDefinition) -> str:
+    return eve_utils.content_hash(past_definition.past_node, past_definition.grid_type)

--- a/src/gt4py/next/ffront/stages.py
+++ b/src/gt4py/next/ffront/stages.py
@@ -15,12 +15,49 @@
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import types
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 
 from gt4py.eve import utils as eve_utils
 from gt4py.next import common
-from gt4py.next.ffront import program_ast as past
+from gt4py.next.ffront import field_operator_ast as foast, program_ast as past
+
+
+OperatorNodeT = TypeVar("OperatorNodeT", bound=foast.LocatedNode)
+
+
+@dataclasses.dataclass(frozen=True)
+class FieldOperatorDefinition(Generic[OperatorNodeT]):
+    definition: types.FunctionType
+    grid_type: Optional[common.GridType] = None
+    node_class: type[OperatorNodeT] = dataclasses.field(default=foast.FieldOperator)  # type: ignore[assignment] # TODO(ricoh): understand why mypy complains
+    attributes: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+def hash_field_operator_definition(fieldop_definition: FieldOperatorDefinition) -> str:
+    return eve_utils.content_hash(
+        fieldop_definition.definition.__name__,
+        hash(fieldop_definition.definition),
+        inspect.getsourcelines(fieldop_definition.definition),
+        fieldop_definition.grid_type,
+        fieldop_definition.node_class,
+        fieldop_definition.attributes,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class FoastOperatorDefinition(Generic[OperatorNodeT]):
+    foast_node: OperatorNodeT
+    closure_vars: dict[str, Any]
+    grid_type: Optional[common.GridType] = None
+    attributes: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+def hash_foast_operator_definition(foast_definition: FoastOperatorDefinition) -> str:
+    return eve_utils.content_hash(
+        foast_definition.foast_node, foast_definition.grid_type, foast_definition.attributes
+    )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -36,6 +73,10 @@ class PastProgramDefinition:
     grid_type: Optional[common.GridType] = None
 
 
+def hash_past_program_definition(past_definition: PastProgramDefinition) -> str:
+    return eve_utils.content_hash(past_definition.past_node, past_definition.grid_type)
+
+
 @dataclasses.dataclass(frozen=True)
 class PastClosure:
     closure_vars: dict[str, Any]
@@ -43,7 +84,3 @@ class PastClosure:
     grid_type: Optional[common.GridType]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
-
-
-def hash_past_program_definition(past_definition: PastProgramDefinition) -> str:
-    return eve_utils.content_hash(past_definition.past_node, past_definition.grid_type)

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
 
 from gt4py.next.ffront import stages as ffront_stages
 from gt4py.next.otf import stages, step_types, workflow
@@ -28,28 +27,14 @@ class ProgramTransformWorkflow(workflow.NamedStepSequence):
         ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
         ffront_stages.PastProgramDefinition,
     ]
+    past_lint: workflow.Workflow[
+        ffront_stages.PastProgramDefinition, ffront_stages.PastProgramDefinition
+    ]
+    past_inject_args: workflow.Workflow[
+        ffront_stages.PastProgramDefinition, ffront_stages.PastClosure
+    ]
     past_transform_args: workflow.Workflow[ffront_stages.PastClosure, ffront_stages.PastClosure]
     past_to_itir: workflow.Workflow[ffront_stages.PastClosure, stages.ProgramCall]
-
-    args: tuple[Any, ...] = dataclasses.field(default_factory=tuple)
-    kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
-
-    def __call__(
-        self,
-        inp: ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
-    ) -> stages.ProgramCall:
-        past_stage = self.func_to_past(inp)
-        return self.past_to_itir(
-            self.past_transform_args(
-                ffront_stages.PastClosure(
-                    past_node=past_stage.past_node,
-                    closure_vars=past_stage.closure_vars,
-                    grid_type=past_stage.grid_type,
-                    args=self.args,
-                    kwargs=self.kwargs,
-                )
-            )
-        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/gt4py/next/otf/recipes.py
+++ b/src/gt4py/next/otf/recipes.py
@@ -16,7 +16,19 @@ from __future__ import annotations
 import dataclasses
 
 from gt4py.next.ffront import stages as ffront_stages
+from gt4py.next.iterator import ir as itir
 from gt4py.next.otf import stages, step_types, workflow
+
+
+@dataclasses.dataclass(frozen=True)
+class FieldopTransformWorkflow(workflow.NamedStepSequence):
+    """Modular workflow for transformations with access to intermediates."""
+
+    func_to_foast: workflow.SkippableStep[
+        ffront_stages.FieldOperatorDefinition | ffront_stages.FoastOperatorDefinition,
+        ffront_stages.FoastOperatorDefinition,
+    ]
+    foast_to_itir: workflow.Workflow[ffront_stages.FoastOperatorDefinition, itir.Expr]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_foast_pretty_printer.py
@@ -69,7 +69,7 @@ def test_fieldop():
         """
     ).strip()
 
-    assert pretty_format(bar.foast_node) == expected
+    assert pretty_format(bar.foast_stage.foast_node) == expected
 
 
 def test_scanop():
@@ -89,4 +89,4 @@ def test_scanop():
         """
     ).strip()
 
-    assert pretty_format(scan.foast_node) == expected
+    assert pretty_format(scan.foast_stage.foast_node) == expected

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_builtin_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_builtin_execution.py
@@ -18,9 +18,13 @@ from typing import Callable, Optional
 import numpy as np
 import pytest
 
-import gt4py.next as gtx
-from gt4py.next.ffront import dialect_ast_enums, fbuiltins, field_operator_ast as foast
-from gt4py.next.ffront.decorator import FieldOperator
+from gt4py.next.ffront import (
+    decorator,
+    dialect_ast_enums,
+    fbuiltins,
+    field_operator_ast as foast,
+    stages as ffront_stages,
+)
 from gt4py.next.ffront.foast_passes.type_deduction import FieldOperatorTypeDeduction
 from gt4py.next.program_processors import processor_interface as ppi
 from gt4py.next.type_system import type_translation
@@ -107,12 +111,14 @@ def make_builtin_field_operator(builtin_name: str, backend: Optional[ppi.Program
     )
     typed_foast_node = FieldOperatorTypeDeduction.apply(foast_node)
 
-    return FieldOperator(
-        foast_node=typed_foast_node,
-        closure_vars=closure_vars,
-        definition=None,
+    return decorator.FieldOperatorFromFoast(
+        definition_stage=None,
+        foast_stage=ffront_stages.FoastOperatorDefinition(
+            foast_node=typed_foast_node,
+            closure_vars=closure_vars,
+            grid_type=None,
+        ),
         backend=backend,
-        grid_type=None,
     )
 
 


### PR DESCRIPTION
## Description

### New:

- `ffront.stages.FieldOperatorDefinition`
  - all the data to start the toolchain from a field operator dsl definition

- `ffront.stages.FoastOperatorDefinition`
  - data after lowering from field operator dsl code

### Changed:

- `decorator.Program.__post_init__`
  - implementation moved to `past_passes.linters` workflow steps
  - linting stage added to program transforms

- `decorator.FieldOperator.from_function`
  - implementation moved to workflow step in `ffront.func_to_foast`

- `decorator.FieldOperator` data attributes
  - added: `definition_stage`
  - removed:
    - `.foast_node`: replaced with `.foast_stage.foast_node`
    - `.definition`: replaced with `.definition_stage.definition`

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
