### PR TITLE
bug[next]: Fix missing visit call in call to cast builtin in ITIR type inference

### DIFF
--- a/src/gt4py/next/iterator/type_system/inference.py
+++ b/src/gt4py/next/iterator/type_system/inference.py
@@ -601,6 +601,7 @@ class ITIRTypeInference(eve.NodeTranslator):
         # grammar builtins
         if is_call_to(node, "cast_"):
             value, type_constructor = node.args
+            self.visit(value, ctx=ctx)  # ensure types in value are also inferred
             assert (
                 isinstance(type_constructor, itir.SymRef)
                 and type_constructor.id in itir.TYPEBUILTINS

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -222,6 +222,18 @@ def test_late_offset_axis():
     assert result.type == it_on_e_of_e_type
 
 
+def test_type_inference_in_cast():
+    # since cast_ is a grammer builtin whose return type is given by its second argument it is
+    # easy to forget inferring the types of the first argument and its children. Simply check
+    # if the first argument has a type inferred correctly here.
+    testee = im.call("cast_")(
+        im.plus(im.literal_from_value(1), im.literal_from_value(2)), "float64"
+    )
+    result = itir_type_inference.infer(testee, offset_provider={}, allow_undeclared_symbols=True)
+
+    assert result.args[0].type == int_type
+
+
 # TODO(tehrengruber): Rewrite tests to use itir.Program
 def test_cartesian_fencil_definition():
     cartesian_domain = im.call("cartesian_domain")(

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -232,6 +232,7 @@ def test_cast_first_arg_inference():
     result = itir_type_inference.infer(testee, offset_provider={}, allow_undeclared_symbols=True)
 
     assert result.args[0].type == int_type
+    assert result.type == float64_type
 
 
 # TODO(tehrengruber): Rewrite tests to use itir.Program

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -222,7 +222,7 @@ def test_late_offset_axis():
     assert result.type == it_on_e_of_e_type
 
 
-def test_type_inference_in_cast():
+def test_cast_first_arg_inference():
     # since cast_ is a grammar builtin whose return type is given by its second argument it is
     # easy to forget inferring the types of the first argument and its children. Simply check
     # if the first argument has a type inferred correctly here.

--- a/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_type_inference.py
@@ -223,7 +223,7 @@ def test_late_offset_axis():
 
 
 def test_type_inference_in_cast():
-    # since cast_ is a grammer builtin whose return type is given by its second argument it is
+    # since cast_ is a grammar builtin whose return type is given by its second argument it is
     # easy to forget inferring the types of the first argument and its children. Simply check
     # if the first argument has a type inferred correctly here.
     testee = im.call("cast_")(


### PR DESCRIPTION
Since `cast_` is a grammar builtin whose return type is given by its second argument it is easy to forget inferring the types of the first argument and its children. This surfaced in icon4py and is fixed here.