### PR TITLE
build: bump DaCe package version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
   ## version = re.search('ruff==([0-9\.]*)', open("constraints.txt").read())[1]
   ## print(f"rev: v{version}")
   ##]]]
-  rev: v0.4.4
+  rev: v0.4.10
   ##[[[end]]]
   hooks:
     # Run the linter.
@@ -66,7 +66,7 @@ repos:
   ## version = re.search('mypy==([0-9\.]*)', open("constraints.txt").read())[1]
   ## print(f"#========= FROM constraints.txt: v{version} =========")
   ##]]]
-  #========= FROM constraints.txt: v1.10.0 =========
+  #========= FROM constraints.txt: v1.10.1 =========
   ##[[[end]]]
   rev: v1.10.0  # MUST match version ^^^^ in constraints.txt (if the mirror is up-to-date)
   hooks:
@@ -90,7 +90,7 @@ repos:
     - boltons==24.0.0
     - cached-property==1.5.2
     - click==8.1.7
-    - cmake==3.29.3
+    - cmake==3.29.6
     - cytoolz==0.12.3
     - deepdiff==7.0.1
     - devtools==0.12.2
@@ -101,14 +101,14 @@ repos:
     - jinja2==3.1.4
     - lark==1.1.9
     - mako==1.3.5
-    - nanobind==1.9.2
+    - nanobind==2.0.0
     - ninja==1.11.1.1
     - numpy==1.24.4
-    - packaging==24.0
+    - packaging==24.1
     - pybind11==2.12.0
-    - setuptools==69.5.1
+    - setuptools==70.1.0
     - tabulate==0.9.0
-    - typing-extensions==4.11.0
+    - typing-extensions==4.12.2
     - xxhash==3.0.0
     ##[[[end]]]
     # Add all type stubs from typeshed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
     - jinja2==3.1.4
     - lark==1.1.9
     - mako==1.3.5
-    - nanobind==2.0.0
+    - nanobind==1.9.2
     - ninja==1.11.1.1
     - numpy==1.24.4
     - packaging==24.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
   ## version = re.search('mypy==([0-9\.]*)', open("constraints.txt").read())[1]
   ## print(f"#========= FROM constraints.txt: v{version} =========")
   ##]]]
-  #========= FROM constraints.txt: v1.10.1 =========
+  #========= FROM constraints.txt: v1.10.0 =========
   ##[[[end]]]
   rev: v1.10.0  # MUST match version ^^^^ in constraints.txt (if the mirror is up-to-date)
   hooks:

--- a/constraints.txt
+++ b/constraints.txt
@@ -98,7 +98,7 @@ mdit-py-plugins==0.4.1    # via jupytext
 mdurl==0.1.2              # via markdown-it-py
 ml-dtypes==0.2.0          # via jax, jaxlib
 mpmath==1.3.0             # via sympy
-mypy==1.10.1              # via -r requirements-dev.in
+mypy==1.10.0              # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
 nanobind==1.9.2           # via gt4py (pyproject.toml)
 nbclient==0.6.8           # via nbmake

--- a/constraints.txt
+++ b/constraints.txt
@@ -36,7 +36,7 @@ coverage==7.5.1           # via -r requirements-dev.in, pytest-cov
 cryptography==42.0.7      # via types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via matplotlib
 cytoolz==0.12.3           # via gt4py (pyproject.toml)
-dace==0.16.0              # via gt4py (pyproject.toml)
+dace==0.16.1              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
 debugpy==1.8.1            # via ipykernel
 decorator==5.1.1          # via ipython

--- a/constraints.txt
+++ b/constraints.txt
@@ -100,7 +100,7 @@ ml-dtypes==0.2.0          # via jax, jaxlib
 mpmath==1.3.0             # via sympy
 mypy==1.10.1              # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
-nanobind==2.0.0           # via gt4py (pyproject.toml)
+nanobind==1.9.2           # via gt4py (pyproject.toml)
 nbclient==0.6.8           # via nbmake
 nbformat==5.10.4          # via jupytext, nbclient, nbmake
 nbmake==1.5.4             # via -r requirements-dev.in

--- a/constraints.txt
+++ b/constraints.txt
@@ -35,7 +35,7 @@ coverage==7.4.4           # via -r requirements-dev.in, pytest-cov
 cryptography==42.0.5      # via types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via matplotlib
 cytoolz==0.12.3           # via gt4py (pyproject.toml)
-dace==0.15.1              # via gt4py (pyproject.toml)
+dace==0.16.0              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
 debugpy==1.8.1            # via ipykernel
 decorator==5.1.1          # via ipython

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,34 +6,34 @@
 #
 aenum==3.1.15             # via dace
 alabaster==0.7.13         # via sphinx
-annotated-types==0.6.0    # via pydantic
+annotated-types==0.7.0    # via pydantic
+appnope==0.1.4            # via ipykernel, ipython
 asttokens==2.4.1          # via devtools, stack-data
 astunparse==1.6.3 ; python_version < "3.9"  # via dace, gt4py (pyproject.toml)
 attrs==23.2.0             # via flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, referencing
 babel==2.15.0             # via sphinx
 backcall==0.2.0           # via ipython
 black==24.4.2             # via gt4py (pyproject.toml)
-blinker==1.8.2            # via flask
 boltons==24.0.0           # via gt4py (pyproject.toml)
 bracex==2.4               # via wcmatch
 build==1.2.1              # via pip-tools
-bump-my-version==0.21.0   # via -r requirements-dev.in
+bump-my-version==0.23.0   # via -r requirements-dev.in
 cached-property==1.5.2    # via gt4py (pyproject.toml)
 cachetools==5.3.3         # via tox
-certifi==2024.2.2         # via requests
+certifi==2024.6.2         # via requests
 cffi==1.16.0              # via cryptography
 cfgv==3.4.0               # via pre-commit
 chardet==5.2.0            # via tox
 charset-normalizer==3.3.2  # via requests
-clang-format==18.1.5      # via -r requirements-dev.in, gt4py (pyproject.toml)
-click==8.1.7              # via black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
-cmake==3.29.3             # via gt4py (pyproject.toml)
+clang-format==18.1.7      # via -r requirements-dev.in, gt4py (pyproject.toml)
+click==8.1.7              # via black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
+cmake==3.29.6             # via gt4py (pyproject.toml)
 cogapp==3.4.1             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
 comm==0.2.2               # via ipykernel
 contourpy==1.1.1          # via matplotlib
