### PR TITLE
feat[storage]: add support for numpy and cupy 2.0 

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -5,11 +5,11 @@ on:
   - cron: '0 4 * * *'
   workflow_dispatch:
 
-  # COMMENTED OUT: only for testing CI action changes
-  pull_request:
-    branches:
-    - main
-  # END
+  ## COMMENTED OUT: only for testing CI action changes
+  # pull_request:
+  #   branches:
+  #   - main
+  ## END
 
 jobs:
   daily-ci:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -5,11 +5,11 @@ on:
   - cron: '0 4 * * *'
   workflow_dispatch:
 
-  ## COMMENTED OUT: only for testing CI action changes
-  # pull_request:
-  #   branches:
-  #   - main
-  ## END
+  # COMMENTED OUT: only for testing CI action changes
+  pull_request:
+    branches:
+    - main
+  # END
 
 jobs:
   daily-ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
     - ninja==1.11.1.1
     - numpy==1.24.4
     - packaging==24.1
-    - pybind11==2.13.0
+    - pybind11==2.13.1
     - setuptools==70.1.1
     - tabulate==0.9.0
     - typing-extensions==4.12.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -49,7 +49,7 @@ exceptiongroup==1.2.1     # via hypothesis, pytest
 execnet==2.1.1            # via pytest-cache, pytest-xdist
 executing==2.0.1          # via devtools, stack-data
 factory-boy==3.3.0        # via gt4py (pyproject.toml), pytest-factoryboy
-faker==25.9.2             # via factory-boy
+faker==26.0.0             # via factory-boy
 fastjsonschema==2.20.0    # via nbformat
 filelock==3.15.4          # via tox, virtualenv
 flake8==7.1.0             # via -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
@@ -127,7 +127,7 @@ prompt-toolkit==3.0.36    # via ipython, questionary
 psutil==6.0.0             # via -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via pexpect
 pure-eval==0.2.2          # via stack-data
-pybind11==2.13.0          # via gt4py (pyproject.toml)
+pybind11==2.13.1          # via gt4py (pyproject.toml)
 pycodestyle==2.12.0       # via flake8, flake8-debugger
 pycparser==2.22           # via cffi
 pydantic==2.7.4           # via bump-my-version, pydantic-settings
@@ -257,7 +257,7 @@ types-requests==2.32.0.20240622  # via types-all
 types-retry==0.9.9.4      # via types-all
 types-routes==2.5.0       # via types-all
 types-scribe==2.0.0       # via types-all
-types-setuptools==70.1.0.20240625  # via types-cffi
+types-setuptools==70.1.0.20240627  # via types-cffi
 types-simplejson==3.19.0.20240310  # via types-all
 types-singledispatch==4.1.0.0  # via types-all
 types-six==1.16.21.20240513  # via types-all
@@ -282,5 +282,5 @@ xxhash==3.0.0             # via gt4py (pyproject.toml)
 zipp==3.19.2              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.1                 # via pip-tools, pipdeptree
+pip==24.1.1               # via pip-tools, pipdeptree
 setuptools==70.1.1        # via gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   'mako>=1.1',
   'nanobind>=1.4.0 ',
   'ninja>=1.10',
-  'numpy>=1.23.3,==1.*',
+  'numpy>=1.23.3',
   'packaging>=20.0',
   'pybind11>=2.10.1',
   'setuptools>=65.5.0',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -49,7 +49,7 @@ exceptiongroup==1.2.1     # via -c constraints.txt, hypothesis, pytest
 execnet==2.1.1            # via -c constraints.txt, pytest-cache, pytest-xdist
 executing==2.0.1          # via -c constraints.txt, devtools, stack-data
 factory-boy==3.3.0        # via -c constraints.txt, gt4py (pyproject.toml), pytest-factoryboy
-faker==25.9.2             # via -c constraints.txt, factory-boy
+faker==26.0.0             # via -c constraints.txt, factory-boy
 fastjsonschema==2.20.0    # via -c constraints.txt, nbformat
 filelock==3.15.4          # via -c constraints.txt, tox, virtualenv
 flake8==7.1.0             # via -c constraints.txt, -r requirements-dev.in, flake8-bugbear, flake8-builtins, flake8-debugger, flake8-docstrings, flake8-eradicate, flake8-mutable, flake8-pyproject, flake8-rst-docstrings
