### PR TITLE
build[next]: Compatibility with nanobind 2.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,9 +66,9 @@ repos:
   ## version = re.search('mypy==([0-9\.]*)', open("constraints.txt").read())[1]
   ## print(f"#========= FROM constraints.txt: v{version} =========")
   ##]]]
-  #========= FROM constraints.txt: v1.10.0 =========
+  #========= FROM constraints.txt: v1.10.1 =========
   ##[[[end]]]
-  rev: v1.10.0  # MUST match version ^^^^ in constraints.txt (if the mirror is up-to-date)
+  rev: v1.10.1  # MUST match version ^^^^ in constraints.txt (if the mirror is up-to-date)
   hooks:
   - id: mypy
     additional_dependencies:  # versions from constraints.txt
@@ -96,17 +96,17 @@ repos:
     - devtools==0.12.2
     - factory-boy==3.3.0
     - frozendict==2.4.4
-    - gridtools-cpp==2.3.2
+    - gridtools-cpp==2.3.4
     - importlib-resources==6.4.0
     - jinja2==3.1.4
     - lark==1.1.9
     - mako==1.3.5
-    - nanobind==1.9.2
+    - nanobind==2.0.0
     - ninja==1.11.1.1
     - numpy==1.24.4
     - packaging==24.1
-    - pybind11==2.12.0
-    - setuptools==70.1.0
+    - pybind11==2.13.0
+    - setuptools==70.1.1
     - tabulate==0.9.0
     - typing-extensions==4.12.2
     - xxhash==3.0.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,11 +13,10 @@ attrs==23.2.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproje
 babel==2.15.0             # via sphinx
 backcall==0.2.0           # via ipython
 black==24.4.2             # via gt4py (pyproject.toml)
-blinker==1.8.2            # via flask
 boltons==24.0.0           # via gt4py (pyproject.toml)
 bracex==2.4               # via wcmatch
 build==1.2.1              # via pip-tools
-bump-my-version==0.24.0   # via -r requirements-dev.in
+bump-my-version==0.24.1   # via -r requirements-dev.in
 cached-property==1.5.2    # via gt4py (pyproject.toml)
 cachetools==5.3.3         # via tox
 certifi==2024.6.2         # via requests
@@ -26,7 +25,7 @@ cfgv==3.4.0               # via pre-commit
 chardet==5.2.0            # via tox
 charset-normalizer==3.3.2  # via requests
 clang-format==18.1.7      # via -r requirements-dev.in, gt4py (pyproject.toml)
-click==8.1.7              # via black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
+click==8.1.7              # via black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
 cmake==3.29.6             # via gt4py (pyproject.toml)
 cogapp==3.4.1             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
@@ -36,7 +35,7 @@ coverage==7.5.4           # via -r requirements-dev.in, pytest-cov
 cryptography==42.0.8      # via types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via matplotlib
 cytoolz==0.12.3           # via gt4py (pyproject.toml)
-dace==0.15.1              # via gt4py (pyproject.toml)
+dace==0.16.1              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
 debugpy==1.8.2            # via ipykernel
 decorator==5.1.1          # via ipython
@@ -62,7 +61,6 @@ flake8-eradicate==1.5.0   # via -r requirements-dev.in
 flake8-mutable==1.2.0     # via -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -r requirements-dev.in
-flask==3.0.3              # via dace
 fonttools==4.53.0         # via matplotlib
 fparser==0.1.4            # via dace
 frozendict==2.4.4         # via gt4py (pyproject.toml)
@@ -71,18 +69,17 @@ hypothesis==6.104.1       # via -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.5.36          # via pre-commit
 idna==3.7                 # via requests
 imagesize==1.4.1          # via sphinx
-importlib-metadata==8.0.0  # via build, flask, jax, jupyter-client, sphinx
+importlib-metadata==8.0.0  # via build, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
 ipykernel==6.29.4         # via nbmake
 ipython==8.12.3           # via ipykernel
 isort==5.13.2             # via -r requirements-dev.in
-itsdangerous==2.2.0       # via flask
 jax==0.4.13               # via gt4py (pyproject.toml)
 jaxlib==0.4.13            # via jax
 jedi==0.19.1              # via ipython
-jinja2==3.1.4             # via flask, gt4py (pyproject.toml), sphinx
+jinja2==3.1.4             # via dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.22.0        # via nbformat
 jsonschema-specifications==2023.12.1  # via jsonschema
 jupyter-client==8.6.2     # via ipykernel, nbclient
@@ -92,7 +89,7 @@ kiwisolver==1.4.5         # via matplotlib
 lark==1.1.9               # via gt4py (pyproject.toml)
 mako==1.3.5               # via gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via jupytext, mdit-py-plugins, rich
