### PR TITLE
ci: define pytest addopts settings as env var in tox config

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -83,7 +83,7 @@ test py38:
   script:
   - cd /gt4py.src
   - python -c "import cupy"
-  - tox run -e $SUBPACKAGE-$PYVERSION_PREFIX$VARIANT$SUBVARIANT -- --instafail
+  - tox run -e $SUBPACKAGE-$PYVERSION_PREFIX$VARIANT$SUBVARIANT
   parallel:
     matrix:
     - SUBPACKAGE: [cartesian, storage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,10 +233,6 @@ module = 'gt4py.next.iterator.runtime'
 [tool.pytest]
 
 [tool.pytest.ini_options]
-addopts = "--instafail"
-filterwarnings = [
-  "ignore::UserWarning"
-]
 markers = [
   'requires_atlas: tests that require `atlas4py` bindings package',
   'requires_dace: tests that require `dace` package',

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ package = wheel
 wheel_build_env = .pkg
 pass_env = NUM_PROCESSES, GT4PY_*
 set_env =
+    PYTEST_ADDOPTS = --color=auto --instafail
     PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning}
 
 # -- Primary tests --

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,8 @@ package = wheel
 wheel_build_env = .pkg
 pass_env = NUM_PROCESSES, GT4PY_*
 set_env =
-PYTEST_ADDOPTS = --color=auto --instafail
-PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning,ignore:Field View Program ':UserWarning}
+    PYTEST_ADDOPTS = --color=auto --instafail
+    PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning,ignore:Field View Program ':UserWarning}
 
 # -- Primary tests --
 [testenv:cartesian-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,8 @@ package = wheel
 wheel_build_env = .pkg
 pass_env = NUM_PROCESSES, GT4PY_*
 set_env =
-    PYTEST_ADDOPTS = --color=auto --instafail
-    PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning}
+PYTEST_ADDOPTS = --color=auto --instafail
+PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning,ignore:Field View Program ':UserWarning}
 
 # -- Primary tests --
 [testenv:cartesian-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]


### PR DESCRIPTION
Move pytest addopts setting from pytest config in pyproject.toml to an enviroment setting in tox to keep pytest CLI invocation clean during local development.