@@ -127,7 +127,7 @@ prompt-toolkit==3.0.36    # via -c constraints.txt, ipython, questionary
 psutil==6.0.0             # via -c constraints.txt, -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via -c constraints.txt, pexpect
 pure-eval==0.2.2          # via -c constraints.txt, stack-data
-pybind11==2.13.0          # via -c constraints.txt, gt4py (pyproject.toml)
+pybind11==2.13.1          # via -c constraints.txt, gt4py (pyproject.toml)
 pycodestyle==2.12.0       # via -c constraints.txt, flake8, flake8-debugger
 pycparser==2.22           # via -c constraints.txt, cffi
 pydantic==2.7.4           # via -c constraints.txt, bump-my-version, pydantic-settings
@@ -257,7 +257,7 @@ types-requests==2.32.0.20240622  # via -c constraints.txt, types-all
 types-retry==0.9.9.4      # via -c constraints.txt, types-all
 types-routes==2.5.0       # via -c constraints.txt, types-all
 types-scribe==2.0.0       # via -c constraints.txt, types-all
-types-setuptools==70.1.0.20240625  # via -c constraints.txt, types-cffi
+types-setuptools==70.1.0.20240627  # via -c constraints.txt, types-cffi
 types-simplejson==3.19.0.20240310  # via -c constraints.txt, types-all
 types-singledispatch==4.1.0.0  # via -c constraints.txt, types-all
 types-six==1.16.21.20240513  # via -c constraints.txt, types-all
@@ -282,5 +282,5 @@ xxhash==3.0.0             # via -c constraints.txt, gt4py (pyproject.toml)
 zipp==3.19.2              # via -c constraints.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.1                 # via -c constraints.txt, pip-tools, pipdeptree
+pip==24.1.1               # via -c constraints.txt, pip-tools, pipdeptree
 setuptools==70.1.1        # via -c constraints.txt, gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -259,7 +259,7 @@ class InvalidFieldBufferAllocator(FieldBufferAllocatorProtocol[core_defs.DeviceT
 
 if CUPY_DEVICE is not None:
     assert isinstance(core_allocators.cupy_array_utils, core_allocators.ArrayUtils)
-    cupy_array_utils = cast(core_allocators.ArrayUtils, core_allocators.cupy_array_utils)
+    cupy_array_utils = core_allocators.cupy_array_utils
 
     if CUPY_DEVICE is core_defs.DeviceType.CUDA:
 

--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -14,6 +14,7 @@
 
 import abc
 import dataclasses
+import functools
 
 import gt4py._core.definitions as core_defs
 import gt4py.next.common as common
