### PR TITLE
ci[cartesian]: env var on CSCS-CI to suppress cuda backend deprecation error

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -96,6 +96,7 @@ test py38:
     SLURM_TIMELIMIT: 120
     NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
+    GT4PY_GTC_ENABLE_CUDA: 1
     <<: *py38
 
 test py39:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -83,7 +83,7 @@ test py38:
   script:
   - cd /gt4py.src
   - python -c "import cupy"
-  - tox run -e $SUBPACKAGE-$PYVERSION_PREFIX$VARIANT$SUBVARIANT
+  - tox run -e $SUBPACKAGE-$PYVERSION_PREFIX$VARIANT$SUBVARIANT -- --instafail
   parallel:
     matrix:
     - SUBPACKAGE: [cartesian, storage]
@@ -96,7 +96,6 @@ test py38:
     SLURM_TIMELIMIT: 120
     NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
-    GT4PY_GTC_ENABLE_CUDA: 1
     <<: *py38
 
 test py39:

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,16 +7,18 @@
 aenum==3.1.15             # via dace
 alabaster==0.7.13         # via sphinx
 annotated-types==0.6.0    # via pydantic
+appnope==0.1.4            # via ipykernel, ipython
 asttokens==2.4.1          # via devtools, stack-data
 astunparse==1.6.3 ; python_version < "3.9"  # via dace, gt4py (pyproject.toml)
 attrs==23.2.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, referencing
 babel==2.14.0             # via sphinx
 backcall==0.2.0           # via ipython
-black==24.3.0             # via gt4py (pyproject.toml)
-blinker==1.7.0            # via flask
+black==24.4.2             # via gt4py (pyproject.toml)
+blinker==1.8.1            # via flask
 boltons==24.0.0           # via gt4py (pyproject.toml)
+bracex==2.4               # via wcmatch
 build==1.2.1              # via pip-tools
-bump-my-version==0.20.0   # via -r requirements-dev.in
+bump-my-version==0.21.0   # via -r requirements-dev.in
 cached-property==1.5.2    # via gt4py (pyproject.toml)
 cachetools==5.3.3         # via tox
 certifi==2024.2.2         # via requests
@@ -24,14 +26,14 @@ cffi==1.16.0              # via cryptography
 cfgv==3.4.0               # via pre-commit
 chardet==5.2.0            # via tox
 charset-normalizer==3.3.2  # via requests
-clang-format==18.1.2      # via -r requirements-dev.in, gt4py (pyproject.toml)
+clang-format==18.1.4      # via -r requirements-dev.in, gt4py (pyproject.toml)
 click==8.1.7              # via black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
-cmake==3.29.0.1           # via gt4py (pyproject.toml)
+cmake==3.29.2             # via gt4py (pyproject.toml)
 cogapp==3.4.1             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
 comm==0.2.2               # via ipykernel
 contourpy==1.1.1          # via matplotlib
-coverage==7.4.4           # via -r requirements-dev.in, pytest-cov
+coverage==7.5.0           # via -r requirements-dev.in, pytest-cov
 cryptography==42.0.5      # via types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via matplotlib
 cytoolz==0.12.3           # via gt4py (pyproject.toml)
@@ -39,36 +41,36 @@ dace==0.15.1              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
 debugpy==1.8.1            # via ipykernel
 decorator==5.1.1          # via ipython
-deepdiff==6.7.1           # via gt4py (pyproject.toml)
+deepdiff==7.0.1           # via gt4py (pyproject.toml)
 devtools==0.12.2          # via gt4py (pyproject.toml)
 dill==0.3.8               # via dace
 distlib==0.3.8            # via virtualenv
 docutils==0.20.1          # via restructuredtext-lint, sphinx, sphinx-rtd-theme
 eradicate==2.3.0          # via flake8-eradicate
-exceptiongroup==1.2.0     # via hypothesis, pytest
-execnet==2.0.2            # via pytest-cache, pytest-xdist
+exceptiongroup==1.2.1     # via hypothesis, pytest
+execnet==2.1.1            # via pytest-cache, pytest-xdist
 executing==2.0.1          # via devtools, stack-data
 factory-boy==3.3.0        # via gt4py (pyproject.toml), pytest-factoryboy
-faker==24.4.0             # via factory-boy
+faker==25.0.1             # via factory-boy
 fastjsonschema==2.19.1    # via nbformat
-filelock==3.13.3          # via tox, virtualenv
+filelock==3.14.0          # via tox, virtualenv
 flake8==7.0.0             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
-flake8-bugbear==24.2.6    # via -r requirements-dev.in
-flake8-builtins==2.4.0    # via -r requirements-dev.in
+flake8-bugbear==24.4.26   # via -r requirements-dev.in
+flake8-builtins==2.5.0    # via -r requirements-dev.in
 flake8-debugger==4.1.2    # via -r requirements-dev.in
 flake8-docstrings==1.7.0  # via -r requirements-dev.in
 flake8-eradicate==1.5.0   # via -r requirements-dev.in
 flake8-mutable==1.2.0     # via -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -r requirements-dev.in
-flask==3.0.2              # via dace
-fonttools==4.50.0         # via matplotlib
+flask==3.0.3              # via dace
+fonttools==4.51.0         # via matplotlib
 fparser==0.1.4            # via dace
-frozendict==2.4.1         # via gt4py (pyproject.toml)
+frozendict==2.4.2         # via gt4py (pyproject.toml)
 gridtools-cpp==2.3.2      # via gt4py (pyproject.toml)
-hypothesis==6.100.0       # via -r requirements-dev.in, gt4py (pyproject.toml)
-identify==2.5.35          # via pre-commit
-idna==3.6                 # via requests
+hypothesis==6.100.2       # via -r requirements-dev.in, gt4py (pyproject.toml)
+identify==2.5.36          # via pre-commit
+idna==3.7                 # via requests
 imagesize==1.4.1          # via sphinx
 importlib-metadata==7.1.0  # via build, flask, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
@@ -77,29 +79,29 @@ iniconfig==2.0.0          # via pytest
 ipykernel==6.29.4         # via nbmake
 ipython==8.12.3           # via ipykernel
 isort==5.13.2             # via -r requirements-dev.in
-itsdangerous==2.1.2       # via flask
+itsdangerous==2.2.0       # via flask
 jax==0.4.13               # via gt4py (pyproject.toml)
 jaxlib==0.4.13            # via jax
 jedi==0.19.1              # via ipython
 jinja2==3.1.3             # via flask, gt4py (pyproject.toml), sphinx