-markupsafe==2.1.5         # via jinja2, mako, werkzeug
+markupsafe==2.1.5         # via jinja2, mako
 matplotlib==3.7.5         # via -r requirements-dev.in
 matplotlib-inline==0.1.7  # via ipykernel, ipython
 mccabe==0.7.0             # via flake8
@@ -155,7 +152,7 @@ pyyaml==6.0.1             # via dace, jupytext, pre-commit
 pyzmq==26.0.3             # via ipykernel, jupyter-client
 questionary==2.0.1        # via bump-my-version
 referencing==0.35.1       # via jsonschema, jsonschema-specifications
-requests==2.32.3          # via dace, sphinx
+requests==2.32.3          # via sphinx
 restructuredtext-lint==1.4.0  # via flake8-rst-docstrings
 rich==13.7.1              # via bump-my-version, rich-click
 rich-click==1.8.3         # via bump-my-version
@@ -176,7 +173,7 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via sphinx
 stack-data==0.6.3         # via ipython
-sympy==1.9                # via dace, gt4py (pyproject.toml)
+sympy==1.12.1             # via dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via gt4py (pyproject.toml)
 tomli==2.0.1 ; python_version < "3.11"  # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.5           # via bump-my-version
@@ -280,7 +277,6 @@ virtualenv==20.26.3       # via pre-commit, tox
 wcmatch==8.5.2            # via bump-my-version
 wcwidth==0.2.13           # via prompt-toolkit
 websockets==12.0          # via dace
-werkzeug==3.0.3           # via flask
 wheel==0.43.0             # via astunparse, pip-tools
 xxhash==3.0.0             # via gt4py (pyproject.toml)
 zipp==3.19.2              # via importlib-metadata, importlib-resources

--- a/constraints.txt
+++ b/constraints.txt
@@ -7,17 +7,17 @@
 aenum==3.1.15             # via dace
 alabaster==0.7.13         # via sphinx
 annotated-types==0.7.0    # via pydantic
-appnope==0.1.4            # via ipykernel, ipython
 asttokens==2.4.1          # via devtools, stack-data
 astunparse==1.6.3 ; python_version < "3.9"  # via dace, gt4py (pyproject.toml)
 attrs==23.2.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, referencing
 babel==2.15.0             # via sphinx
 backcall==0.2.0           # via ipython
 black==24.4.2             # via gt4py (pyproject.toml)
+blinker==1.8.2            # via flask
 boltons==24.0.0           # via gt4py (pyproject.toml)
 bracex==2.4               # via wcmatch
 build==1.2.1              # via pip-tools
-bump-my-version==0.23.0   # via -r requirements-dev.in
+bump-my-version==0.24.0   # via -r requirements-dev.in
 cached-property==1.5.2    # via gt4py (pyproject.toml)
 cachetools==5.3.3         # via tox
 certifi==2024.6.2         # via requests
@@ -26,7 +26,7 @@ cfgv==3.4.0               # via pre-commit
 chardet==5.2.0            # via tox
 charset-normalizer==3.3.2  # via requests
 clang-format==18.1.7      # via -r requirements-dev.in, gt4py (pyproject.toml)
-click==8.1.7              # via black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
+click==8.1.7              # via black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
 cmake==3.29.6             # via gt4py (pyproject.toml)
 cogapp==3.4.1             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
@@ -36,9 +36,9 @@ coverage==7.5.4           # via -r requirements-dev.in, pytest-cov
 cryptography==42.0.8      # via types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via matplotlib
 cytoolz==0.12.3           # via gt4py (pyproject.toml)
-dace==0.16.1              # via gt4py (pyproject.toml)
+dace==0.15.1              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
-debugpy==1.8.1            # via ipykernel
+debugpy==1.8.2            # via ipykernel
 decorator==5.1.1          # via ipython
 deepdiff==7.0.1           # via gt4py (pyproject.toml)
 devtools==0.12.2          # via gt4py (pyproject.toml)
@@ -50,7 +50,7 @@ exceptiongroup==1.2.1     # via hypothesis, pytest
 execnet==2.1.1            # via pytest-cache, pytest-xdist
 executing==2.0.1          # via devtools, stack-data
 factory-boy==3.3.0        # via gt4py (pyproject.toml), pytest-factoryboy
-faker==25.9.1             # via factory-boy
+faker==25.9.2             # via factory-boy
 fastjsonschema==2.20.0    # via nbformat
 filelock==3.15.4          # via tox, virtualenv
 flake8==7.1.0             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
@@ -62,25 +62,27 @@ flake8-eradicate==1.5.0   # via -r requirements-dev.in
 flake8-mutable==1.2.0     # via -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -r requirements-dev.in
+flask==3.0.3              # via dace
 fonttools==4.53.0         # via matplotlib
 fparser==0.1.4            # via dace
 frozendict==2.4.4         # via gt4py (pyproject.toml)