-coverage==7.5.1           # via -r requirements-dev.in, pytest-cov
-cryptography==42.0.7      # via types-paramiko, types-pyopenssl, types-redis
+coverage==7.5.4           # via -r requirements-dev.in, pytest-cov
+cryptography==42.0.8      # via types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via matplotlib
 cytoolz==0.12.3           # via gt4py (pyproject.toml)
 dace==0.16.1              # via gt4py (pyproject.toml)
@@ -50,10 +50,10 @@ exceptiongroup==1.2.1     # via hypothesis, pytest
 execnet==2.1.1            # via pytest-cache, pytest-xdist
 executing==2.0.1          # via devtools, stack-data
 factory-boy==3.3.0        # via gt4py (pyproject.toml), pytest-factoryboy
-faker==25.2.0             # via factory-boy
-fastjsonschema==2.19.1    # via nbformat
-filelock==3.14.0          # via tox, virtualenv
-flake8==7.0.0             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
+faker==25.9.1             # via factory-boy
+fastjsonschema==2.20.0    # via nbformat
+filelock==3.15.4          # via tox, virtualenv
+flake8==7.1.0             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
 flake8-bugbear==24.4.26   # via -r requirements-dev.in
 flake8-builtins==2.5.0    # via -r requirements-dev.in
 flake8-debugger==4.1.2    # via -r requirements-dev.in
@@ -62,37 +62,35 @@ flake8-eradicate==1.5.0   # via -r requirements-dev.in
 flake8-mutable==1.2.0     # via -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -r requirements-dev.in
-flask==3.0.3              # via dace
-fonttools==4.51.0         # via matplotlib
+fonttools==4.53.0         # via matplotlib
 fparser==0.1.4            # via dace
 frozendict==2.4.4         # via gt4py (pyproject.toml)
 gridtools-cpp==2.3.2      # via gt4py (pyproject.toml)
-hypothesis==6.102.1       # via -r requirements-dev.in, gt4py (pyproject.toml)
+hypothesis==6.104.0       # via -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.5.36          # via pre-commit
 idna==3.7                 # via requests
 imagesize==1.4.1          # via sphinx
-importlib-metadata==7.1.0  # via build, flask, jax, jupyter-client, sphinx
+importlib-metadata==7.2.1  # via build, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
 inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
 ipykernel==6.29.4         # via nbmake
 ipython==8.12.3           # via ipykernel
 isort==5.13.2             # via -r requirements-dev.in
-itsdangerous==2.2.0       # via flask
 jax==0.4.13               # via gt4py (pyproject.toml)
 jaxlib==0.4.13            # via jax
 jedi==0.19.1              # via ipython
-jinja2==3.1.4             # via flask, gt4py (pyproject.toml), sphinx
+jinja2==3.1.4             # via dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.22.0        # via nbformat
 jsonschema-specifications==2023.12.1  # via jsonschema
-jupyter-client==8.6.1     # via ipykernel, nbclient
+jupyter-client==8.6.2     # via ipykernel, nbclient
 jupyter-core==5.7.2       # via ipykernel, jupyter-client, nbformat
 jupytext==1.16.2          # via -r requirements-dev.in
 kiwisolver==1.4.5         # via matplotlib
 lark==1.1.9               # via gt4py (pyproject.toml)
 mako==1.3.5               # via gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via jupytext, mdit-py-plugins, rich
-markupsafe==2.1.5         # via jinja2, mako, werkzeug
+markupsafe==2.1.5         # via jinja2, mako
 matplotlib==3.7.5         # via -r requirements-dev.in
 matplotlib-inline==0.1.7  # via ipykernel, ipython
 mccabe==0.7.0             # via flake8
@@ -100,49 +98,49 @@ mdit-py-plugins==0.4.1    # via jupytext
 mdurl==0.1.2              # via markdown-it-py
 ml-dtypes==0.2.0          # via jax, jaxlib
 mpmath==1.3.0             # via sympy
-mypy==1.10.0              # via -r requirements-dev.in
+mypy==1.10.1              # via -r requirements-dev.in
 mypy-extensions==1.0.0    # via black, mypy
-nanobind==1.9.2           # via gt4py (pyproject.toml)
+nanobind==2.0.0           # via gt4py (pyproject.toml)
 nbclient==0.6.8           # via nbmake
 nbformat==5.10.4          # via jupytext, nbclient, nbmake
-nbmake==1.5.3             # via -r requirements-dev.in
+nbmake==1.5.4             # via -r requirements-dev.in
 nest-asyncio==1.6.0       # via ipykernel, nbclient
 networkx==3.1             # via dace
 ninja==1.11.1.1           # via gt4py (pyproject.toml)
-nodeenv==1.8.0            # via pre-commit
+nodeenv==1.9.1            # via pre-commit
 numpy==1.24.4             # via contourpy, dace, gt4py (pyproject.toml), jax, jaxlib, matplotlib, ml-dtypes, opt-einsum, scipy, types-jack-client
 opt-einsum==3.3.0         # via jax
 ordered-set==4.1.0        # via deepdiff
-packaging==24.0           # via black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
+packaging==24.1           # via black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
 parso==0.8.4              # via jedi
 pathspec==0.12.1          # via black
 pexpect==4.9.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pillow==10.3.0            # via matplotlib
 pip-tools==7.4.1          # via -r requirements-dev.in
-pipdeptree==2.20.0        # via -r requirements-dev.in
+pipdeptree==2.23.0        # via -r requirements-dev.in
 pkgutil-resolve-name==1.3.10  # via jsonschema
-platformdirs==4.2.1       # via black, jupyter-core, tox, virtualenv
+platformdirs==4.2.2       # via black, jupyter-core, tox, virtualenv
 pluggy==1.5.0             # via pytest, tox
 ply==3.11                 # via dace
 pre-commit==3.5.0         # via -r requirements-dev.in
 prompt-toolkit==3.0.36    # via ipython, questionary
-psutil==5.9.8             # via -r requirements-dev.in, ipykernel, pytest-xdist
+psutil==6.0.0             # via -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via pexpect
 pure-eval==0.2.2          # via stack-data
 pybind11==2.12.0          # via gt4py (pyproject.toml)
