### PR TITLE
add extra_link_args for flexible support of various compiler build

### DIFF
--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -53,6 +53,10 @@ GT4PY_EXTRA_COMPILE_ARGS: str = os.environ.get("GT4PY_EXTRA_COMPILE_ARGS", "")
 extra_compile_args: List[str] = (
     list(GT4PY_EXTRA_COMPILE_ARGS.split(" ")) if GT4PY_EXTRA_COMPILE_ARGS else []
 )
+GT4PY_EXTRA_LINK_ARGS: str = os.environ.get("GT4PY_EXTRA_LINK_ARGS", "")
+extra_link_args: List[str] = (
+    list(GT4PY_EXTRA_LINK_ARGS.split(" ")) if GT4PY_EXTRA_LINK_ARGS else []
+)
 build_settings: Dict[str, Any] = {
     "boost_include_path": os.path.join(BOOST_ROOT, "include"),
     "cuda_bin_path": os.path.join(CUDA_ROOT, "bin"),
@@ -62,7 +66,7 @@ build_settings: Dict[str, Any] = {
     "openmp_cppflags": os.environ.get("OPENMP_CPPFLAGS", "-fopenmp").split(),
     "openmp_ldflags": os.environ.get("OPENMP_LDFLAGS", "-fopenmp").split(),
     "extra_compile_args": {"cxx": extra_compile_args, "cuda": extra_compile_args},
-    "extra_link_args": [],
+    "extra_link_args": {"cxx": extra_link_args, "cuda": extra_link_args},
     "parallel_jobs": multiprocessing.cpu_count(),
     "cpp_template_depth": os.environ.get("GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH),
 }

--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -66,7 +66,7 @@ build_settings: Dict[str, Any] = {
     "openmp_cppflags": os.environ.get("OPENMP_CPPFLAGS", "-fopenmp").split(),
     "openmp_ldflags": os.environ.get("OPENMP_LDFLAGS", "-fopenmp").split(),
     "extra_compile_args": {"cxx": extra_compile_args, "cuda": extra_compile_args},
-    "extra_link_args": {"cxx": extra_link_args, "cuda": extra_link_args},
+    "extra_link_args": extra_link_args,
     "parallel_jobs": multiprocessing.cpu_count(),
     "cpp_template_depth": os.environ.get("GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH),
 }


### PR DESCRIPTION
add one more environment GT4PY_EXTRA_LINK_ARGS for flexible support of various compiler build

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian 
    # ONLY if changes are limited to a specific subsytem

- PR Description:
add one more environment GT4PY_EXTRA_LINK_ARGS for flexible support of various compiler build


## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] All the authors are covered by a valid contributor assignment agreement provided to ETH Zurich and signed by the employer if needed.
- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