-jsonschema==4.21.1        # via nbformat
+jsonschema==4.22.0        # via nbformat
 jsonschema-specifications==2023.12.1  # via jsonschema
 jupyter-client==8.6.1     # via ipykernel, nbclient
 jupyter-core==5.7.2       # via ipykernel, jupyter-client, nbformat
 jupytext==1.16.1          # via -r requirements-dev.in
 kiwisolver==1.4.5         # via matplotlib
 lark==1.1.9               # via gt4py (pyproject.toml)
-mako==1.3.2               # via gt4py (pyproject.toml)
+mako==1.3.3               # via gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via jupytext, mdit-py-plugins, rich
 markupsafe==2.1.5         # via jinja2, mako, werkzeug
 matplotlib==3.7.5         # via -r requirements-dev.in
-matplotlib-inline==0.1.6  # via ipykernel, ipython
+matplotlib-inline==0.1.7  # via ipykernel, ipython
 mccabe==0.7.0             # via flake8
 mdit-py-plugins==0.4.0    # via jupytext
 mdurl==0.1.2              # via markdown-it-py
 ml-dtypes==0.2.0          # via jax, jaxlib
 mpmath==1.3.0             # via sympy
-mypy==1.9.0               # via -r requirements-dev.in
+mypy==1.10.0              # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
 nanobind==1.9.2           # via gt4py (pyproject.toml)
 nbclient==0.6.8           # via nbmake
@@ -112,17 +114,17 @@ nodeenv==1.8.0            # via pre-commit
 numpy==1.24.4             # via contourpy, dace, gt4py (pyproject.toml), jax, jaxlib, matplotlib, ml-dtypes, opt-einsum, scipy, types-jack-client
 opt-einsum==3.3.0         # via jax
 ordered-set==4.1.0        # via deepdiff
-packaging==24.0           # via black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
-parso==0.8.3              # via jedi
+packaging==24.0           # via black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
+parso==0.8.4              # via jedi
 pathspec==0.12.1          # via black
 pexpect==4.9.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pillow==10.3.0            # via matplotlib
 pip-tools==7.4.1          # via -r requirements-dev.in
-pipdeptree==2.16.2        # via -r requirements-dev.in
+pipdeptree==2.19.1        # via -r requirements-dev.in
 pkgutil-resolve-name==1.3.10  # via jsonschema
-platformdirs==4.2.0       # via black, jupyter-core, tox, virtualenv
-pluggy==1.4.0             # via pytest, tox
+platformdirs==4.2.1       # via black, jupyter-core, tox, virtualenv
+pluggy==1.5.0             # via pytest, tox
 ply==3.11                 # via dace
 pre-commit==3.5.0         # via -r requirements-dev.in
 prompt-toolkit==3.0.36    # via ipython, questionary
@@ -132,33 +134,34 @@ pure-eval==0.2.2          # via stack-data
 pybind11==2.12.0          # via gt4py (pyproject.toml)
 pycodestyle==2.11.1       # via flake8, flake8-debugger
 pycparser==2.22           # via cffi
-pydantic==2.6.4           # via bump-my-version, pydantic-settings
-pydantic-core==2.16.3     # via pydantic
+pydantic==2.7.1           # via bump-my-version, pydantic-settings
+pydantic-core==2.18.2     # via pydantic
 pydantic-settings==2.2.1  # via bump-my-version
 pydocstyle==6.3.0         # via flake8-docstrings
 pyflakes==3.2.0           # via flake8
 pygments==2.17.2          # via -r requirements-dev.in, devtools, flake8-rst-docstrings, ipython, nbmake, rich, sphinx
 pyparsing==3.1.2          # via matplotlib
 pyproject-api==1.6.1      # via tox
-pyproject-hooks==1.0.0    # via build, pip-tools
-pytest==8.1.1             # via -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-xdist
+pyproject-hooks==1.1.0    # via build, pip-tools
+pytest==8.2.0             # via -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-instafail, pytest-xdist
 pytest-cache==1.0         # via -r requirements-dev.in
 pytest-cov==5.0.0         # via -r requirements-dev.in
 pytest-factoryboy==2.7.0  # via -r requirements-dev.in
-pytest-xdist==3.5.0       # via -r requirements-dev.in
+pytest-instafail==0.5.0   # via -r requirements-dev.in
+pytest-xdist==3.6.1       # via -r requirements-dev.in
 python-dateutil==2.9.0.post0  # via faker, jupyter-client, matplotlib
 python-dotenv==1.0.1      # via pydantic-settings
 pytz==2024.1              # via babel
 pyyaml==6.0.1             # via dace, jupytext, pre-commit
-pyzmq==25.1.2             # via ipykernel, jupyter-client
+pyzmq==26.0.3             # via ipykernel, jupyter-client
 questionary==2.0.1        # via bump-my-version
-referencing==0.34.0       # via jsonschema, jsonschema-specifications
+referencing==0.35.1       # via jsonschema, jsonschema-specifications
 requests==2.31.0          # via dace, sphinx
 restructuredtext-lint==1.4.0  # via flake8-rst-docstrings
 rich==13.7.1              # via bump-my-version, rich-click
-rich-click==1.7.4         # via bump-my-version
+rich-click==1.8.0         # via bump-my-version
 rpds-py==0.18.0           # via jsonschema, referencing
-ruff==0.3.5               # via -r requirements-dev.in
+ruff==0.4.2               # via -r requirements-dev.in
 scipy==1.10.1             # via gt4py (pyproject.toml), jax, jaxlib
 setuptools-scm==8.0.4     # via fparser
 six==1.16.0               # via asttokens, astunparse, python-dateutil
@@ -177,12 +180,12 @@ stack-data==0.6.3         # via ipython
 sympy==1.9                # via dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via gt4py (pyproject.toml)
 toml==0.10.2              # via jupytext
-tomli==2.0.1 ; python_version < "3.11"  # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, mypy, pip-tools, pyproject-api, pyproject-hooks, pytest, setuptools-scm, tox
+tomli==2.0.1 ; python_version < "3.11"  # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.4           # via bump-my-version
 toolz==0.12.1             # via cytoolz
 tornado==6.4              # via ipykernel, jupyter-client
-tox==4.14.2               # via -r requirements-dev.in
-traitlets==5.14.2         # via comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
+tox==4.15.0               # via -r requirements-dev.in
+traitlets==5.14.3         # via comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
 types-aiofiles==23.2.0.20240403  # via types-all
 types-all==1.0.0          # via -r requirements-dev.in
 types-annoy==1.17.8.4     # via types-all