-pycodestyle==2.11.1       # via flake8, flake8-debugger
+pycodestyle==2.12.0       # via flake8, flake8-debugger
 pycparser==2.22           # via cffi
-pydantic==2.7.1           # via bump-my-version, pydantic-settings
-pydantic-core==2.18.2     # via pydantic
-pydantic-settings==2.2.1  # via bump-my-version
+pydantic==2.7.4           # via bump-my-version, pydantic-settings
+pydantic-core==2.18.4     # via pydantic
+pydantic-settings==2.3.4  # via bump-my-version
 pydocstyle==6.3.0         # via flake8-docstrings
 pyflakes==3.2.0           # via flake8
 pygments==2.18.0          # via -r requirements-dev.in, devtools, flake8-rst-docstrings, ipython, nbmake, rich, sphinx
 pyparsing==3.1.2          # via matplotlib
-pyproject-api==1.6.1      # via tox
+pyproject-api==1.7.1      # via tox
 pyproject-hooks==1.1.0    # via build, pip-tools
-pytest==8.2.0             # via -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-instafail, pytest-xdist
+pytest==8.2.2             # via -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-instafail, pytest-xdist
 pytest-cache==1.0         # via -r requirements-dev.in
 pytest-cov==5.0.0         # via -r requirements-dev.in
 pytest-factoryboy==2.7.0  # via -r requirements-dev.in
@@ -155,12 +153,12 @@ pyyaml==6.0.1             # via dace, jupytext, pre-commit
 pyzmq==26.0.3             # via ipykernel, jupyter-client
 questionary==2.0.1        # via bump-my-version
 referencing==0.35.1       # via jsonschema, jsonschema-specifications
-requests==2.31.0          # via dace, sphinx
+requests==2.32.3          # via sphinx
 restructuredtext-lint==1.4.0  # via flake8-rst-docstrings
 rich==13.7.1              # via bump-my-version, rich-click
-rich-click==1.8.2         # via bump-my-version
+rich-click==1.8.3         # via bump-my-version
 rpds-py==0.18.1           # via jsonschema, referencing
-ruff==0.4.4               # via -r requirements-dev.in
+ruff==0.4.10              # via -r requirements-dev.in
 scipy==1.10.1             # via gt4py (pyproject.toml), jax, jaxlib
 setuptools-scm==8.1.0     # via fparser
 six==1.16.0               # via asttokens, astunparse, python-dateutil
@@ -176,15 +174,15 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via sphinx
 stack-data==0.6.3         # via ipython
-sympy==1.9                # via dace, gt4py (pyproject.toml)
+sympy==1.12.1             # via dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via gt4py (pyproject.toml)
 tomli==2.0.1 ; python_version < "3.11"  # via -r requirements-dev.in, black, build, coverage, flake8-pyproject, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.5           # via bump-my-version
 toolz==0.12.1             # via cytoolz
-tornado==6.4              # via ipykernel, jupyter-client
-tox==4.15.0               # via -r requirements-dev.in
+tornado==6.4.1            # via ipykernel, jupyter-client
+tox==4.15.1               # via -r requirements-dev.in
 traitlets==5.14.3         # via comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
-types-aiofiles==23.2.0.20240403  # via types-all
+types-aiofiles==23.2.0.20240623  # via types-all
 types-all==1.0.0          # via -r requirements-dev.in
 types-annoy==1.17.8.4     # via types-all
 types-atomicwrites==1.4.5.1  # via types-all
@@ -236,16 +234,16 @@ types-openssl-python==0.1.3  # via types-all
 types-orjson==3.6.2       # via types-all
 types-paramiko==3.4.0.20240423  # via types-all, types-pysftp
 types-pathlib2==2.3.0     # via types-all
-types-pillow==10.2.0.20240511  # via types-all
+types-pillow==10.2.0.20240520  # via types-all
 types-pkg-resources==0.1.3  # via types-all
 types-polib==1.2.0.20240327  # via types-all
 types-protobuf==5.26.0.20240422  # via types-all
-types-pyaudio==0.2.16.20240425  # via types-all
+types-pyaudio==0.2.16.20240516  # via types-all
 types-pycurl==7.45.3.20240421  # via types-all
 types-pyfarmhash==0.3.1.20240311  # via types-all
 types-pyjwt==1.7.1        # via types-all
 types-pymssql==2.1.0      # via types-all
-types-pymysql==1.1.0.20240425  # via types-all
+types-pymysql==1.1.0.20240524  # via types-all
 types-pyopenssl==24.1.0.20240425  # via types-redis
 types-pyrfc3339==1.1.1.5  # via types-all
 types-pysftp==0.2.17.20240106  # via types-all
@@ -256,11 +254,11 @@ types-pytz==2024.1.0.20240417  # via types-all, types-tzlocal
 types-pyvmomi==8.0.0.6    # via types-all
 types-pyyaml==6.0.12.20240311  # via types-all
 types-redis==4.6.0.20240425  # via types-all
-types-requests==2.31.0.20240406  # via types-all
+types-requests==2.32.0.20240622  # via types-all
 types-retry==0.9.9.4      # via types-all
 types-routes==2.5.0       # via types-all
 types-scribe==2.0.0       # via types-all
-types-setuptools==69.5.0.20240513  # via types-cffi
+types-setuptools==70.1.0.20240625  # via types-cffi
 types-simplejson==3.19.0.20240310  # via types-all
 types-singledispatch==4.1.0.0  # via types-all
 types-six==1.16.21.20240513  # via types-all
@@ -270,21 +268,20 @@ types-toml==0.10.8.20240310  # via types-all
 types-tornado==5.1.1      # via types-all
 types-typed-ast==1.5.8.7  # via types-all
 types-tzlocal==5.1.0.1    # via types-all
-types-ujson==5.9.0.0      # via types-all
+types-ujson==5.10.0.20240515  # via types-all
 types-waitress==3.0.0.20240423  # via types-all
 types-werkzeug==1.0.9     # via types-all, types-flask
 types-xxhash==3.0.5.2     # via types-all
