### PR TITLE
test[next]: Use pytest marker to skip GTIR test (fix spack build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,7 @@ markers = [
   'requires_atlas: tests that require `atlas4py` bindings package',
   'requires_dace: tests that require `dace` package',
   'requires_gpu: tests that require a NVidia GPU (`cupy` and `cudatoolkit` are required)',
+  'requires_gtir_program: tests that require backend support for GTIR program',
   'uses_applied_shifts: tests that require backend support for applied-shifts',
   'uses_constant_fields: tests that require backend support for constant fields',
   'uses_dynamic_offsets: tests that require backend support for dynamic offsets',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ markers = [
   'requires_atlas: tests that require `atlas4py` bindings package',
   'requires_dace: tests that require `dace` package',
   'requires_gpu: tests that require a NVidia GPU (`cupy` and `cudatoolkit` are required)',
-  'requires_gtir_program: tests that require backend support for GTIR program',
+  'starts_from_gtir_program: tests that require backend to start lowering from GTIR program',
   'uses_applied_shifts: tests that require backend support for applied-shifts',
   'uses_constant_fields: tests that require backend support for constant fields',
   'uses_dynamic_offsets: tests that require backend support for dynamic offsets',

--- a/tests/next_tests/definitions.py
+++ b/tests/next_tests/definitions.py
@@ -98,7 +98,8 @@ class ProgramFormatterId(_PythonObjectIdMixin, str, enum.Enum):
 
 # Test markers
 REQUIRES_ATLAS = "requires_atlas"
-REQUIRES_GTIR_PROGRAM = "requires_gtir_program"
+# TODO(havogt): Remove, skipped during refactoring to GTIR
+STARTS_FROM_GTIR_PROGRAM = "starts_from_gtir_program"
 USES_APPLIED_SHIFTS = "uses_applied_shifts"
 USES_CONSTANT_FIELDS = "uses_constant_fields"
 USES_DYNAMIC_OFFSETS = "uses_dynamic_offsets"
@@ -136,7 +137,7 @@ REDUCTION_WITH_ONLY_SPARSE_FIELDS_MESSAGE = (
 # Common list of feature markers to skip
 COMMON_SKIP_TEST_LIST = [
     (REQUIRES_ATLAS, XFAIL, BINDINGS_UNSUPPORTED_MESSAGE),
-    (REQUIRES_GTIR_PROGRAM, SKIP, UNSUPPORTED_MESSAGE),
+    (STARTS_FROM_GTIR_PROGRAM, SKIP, UNSUPPORTED_MESSAGE),
     (USES_APPLIED_SHIFTS, XFAIL, UNSUPPORTED_MESSAGE),
     (USES_IF_STMTS, XFAIL, UNSUPPORTED_MESSAGE),
     (USES_NEGATIVE_MODULO, XFAIL, UNSUPPORTED_MESSAGE),

--- a/tests/next_tests/definitions.py
+++ b/tests/next_tests/definitions.py
@@ -98,6 +98,7 @@ class ProgramFormatterId(_PythonObjectIdMixin, str, enum.Enum):
 
 # Test markers
 REQUIRES_ATLAS = "requires_atlas"
+REQUIRES_GTIR_PROGRAM = "requires_gtir_program"
 USES_APPLIED_SHIFTS = "uses_applied_shifts"
 USES_CONSTANT_FIELDS = "uses_constant_fields"
 USES_DYNAMIC_OFFSETS = "uses_dynamic_offsets"
@@ -135,6 +136,7 @@ REDUCTION_WITH_ONLY_SPARSE_FIELDS_MESSAGE = (
 # Common list of feature markers to skip
 COMMON_SKIP_TEST_LIST = [
     (REQUIRES_ATLAS, XFAIL, BINDINGS_UNSUPPORTED_MESSAGE),
+    (REQUIRES_GTIR_PROGRAM, SKIP, UNSUPPORTED_MESSAGE),
     (USES_APPLIED_SHIFTS, XFAIL, UNSUPPORTED_MESSAGE),
     (USES_IF_STMTS, XFAIL, UNSUPPORTED_MESSAGE),
     (USES_NEGATIVE_MODULO, XFAIL, UNSUPPORTED_MESSAGE),

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py
@@ -40,17 +40,9 @@ def copy_program(inp, out, size):
     )
 
 
+@pytest.mark.requires_gtir_program
 def test_prog(program_processor):
     program_processor, validate = program_processor
-
-    if program_processor in [
-        gtfn.run_gtfn.executor,
-        gtfn.run_gtfn_imperative.executor,
-        gtfn.run_gtfn_with_temporaries.executor,
-        dace.run_dace_cpu.executor,
-    ]:
-        # TODO(havogt): Remove, skipped during refactoring to GTIR
-        pytest.skip("Executor requires to start from fencil.")
 
     isize = 10
     inp = gtx.as_field([I], np.arange(0, isize, dtype=np.float64))

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py
@@ -39,7 +39,7 @@ def copy_program(inp, out, size):
     )
 
 
-@pytest.mark.requires_gtir_program
+@pytest.mark.starts_from_gtir_program
 def test_prog(program_processor):
     program_processor, validate = program_processor
 

--- a/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py
@@ -18,7 +18,6 @@ import pytest
 import gt4py.next as gtx
 from gt4py.next.iterator.builtins import as_fieldop, cartesian_domain, deref, named_range
 from gt4py.next.iterator.runtime import fendef, fundef, set_at
-from gt4py.next.program_processors.runners import dace, gtfn
 
 from next_tests.unit_tests.conftest import program_processor, run_processor
 


### PR DESCRIPTION
The `import dace` statement causes the Spack build (spack-c2sm) to fail:
```
ImportError while importing test module '/scratch/snx3000/epaone/repo/gt4py/tests/next_tests/integration_tests/feature_tests/iterator_tests/test_program.py'.

    import dace
E   ModuleNotFoundError: No module named 'dace'
```

Use the pytest marker to avoid this error.