@@ -150,14 +151,10 @@ class BaseFieldBufferAllocator(FieldBufferAllocatorProtocol[core_defs.DeviceType
     array_utils: core_allocators.ArrayUtils
     layout_mapper: FieldLayoutMapper
     byte_alignment: int
-    buffer_allocator: core_allocators.BufferAllocator = dataclasses.field(init=False)
 
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "buffer_allocator",
-            core_allocators.NDArrayBufferAllocator(self.device_type, self.array_utils),
-        )
+    @functools.cached_property
+    def buffer_allocator(self) -> core_allocators.BufferAllocator:
+        return core_allocators.NDArrayBufferAllocator(self.device_type, self.array_utils)
 
     @property
     def __gt_device_type__(self) -> core_defs.DeviceTypeT:

--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -156,9 +156,7 @@ class BaseFieldBufferAllocator(FieldBufferAllocatorProtocol[core_defs.DeviceType
         object.__setattr__(
             self,
             "buffer_allocator",
-            core_allocators.NDArrayBufferAllocator(
-                self.device_type, core_allocators.numpy_array_utils
-            ),
+            core_allocators.NDArrayBufferAllocator(self.device_type, self.array_utils),
         )
 
     @property

--- a/src/gt4py/storage/allocators.py
+++ b/src/gt4py/storage/allocators.py
@@ -314,7 +314,7 @@ class _BaseNDArrayBufferAllocator(abc.ABC, Generic[core_defs.DeviceTypeT]):
         pass
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass
 class ArrayUtils:
     array_ns: types.ModuleType
     empty: Callable[..., _NDBuffer]

--- a/src/gt4py/storage/allocators.py
+++ b/src/gt4py/storage/allocators.py
@@ -20,6 +20,7 @@ import dataclasses
 import functools
 import math
 import operator
+import types
 
 import numpy as np
 import numpy.typing as npt
@@ -29,6 +30,7 @@ from gt4py.eve import extended_typing as xtyping
 from gt4py.eve.extended_typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Generic,
     NewType,
     Optional,
@@ -238,7 +240,7 @@ class _BaseNDArrayBufferAllocator(abc.ABC, Generic[core_defs.DeviceTypeT]):
 
         # Allocate total size
         buffer = self.malloc(total_length, device_id)
-        memory_address = self.array_ns.byte_bounds(buffer)[0]
+        memory_address = self.array_utils.byte_bounds(buffer)[0]
 
         # Compute final byte offset to align the requested buffer index
         aligned_index = tuple(aligned_index or ([0] * len(shape)))
@@ -291,7 +293,7 @@ class _BaseNDArrayBufferAllocator(abc.ABC, Generic[core_defs.DeviceTypeT]):
 
     @property
     @abc.abstractmethod
-    def array_ns(self) -> ValidNumPyLikeAllocationNS:
+    def array_utils(self) -> ArrayUtils:
         pass
 
     @abc.abstractmethod
@@ -312,53 +314,50 @@ class _BaseNDArrayBufferAllocator(abc.ABC, Generic[core_defs.DeviceTypeT]):
         pass
 
 
-class ValidNumPyLikeAllocationNS(Protocol):
-    class _NumPyLibModule(Protocol):
-        class _NumPyLibStridesModule(Protocol):
-            @staticmethod
-            def as_strided(
-                ndarray: core_defs.NDArrayObject, **kwargs: Any
-            ) -> core_defs.NDArrayObject: ...
-
-        stride_tricks: _NumPyLibStridesModule
-
-    lib: _NumPyLibModule
-
-    @staticmethod
-    def empty(shape: Tuple[int, ...], dtype: Any) -> _NDBuffer: ...
-
-    @staticmethod
-    def byte_bounds(ndarray: _NDBuffer) -> Tuple[int, int]: ...
+@dataclasses.dataclass(slots=True)
+class ArrayUtils:
+    array_ns: types.ModuleType
+    empty: Callable[..., _NDBuffer]
+    byte_bounds: Callable[[_NDBuffer], Tuple[int, int]]
+    as_strided: Callable[..., core_defs.NDArrayObject]
 
 
-def is_valid_nplike_allocation_ns(obj: Any) -> TypeGuard[ValidNumPyLikeAllocationNS]:
-    return (
-        len(required_keys := {"empty", "byte_bounds", "lib"} & set(dir(np))) == len(required_keys)
-        and "stride_tricks" in dir(np.lib)
-        and "as_strided" in dir(np.lib.stride_tricks)
+numpy_array_utils = ArrayUtils(
+    array_ns=np,
+    empty=np.empty,
+    byte_bounds=np.byte_bounds if hasattr(np, "byte_bounds") else np.lib.array_utils.byte_bounds,  # type: ignore  # noqa: NPY201
+    as_strided=np.lib.stride_tricks.as_strided,
+)
+
+cupy_array_utils = None
+
+if cp is not None:
+    cupy_array_utils = ArrayUtils(
+        array_ns=cp,
+        empty=cp.empty,
+        byte_bounds=cp.byte_bounds
+        if hasattr(cp, "byte_bounds")
+        else cp.lib.array_utils.byte_bounds,
+        as_strided=cp.lib.stride_tricks.as_strided,
     )
-
-
-if not TYPE_CHECKING:
-    is_valid_nplike_allocation_ns = functools.lru_cache(maxsize=None)(is_valid_nplike_allocation_ns)
 
 
 @dataclasses.dataclass(frozen=True, init=False)
 class NDArrayBufferAllocator(_BaseNDArrayBufferAllocator[core_defs.DeviceTypeT]):
     _device_type: core_defs.DeviceTypeT
-    _array_ns: ValidNumPyLikeAllocationNS
+    _array_utils: ArrayUtils
 
-    def __init__(self, device_type: core_defs.DeviceTypeT, array_ns: ValidNumPyLikeAllocationNS):
+    def __init__(self, device_type: core_defs.DeviceTypeT, array_utils: ArrayUtils):
         object.__setattr__(self, "_device_type", device_type)
-        object.__setattr__(self, "_array_ns", array_ns)
+        object.__setattr__(self, "_array_ns", array_utils)
 
     @property
     def device_type(self) -> core_defs.DeviceTypeT:
         return self._device_type
 
     @property
-    def array_ns(self) -> ValidNumPyLikeAllocationNS:
-        return self._array_ns
+    def array_utils(self) -> ArrayUtils:
+        return self._array_utils
 
     def malloc(self, length: int, device_id: int) -> _NDBuffer:
         if self.device_type == core_defs.DeviceType.CPU and device_id != 0:
@@ -366,7 +365,7 @@ class NDArrayBufferAllocator(_BaseNDArrayBufferAllocator[core_defs.DeviceTypeT])
 
         shape = (length,)
         assert core_defs.is_valid_tensor_shape(shape)  # for mypy
-        out = self.array_ns.empty(shape=tuple(shape), dtype=np.dtype(np.uint8))
+        out = self._array_utils.empty(shape=tuple(shape), dtype=np.dtype(np.uint8))
         return out
 
     def tensorize(
@@ -381,7 +380,7 @@ class NDArrayBufferAllocator(_BaseNDArrayBufferAllocator[core_defs.DeviceTypeT])
     ) -> core_defs.NDArrayObject:
         aligned_buffer = buffer[byte_offset : byte_offset + math.prod(allocated_shape) * item_size]  # type: ignore[index] # TODO(egparedes): should we extend `_NDBuffer`s to cover __getitem__?
         flat_ndarray = aligned_buffer.view(dtype=np.dtype(dtype))
-        tensor_view = self.array_ns.lib.stride_tricks.as_strided(
+        tensor_view = self._array_utils.lib.stride_tricks.as_strided(
             flat_ndarray, shape=allocated_shape, strides=strides
         )
         if len(shape) and shape != allocated_shape:

--- a/src/gt4py/storage/allocators.py
+++ b/src/gt4py/storage/allocators.py
@@ -326,7 +326,7 @@ numpy_array_utils = ArrayUtils(
     array_ns=np,
     empty=np.empty,
     byte_bounds=np.byte_bounds if hasattr(np, "byte_bounds") else np.lib.array_utils.byte_bounds,  # type: ignore  # noqa: NPY201
-    as_strided=np.lib.stride_tricks.as_strided,
+    as_strided=np.lib.stride_tricks.as_strided,  # type: ignore[arg-type]  # as_strided signature is just a sketch
 )
 
 cupy_array_utils = None
@@ -338,7 +338,7 @@ if cp is not None:
         byte_bounds=cp.byte_bounds
         if hasattr(cp, "byte_bounds")
         else cp.lib.array_utils.byte_bounds,
-        as_strided=cp.lib.stride_tricks.as_strided,
+        as_strided=cp.lib.stride_tricks.as_strided,  # type: ignore[arg-type]  # as_strided signature is just a sketch
     )
 
 
@@ -349,7 +349,7 @@ class NDArrayBufferAllocator(_BaseNDArrayBufferAllocator[core_defs.DeviceTypeT])
 
     def __init__(self, device_type: core_defs.DeviceTypeT, array_utils: ArrayUtils):
         object.__setattr__(self, "_device_type", device_type)
-        object.__setattr__(self, "_array_ns", array_utils)
+        object.__setattr__(self, "_array_utils", array_utils)
 
     @property
     def device_type(self) -> core_defs.DeviceTypeT:
@@ -380,7 +380,7 @@ class NDArrayBufferAllocator(_BaseNDArrayBufferAllocator[core_defs.DeviceTypeT])
     ) -> core_defs.NDArrayObject:
         aligned_buffer = buffer[byte_offset : byte_offset + math.prod(allocated_shape) * item_size]  # type: ignore[index] # TODO(egparedes): should we extend `_NDBuffer`s to cover __getitem__?
         flat_ndarray = aligned_buffer.view(dtype=np.dtype(dtype))
-        tensor_view = self._array_utils.lib.stride_tricks.as_strided(
+        tensor_view = self._array_utils.as_strided(
             flat_ndarray, shape=allocated_shape, strides=strides
         )
         if len(shape) and shape != allocated_shape:

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -48,22 +48,19 @@ CUPY_DEVICE: Final[Literal[None, core_defs.DeviceType.CUDA, core_defs.DeviceType
 
 FieldLike = Union["cp.ndarray", np.ndarray, ArrayInterface, CUDAArrayInterface]
 
-assert allocators.is_valid_nplike_allocation_ns(np)
-
 _CPUBufferAllocator = allocators.NDArrayBufferAllocator(
-    device_type=core_defs.DeviceType.CPU, array_ns=np
+    device_type=core_defs.DeviceType.CPU, array_utils=allocators.numpy_array_utils
 )
 
 _GPUBufferAllocator: Optional[allocators.NDArrayBufferAllocator] = None
 if cp:
-    assert allocators.is_valid_nplike_allocation_ns(cp)
     if CUPY_DEVICE == core_defs.DeviceType.CUDA:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
-            device_type=core_defs.DeviceType.CUDA, array_ns=cp
+            device_type=core_defs.DeviceType.CUDA, array_utils=allocators.cupy_array_utils
         )
     else:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
-            device_type=core_defs.DeviceType.ROCM, array_ns=cp
+            device_type=core_defs.DeviceType.ROCM, array_utils=allocators.cupy_array_utils
         )
 
 

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -54,6 +54,8 @@ _CPUBufferAllocator = allocators.NDArrayBufferAllocator(
 
 _GPUBufferAllocator: Optional[allocators.NDArrayBufferAllocator] = None
 if cp:
+    assert isinstance(allocators.cupy_array_utils, allocators.ArrayUtils)
+
     if CUPY_DEVICE == core_defs.DeviceType.CUDA:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
             device_type=core_defs.DeviceType.CUDA, array_utils=allocators.cupy_array_utils

--- a/tests/storage_tests/unit_tests/test_interface.py
+++ b/tests/storage_tests/unit_tests/test_interface.py
@@ -130,9 +130,10 @@ def test_allocate_cpu(param_dict):
     raw_buffer, field = allocate_cpu(shape, layout_map, dtype, alignment_bytes, aligned_index)
 
     # check that memory of field is contained in raw_buffer
+    np_byte_bounds = np.byte_bounds if hasattr(np, "byte_bounds") else np.lib.array_utils.byte_bounds
     assert (
-        np.byte_bounds(field)[0] >= np.byte_bounds(raw_buffer)[0]
-        and np.byte_bounds(field)[1] <= np.byte_bounds(raw_buffer)[1]
+        np_byte_bounds(field)[0] >= np_byte_bounds(raw_buffer)[0]
+        and np_byte_bounds(field)[1] <= np_byte_bounds(raw_buffer)[1]
     )
 
     # check if the first compute-domain point in the last dimension is aligned for 100 random "columns"

--- a/tests/storage_tests/unit_tests/test_interface.py
+++ b/tests/storage_tests/unit_tests/test_interface.py
@@ -130,7 +130,9 @@ def test_allocate_cpu(param_dict):
     raw_buffer, field = allocate_cpu(shape, layout_map, dtype, alignment_bytes, aligned_index)
 
     # check that memory of field is contained in raw_buffer
-    np_byte_bounds = np.byte_bounds if hasattr(np, "byte_bounds") else np.lib.array_utils.byte_bounds
+    np_byte_bounds = (
+        np.byte_bounds if hasattr(np, "byte_bounds") else np.lib.array_utils.byte_bounds
+    )
     assert (
         np_byte_bounds(field)[0] >= np_byte_bounds(raw_buffer)[0]
         and np_byte_bounds(field)[1] <= np_byte_bounds(raw_buffer)[1]


### PR DESCRIPTION
Support NumPy 2.0 by collecting the functions required for creating storages in a single object, created at initialization time, from their actual location in NumPy v1 or v2 APIs.