-typing-extensions==4.11.0  # via annotated-types, black, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
-urllib3==2.2.1            # via requests, types-requests
-virtualenv==20.26.2       # via pre-commit, tox
-wcmatch==8.5.1            # via bump-my-version
+typing-extensions==4.12.2  # via annotated-types, black, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
+urllib3==2.2.2            # via requests, types-requests
+virtualenv==20.26.3       # via pre-commit, tox
+wcmatch==8.5.2            # via bump-my-version
 wcwidth==0.2.13           # via prompt-toolkit
 websockets==12.0          # via dace
-werkzeug==3.0.3           # via flask
 wheel==0.43.0             # via astunparse, pip-tools
 xxhash==3.0.0             # via gt4py (pyproject.toml)
-zipp==3.18.1              # via importlib-metadata, importlib-resources
+zipp==3.19.2              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.0                 # via pip-tools, pipdeptree
-setuptools==69.5.1        # via gt4py (pyproject.toml), nodeenv, pip-tools, setuptools-scm
+pip==24.1                 # via pip-tools, pipdeptree
+setuptools==70.1.0        # via gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -61,7 +61,7 @@ cmake==3.22
 cogapp==3.3
 coverage[toml]==5.0
 cytoolz==0.12.1
-dace==0.16.0
+dace==0.16.1
 darglint==1.6
 deepdiff==5.6.0
 devtools==0.6

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -61,7 +61,7 @@ cmake==3.22
 cogapp==3.3
 coverage[toml]==5.0
 cytoolz==0.12.1
-dace==0.15.1
+dace==0.16.0
 darglint==1.6
 deepdiff==5.6.0
 devtools==0.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all-cuda12 = ['gt4py[cuda12,dace,formatting,jax-cuda12,performance,testing]']
 # Other extras
 cuda11 = ['cupy-cuda11x>=12.0']
 cuda12 = ['cupy-cuda12x>=12.0']
-dace = ['dace>=0.15.1,<0.16', 'sympy>=1.9']
+dace = ['dace>=0.16', 'sympy>=1.9']
 formatting = ['clang-format>=9.0']
 gpu = ['cupy>=12.0']
 jax-cpu = ['jax[cpu]>=0.4.13']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ all-cuda12 = ['gt4py[cuda12,dace,formatting,jax-cuda12,performance,testing]']
 # Other extras
 cuda11 = ['cupy-cuda11x>=12.0']
 cuda12 = ['cupy-cuda12x>=12.0']
-dace = ['dace>=0.16', 'sympy>=1.9']
+dace = ['dace>=0.16.1', 'sympy>=1.9']
 formatting = ['clang-format>=9.0']
 gpu = ['cupy>=12.0']
 jax-cpu = ['jax[cpu]>=0.4.13']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,34 +6,34 @@
 #
 aenum==3.1.15             # via -c constraints.txt, dace
 alabaster==0.7.13         # via -c constraints.txt, sphinx
-annotated-types==0.6.0    # via -c constraints.txt, pydantic
+annotated-types==0.7.0    # via -c constraints.txt, pydantic
+appnope==0.1.4            # via -c constraints.txt, ipykernel, ipython
 asttokens==2.4.1          # via -c constraints.txt, devtools, stack-data
 astunparse==1.6.3 ; python_version < "3.9"  # via -c constraints.txt, dace, gt4py (pyproject.toml)
 attrs==23.2.0             # via -c constraints.txt, flake8-bugbear, flake8-eradicate, gt4py (pyproject.toml), hypothesis, jsonschema, referencing
 babel==2.15.0             # via -c constraints.txt, sphinx
 backcall==0.2.0           # via -c constraints.txt, ipython
 black==24.4.2             # via -c constraints.txt, gt4py (pyproject.toml)
-blinker==1.8.2            # via -c constraints.txt, flask
 boltons==24.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
 bracex==2.4               # via -c constraints.txt, wcmatch
 build==1.2.1              # via -c constraints.txt, pip-tools
-bump-my-version==0.21.0   # via -c constraints.txt, -r requirements-dev.in
+bump-my-version==0.23.0   # via -c constraints.txt, -r requirements-dev.in
 cached-property==1.5.2    # via -c constraints.txt, gt4py (pyproject.toml)
 cachetools==5.3.3         # via -c constraints.txt, tox
-certifi==2024.2.2         # via -c constraints.txt, requests
+certifi==2024.6.2         # via -c constraints.txt, requests
 cffi==1.16.0              # via -c constraints.txt, cryptography
 cfgv==3.4.0               # via -c constraints.txt, pre-commit
 chardet==5.2.0            # via -c constraints.txt, tox
 charset-normalizer==3.3.2  # via -c constraints.txt, requests
-clang-format==18.1.5      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
-click==8.1.7              # via -c constraints.txt, black, bump-my-version, flask, gt4py (pyproject.toml), pip-tools, rich-click
-cmake==3.29.3             # via -c constraints.txt, gt4py (pyproject.toml)
+clang-format==18.1.7      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
+click==8.1.7              # via -c constraints.txt, black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
+cmake==3.29.6             # via -c constraints.txt, gt4py (pyproject.toml)
 cogapp==3.4.1             # via -c constraints.txt, -r requirements-dev.in
 colorama==0.4.6           # via -c constraints.txt, tox
 comm==0.2.2               # via -c constraints.txt, ipykernel
 contourpy==1.1.1          # via -c constraints.txt, matplotlib
-coverage[toml]==7.5.1     # via -c constraints.txt, -r requirements-dev.in, pytest-cov
-cryptography==42.0.7      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
+coverage[toml]==7.5.4     # via -c constraints.txt, -r requirements-dev.in, pytest-cov
+cryptography==42.0.8      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==0.12.3           # via -c constraints.txt, gt4py (pyproject.toml)
 dace==0.16.1              # via -c constraints.txt, gt4py (pyproject.toml)
@@ -50,10 +50,10 @@ exceptiongroup==1.2.1     # via -c constraints.txt, hypothesis, pytest
 execnet==2.1.1            # via -c constraints.txt, pytest-cache, pytest-xdist
 executing==2.0.1          # via -c constraints.txt, devtools, stack-data
 factory-boy==3.3.0        # via -c constraints.txt, gt4py (pyproject.toml), pytest-factoryboy