@@ -193,22 +196,22 @@ types-bleach==6.1.0.20240331  # via types-all
 types-boto==2.49.18.20240205  # via types-all
 types-cachetools==5.3.0.7  # via types-all
 types-certifi==2021.10.8.3  # via types-all
-types-cffi==1.16.0.20240331  # via types-jack-client
+types-cffi==1.16.0.20240331  # via types-jack-client, types-pyopenssl
 types-characteristic==14.3.7  # via types-all
 types-chardet==5.0.4.6    # via types-all
 types-click==7.1.8        # via types-all, types-flask
 types-click-spinner==0.1.13.20240311  # via types-all
 types-colorama==0.4.15.20240311  # via types-all
 types-contextvars==2.4.7.3  # via types-all
-types-croniter==2.0.0.20240321  # via types-all
+types-croniter==2.0.0.20240423  # via types-all
 types-cryptography==3.3.23.2  # via types-all, types-openssl-python, types-pyjwt
 types-dataclasses==0.6.6  # via types-all
-types-dateparser==1.1.4.20240331  # via types-all
+types-dateparser==1.2.0.20240420  # via types-all
 types-datetimerange==2.0.0.6  # via types-all
 types-decorator==5.1.8.20240310  # via types-all
 types-deprecated==1.2.9.20240311  # via types-all
 types-docopt==0.6.11.4    # via types-all
-types-docutils==0.20.0.20240331  # via types-all
+types-docutils==0.21.0.20240423  # via types-all
 types-emoji==2.1.0.3      # via types-all
 types-enum34==1.1.8       # via types-all
 types-fb303==1.0.0        # via types-all, types-scribe
@@ -222,47 +225,47 @@ types-geoip2==3.0.0       # via types-all
 types-html5lib==1.1.11.20240228  # via types-bleach
 types-ipaddress==1.0.8    # via types-all, types-maxminddb
 types-itsdangerous==1.1.6  # via types-all
-types-jack-client==0.5.10.20240106  # via types-all
+types-jack-client==0.5.10.20240425  # via types-all
 types-jinja2==2.11.9      # via types-all, types-flask
 types-kazoo==0.1.3        # via types-all
 types-markdown==3.6.0.20240316  # via types-all
 types-markupsafe==1.1.10  # via types-all, types-jinja2
 types-maxminddb==1.5.0    # via types-all, types-geoip2
-types-mock==5.1.0.20240311  # via types-all
+types-mock==5.1.0.20240425  # via types-all
 types-mypy-extensions==1.0.0.20240311  # via types-all
 types-nmap==0.1.6         # via types-all
 types-openssl-python==0.1.3  # via types-all
 types-orjson==3.6.2       # via types-all
-types-paramiko==3.4.0.20240311  # via types-all, types-pysftp
+types-paramiko==3.4.0.20240423  # via types-all, types-pysftp
 types-pathlib2==2.3.0     # via types-all
-types-pillow==10.2.0.20240331  # via types-all
+types-pillow==10.2.0.20240423  # via types-all
 types-pkg-resources==0.1.3  # via types-all
 types-polib==1.2.0.20240327  # via types-all
-types-protobuf==4.24.0.20240311  # via types-all
-types-pyaudio==0.2.16.20240106  # via types-all
-types-pycurl==7.45.2.20240311  # via types-all
+types-protobuf==5.26.0.20240422  # via types-all
+types-pyaudio==0.2.16.20240425  # via types-all
+types-pycurl==7.45.3.20240421  # via types-all
 types-pyfarmhash==0.3.1.20240311  # via types-all
 types-pyjwt==1.7.1        # via types-all
 types-pymssql==2.1.0      # via types-all
-types-pymysql==1.1.0.1    # via types-all
-types-pyopenssl==24.0.0.20240311  # via types-redis
+types-pymysql==1.1.0.20240425  # via types-all
+types-pyopenssl==24.1.0.20240425  # via types-redis
 types-pyrfc3339==1.1.1.5  # via types-all
 types-pysftp==0.2.17.20240106  # via types-all
 types-python-dateutil==2.9.0.20240316  # via types-all, types-datetimerange
 types-python-gflags==3.1.7.3  # via types-all
 types-python-slugify==8.0.2.20240310  # via types-all
-types-pytz==2024.1.0.20240203  # via types-all, types-tzlocal
+types-pytz==2024.1.0.20240417  # via types-all, types-tzlocal
 types-pyvmomi==8.0.0.6    # via types-all
 types-pyyaml==6.0.12.20240311  # via types-all
-types-redis==4.6.0.20240311  # via types-all
-types-requests==2.31.0.20240403  # via types-all
+types-redis==4.6.0.20240425  # via types-all
+types-requests==2.31.0.20240406  # via types-all
 types-retry==0.9.9.4      # via types-all
 types-routes==2.5.0       # via types-all
 types-scribe==2.0.0       # via types-all
-types-setuptools==69.2.0.20240317  # via types-cffi
+types-setuptools==69.5.0.20240423  # via types-cffi
 types-simplejson==3.19.0.20240310  # via types-all
 types-singledispatch==4.1.0.0  # via types-all
-types-six==1.16.21.20240311  # via types-all
+types-six==1.16.21.20240425  # via types-all
 types-tabulate==0.9.0.20240106  # via types-all
 types-termcolor==1.1.6.2  # via types-all
 types-toml==0.10.8.20240310  # via types-all
@@ -270,12 +273,13 @@ types-tornado==5.1.1      # via types-all
 types-typed-ast==1.5.8.7  # via types-all
 types-tzlocal==5.1.0.1    # via types-all
 types-ujson==5.9.0.0      # via types-all
-types-waitress==2.1.4.20240106  # via types-all
+types-waitress==3.0.0.20240423  # via types-all
 types-werkzeug==1.0.9     # via types-all, types-flask
 types-xxhash==3.0.5.2     # via types-all
-typing-extensions==4.10.0  # via annotated-types, black, faker, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
+typing-extensions==4.11.0  # via annotated-types, black, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
 urllib3==2.2.1            # via requests, types-requests
-virtualenv==20.25.1       # via pre-commit, tox
+virtualenv==20.26.1       # via pre-commit, tox
+wcmatch==8.5.1            # via bump-my-version
 wcwidth==0.2.13           # via prompt-toolkit
 websockets==12.0          # via dace
 werkzeug==3.0.2           # via flask
