### PR TITLE
bug[next]: Fix func to past caching

### DIFF
--- a/src/gt4py/next/backend.py
+++ b/src/gt4py/next/backend.py
@@ -106,7 +106,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequenceWithArgs):
         ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
         ffront_stages.PastProgramDefinition,
     ] = dataclasses.field(
-        default_factory=lambda: func_to_past.OptionalFuncToPastFactory(cached=False, workflow="123")
+        default_factory=lambda: func_to_past.OptionalFuncToPastFactory(cached=True)
     )
     past_lint: workflow.Workflow[
         ffront_stages.PastProgramDefinition, ffront_stages.PastProgramDefinition

--- a/src/gt4py/next/backend.py
+++ b/src/gt4py/next/backend.py
@@ -106,7 +106,7 @@ class ProgramTransformWorkflow(workflow.NamedStepSequenceWithArgs):
         ffront_stages.ProgramDefinition | ffront_stages.PastProgramDefinition,
         ffront_stages.PastProgramDefinition,
     ] = dataclasses.field(
-        default_factory=lambda: func_to_past.OptionalFuncToPastFactory(cached=True)
+        default_factory=lambda: func_to_past.OptionalFuncToPastFactory(cached=False, workflow="123")
     )
     past_lint: workflow.Workflow[
         ffront_stages.PastProgramDefinition, ffront_stages.PastProgramDefinition

--- a/src/gt4py/next/ffront/func_to_past.py
+++ b/src/gt4py/next/ffront/func_to_past.py
@@ -72,13 +72,11 @@ class OptionalFuncToPastFactory(factory.Factory):
         workflow = func_to_past
         cached = factory.Trait(
             step=factory.LazyAttribute(
-                lambda o: workflow.CachedStep(
-                    step=o.workflow, hash_function=ffront_stages.fingerprint_stage
-                )
+                lambda o: workflow.CachedStep(step=o.workflow, hash_function=id)
             )
         )
 
-        step = factory.LazyAttribute(lambda o: o.workflow)
+    step = factory.LazyAttribute(lambda o: o.workflow)
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
A small indentation error in the `FuncToPast` factory prevented caching of the step, which is fixed here. Additionally the hashing algorithm is changed to `id`.