-faker==25.2.0             # via -c constraints.txt, factory-boy
-fastjsonschema==2.19.1    # via -c constraints.txt, nbformat
-filelock==3.14.0          # via -c constraints.txt, tox, virtualenv
-flake8==7.0.0             # via -c constraints.txt, -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
+faker==25.9.1             # via -c constraints.txt, factory-boy
+fastjsonschema==2.20.0    # via -c constraints.txt, nbformat
+filelock==3.15.4          # via -c constraints.txt, tox, virtualenv
+flake8==7.1.0             # via -c constraints.txt, -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
 flake8-bugbear==24.4.26   # via -c constraints.txt, -r requirements-dev.in
 flake8-builtins==2.5.0    # via -c constraints.txt, -r requirements-dev.in
 flake8-debugger==4.1.2    # via -c constraints.txt, -r requirements-dev.in
@@ -62,37 +62,35 @@ flake8-eradicate==1.5.0   # via -c constraints.txt, -r requirements-dev.in
 flake8-mutable==1.2.0     # via -c constraints.txt, -r requirements-dev.in
 flake8-pyproject==1.2.3   # via -c constraints.txt, -r requirements-dev.in
 flake8-rst-docstrings==0.3.0  # via -c constraints.txt, -r requirements-dev.in
-flask==3.0.3              # via -c constraints.txt, dace
-fonttools==4.51.0         # via -c constraints.txt, matplotlib
+fonttools==4.53.0         # via -c constraints.txt, matplotlib
 fparser==0.1.4            # via -c constraints.txt, dace
 frozendict==2.4.4         # via -c constraints.txt, gt4py (pyproject.toml)
 gridtools-cpp==2.3.2      # via -c constraints.txt, gt4py (pyproject.toml)
-hypothesis==6.102.1       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
+hypothesis==6.104.0       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.5.36          # via -c constraints.txt, pre-commit
 idna==3.7                 # via -c constraints.txt, requests
 imagesize==1.4.1          # via -c constraints.txt, sphinx
-importlib-metadata==7.1.0  # via -c constraints.txt, build, flask, jax, jupyter-client, sphinx
+importlib-metadata==7.2.1  # via -c constraints.txt, build, jax, jupyter-client, sphinx
 importlib-resources==6.4.0 ; python_version < "3.9"  # via -c constraints.txt, gt4py (pyproject.toml), jsonschema, jsonschema-specifications, matplotlib
 inflection==0.5.1         # via -c constraints.txt, pytest-factoryboy
 iniconfig==2.0.0          # via -c constraints.txt, pytest
 ipykernel==6.29.4         # via -c constraints.txt, nbmake
 ipython==8.12.3           # via -c constraints.txt, ipykernel
 isort==5.13.2             # via -c constraints.txt, -r requirements-dev.in
-itsdangerous==2.2.0       # via -c constraints.txt, flask
 jax[cpu]==0.4.13          # via -c constraints.txt, gt4py (pyproject.toml)
 jaxlib==0.4.13            # via -c constraints.txt, jax
 jedi==0.19.1              # via -c constraints.txt, ipython
-jinja2==3.1.4             # via -c constraints.txt, flask, gt4py (pyproject.toml), sphinx
+jinja2==3.1.4             # via -c constraints.txt, dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.22.0        # via -c constraints.txt, nbformat
 jsonschema-specifications==2023.12.1  # via -c constraints.txt, jsonschema
-jupyter-client==8.6.1     # via -c constraints.txt, ipykernel, nbclient
+jupyter-client==8.6.2     # via -c constraints.txt, ipykernel, nbclient
 jupyter-core==5.7.2       # via -c constraints.txt, ipykernel, jupyter-client, nbformat
 jupytext==1.16.2          # via -c constraints.txt, -r requirements-dev.in
 kiwisolver==1.4.5         # via -c constraints.txt, matplotlib
 lark==1.1.9               # via -c constraints.txt, gt4py (pyproject.toml)
 mako==1.3.5               # via -c constraints.txt, gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via -c constraints.txt, jupytext, mdit-py-plugins, rich
-markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako, werkzeug
+markupsafe==2.1.5         # via -c constraints.txt, jinja2, mako
 matplotlib==3.7.5         # via -c constraints.txt, -r requirements-dev.in
 matplotlib-inline==0.1.7  # via -c constraints.txt, ipykernel, ipython
 mccabe==0.7.0             # via -c constraints.txt, flake8
@@ -100,49 +98,49 @@ mdit-py-plugins==0.4.1    # via -c constraints.txt, jupytext
 mdurl==0.1.2              # via -c constraints.txt, markdown-it-py
 ml-dtypes==0.2.0          # via -c constraints.txt, jax, jaxlib
 mpmath==1.3.0             # via -c constraints.txt, sympy
-mypy==1.10.0              # via -c constraints.txt, -r requirements-dev.in
+mypy==1.10.1              # via -c constraints.txt, -r requirements-dev.in
 mypy-extensions==1.0.0    # via -c constraints.txt, black, mypy
-nanobind==1.9.2           # via -c constraints.txt, gt4py (pyproject.toml)
+nanobind==2.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
 nbclient==0.6.8           # via -c constraints.txt, nbmake
 nbformat==5.10.4          # via -c constraints.txt, jupytext, nbclient, nbmake
-nbmake==1.5.3             # via -c constraints.txt, -r requirements-dev.in
+nbmake==1.5.4             # via -c constraints.txt, -r requirements-dev.in
 nest-asyncio==1.6.0       # via -c constraints.txt, ipykernel, nbclient
 networkx==3.1             # via -c constraints.txt, dace
 ninja==1.11.1.1           # via -c constraints.txt, gt4py (pyproject.toml)
-nodeenv==1.8.0            # via -c constraints.txt, pre-commit
+nodeenv==1.9.1            # via -c constraints.txt, pre-commit
 numpy==1.24.4             # via -c constraints.txt, contourpy, dace, gt4py (pyproject.toml), jax, jaxlib, matplotlib, ml-dtypes, opt-einsum, scipy, types-jack-client
 opt-einsum==3.3.0         # via -c constraints.txt, jax
 ordered-set==4.1.0        # via -c constraints.txt, deepdiff
