### PR TITLE
feat[cartesian]: Feedback when a bad backend is selected

### DIFF
--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -50,7 +50,12 @@ REGISTRY = gt_utils.Registry()
 
 
 def from_name(name: str) -> Optional[Type["Backend"]]:
-    return REGISTRY.get(name, None)
+    backend = REGISTRY.get(name, None)
+    if not backend:
+        raise NotImplementedError(
+            f"Backend {name} is not implemented, options are: {REGISTRY.names}"
+        )
+    return backend
 
 
 def register(backend_cls: Type["Backend"]) -> Type["Backend"]:

--- a/src/gt4py/cartesian/cli.py
+++ b/src/gt4py/cartesian/cli.py
@@ -143,7 +143,7 @@ class BackendOption(click.ParamType):
     def convert(
         self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]
     ) -> Tuple[str, Any]:
-        backend = ctx.params["backend"] if ctx else gt4pyc.backend.from_name("debug")
+        backend = ctx.params["backend"] if ctx else gt4pyc.backend.from_name("numpy")
         name, value = self._try_split(value)
         if name.strip() not in backend.options:
             self.fail(f"Backend {backend.name} received unknown option: {name}!")

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from gt4py.cartesian.backend import REGISTRY as backend_registry
+from gt4py.cartesian.backend import from_name as backend_from_name
 from gt4py.cartesian.backend.module_generator import make_args_data_from_gtir
 from gt4py.cartesian.definitions import AccessKind
 from gt4py.cartesian.gtc import gtir, utils
@@ -191,6 +192,14 @@ def test_deprecation_gtc_cuda(backend_name: str):
     )
     with pytest.raises(NotImplementedError):
         builder.build()
+
+
+def test_bad_backend_feedback():
+    existing_backend = backend_from_name("numpy")
+    assert existing_backend
+
+    with pytest.raises(NotImplementedError):
+        backend_from_name("xxxxx")
 
 
 if __name__ == "__main__":

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_definitive_assignment_analysis.py
@@ -198,7 +198,7 @@ def daa_10(in_field: Field[float], cond_field: Field[float], mask: bool, out_fie
 
 @pytest.mark.parametrize("definition,valid", [(stencil, valid) for stencil, valid in test_data])
 def test_daa(definition, valid, clear_gtir_caches):
-    builder = StencilBuilder(definition, backend=from_name("debug"))
+    builder = StencilBuilder(definition, backend=None)
     gtir_stencil_expr = builder.gtir_pipeline.full()
     invalid_accesses = daa.analyze(gtir_stencil_expr)
     if valid:


### PR DESCRIPTION
## Description

Recent work with new user showed that basic mistake can lead to pretty gnarly stack trace instead of a clean error message. This fixes one of the most common: a bad backend name required.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