@@ -285,4 +289,4 @@ zipp==3.18.1              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0                 # via pip-tools, pipdeptree
-setuptools==69.2.0        # via gt4py (pyproject.toml), nodeenv, pip-tools, setuptools-scm
+setuptools==69.5.1        # via gt4py (pyproject.toml), nodeenv, pip-tools, setuptools-scm

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -101,6 +101,7 @@ pygments==2.7.3
 pytest-cache==1.0
 pytest-cov==2.8
 pytest-factoryboy==2.0.3
+pytest-instafail==0.5.0
 pytest-xdist[psutil]==2.4
 pytest==7.0
 ruff==0.2.0

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -96,6 +96,7 @@ pygments==2.7.3
 pytest-cache==1.0
 pytest-cov==2.8
 pytest-factoryboy==2.0.3
+pytest-instafail==0.5.0
 pytest-xdist[psutil]==2.4
 pytest==7.0
 ruff==0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ module = 'gt4py.next.iterator.runtime'
 [tool.pytest]
 
 [tool.pytest.ini_options]
+addopts = "--instafail"
 filterwarnings = [
   "ignore::UserWarning"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,9 @@ module = 'gt4py.next.iterator.runtime'
 [tool.pytest]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+  "ignore::UserWarning"
+]
 markers = [
   'requires_atlas: tests that require `atlas4py` bindings package',
   'requires_dace: tests that require `dace` package',

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -35,6 +35,7 @@ pytest-cache>=1.0
 pytest-cov>=2.8
 pytest-factoryboy>=2.0.3
 pytest-xdist[psutil]>=2.4
+pytest-instafail>=0.5.0
 ruff>=0.2.0
 sphinx>=4.4
 sphinx_rtd_theme>=1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,16 +7,18 @@
 aenum==3.1.15             # via -c constraints.txt, dace
 alabaster==0.7.13         # via -c constraints.txt, sphinx
 annotated-types==0.6.0    # via -c constraints.txt, pydantic
+appnope==0.1.4            # via -c constraints.txt, ipykernel, ipython
 asttokens==2.4.1          # via -c constraints.txt, devtools, stack-data
 astunparse==1.6.3 ; python_version < "3.9"  # via -c constraints.txt, dace, gt4py (pyproject.toml)
 attrs==23.2.0             # via -c constraints.txt, flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, referencing
 babel==2.14.0             # via -c constraints.txt, sphinx
 backcall==0.2.0           # via -c constraints.txt, ipython
-black==24.3.0             # via -c constraints.txt, gt4py (pyproject.toml)
-blinker==1.7.0            # via -c constraints.txt, flask
+black==24.4.2             # via -c constraints.txt, gt4py (pyproject.toml)
+blinker==1.8.1            # via -c constraints.txt, flask
 boltons==24.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
+bracex==2.4               # via -c constraints.txt, wcmatch
 build==1.2.1              # via -c constraints.txt, pip-tools
-bump-my-version==0.20.0   # via -c constraints.txt, -r requirements-dev.in
+bump-my-version==0.21.0   # via -c constraints.txt, -r requirements-dev.in
 cached-property==1.5.2    # via -c constraints.txt, gt4py (pyproject.toml)
 cachetools==5.3.3         # via -c constraints.txt, tox
 certifi==2024.2.2         # via -c constraints.txt, requests
@@ -24,14 +26,14 @@ cffi==1.16.0              # via -c constraints.txt, cryptography
 cfgv==3.4.0               # via -c constraints.txt, pre-commit
 chardet==5.2.0            # via -c constraints.txt, tox
 charset-normalizer==3.3.2  # via -c constraints.txt, requests
-clang-format==18.1.2      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
+clang-format==18.1.4      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
 click==8.1.7              # via -c constraints.txt, black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
-cmake==3.29.0.1           # via -c constraints.txt, gt4py (pyproject.toml)
+cmake==3.29.2             # via -c constraints.txt, gt4py (pyproject.toml)
 cogapp==3.4.1             # via -c constraints.txt, -r requirements-dev.in
 colorama==0.4.6           # via -c constraints.txt, tox
 comm==0.2.2               # via -c constraints.txt, ipykernel
 contourpy==1.1.1          # via -c constraints.txt, matplotlib
-coverage[toml]==7.4.4     # via -c constraints.txt, -r requirements-dev.in, pytest-cov
+coverage[toml]==7.5.0     # via -c constraints.txt, -r requirements-dev.in, pytest-cov
 cryptography==42.0.5      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==0.12.3           # via -c constraints.txt, gt4py (pyproject.toml)
@@ -39,36 +41,36 @@ dace==0.15.1              # via -c constraints.txt, gt4py (pyproject.toml)
 darglint==1.8.1           # via -c constraints.txt, -r requirements-dev.in
 debugpy==1.8.1            # via -c constraints.txt, ipykernel
 decorator==5.1.1          # via -c constraints.txt, ipython
-deepdiff==6.7.1           # via -c constraints.txt, gt4py (pyproject.toml)
+deepdiff==7.0.1           # via -c constraints.txt, gt4py (pyproject.toml)
 devtools==0.12.2          # via -c constraints.txt, gt4py (pyproject.toml)
 dill==0.3.8               # via -c constraints.txt, dace
 distlib==0.3.8            # via -c constraints.txt, virtualenv
 docutils==0.20.1          # via -c constraints.txt, restructuredtext-lint, sphinx, sphinx-rtd-theme
 eradicate==2.3.0          # via -c constraints.txt, flake8-eradicate
-exceptiongroup==1.2.0     # via -c constraints.txt, hypothesis, pytest
-execnet==2.0.2            # via -c constraints.txt, pytest-cache, pytest-xdist
+exceptiongroup==1.2.1     # via -c constraints.txt, hypothesis, pytest
+execnet==2.1.1            # via -c constraints.txt, pytest-cache, pytest-xdist
 executing==2.0.1          # via -c constraints.txt, devtools, stack-data
 factory-boy==3.3.0        # via -c constraints.txt, gt4py (pyproject.toml), pytest-factoryboy
-faker==24.4.0             # via -c constraints.txt, factory-boy
+faker==25.0.1             # via -c constraints.txt, factory-boy
 fastjsonschema==2.19.1    # via -c constraints.txt, nbformat
-filelock==3.13.3          # via -c constraints.txt, tox, virtualenv
+filelock==3.14.0          # via -c constraints.txt, tox, virtualenv
 flake8==7.0.0             # via -c constraints.txt, -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
-flake8-bugbear==24.2.6    # via -c constraints.txt, -r requirements-dev.in
-flake8-builtins==2.4.0    # via -c constraints.txt, -r requirements-dev.in
+flake8-bugbear==24.4.26   # via -c constraints.txt, -r requirements-dev.in
+flake8-builtins==2.5.0    # via -c constraints.txt, -r requirements-dev.in
 flake8-debugger==4.1.2    # via -c constraints.txt, -r requirements-dev.in
 flake8-docstrings==1.7.0  # via -c constraints.txt, -r requirements-dev.in
 flake8-eradicate==1.5.0   # via -c constraints.txt, -r requirements-dev.in
 flake8-mutable==1.2.0     # via -c constraints.txt, -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -c constraints.txt, -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -c constraints.txt, -r requirements-dev.in
-flask==3.0.2              # via -c constraints.txt, dace
-fonttools==4.50.0         # via -c constraints.txt, matplotlib
+flask==3.0.3              # via -c constraints.txt, dace
+fonttools==4.51.0         # via -c constraints.txt, matplotlib
 fparser==0.1.4            # via -c constraints.txt, dace
-frozendict==2.4.1         # via -c constraints.txt, gt4py (pyproject.toml)
+frozendict==2.4.2         # via -c constraints.txt, gt4py (pyproject.toml)
 gridtools-cpp==2.3.2      # via -c constraints.txt, gt4py (pyproject.toml)
-hypothesis==6.100.0       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
-identify==2.5.35          # via -c constraints.txt, pre-commit
-idna==3.6                 # via -c constraints.txt, requests
+hypothesis==6.100.2       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
+identify==2.5.36          # via -c constraints.txt, pre-commit
+idna==3.7                 # via -c constraints.txt, requests
 imagesize==1.4.1          # via -c constraints.txt, sphinx
 importlib-metadata==7.1.0  # via -c constraints.txt, build, flask, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via -c constraints.txt, gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
@@ -77,29 +79,29 @@ iniconfig==2.0.0          # via -c constraints.txt, pytest
 ipykernel==6.29.4         # via -c constraints.txt, nbmake
 ipython==8.12.3           # via -c constraints.txt, ipykernel
 isort==5.13.2             # via -c constraints.txt, -r requirements-dev.in
-itsdangerous==2.1.2       # via -c constraints.txt, flask
+itsdangerous==2.2.0       # via -c constraints.txt, flask
 jax[cpu]==0.4.13          # via -c constraints.txt, gt4py (pyproject.toml)
 jaxlib==0.4.13            # via -c constraints.txt, jax
 jedi==0.19.1              # via -c constraints.txt, ipython
 jinja2==3.1.3             # via -c constraints.txt, flask, gt4py (pyproject.toml), sphinx
-jsonschema==4.21.1        # via -c constraints.txt, nbformat
+jsonschema==4.22.0        # via -c constraints.txt, nbformat
 jsonschema-specifications==2023.12.1  # via -c constraints.txt, jsonschema
 jupyter-client==8.6.1     # via -c constraints.txt, ipykernel, nbclient
 jupyter-core==5.7.2       # via -c constraints.txt, ipykernel, jupyter-client, nbformat
 jupytext==1.16.1          # via -c constraints.txt, -r requirements-dev.in
 kiwisolver==1.4.5         # via -c constraints.txt, matplotlib
 lark==1.1.9               # via -c constraints.txt, gt4py (pyproject.toml)
-mako==1.3.2               # via -c constraints.txt, gt4py (pyproject.toml)
+mako==1.3.3               # via -c constraints.txt, gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via -c constraints.txt, jupytext, mdit-py-plugins, rich
 markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako, werkzeug
 matplotlib==3.7.5         # via -c constraints.txt, -r requirements-dev.in
-matplotlib-inline==0.1.6  # via -c constraints.txt, ipykernel, ipython
+matplotlib-inline==0.1.7  # via -c constraints.txt, ipykernel, ipython
 mccabe==0.7.0             # via -c constraints.txt, flake8
 mdit-py-plugins==0.4.0    # via -c constraints.txt, jupytext
 mdurl==0.1.2              # via -c constraints.txt, markdown-it-py
 ml-dtypes==0.2.0          # via -c constraints.txt, jax, jaxlib
 mpmath==1.3.0             # via -c constraints.txt, sympy
-mypy==1.9.0               # via -c constraints.txt, -r requirements-dev.in
+mypy==1.10.0              # via -c constraints.txt, -r requirements-dev.in
 mypy-extensions==1.0.0    # via -c constraints.txt, black, mypy
 nanobind==1.9.2           # via -c constraints.txt, gt4py (pyproject.toml)
 nbclient==0.6.8           # via -c constraints.txt, nbmake
@@ -112,17 +114,17 @@ nodeenv==1.8.0            # via -c constraints.txt, pre-commit
 numpy==1.24.4             # via -c constraints.txt, contourpy, dace, gt4py (pyproject.toml), jax, jaxlib, matplotlib, ml-dtypes, opt-einsum, scipy, types-jack-client
 opt-einsum==3.3.0         # via -c constraints.txt, jax
 ordered-set==4.1.0        # via -c constraints.txt, deepdiff
-packaging==24.0           # via -c constraints.txt, black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
-parso==0.8.3              # via -c constraints.txt, jedi
+packaging==24.0           # via -c constraints.txt, black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
+parso==0.8.4              # via -c constraints.txt, jedi
 pathspec==0.12.1          # via -c constraints.txt, black
 pexpect==4.9.0            # via -c constraints.txt, ipython
 pickleshare==0.7.5        # via -c constraints.txt, ipython
 pillow==10.3.0            # via -c constraints.txt, matplotlib
 pip-tools==7.4.1          # via -c constraints.txt, -r requirements-dev.in
-pipdeptree==2.16.2        # via -c constraints.txt, -r requirements-dev.in
+pipdeptree==2.19.1        # via -c constraints.txt, -r requirements-dev.in
 pkgutil-resolve-name==1.3.10  # via -c constraints.txt, jsonschema
-platformdirs==4.2.0       # via -c constraints.txt, black, jupyter-core, tox, virtualenv
-pluggy==1.4.0             # via -c constraints.txt, pytest, tox
+platformdirs==4.2.1       # via -c constraints.txt, black, jupyter-core, tox, virtualenv
+pluggy==1.5.0             # via -c constraints.txt, pytest, tox
 ply==3.11                 # via -c constraints.txt, dace
 pre-commit==3.5.0         # via -c constraints.txt, -r requirements-dev.in
 prompt-toolkit==3.0.36    # via -c constraints.txt, ipython, questionary
@@ -132,33 +134,34 @@ pure-eval==0.2.2          # via -c constraints.txt, stack-data
 pybind11==2.12.0          # via -c constraints.txt, gt4py (pyproject.toml)
 pycodestyle==2.11.1       # via -c constraints.txt, flake8, flake8-debugger
 pycparser==2.22           # via -c constraints.txt, cffi
-pydantic==2.6.4           # via -c constraints.txt, bump-my-version, pydantic-settings
-pydantic-core==2.16.3     # via -c constraints.txt, pydantic
+pydantic==2.7.1           # via -c constraints.txt, bump-my-version, pydantic-settings
+pydantic-core==2.18.2     # via -c constraints.txt, pydantic
 pydantic-settings==2.2.1  # via -c constraints.txt, bump-my-version
 pydocstyle==6.3.0         # via -c constraints.txt, flake8-docstrings
 pyflakes==3.2.0           # via -c constraints.txt, flake8
 pygments==2.17.2          # via -c constraints.txt, -r requirements-dev.in, devtools, flake8-rst-docstrings, ipython, nbmake, rich, sphinx
 pyparsing==3.1.2          # via -c constraints.txt, matplotlib
 pyproject-api==1.6.1      # via -c constraints.txt, tox
-pyproject-hooks==1.0.0    # via -c constraints.txt, build, pip-tools
-pytest==8.1.1             # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-xdist
+pyproject-hooks==1.1.0    # via -c constraints.txt, build, pip-tools
+pytest==8.2.0             # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-instafail, pytest-xdist
 pytest-cache==1.0         # via -c constraints.txt, -r requirements-dev.in
 pytest-cov==5.0.0         # via -c constraints.txt, -r requirements-dev.in
 pytest-factoryboy==2.7.0  # via -c constraints.txt, -r requirements-dev.in
-pytest-xdist[psutil]==3.5.0  # via -c constraints.txt, -r requirements-dev.in
+pytest-instafail==0.5.0   # via -c constraints.txt, -r requirements-dev.in
+pytest-xdist[psutil]==3.6.1  # via -c constraints.txt, -r requirements-dev.in
 python-dateutil==2.9.0.post0  # via -c constraints.txt, faker, jupyter-client, matplotlib
 python-dotenv==1.0.1      # via -c constraints.txt, pydantic-settings
 pytz==2024.1              # via -c constraints.txt, babel
 pyyaml==6.0.1             # via -c constraints.txt, dace, jupytext, pre-commit
-pyzmq==25.1.2             # via -c constraints.txt, ipykernel, jupyter-client
+pyzmq==26.0.3             # via -c constraints.txt, ipykernel, jupyter-client
 questionary==2.0.1        # via -c constraints.txt, bump-my-version
-referencing==0.34.0       # via -c constraints.txt, jsonschema, jsonschema-specifications
+referencing==0.35.1       # via -c constraints.txt, jsonschema, jsonschema-specifications
 requests==2.31.0          # via -c constraints.txt, dace, sphinx
 restructuredtext-lint==1.4.0  # via -c constraints.txt, flake8-rst-docstrings
 rich==13.7.1              # via -c constraints.txt, bump-my-version, rich-click
-rich-click==1.7.4         # via -c constraints.txt, bump-my-version
+rich-click==1.8.0         # via -c constraints.txt, bump-my-version
 rpds-py==0.18.0           # via -c constraints.txt, jsonschema, referencing
-ruff==0.3.5               # via -c constraints.txt, -r requirements-dev.in
+ruff==0.4.2               # via -c constraints.txt, -r requirements-dev.in
 scipy==1.10.1             # via -c constraints.txt, jax, jaxlib
 setuptools-scm==8.0.4     # via -c constraints.txt, fparser
 six==1.16.0               # via -c constraints.txt, asttokens, astunparse, python-dateutil
@@ -177,12 +180,12 @@ stack-data==0.6.3         # via -c constraints.txt, ipython
 sympy==1.9                # via -c constraints.txt, dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via -c constraints.txt, gt4py (pyproject.toml)
 toml==0.10.2              # via -c constraints.txt, jupytext
-tomli==2.0.1 ; python_version < "3.11"  # via -c constraints.txt, -r requirements-dev.in, black, build, coverage, flake8-pyproject, mypy, pip-tools, pyproject-api, pyproject-hooks, pytest, setuptools-scm, tox
+tomli==2.0.1 ; python_version < "3.11"  # via -c constraints.txt, -r requirements-dev.in, black, build, coverage, flake8-pyproject, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.4           # via -c constraints.txt, bump-my-version
 toolz==0.12.1             # via -c constraints.txt, cytoolz
 tornado==6.4              # via -c constraints.txt, ipykernel, jupyter-client
-tox==4.14.2               # via -c constraints.txt, -r requirements-dev.in
-traitlets==5.14.2         # via -c constraints.txt, comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
+tox==4.15.0               # via -c constraints.txt, -r requirements-dev.in
+traitlets==5.14.3         # via -c constraints.txt, comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
 types-aiofiles==23.2.0.20240403  # via -c constraints.txt, types-all
 types-all==1.0.0          # via -c constraints.txt, -r requirements-dev.in
 types-annoy==1.17.8.4     # via -c constraints.txt, types-all
@@ -193,22 +196,22 @@ types-bleach==6.1.0.20240331  # via -c constraints.txt, types-all
 types-boto==2.49.18.20240205  # via -c constraints.txt, types-all
 types-cachetools==5.3.0.7  # via -c constraints.txt, types-all
 types-certifi==2021.10.8.3  # via -c constraints.txt, types-all
-types-cffi==1.16.0.20240331  # via -c constraints.txt, types-jack-client
+types-cffi==1.16.0.20240331  # via -c constraints.txt, types-jack-client, types-pyopenssl
 types-characteristic==14.3.7  # via -c constraints.txt, types-all
 types-chardet==5.0.4.6    # via -c constraints.txt, types-all
 types-click==7.1.8        # via -c constraints.txt, types-all, types-flask
 types-click-spinner==0.1.13.20240311  # via -c constraints.txt, types-all
 types-colorama==0.4.15.20240311  # via -c constraints.txt, types-all
 types-contextvars==2.4.7.3  # via -c constraints.txt, types-all
-types-croniter==2.0.0.20240321  # via -c constraints.txt, types-all
+types-croniter==2.0.0.20240423  # via -c constraints.txt, types-all
 types-cryptography==3.3.23.2  # via -c constraints.txt, types-all, types-openssl-python, types-pyjwt
 types-dataclasses==0.6.6  # via -c constraints.txt, types-all
-types-dateparser==1.1.4.20240331  # via -c constraints.txt, types-all
+types-dateparser==1.2.0.20240420  # via -c constraints.txt, types-all
 types-datetimerange==2.0.0.6  # via -c constraints.txt, types-all
 types-decorator==5.1.8.20240310  # via -c constraints.txt, types-all
 types-deprecated==1.2.9.20240311  # via -c constraints.txt, types-all
 types-docopt==0.6.11.4    # via -c constraints.txt, types-all
-types-docutils==0.20.0.20240331  # via -c constraints.txt, types-all
+types-docutils==0.21.0.20240423  # via -c constraints.txt, types-all
 types-emoji==2.1.0.3      # via -c constraints.txt, types-all
 types-enum34==1.1.8       # via -c constraints.txt, types-all
 types-fb303==1.0.0        # via -c constraints.txt, types-all, types-scribe
@@ -222,47 +225,47 @@ types-geoip2==3.0.0       # via -c constraints.txt, types-all
 types-html5lib==1.1.11.20240228  # via -c constraints.txt, types-bleach
 types-ipaddress==1.0.8    # via -c constraints.txt, types-all, types-maxminddb
 types-itsdangerous==1.1.6  # via -c constraints.txt, types-all
-types-jack-client==0.5.10.20240106  # via -c constraints.txt, types-all
+types-jack-client==0.5.10.20240425  # via -c constraints.txt, types-all
 types-jinja2==2.11.9      # via -c constraints.txt, types-all, types-flask
 types-kazoo==0.1.3        # via -c constraints.txt, types-all
 types-markdown==3.6.0.20240316  # via -c constraints.txt, types-all
 types-markupsafe==1.1.10  # via -c constraints.txt, types-all, types-jinja2
 types-maxminddb==1.5.0    # via -c constraints.txt, types-all, types-geoip2
-types-mock==5.1.0.20240311  # via -c constraints.txt, types-all
+types-mock==5.1.0.20240425  # via -c constraints.txt, types-all
 types-mypy-extensions==1.0.0.20240311  # via -c constraints.txt, types-all
 types-nmap==0.1.6         # via -c constraints.txt, types-all
 types-openssl-python==0.1.3  # via -c constraints.txt, types-all
 types-orjson==3.6.2       # via -c constraints.txt, types-all
-types-paramiko==3.4.0.20240311  # via -c constraints.txt, types-all, types-pysftp
+types-paramiko==3.4.0.20240423  # via -c constraints.txt, types-all, types-pysftp
 types-pathlib2==2.3.0     # via -c constraints.txt, types-all
-types-pillow==10.2.0.20240331  # via -c constraints.txt, types-all
+types-pillow==10.2.0.20240423  # via -c constraints.txt, types-all
 types-pkg-resources==0.1.3  # via -c constraints.txt, types-all
 types-polib==1.2.0.20240327  # via -c constraints.txt, types-all
-types-protobuf==4.24.0.20240311  # via -c constraints.txt, types-all
-types-pyaudio==0.2.16.20240106  # via -c constraints.txt, types-all
-types-pycurl==7.45.2.20240311  # via -c constraints.txt, types-all
+types-protobuf==5.26.0.20240422  # via -c constraints.txt, types-all
+types-pyaudio==0.2.16.20240425  # via -c constraints.txt, types-all
+types-pycurl==7.45.3.20240421  # via -c constraints.txt, types-all
 types-pyfarmhash==0.3.1.20240311  # via -c constraints.txt, types-all
 types-pyjwt==1.7.1        # via -c constraints.txt, types-all
 types-pymssql==2.1.0      # via -c constraints.txt, types-all
-types-pymysql==1.1.0.1    # via -c constraints.txt, types-all
-types-pyopenssl==24.0.0.20240311  # via -c constraints.txt, types-redis
+types-pymysql==1.1.0.20240425  # via -c constraints.txt, types-all
+types-pyopenssl==24.1.0.20240425  # via -c constraints.txt, types-redis
 types-pyrfc3339==1.1.1.5  # via -c constraints.txt, types-all
 types-pysftp==0.2.17.20240106  # via -c constraints.txt, types-all
 types-python-dateutil==2.9.0.20240316  # via -c constraints.txt, types-all, types-datetimerange
 types-python-gflags==3.1.7.3  # via -c constraints.txt, types-all
 types-python-slugify==8.0.2.20240310  # via -c constraints.txt, types-all
-types-pytz==2024.1.0.20240203  # via -c constraints.txt, types-all, types-tzlocal
+types-pytz==2024.1.0.20240417  # via -c constraints.txt, types-all, types-tzlocal
 types-pyvmomi==8.0.0.6    # via -c constraints.txt, types-all
 types-pyyaml==6.0.12.20240311  # via -c constraints.txt, types-all
-types-redis==4.6.0.20240311  # via -c constraints.txt, types-all
-types-requests==2.31.0.20240403  # via -c constraints.txt, types-all
+types-redis==4.6.0.20240425  # via -c constraints.txt, types-all
+types-requests==2.31.0.20240406  # via -c constraints.txt, types-all
 types-retry==0.9.9.4      # via -c constraints.txt, types-all
 types-routes==2.5.0       # via -c constraints.txt, types-all
 types-scribe==2.0.0       # via -c constraints.txt, types-all
-types-setuptools==69.2.0.20240317  # via -c constraints.txt, types-cffi
+types-setuptools==69.5.0.20240423  # via -c constraints.txt, types-cffi
 types-simplejson==3.19.0.20240310  # via -c constraints.txt, types-all
 types-singledispatch==4.1.0.0  # via -c constraints.txt, types-all
-types-six==1.16.21.20240311  # via -c constraints.txt, types-all
+types-six==1.16.21.20240425  # via -c constraints.txt, types-all
 types-tabulate==0.9.0.20240106  # via -c constraints.txt, types-all
 types-termcolor==1.1.6.2  # via -c constraints.txt, types-all
 types-toml==0.10.8.20240310  # via -c constraints.txt, types-all
@@ -270,12 +273,13 @@ types-tornado==5.1.1      # via -c constraints.txt, types-all
 types-typed-ast==1.5.8.7  # via -c constraints.txt, types-all
 types-tzlocal==5.1.0.1    # via -c constraints.txt, types-all
 types-ujson==5.9.0.0      # via -c constraints.txt, types-all
-types-waitress==2.1.4.20240106  # via -c constraints.txt, types-all
+types-waitress==3.0.0.20240423  # via -c constraints.txt, types-all
 types-werkzeug==1.0.9     # via -c constraints.txt, types-all, types-flask
 types-xxhash==3.0.5.2     # via -c constraints.txt, types-all
-typing-extensions==4.10.0  # via -c constraints.txt, annotated-types, black, faker, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
+typing-extensions==4.11.0  # via -c constraints.txt, annotated-types, black, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
 urllib3==2.2.1            # via -c constraints.txt, requests, types-requests
-virtualenv==20.25.1       # via -c constraints.txt, pre-commit, tox
+virtualenv==20.26.1       # via -c constraints.txt, pre-commit, tox
+wcmatch==8.5.1            # via -c constraints.txt, bump-my-version
 wcwidth==0.2.13           # via -c constraints.txt, prompt-toolkit
 websockets==12.0          # via -c constraints.txt, dace
 werkzeug==3.0.2           # via -c constraints.txt, flask
@@ -285,4 +289,4 @@ zipp==3.18.1              # via -c constraints.txt, importlib-metadata, importli
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0                 # via -c constraints.txt, pip-tools, pipdeptree
-setuptools==69.2.0        # via -c constraints.txt, gt4py (pyproject.toml), nodeenv, pip-tools, setuptools-scm
+setuptools==69.5.1        # via -c constraints.txt, gt4py (pyproject.toml), nodeenv, pip-tools, setuptools-scm

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -53,7 +53,7 @@ CPU_BACKENDS = _get_backends_with_storage_info("cpu")
 GPU_BACKENDS = _get_backends_with_storage_info("gpu")
 ALL_BACKENDS = CPU_BACKENDS + GPU_BACKENDS
 
-_PERFORMANCE_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name != "numpy"]
+_PERFORMANCE_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name not in ("numpy", "cuda")]
 PERFORMANCE_BACKENDS = [_backend_name_as_param(name) for name in _PERFORMANCE_BACKEND_NAMES]
 
 

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
@@ -176,7 +176,7 @@ def test_toolchain_profiling(backend_name: str, mode: int, rebuild: bool):
 @pytest.fixture
 def enable_cuda_not_set():
     value = os.environ.pop("GT4PY_GTC_ENABLE_CUDA", None)