-packaging==24.0           # via -c constraints.txt, black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
+packaging==24.1           # via -c constraints.txt, black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
 parso==0.8.4              # via -c constraints.txt, jedi
 pathspec==0.12.1          # via -c constraints.txt, black
 pexpect==4.9.0            # via -c constraints.txt, ipython
 pickleshare==0.7.5        # via -c constraints.txt, ipython
 pillow==10.3.0            # via -c constraints.txt, matplotlib
 pip-tools==7.4.1          # via -c constraints.txt, -r requirements-dev.in
-pipdeptree==2.20.0        # via -c constraints.txt, -r requirements-dev.in
+pipdeptree==2.23.0        # via -c constraints.txt, -r requirements-dev.in
 pkgutil-resolve-name==1.3.10  # via -c constraints.txt, jsonschema
-platformdirs==4.2.1       # via -c constraints.txt, black, jupyter-core, tox, virtualenv
+platformdirs==4.2.2       # via -c constraints.txt, black, jupyter-core, tox, virtualenv
 pluggy==1.5.0             # via -c constraints.txt, pytest, tox
 ply==3.11                 # via -c constraints.txt, dace
 pre-commit==3.5.0         # via -c constraints.txt, -r requirements-dev.in
 prompt-toolkit==3.0.36    # via -c constraints.txt, ipython, questionary
-psutil==5.9.8             # via -c constraints.txt, -r requirements-dev.in, ipykernel, pytest-xdist
+psutil==6.0.0             # via -c constraints.txt, -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via -c constraints.txt, pexpect
 pure-eval==0.2.2          # via -c constraints.txt, stack-data
 pybind11==2.12.0          # via -c constraints.txt, gt4py (pyproject.toml)
-pycodestyle==2.11.1       # via -c constraints.txt, flake8, flake8-debugger
+pycodestyle==2.12.0       # via -c constraints.txt, flake8, flake8-debugger
 pycparser==2.22           # via -c constraints.txt, cffi
-pydantic==2.7.1           # via -c constraints.txt, bump-my-version, pydantic-settings
-pydantic-core==2.18.2     # via -c constraints.txt, pydantic
-pydantic-settings==2.2.1  # via -c constraints.txt, bump-my-version
+pydantic==2.7.4           # via -c constraints.txt, bump-my-version, pydantic-settings
+pydantic-core==2.18.4     # via -c constraints.txt, pydantic
+pydantic-settings==2.3.4  # via -c constraints.txt, bump-my-version
 pydocstyle==6.3.0         # via -c constraints.txt, flake8-docstrings
 pyflakes==3.2.0           # via -c constraints.txt, flake8
 pygments==2.18.0          # via -c constraints.txt, -r requirements-dev.in, devtools, flake8-rst-docstrings, ipython, nbmake, rich, sphinx
 pyparsing==3.1.2          # via -c constraints.txt, matplotlib
-pyproject-api==1.6.1      # via -c constraints.txt, tox
+pyproject-api==1.7.1      # via -c constraints.txt, tox
 pyproject-hooks==1.1.0    # via -c constraints.txt, build, pip-tools
-pytest==8.2.0             # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-instafail, pytest-xdist
+pytest==8.2.2             # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml), nbmake, pytest-cache, pytest-cov, pytest-factoryboy, pytest-instafail, pytest-xdist
 pytest-cache==1.0         # via -c constraints.txt, -r requirements-dev.in
 pytest-cov==5.0.0         # via -c constraints.txt, -r requirements-dev.in
 pytest-factoryboy==2.7.0  # via -c constraints.txt, -r requirements-dev.in
@@ -155,12 +153,12 @@ pyyaml==6.0.1             # via -c constraints.txt, dace, jupytext, pre-commit
 pyzmq==26.0.3             # via -c constraints.txt, ipykernel, jupyter-client
 questionary==2.0.1        # via -c constraints.txt, bump-my-version
 referencing==0.35.1       # via -c constraints.txt, jsonschema, jsonschema-specifications
-requests==2.31.0          # via -c constraints.txt, dace, sphinx
+requests==2.32.3          # via -c constraints.txt, sphinx
 restructuredtext-lint==1.4.0  # via -c constraints.txt, flake8-rst-docstrings
 rich==13.7.1              # via -c constraints.txt, bump-my-version, rich-click
-rich-click==1.8.2         # via -c constraints.txt, bump-my-version
+rich-click==1.8.3         # via -c constraints.txt, bump-my-version
 rpds-py==0.18.1           # via -c constraints.txt, jsonschema, referencing
-ruff==0.4.4               # via -c constraints.txt, -r requirements-dev.in
+ruff==0.4.10              # via -c constraints.txt, -r requirements-dev.in
 scipy==1.10.1             # via -c constraints.txt, jax, jaxlib
 setuptools-scm==8.1.0     # via -c constraints.txt, fparser
 six==1.16.0               # via -c constraints.txt, asttokens, astunparse, python-dateutil
@@ -176,15 +174,15 @@ sphinxcontrib-jsmath==1.0.1  # via -c constraints.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -c constraints.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.5  # via -c constraints.txt, sphinx
 stack-data==0.6.3         # via -c constraints.txt, ipython
-sympy==1.9                # via -c constraints.txt, dace, gt4py (pyproject.toml)
+sympy==1.12.1             # via -c constraints.txt, dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via -c constraints.txt, gt4py (pyproject.toml)
 tomli==2.0.1 ; python_version < "3.11"  # via -c constraints.txt, -r requirements-dev.in, black, build, coverage, flake8-pyproject, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tox
 tomlkit==0.12.5           # via -c constraints.txt, bump-my-version
 toolz==0.12.1             # via -c constraints.txt, cytoolz
-tornado==6.4              # via -c constraints.txt, ipykernel, jupyter-client
-tox==4.15.0               # via -c constraints.txt, -r requirements-dev.in
+tornado==6.4.1            # via -c constraints.txt, ipykernel, jupyter-client
+tox==4.15.1               # via -c constraints.txt, -r requirements-dev.in
 traitlets==5.14.3         # via -c constraints.txt, comm, ipykernel, ipython, jupyter-client, jupyter-core, matplotlib-inline, nbclient, nbformat
-types-aiofiles==23.2.0.20240403  # via -c constraints.txt, types-all
+types-aiofiles==23.2.0.20240623  # via -c constraints.txt, types-all
 types-all==1.0.0          # via -c constraints.txt, -r requirements-dev.in
 types-annoy==1.17.8.4     # via -c constraints.txt, types-all
 types-atomicwrites==1.4.5.1  # via -c constraints.txt, types-all
