### PR TITLE
build: bump required typing_extensions version to skip buggy versions

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -103,7 +103,7 @@ mypy==1.9.0               # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
 nanobind==1.9.2           # via gt4py (pyproject.toml)
 nbclient==0.6.8           # via nbmake
-nbformat==5.10.3          # via jupytext, nbclient, nbmake
+nbformat==5.10.4          # via jupytext, nbclient, nbmake
 nbmake==1.5.3             # via -r requirements-dev.in
 nest-asyncio==1.6.0       # via ipykernel, nbclient
 networkx==3.1             # via dace

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -113,6 +113,6 @@ tabulate==0.8.10
 tomli==2.0.1; python_version < "3.11"
 tox==3.2.0
 types-all==1.0.0
-typing-extensions==4.6.0
+typing-extensions==4.10.0
 xxhash==1.4.4
 ##[[[end]]]

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -106,6 +106,6 @@ tabulate==0.8.10
 tomli==2.0.1; python_version < "3.11"
 tox==3.2.0
 types-all==1.0.0
-typing-extensions==4.6.0
+typing-extensions==4.10.0
 xxhash==1.4.4
 ##[[[end]]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   'pybind11>=2.10.1',
   'setuptools>=65.5.0',
   'tabulate>=0.8.10',
-  'typing-extensions>=4.6.0',
+  'typing-extensions>=4.10.0',
   'xxhash>=1.4.4,<3.1.0'
 ]
 description = 'Python library for generating high-performance implementations of stencil kernels for weather and climate modeling from a domain-specific language (DSL)'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -103,7 +103,7 @@ mypy==1.9.0               # via -c constraints.txt, -r requirements-dev.in
 mypy-extensions==1.0.0    # via -c constraints.txt, black, mypy
 nanobind==1.9.2           # via -c constraints.txt, gt4py (pyproject.toml)
 nbclient==0.6.8           # via -c constraints.txt, nbmake
-nbformat==5.10.3          # via -c constraints.txt, jupytext, nbclient, nbmake
+nbformat==5.10.4          # via -c constraints.txt, jupytext, nbclient, nbmake
 nbmake==1.5.3             # via -c constraints.txt, -r requirements-dev.in
 nest-asyncio==1.6.0       # via -c constraints.txt, ipykernel, nbclient
 networkx==3.1             # via -c constraints.txt, dace


### PR DESCRIPTION
Skip typing_extensions versions 4.6 - to 4.9 which have problems in the Protocol class.