### PR TITLE
ci: Disable CSCS-CI on gh200 nodes

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -52,6 +52,8 @@ stages:
   variables:
     CUDA_VERSION: 12.4.1
     CUPY_PACKAGE: cupy-cuda12x
+  # TODO: re-enable CI job when Todi is back in operational state
+  when: never
 
 build_py311_baseimage_x86_64:
   extends: .build_baseimage_x86_64

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -53,7 +53,7 @@ stages:
     CUDA_VERSION: 12.4.1
     CUPY_PACKAGE: cupy-cuda12x
   # TODO: re-enable CI job when Todi is back in operational state
-  when: never
+  when: manual
 
 build_py311_baseimage_x86_64:
   extends: .build_baseimage_x86_64


### PR DESCRIPTION
The Tödi vCluster is temporarily unavailable, so the CI jobs will timeout. This PR will disables the CSCS CI jobs on Tödi, until it is back in operational state.