@@ -236,16 +234,16 @@ types-openssl-python==0.1.3  # via -c constraints.txt, types-all
 types-orjson==3.6.2       # via -c constraints.txt, types-all
 types-paramiko==3.4.0.20240423  # via -c constraints.txt, types-all, types-pysftp
 types-pathlib2==2.3.0     # via -c constraints.txt, types-all
-types-pillow==10.2.0.20240511  # via -c constraints.txt, types-all
+types-pillow==10.2.0.20240520  # via -c constraints.txt, types-all
 types-pkg-resources==0.1.3  # via -c constraints.txt, types-all
 types-polib==1.2.0.20240327  # via -c constraints.txt, types-all
 types-protobuf==5.26.0.20240422  # via -c constraints.txt, types-all
-types-pyaudio==0.2.16.20240425  # via -c constraints.txt, types-all
+types-pyaudio==0.2.16.20240516  # via -c constraints.txt, types-all
 types-pycurl==7.45.3.20240421  # via -c constraints.txt, types-all
 types-pyfarmhash==0.3.1.20240311  # via -c constraints.txt, types-all
 types-pyjwt==1.7.1        # via -c constraints.txt, types-all
 types-pymssql==2.1.0      # via -c constraints.txt, types-all
-types-pymysql==1.1.0.20240425  # via -c constraints.txt, types-all
+types-pymysql==1.1.0.20240524  # via -c constraints.txt, types-all
 types-pyopenssl==24.1.0.20240425  # via -c constraints.txt, types-redis
 types-pyrfc3339==1.1.1.5  # via -c constraints.txt, types-all
 types-pysftp==0.2.17.20240106  # via -c constraints.txt, types-all
@@ -256,11 +254,11 @@ types-pytz==2024.1.0.20240417  # via -c constraints.txt, types-all, types-tzloca
 types-pyvmomi==8.0.0.6    # via -c constraints.txt, types-all
 types-pyyaml==6.0.12.20240311  # via -c constraints.txt, types-all
 types-redis==4.6.0.20240425  # via -c constraints.txt, types-all
-types-requests==2.31.0.20240406  # via -c constraints.txt, types-all
+types-requests==2.32.0.20240622  # via -c constraints.txt, types-all
 types-retry==0.9.9.4      # via -c constraints.txt, types-all
 types-routes==2.5.0       # via -c constraints.txt, types-all
 types-scribe==2.0.0       # via -c constraints.txt, types-all
-types-setuptools==69.5.0.20240513  # via -c constraints.txt, types-cffi
+types-setuptools==70.1.0.20240625  # via -c constraints.txt, types-cffi
 types-simplejson==3.19.0.20240310  # via -c constraints.txt, types-all
 types-singledispatch==4.1.0.0  # via -c constraints.txt, types-all
 types-six==1.16.21.20240513  # via -c constraints.txt, types-all
@@ -270,21 +268,20 @@ types-toml==0.10.8.20240310  # via -c constraints.txt, types-all
 types-tornado==5.1.1      # via -c constraints.txt, types-all
 types-typed-ast==1.5.8.7  # via -c constraints.txt, types-all
 types-tzlocal==5.1.0.1    # via -c constraints.txt, types-all
-types-ujson==5.9.0.0      # via -c constraints.txt, types-all
+types-ujson==5.10.0.20240515  # via -c constraints.txt, types-all
 types-waitress==3.0.0.20240423  # via -c constraints.txt, types-all
 types-werkzeug==1.0.9     # via -c constraints.txt, types-all, types-flask
 types-xxhash==3.0.5.2     # via -c constraints.txt, types-all
-typing-extensions==4.11.0  # via -c constraints.txt, annotated-types, black, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
-urllib3==2.2.1            # via -c constraints.txt, requests, types-requests
-virtualenv==20.26.2       # via -c constraints.txt, pre-commit, tox
-wcmatch==8.5.1            # via -c constraints.txt, bump-my-version
+typing-extensions==4.12.2  # via -c constraints.txt, annotated-types, black, gt4py (pyproject.toml), ipython, mypy, pydantic, pydantic-core, pytest-factoryboy, rich, rich-click, setuptools-scm
+urllib3==2.2.2            # via -c constraints.txt, requests, types-requests
+virtualenv==20.26.3       # via -c constraints.txt, pre-commit, tox
+wcmatch==8.5.2            # via -c constraints.txt, bump-my-version
 wcwidth==0.2.13           # via -c constraints.txt, prompt-toolkit
 websockets==12.0          # via -c constraints.txt, dace
-werkzeug==3.0.3           # via -c constraints.txt, flask
 wheel==0.43.0             # via -c constraints.txt, astunparse, pip-tools
 xxhash==3.0.0             # via -c constraints.txt, gt4py (pyproject.toml)
-zipp==3.18.1              # via -c constraints.txt, importlib-metadata, importlib-resources
+zipp==3.19.2              # via -c constraints.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.0                 # via -c constraints.txt, pip-tools, pipdeptree
-setuptools==69.5.1        # via -c constraints.txt, gt4py (pyproject.toml), nodeenv, pip-tools, setuptools-scm
+pip==24.1                 # via -c constraints.txt, pip-tools, pipdeptree
+setuptools==70.1.0        # via -c constraints.txt, gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -100,7 +100,7 @@ ml-dtypes==0.2.0          # via -c constraints.txt, jax, jaxlib
 mpmath==1.3.0             # via -c constraints.txt, sympy
 mypy==1.10.1              # via -c constraints.txt, -r requirements-dev.in
 mypy-extensions==1.0.0    # via -c constraints.txt, black, mypy
-nanobind==2.0.0           # via -c constraints.txt, gt4py (pyproject.toml)
+nanobind==1.9.2           # via -c constraints.txt, gt4py (pyproject.toml)
 nbclient==0.6.8           # via -c constraints.txt, nbmake
 nbformat==5.10.4          # via -c constraints.txt, jupytext, nbclient, nbmake
 nbmake==1.5.4             # via -c constraints.txt, -r requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,7 +98,7 @@ mdit-py-plugins==0.4.1    # via -c constraints.txt, jupytext
 mdurl==0.1.2              # via -c constraints.txt, markdown-it-py
 ml-dtypes==0.2.0          # via -c constraints.txt, jax, jaxlib
 mpmath==1.3.0             # via -c constraints.txt, sympy
