### PR TITLE
fix[next]: Fix size temporary size computation

### DIFF
--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -407,7 +407,7 @@ def _max_domain_sizes_by_location_type(offset_provider: Mapping[str, Any]) -> di
             )
             sizes[provider.neighbor_axis.value] = max(
                 sizes.get(provider.neighbor_axis.value, 0),
-                provider.table.max(),  # type: ignore[attr-defined] # TODO(havogt): improve typing for NDArrayObject
+                provider.table.max()+1,  # type: ignore[attr-defined] # TODO(havogt): improve typing for NDArrayObject
             )
     return sizes
 

--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -407,7 +407,7 @@ def _max_domain_sizes_by_location_type(offset_provider: Mapping[str, Any]) -> di
             )
             sizes[provider.neighbor_axis.value] = max(
                 sizes.get(provider.neighbor_axis.value, 0),
-                provider.table.max()+1,  # type: ignore[attr-defined] # TODO(havogt): improve typing for NDArrayObject
+                provider.table.max() + 1,  # type: ignore[attr-defined] # TODO(havogt): improve typing for NDArrayObject
             )
     return sizes
 


### PR DESCRIPTION
This PR fixes a bug where the size of unstructured temporary fields was wrong in certain cases. This bug surfaced while working on #1568. It took me a while to figure out why this never surfaced in validation tests anywhere:
Right now we compute temporaries for unstructured everywhere, e.g. on all vertices, etc.. What _everywhere_ means is derived from the offset provider in `_max_domain_sizes_by_location_type`. The information is contained either
- explicitly if we have a connectivity with origin axis being the axis whose size we want to know. E.g. if we have a V2E connectivity then we have `table.shape[0]` many vertices.
- or implicitly if we have a connectivity with the neighbor axis whose size we want to know. E.g. if we have a V2E connectivity then we have at least `table.max()+1` many edges. This computation was wrong.

So as long as we have also the E2V connectivity for the examples above, the implicit information is not needed / used and everything works fine. For all our test cases this is indeed the case and since computing temporaries everywhere is only a temporary solution anyway I am fine with just fixing this without increasing test coverage.