-    yield
+    yield "GT4PY_GTC_ENABLE_CUDA" not in os.environ
     if value:
         os.environ["GT4PY_GTC_ENABLE_CUDA"] = value
 

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
@@ -173,17 +173,11 @@ def test_toolchain_profiling(backend_name: str, mode: int, rebuild: bool):
         assert build_info["load_time"] > 0.0
 
 
-@pytest.fixture
-def enable_cuda_not_set():
-    value = os.environ.pop("GT4PY_GTC_ENABLE_CUDA", None)
-    yield "GT4PY_GTC_ENABLE_CUDA" not in os.environ
-    if value:
-        os.environ["GT4PY_GTC_ENABLE_CUDA"] = value
-
-
 @pytest.mark.parametrize("backend_name", ["cuda"])
-def test_deprecation_gtc_cuda(backend_name: str, enable_cuda_not_set):
+def test_deprecation_gtc_cuda(backend_name: str):
     # Default deprecation, raise an error
+    # Assumes that the GT4PY_GTC_ENABLE_CUDA env variable is not set or set to "0"
+    # Renders the "cuda" backend untestable
     build_info: Dict[str, Any] = {}
     builder = (
         StencilBuilder(cast(StencilFunc, stencil_def))

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
@@ -12,6 +12,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import os
 from typing import Any, Dict, cast
 
 import numpy as np
@@ -172,8 +173,16 @@ def test_toolchain_profiling(backend_name: str, mode: int, rebuild: bool):
         assert build_info["load_time"] > 0.0
 
 
+@pytest.fixture
+def enable_cuda_not_set():
+    value = os.environ.pop("GT4PY_GTC_ENABLE_CUDA", None)
+    yield
+    if value:
+        os.environ["GT4PY_GTC_ENABLE_CUDA"] = value
+
+
 @pytest.mark.parametrize("backend_name", ["cuda"])
-def test_deprecation_gtc_cuda(backend_name: str):
+def test_deprecation_gtc_cuda(backend_name: str, enable_cuda_not_set):
     # Default deprecation, raise an error
     build_info: Dict[str, Any] = {}
     builder = (

--- a/tox.ini
+++ b/tox.ini
@@ -43,14 +43,14 @@ extras =
     cuda12x: cuda12x
 package = wheel
 wheel_build_env = .pkg
-pass_env = NUM_PROCESSES, GT4PY_BUILD_CACHE_LIFETIME, GT4PY_BUILD_CACHE_DIR
+pass_env = NUM_PROCESSES, GT4PY_*
 set_env =
     PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning}
 
 # -- Primary tests --
 [testenv:cartesian-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.cartesian' tests
-pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH, CXX, CC, OPENMP_CPPFLAGS, OPENMP_LDFLAGS, PIP_USER, PYTHONUSERBASE, GT4PY_GTC_ENABLE_CUDA
+pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH, CXX, CC, OPENMP_CPPFLAGS, OPENMP_LDFLAGS, PIP_USER, PYTHONUSERBASE
 allowlist_externals =
     make
     gcc

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ set_env =
 # -- Primary tests --
 [testenv:cartesian-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.cartesian' tests
-pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH, CXX, CC, OPENMP_CPPFLAGS, OPENMP_LDFLAGS, PIP_USER, PYTHONUSERBASE
+pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH, CXX, CC, OPENMP_CPPFLAGS, OPENMP_LDFLAGS, PIP_USER, PYTHONUSERBASE, GT4PY_GTC_ENABLE_CUDA
 allowlist_externals =
     make
     gcc


### PR DESCRIPTION
## Description

Suppress the deprecation error for cartesian "CUDA" backend on CSCS-CI.

The following open questions remain (should be answered for a more long-term solution):

- Why is there a deprecation **error**, not a **warning** by default (warning seems to be the convention in GT4Py)?
- Why did CSCS-CI not fail on #1498, only on main after merging?
- Why does only one test fail (`test_bad_layout_warns[cuda]`)? Is the CUDA backend otherwise untested now?

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [x] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.