-gridtools-cpp==2.3.2      # via gt4py (pyproject.toml)
-hypothesis==6.104.0       # via -r requirements-dev.in, gt4py (pyproject.toml)
+gridtools-cpp==2.3.4      # via gt4py (pyproject.toml)
+hypothesis==6.104.1       # via -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.5.36          # via pre-commit
 idna==3.7                 # via requests
 imagesize==1.4.1          # via sphinx
-importlib-metadata==7.2.1  # via build, jax, jupyter-client, sphinx
+importlib-metadata==8.0.0  # via build, flask, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
 ipykernel==6.29.4         # via nbmake
 ipython==8.12.3           # via ipykernel
 isort==5.13.2             # via -r requirements-dev.in
+itsdangerous==2.2.0       # via flask
 jax==0.4.13               # via gt4py (pyproject.toml)
 jaxlib==0.4.13            # via jax
 jedi==0.19.1              # via ipython
-jinja2==3.1.4             # via dace, gt4py (pyproject.toml), sphinx
+jinja2==3.1.4             # via flask, gt4py (pyproject.toml), sphinx
 jsonschema==4.22.0        # via nbformat
 jsonschema-specifications==2023.12.1  # via jsonschema
 jupyter-client==8.6.2     # via ipykernel, nbclient
@@ -90,7 +92,7 @@ kiwisolver==1.4.5         # via matplotlib
 lark==1.1.9               # via gt4py (pyproject.toml)
 mako==1.3.5               # via gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via jupytext, mdit-py-plugins, rich
-markupsafe==2.1.5         # via jinja2, mako
+markupsafe==2.1.5         # via jinja2, mako, werkzeug
 matplotlib==3.7.5         # via -r requirements-dev.in
 matplotlib-inline==0.1.7  # via ipykernel, ipython
 mccabe==0.7.0             # via flake8
@@ -98,9 +100,9 @@ mdit-py-plugins==0.4.1    # via jupytext
 mdurl==0.1.2              # via markdown-it-py
 ml-dtypes==0.2.0          # via jax, jaxlib
 mpmath==1.3.0             # via sympy
-mypy==1.10.0              # via -r requirements-dev.in
+mypy==1.10.1              # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
-nanobind==1.9.2           # via gt4py (pyproject.toml)
+nanobind==2.0.0           # via gt4py (pyproject.toml)
 nbclient==0.6.8           # via nbmake
 nbformat==5.10.4          # via jupytext, nbclient, nbmake
 nbmake==1.5.4             # via -r requirements-dev.in
@@ -128,7 +130,7 @@ prompt-toolkit==3.0.36    # via ipython, questionary
 psutil==6.0.0             # via -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via pexpect
 pure-eval==0.2.2          # via stack-data
-pybind11==2.12.0          # via gt4py (pyproject.toml)
+pybind11==2.13.0          # via gt4py (pyproject.toml)
 pycodestyle==2.12.0       # via flake8, flake8-debugger
 pycparser==2.22           # via cffi
 pydantic==2.7.4           # via bump-my-version, pydantic-settings
@@ -153,7 +155,7 @@ pyyaml==6.0.1             # via dace, jupytext, pre-commit
 pyzmq==26.0.3             # via ipykernel, jupyter-client
 questionary==2.0.1        # via bump-my-version
 referencing==0.35.1       # via jsonschema, jsonschema-specifications
-requests==2.32.3          # via sphinx
+requests==2.32.3          # via dace, sphinx
 restructuredtext-lint==1.4.0  # via flake8-rst-docstrings
 rich==13.7.1              # via bump-my-version, rich-click
 rich-click==1.8.3         # via bump-my-version
@@ -174,7 +176,7 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via sphinx
 stack-data==0.6.3         # via ipython
-sympy==1.12.1             # via dace, gt4py (pyproject.toml)
+sympy==1.9                # via dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via gt4py (pyproject.toml)
 tomli==2.0.1 ; python_version < "3.11"  # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.5           # via bump-my-version
@@ -182,7 +184,7 @@ toolz==0.12.1             # via cytoolz
 tornado==6.4.1            # via ipykernel, jupyter-client
 tox==4.15.1               # via -r requirements-dev.in
 traitlets==5.14.3         # via comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
-types-aiofiles==23.2.0.20240623  # via types-all
+types-aiofiles==24.1.0.20240626  # via types-all
 types-all==1.0.0          # via -r requirements-dev.in
 types-annoy==1.17.8.4     # via types-all
 types-atomicwrites==1.4.5.1  # via types-all
@@ -237,7 +239,7 @@ types-pathlib2==2.3.0     # via types-all
 types-pillow==10.2.0.20240520  # via types-all
 types-pkg-resources==0.1.3  # via types-all
 types-polib==1.2.0.20240327  # via types-all