-mypy==1.10.1              # via -c constraints.txt, -r requirements-dev.in
+mypy==1.10.0              # via -c constraints.txt, -r requirements-dev.in
 mypy-extensions==1.0.0    # via -c constraints.txt, black, mypy
 nanobind==1.9.2           # via -c constraints.txt, gt4py (pyproject.toml)
 nbclient==0.6.8           # via -c constraints.txt, nbmake

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ coverage[toml]==7.5.1     # via -c constraints.txt, -r requirements-dev.in, pyte
 cryptography==42.0.7      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==0.12.3           # via -c constraints.txt, gt4py (pyproject.toml)
-dace==0.16.0              # via -c constraints.txt, gt4py (pyproject.toml)
+dace==0.16.1              # via -c constraints.txt, gt4py (pyproject.toml)
 darglint==1.8.1           # via -c constraints.txt, -r requirements-dev.in
 debugpy==1.8.1            # via -c constraints.txt, ipykernel
 decorator==5.1.1          # via -c constraints.txt, ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ coverage[toml]==7.4.4     # via -c constraints.txt, -r requirements-dev.in, pyte
 cryptography==42.0.5      # via -c constraints.txt, types-paramiko, types-pyopenssl, types-redis
 cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==0.12.3           # via -c constraints.txt, gt4py (pyproject.toml)
-dace==0.15.1              # via -c constraints.txt, gt4py (pyproject.toml)
+dace==0.16.0              # via -c constraints.txt, gt4py (pyproject.toml)
 darglint==1.8.1           # via -c constraints.txt, -r requirements-dev.in
 debugpy==1.8.1            # via -c constraints.txt, ipykernel
 decorator==5.1.1          # via -c constraints.txt, ipython

--- a/src/gt4py/cartesian/backend/dace_stencil_object.py
+++ b/src/gt4py/cartesian/backend/dace_stencil_object.py
@@ -56,7 +56,7 @@ def add_optional_fields(
     for name, info in parameter_info.items():
         if info.access == AccessKind.NONE and name in kwargs and name not in sdfg.symbols:
             if isinstance(kwargs[name], dace.data.Scalar):
-                sdfg.add_symbol(name, stype=kwargs[name].dtype)
+                sdfg.add_scalar(name, dtype=kwargs[name].dtype)
             else:
                 sdfg.add_symbol(name, stype=dace.typeclass(type(kwargs[name])))
     return sdfg

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
@@ -349,7 +349,6 @@ def test_optional_arg_provide_aot(decorator):
         inp: gtscript.Field[np.float64],
         unused_field: gtscript.Field[np.float64],
         outp: gtscript.Field[np.float64],
-        unused_par: float,
     ):
         with computation(PARALLEL), interval(...):
             outp = inp  # noqa: F841 [unused-variable]

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
@@ -349,6 +349,8 @@ def test_optional_arg_provide_aot(decorator):
         inp: gtscript.Field[np.float64],
         unused_field: gtscript.Field[np.float64],
         outp: gtscript.Field[np.float64],
+        # originally it also tested unused scalar parameters, but starting from DaCe v0.16.1 it led to undefined symbols in SDFG nesting
+        # unused_par: float,
     ):
         with computation(PARALLEL), interval(...):
             outp = inp  # noqa: F841 [unused-variable]

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
@@ -349,8 +349,7 @@ def test_optional_arg_provide_aot(decorator):
         inp: gtscript.Field[np.float64],
         unused_field: gtscript.Field[np.float64],
         outp: gtscript.Field[np.float64],
-        # originally it also tested unused scalar parameters, but starting from DaCe v0.16.1 it led to undefined symbols in SDFG nesting
-        # unused_par: float,
+        unused_par: float,
     ):
         with computation(PARALLEL), interval(...):
             outp = inp  # noqa: F841 [unused-variable]

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
@@ -52,6 +52,8 @@ def dace_env():
         dace.config.Config.set("compiler", "cpu", "args", value="")
         dace.config.Config.set("compiler", "allow_view_arguments", value=True)
         dace.config.Config.set("default_build_folder", value=str(gt_cache_path))
+        # Need to serialize `StencilComputation` library nodes because they contain OIR for `VerticalLoop`
+        dace.config.Config.set("testing", "serialize_all_fields", value=True)
         yield
 
 

--- a/tests/next_tests/definitions.py
+++ b/tests/next_tests/definitions.py
@@ -176,11 +176,7 @@ BACKEND_SKIP_TEST_MATRIX = {
     EmbeddedIds.NUMPY_EXECUTION: EMBEDDED_SKIP_LIST,
     EmbeddedIds.CUPY_EXECUTION: EMBEDDED_SKIP_LIST,
     OptionalProgramBackendId.DACE_CPU: DACE_SKIP_TEST_LIST,
-    OptionalProgramBackendId.DACE_GPU: DACE_SKIP_TEST_LIST
-    + [
-        # awaiting dace fix, see https://github.com/spcl/dace/pull/1442
-        (USES_FLOORDIV, XFAIL, BINDINGS_UNSUPPORTED_MESSAGE)
-    ],
+    OptionalProgramBackendId.DACE_GPU: DACE_SKIP_TEST_LIST,
     ProgramBackendId.GTFN_CPU: GTFN_SKIP_TEST_LIST
     + [(USES_SCAN_NESTED, XFAIL, UNSUPPORTED_MESSAGE)],
     ProgramBackendId.GTFN_CPU_IMPERATIVE: GTFN_SKIP_TEST_LIST


### PR DESCRIPTION
Upgrade DaCe package version to release v0.16.1. Include GT4Py-next code changes enabled by bugfixes included in the new DaCe package.

Package versions updated in requirement files, but keeping `nanobind==1.9.2` (GT4Py does not support v2.0.0) and `mypy==1.10.0` (v1.10.1 not available for pre-commit).

A couple of code changes in GT4Py-cartesian DaCe backend:
- temporary config in test case to force serialize all fields in SDFG JSON representation, because the default config value was chaged in the new dace release
- handle scalar parameters in stencil objects as scalars rather than symbols, to avoid undefined symbol issues when the parameter is not used