### PR TITLE
bug[next]: Add assert for OOB access

### DIFF
--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -1582,7 +1582,7 @@ def _get_output_type(
     pos_in_domain = next(iter(_domain_iterator(domain)))
     with embedded_context.new_context(closure_column_range=col_range) as ctx:
         single_pos_result = ctx.run(_compute_at_position, fun, args, pos_in_domain, col_dim)
-    assert not single_pos_result == _UNDEFINED, "Stencil contains an Out-Of-Bound access."
+    assert single_pos_result is not _UNDEFINED, "Stencil contains an Out-Of-Bound access."
     dtype = _elem_dtype(single_pos_result)
     return _structured_dtype_to_typespec(dtype)
 

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -1582,6 +1582,7 @@ def _get_output_type(
     pos_in_domain = next(iter(_domain_iterator(domain)))
     with embedded_context.new_context(closure_column_range=col_range) as ctx:
         single_pos_result = ctx.run(_compute_at_position, fun, args, pos_in_domain, col_dim)
+    assert not single_pos_result == _UNDEFINED, "Stencil contains an Out-Of-Bound access."
     dtype = _elem_dtype(single_pos_result)
     return _structured_dtype_to_typespec(dtype)
 


### PR DESCRIPTION
In case a stencil contains an Out-Of-Bounds accesses the derivation of the dtype in ITIR embedded can fail with an obscure error like
```
ValueError: DType 'DType(scalar_type=<class 'numpy.object_'>, tensor_shape=())' not supported.
```
This PR adds an assert to catch this earlier and fail more gracefully.