-types-protobuf==5.26.0.20240422  # via types-all
+types-protobuf==5.27.0.20240626  # via types-all
 types-pyaudio==0.2.16.20240516  # via types-all
 types-pycurl==7.45.3.20240421  # via types-all
 types-pyfarmhash==0.3.1.20240311  # via types-all
@@ -278,10 +280,11 @@ virtualenv==20.26.3       # via pre-commit, tox
 wcmatch==8.5.2            # via bump-my-version
 wcwidth==0.2.13           # via prompt-toolkit
 websockets==12.0          # via dace
+werkzeug==3.0.3           # via flask
 wheel==0.43.0             # via astunparse, pip-tools
 xxhash==3.0.0             # via gt4py (pyproject.toml)
 zipp==3.19.2              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.1                 # via pip-tools, pipdeptree
-setuptools==70.1.0        # via gt4py (pyproject.toml), pip-tools, setuptools-scm
+setuptools==70.1.1        # via gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -61,7 +61,7 @@ cmake==3.22
 cogapp==3.3
 coverage[toml]==5.0
 cytoolz==0.12.1
-dace==0.16.1
+dace==0.15.1
 darglint==1.6
 deepdiff==5.6.0
 devtools==0.6
@@ -76,7 +76,7 @@ flake8-pyproject==1.2.2
 flake8-rst-docstrings==0.0.14
 flake8==5.0.4
 frozendict==2.3
-gridtools-cpp==2.3.2
+gridtools-cpp==2.3.4
 hypothesis==6.0.0
 importlib-resources==5.0; python_version < "3.9"
 isort==5.10

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -61,7 +61,7 @@ cmake==3.22
 cogapp==3.3
 coverage[toml]==5.0
 cytoolz==0.12.1
-dace==0.15.1
+dace==0.16.1
 darglint==1.6
 deepdiff==5.6.0
 devtools==0.6

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -72,7 +72,7 @@ flake8-pyproject==1.2.2
 flake8-rst-docstrings==0.0.14
 flake8==5.0.4
 frozendict==2.3
-gridtools-cpp==2.3.2
+gridtools-cpp==2.3.4
 hypothesis==6.0.0
 importlib-resources==5.0; python_version < "3.9"
 isort==5.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,14 @@ dependencies = [
   'devtools>=0.6',
   'factory-boy>=3.3.0',
   'frozendict>=2.3',
-  'gridtools-cpp>=2.3.2,==2.*',
+  'gridtools-cpp>=2.3.4,==2.*',
   "importlib-resources>=5.0;python_version<'3.9'",
   'jinja2>=3.0.0',
   'lark>=1.1.2',
   'mako>=1.1',
   'nanobind>=1.4.0 ',
   'ninja>=1.10',
-  'numpy>=1.23.3',
+  'numpy>=1.23.3,==1.*',
   'packaging>=20.0',
   'pybind11>=2.10.1',
   'setuptools>=65.5.0',
@@ -293,7 +293,6 @@ docstring-code-format = true
 ignore = [
   'E501'  # [line-too-long]
 ]
-ignore-init-module-imports = true
 select = ['E', 'F', 'I', 'B', 'A', 'T10', 'ERA', 'NPY', 'RUF']
 typing-modules = ['gt4py.eve.extended_typing']
 unfixable = []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,17 +7,17 @@
 aenum==3.1.15             # via -c constraints.txt, dace
 alabaster==0.7.13         # via -c constraints.txt, sphinx
 annotated-types==0.7.0    # via -c constraints.txt, pydantic
-appnope==0.1.4            # via -c constraints.txt, ipykernel, ipython
 asttokens==2.4.1          # via -c constraints.txt, devtools, stack-data
 astunparse==1.6.3 ; python_version < "3.9"  # via -c constraints.txt, dace, gt4py (pyproject.toml)
 attrs==23.2.0             # via -c constraints.txt, flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, referencing
 babel==2.15.0             # via -c constraints.txt, sphinx
 backcall==0.2.0           # via -c constraints.txt, ipython
 black==24.4.2             # via -c constraints.txt, gt4py (pyproject.toml)
+blinker==1.8.2            # via -c constraints.txt, flask
 boltons==24.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
 bracex==2.4               # via -c constraints.txt, wcmatch
 build==1.2.1              # via -c constraints.txt, pip-tools
-bump-my-version==0.23.0   # via -c constraints.txt, -r requirements-dev.in
+bump-my-version==0.24.0   # via -c constraints.txt, -r requirements-dev.in
 cached-property==1.5.2    # via -c constraints.txt, gt4py (pyproject.toml)
 cachetools==5.3.3         # via -c constraints.txt, tox
 certifi==2024.6.2         # via -c constraints.txt, requests
@@ -26,7 +26,7 @@ cfgv==3.4.0               # via -c constraints.txt, pre-commit
 chardet==5.2.0            # via -c constraints.txt, tox
 charset-normalizer==3.3.2  # via -c constraints.txt, requests
 clang-format==18.1.7      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
-click==8.1.7              # via -c constraints.txt, black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
+click==8.1.7              # via -c constraints.txt, black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
 cmake==3.29.6             # via -c constraints.txt, gt4py (pyproject.toml)
 cogapp==3.4.1             # via -c constraints.txt, -r requirements-dev.in
 colorama==0.4.6           # via -c constraints.txt, tox
@@ -36,9 +36,9 @@ coverage[toml]==7.5.4     # via -c constraints.txt, -r requirements-dev.in, pyte
 cryptography==42.0.8      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==0.12.3           # via -c constraints.txt, gt4py (pyproject.toml)
-dace==0.16.1              # via -c constraints.txt, gt4py (pyproject.toml)
+dace==0.15.1              # via -c constraints.txt, gt4py (pyproject.toml)
 darglint==1.8.1           # via -c constraints.txt, -r requirements-dev.in
-debugpy==1.8.1            # via -c constraints.txt, ipykernel
+debugpy==1.8.2            # via -c constraints.txt, ipykernel
 decorator==5.1.1          # via -c constraints.txt, ipython
 deepdiff==7.0.1           # via -c constraints.txt, gt4py (pyproject.toml)
 devtools==0.12.2          # via -c constraints.txt, gt4py (pyproject.toml)
@@ -50,7 +50,7 @@ exceptiongroup==1.2.1     # via -c constraints.txt, hypothesis, pytest
 execnet==2.1.1            # via -c constraints.txt, pytest-cache, pytest-xdist
 executing==2.0.1          # via -c constraints.txt, devtools, stack-data
 factory-boy==3.3.0        # via -c constraints.txt, gt4py (pyproject.toml), pytest-factoryboy
-faker==25.9.1             # via -c constraints.txt, factory-boy
+faker==25.9.2             # via -c constraints.txt, factory-boy
 fastjsonschema==2.20.0    # via -c constraints.txt, nbformat
 filelock==3.15.4          # via -c constraints.txt, tox, virtualenv
 flake8==7.1.0             # via -c constraints.txt, -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
@@ -62,25 +62,27 @@ flake8-eradicate==1.5.0   # via -c constraints.txt, -r requirements-dev.in
 flake8-mutable==1.2.0     # via -c constraints.txt, -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -c constraints.txt, -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -c constraints.txt, -r requirements-dev.in
+flask==3.0.3              # via -c constraints.txt, dace
 fonttools==4.53.0         # via -c constraints.txt, matplotlib
 fparser==0.1.4            # via -c constraints.txt, dace
 frozendict==2.4.4         # via -c constraints.txt, gt4py (pyproject.toml)
-gridtools-cpp==2.3.2      # via -c constraints.txt, gt4py (pyproject.toml)
-hypothesis==6.104.0       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
+gridtools-cpp==2.3.4      # via -c constraints.txt, gt4py (pyproject.toml)
+hypothesis==6.104.1       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.5.36          # via -c constraints.txt, pre-commit
 idna==3.7                 # via -c constraints.txt, requests
 imagesize==1.4.1          # via -c constraints.txt, sphinx
-importlib-metadata==7.2.1  # via -c constraints.txt, build, jax, jupyter-client, sphinx
+importlib-metadata==8.0.0  # via -c constraints.txt, build, flask, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via -c constraints.txt, gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
 inflection==0.5.1         # via -c constraints.txt, pytest-factoryboy
 iniconfig==2.0.0          # via -c constraints.txt, pytest
 ipykernel==6.29.4         # via -c constraints.txt, nbmake
 ipython==8.12.3           # via -c constraints.txt, ipykernel
 isort==5.13.2             # via -c constraints.txt, -r requirements-dev.in
+itsdangerous==2.2.0       # via -c constraints.txt, flask
 jax[cpu]==0.4.13          # via -c constraints.txt, gt4py (pyproject.toml)
 jaxlib==0.4.13            # via -c constraints.txt, jax
 jedi==0.19.1              # via -c constraints.txt, ipython
-jinja2==3.1.4             # via -c constraints.txt, dace, gt4py (pyproject.toml), sphinx
+jinja2==3.1.4             # via -c constraints.txt, flask, gt4py (pyproject.toml), sphinx
 jsonschema==4.22.0        # via -c constraints.txt, nbformat
 jsonschema-specifications==2023.12.1  # via -c constraints.txt, jsonschema
 jupyter-client==8.6.2     # via -c constraints.txt, ipykernel, nbclient
@@ -90,7 +92,7 @@ kiwisolver==1.4.5         # via -c constraints.txt, matplotlib
 lark==1.1.9               # via -c constraints.txt, gt4py (pyproject.toml)
 mako==1.3.5               # via -c constraints.txt, gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via -c constraints.txt, jupytext, mdit-py-plugins, rich
-markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako
+markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako, werkzeug
 matplotlib==3.7.5         # via -c constraints.txt, -r requirements-dev.in
 matplotlib-inline==0.1.7  # via -c constraints.txt, ipykernel, ipython
 mccabe==0.7.0             # via -c constraints.txt, flake8
@@ -98,9 +100,9 @@ mdit-py-plugins==0.4.1    # via -c constraints.txt, jupytext
 mdurl==0.1.2              # via -c constraints.txt, markdown-it-py
 ml-dtypes==0.2.0          # via -c constraints.txt, jax, jaxlib
 mpmath==1.3.0             # via -c constraints.txt, sympy
-mypy==1.10.0              # via -c constraints.txt, -r requirements-dev.in
+mypy==1.10.1              # via -c constraints.txt, -r requirements-dev.in
 mypy-extensions==1.0.0    # via -c constraints.txt, black, mypy
-nanobind==1.9.2           # via -c constraints.txt, gt4py (pyproject.toml)
+nanobind==2.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
 nbclient==0.6.8           # via -c constraints.txt, nbmake
 nbformat==5.10.4          # via -c constraints.txt, jupytext, nbclient, nbmake
 nbmake==1.5.4             # via -c constraints.txt, -r requirements-dev.in
@@ -128,7 +130,7 @@ prompt-toolkit==3.0.36    # via -c constraints.txt, ipython, questionary
 psutil==6.0.0             # via -c constraints.txt, -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via -c constraints.txt, pexpect
 pure-eval==0.2.2          # via -c constraints.txt, stack-data
-pybind11==2.12.0          # via -c constraints.txt, gt4py (pyproject.toml)
+pybind11==2.13.0          # via -c constraints.txt, gt4py (pyproject.toml)
 pycodestyle==2.12.0       # via -c constraints.txt, flake8, flake8-debugger
 pycparser==2.22           # via -c constraints.txt, cffi
 pydantic==2.7.4           # via -c constraints.txt, bump-my-version, pydantic-settings
@@ -153,7 +155,7 @@ pyyaml==6.0.1             # via -c constraints.txt, dace, jupytext, pre-commit
 pyzmq==26.0.3             # via -c constraints.txt, ipykernel, jupyter-client
 questionary==2.0.1        # via -c constraints.txt, bump-my-version
 referencing==0.35.1       # via -c constraints.txt, jsonschema, jsonschema-specifications
-requests==2.32.3          # via -c constraints.txt, sphinx
+requests==2.32.3          # via -c constraints.txt, dace, sphinx
 restructuredtext-lint==1.4.0  # via -c constraints.txt, flake8-rst-docstrings
 rich==13.7.1              # via -c constraints.txt, bump-my-version, rich-click
 rich-click==1.8.3         # via -c constraints.txt, bump-my-version
@@ -174,7 +176,7 @@ sphinxcontrib-jsmath==1.0.1  # via -c constraints.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -c constraints.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via -c constraints.txt, sphinx
 stack-data==0.6.3         # via -c constraints.txt, ipython
-sympy==1.12.1             # via -c constraints.txt, dace, gt4py (pyproject.toml)
+sympy==1.9                # via -c constraints.txt, dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via -c constraints.txt, gt4py (pyproject.toml)
 tomli==2.0.1 ; python_version < "3.11"  # via -c constraints.txt, -r requirements-dev.in, black, build, coverage, flake8-pyproject, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.5           # via -c constraints.txt, bump-my-version
@@ -182,7 +184,7 @@ toolz==0.12.1             # via -c constraints.txt, cytoolz
 tornado==6.4.1            # via -c constraints.txt, ipykernel, jupyter-client
 tox==4.15.1               # via -c constraints.txt, -r requirements-dev.in
 traitlets==5.14.3         # via -c constraints.txt, comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
-types-aiofiles==23.2.0.20240623  # via -c constraints.txt, types-all
+types-aiofiles==24.1.0.20240626  # via -c constraints.txt, types-all
 types-all==1.0.0          # via -c constraints.txt, -r requirements-dev.in
 types-annoy==1.17.8.4     # via -c constraints.txt, types-all
 types-atomicwrites==1.4.5.1  # via -c constraints.txt, types-all
@@ -237,7 +239,7 @@ types-pathlib2==2.3.0     # via -c constraints.txt, types-all
 types-pillow==10.2.0.20240520  # via -c constraints.txt, types-all
 types-pkg-resources==0.1.3  # via -c constraints.txt, types-all
 types-polib==1.2.0.20240327  # via -c constraints.txt, types-all
-types-protobuf==5.26.0.20240422  # via -c constraints.txt, types-all
+types-protobuf==5.27.0.20240626  # via -c constraints.txt, types-all
 types-pyaudio==0.2.16.20240516  # via -c constraints.txt, types-all
 types-pycurl==7.45.3.20240421  # via -c constraints.txt, types-all
 types-pyfarmhash==0.3.1.20240311  # via -c constraints.txt, types-all
@@ -278,10 +280,11 @@ virtualenv==20.26.3       # via -c constraints.txt, pre-commit, tox
 wcmatch==8.5.2            # via -c constraints.txt, bump-my-version
 wcwidth==0.2.13           # via -c constraints.txt, prompt-toolkit
 websockets==12.0          # via -c constraints.txt, dace
+werkzeug==3.0.3           # via -c constraints.txt, flask
 wheel==0.43.0             # via -c constraints.txt, astunparse, pip-tools
 xxhash==3.0.0             # via -c constraints.txt, gt4py (pyproject.toml)
 zipp==3.19.2              # via -c constraints.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.1                 # via -c constraints.txt, pip-tools, pipdeptree
-setuptools==70.1.0        # via -c constraints.txt, gt4py (pyproject.toml), pip-tools, setuptools-scm
+setuptools==70.1.1        # via -c constraints.txt, gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,11 +13,10 @@ attrs==23.2.0             # via -c constraints.txt, flake8-bugbear, flake8-eradi
 babel==2.15.0             # via -c constraints.txt, sphinx
 backcall==0.2.0           # via -c constraints.txt, ipython
 black==24.4.2             # via -c constraints.txt, gt4py (pyproject.toml)
-blinker==1.8.2            # via -c constraints.txt, flask
 boltons==24.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
 bracex==2.4               # via -c constraints.txt, wcmatch
 build==1.2.1              # via -c constraints.txt, pip-tools
-bump-my-version==0.24.0   # via -c constraints.txt, -r requirements-dev.in
+bump-my-version==0.24.1   # via -c constraints.txt, -r requirements-dev.in
 cached-property==1.5.2    # via -c constraints.txt, gt4py (pyproject.toml)
 cachetools==5.3.3         # via -c constraints.txt, tox
 certifi==2024.6.2         # via -c constraints.txt, requests
@@ -26,7 +25,7 @@ cfgv==3.4.0               # via -c constraints.txt, pre-commit
 chardet==5.2.0            # via -c constraints.txt, tox
 charset-normalizer==3.3.2  # via -c constraints.txt, requests
 clang-format==18.1.7      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
-click==8.1.7              # via -c constraints.txt, black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
+click==8.1.7              # via -c constraints.txt, black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
 cmake==3.29.6             # via -c constraints.txt, gt4py (pyproject.toml)
 cogapp==3.4.1             # via -c constraints.txt, -r requirements-dev.in
 colorama==0.4.6           # via -c constraints.txt, tox
@@ -36,7 +35,7 @@ coverage[toml]==7.5.4     # via -c constraints.txt, -r requirements-dev.in, pyte
 cryptography==42.0.8      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==0.12.3           # via -c constraints.txt, gt4py (pyproject.toml)
-dace==0.15.1              # via -c constraints.txt, gt4py (pyproject.toml)
+dace==0.16.1              # via -c constraints.txt, gt4py (pyproject.toml)
 darglint==1.8.1           # via -c constraints.txt, -r requirements-dev.in
 debugpy==1.8.2            # via -c constraints.txt, ipykernel
 decorator==5.1.1          # via -c constraints.txt, ipython
@@ -62,7 +61,6 @@ flake8-eradicate==1.5.0   # via -c constraints.txt, -r requirements-dev.in
 flake8-mutable==1.2.0     # via -c constraints.txt, -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -c constraints.txt, -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -c constraints.txt, -r requirements-dev.in
-flask==3.0.3              # via -c constraints.txt, dace
 fonttools==4.53.0         # via -c constraints.txt, matplotlib
 fparser==0.1.4            # via -c constraints.txt, dace
 frozendict==2.4.4         # via -c constraints.txt, gt4py (pyproject.toml)
@@ -71,18 +69,17 @@ hypothesis==6.104.1       # via -c constraints.txt, -r requirements-dev.in, gt4p
 identify==2.5.36          # via -c constraints.txt, pre-commit
 idna==3.7                 # via -c constraints.txt, requests
 imagesize==1.4.1          # via -c constraints.txt, sphinx
-importlib-metadata==8.0.0  # via -c constraints.txt, build, flask, jax, jupyter-client, sphinx
+importlib-metadata==8.0.0  # via -c constraints.txt, build, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via -c constraints.txt, gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
 inflection==0.5.1         # via -c constraints.txt, pytest-factoryboy
 iniconfig==2.0.0          # via -c constraints.txt, pytest
 ipykernel==6.29.4         # via -c constraints.txt, nbmake
 ipython==8.12.3           # via -c constraints.txt, ipykernel
 isort==5.13.2             # via -c constraints.txt, -r requirements-dev.in
-itsdangerous==2.2.0       # via -c constraints.txt, flask
 jax[cpu]==0.4.13          # via -c constraints.txt, gt4py (pyproject.toml)
 jaxlib==0.4.13            # via -c constraints.txt, jax
 jedi==0.19.1              # via -c constraints.txt, ipython
-jinja2==3.1.4             # via -c constraints.txt, flask, gt4py (pyproject.toml), sphinx
+jinja2==3.1.4             # via -c constraints.txt, dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.22.0        # via -c constraints.txt, nbformat
 jsonschema-specifications==2023.12.1  # via -c constraints.txt, jsonschema
 jupyter-client==8.6.2     # via -c constraints.txt, ipykernel, nbclient
@@ -92,7 +89,7 @@ kiwisolver==1.4.5         # via -c constraints.txt, matplotlib
 lark==1.1.9               # via -c constraints.txt, gt4py (pyproject.toml)
 mako==1.3.5               # via -c constraints.txt, gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via -c constraints.txt, jupytext, mdit-py-plugins, rich
-markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako, werkzeug
+markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako
 matplotlib==3.7.5         # via -c constraints.txt, -r requirements-dev.in
 matplotlib-inline==0.1.7  # via -c constraints.txt, ipykernel, ipython
 mccabe==0.7.0             # via -c constraints.txt, flake8
@@ -155,7 +152,7 @@ pyyaml==6.0.1             # via -c constraints.txt, dace, jupytext, pre-commit
 pyzmq==26.0.3             # via -c constraints.txt, ipykernel, jupyter-client
 questionary==2.0.1        # via -c constraints.txt, bump-my-version
 referencing==0.35.1       # via -c constraints.txt, jsonschema, jsonschema-specifications
-requests==2.32.3          # via -c constraints.txt, dace, sphinx
+requests==2.32.3          # via -c constraints.txt, sphinx
 restructuredtext-lint==1.4.0  # via -c constraints.txt, flake8-rst-docstrings
 rich==13.7.1              # via -c constraints.txt, bump-my-version, rich-click
 rich-click==1.8.3         # via -c constraints.txt, bump-my-version
@@ -176,7 +173,7 @@ sphinxcontrib-jsmath==1.0.1  # via -c constraints.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -c constraints.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via -c constraints.txt, sphinx
 stack-data==0.6.3         # via -c constraints.txt, ipython
-sympy==1.9                # via -c constraints.txt, dace, gt4py (pyproject.toml)
+sympy==1.12.1             # via -c constraints.txt, dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via -c constraints.txt, gt4py (pyproject.toml)
 tomli==2.0.1 ; python_version < "3.11"  # via -c constraints.txt, -r requirements-dev.in, black, build, coverage, flake8-pyproject, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.5           # via -c constraints.txt, bump-my-version
@@ -280,7 +277,6 @@ virtualenv==20.26.3       # via -c constraints.txt, pre-commit, tox
 wcmatch==8.5.2            # via -c constraints.txt, bump-my-version
 wcwidth==0.2.13           # via -c constraints.txt, prompt-toolkit
 websockets==12.0          # via -c constraints.txt, dace
-werkzeug==3.0.3           # via -c constraints.txt, flask
 wheel==0.43.0             # via -c constraints.txt, astunparse, pip-tools
 xxhash==3.0.0             # via -c constraints.txt, gt4py (pyproject.toml)
 zipp==3.19.2              # via -c constraints.txt, importlib-metadata, importlib-resources

--- a/src/gt4py/next/otf/binding/nanobind.py
+++ b/src/gt4py/next/otf/binding/nanobind.py
@@ -93,7 +93,7 @@ def _type_string(type_: ts.TypeSpec) -> str:
     elif isinstance(type_, ts.FieldType):
         ndims = len(type_.dims)
         dtype = cpp_interface.render_scalar_type(type_.dtype)
-        shape = f"nanobind::shape<{', '.join(['nanobind::any'] * ndims)}>"
+        shape = f"nanobind::shape<{', '.join(['gridtools::nanobind::dynamic_size'] * ndims)}>"
         buffer_t = f"nanobind::ndarray<{dtype}, {shape}>"
         origin_t = f"std::tuple<{', '.join(['ptrdiff_t'] * ndims)}>"
         return f"std::pair<{buffer_t}, {origin_t}>"
@@ -256,7 +256,7 @@ def create_bindings(
         program_source.language_settings, BindingCodeGenerator.apply(file_binding)
     )
 
-    return stages.BindingSource(src, (interface.LibraryDependency("nanobind", "1.4.0"),))
+    return stages.BindingSource(src, (interface.LibraryDependency("nanobind", "2.0.0"),))
 
 
 @workflow.make_step


### PR DESCRIPTION
requires gridtools_cpp >= 2.3.4 for nanobind 2.x

Additional changes: freezes numpy to 1.x until #1559 