### PR TITLE
test[next]: Start using requires_dace marker (as cartesian tests already do)

### DIFF
--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
@@ -13,7 +13,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import types
-from collections import namedtuple
 from typing import Any, Protocol, TypeVar
 
 import numpy as np
@@ -24,16 +23,6 @@ from gt4py.next import backend as next_backend, common
 from gt4py.next.ffront import decorator
 from gt4py.next.iterator import ir as itir
 from gt4py.next.program_processors import processor_interface as ppi
-from gt4py.next.program_processors.runners import gtfn, roundtrip
-
-
-try:
-    from gt4py.next.program_processors.runners import dace_iterator
-except ModuleNotFoundError as e:
-    if "dace" in str(e):
-        dace_iterator = None
-    else:
-        raise e
 
 import next_tests
 
@@ -52,19 +41,6 @@ class NoBackend(next_backend.Backend):
 no_backend = NoBackend(executor=no_exec, transforms_prog=None, allocator=None)
 
 
-OPTIONAL_PROCESSORS = []
-if dace_iterator:
-    OPTIONAL_PROCESSORS.append(next_tests.definitions.OptionalProgramBackendId.DACE_CPU)
-    (
-        OPTIONAL_PROCESSORS.append(
-            pytest.param(
-                next_tests.definitions.OptionalProgramBackendId.DACE_GPU,
-                marks=pytest.mark.requires_gpu,
-            )
-        ),
-    )
-
-
 @pytest.fixture(
     params=[
         next_tests.definitions.ProgramBackendId.ROUNDTRIP,
@@ -79,8 +55,15 @@ if dace_iterator:
         pytest.param(
             next_tests.definitions.EmbeddedIds.CUPY_EXECUTION, marks=pytest.mark.requires_gpu
         ),
-    ]
-    + OPTIONAL_PROCESSORS,
+        pytest.param(
+            next_tests.definitions.OptionalProgramBackendId.DACE_CPU,
+            marks=pytest.mark.requires_dace,
+        ),
+        pytest.param(
+            next_tests.definitions.OptionalProgramBackendId.DACE_GPU,
+            marks=(pytest.mark.requires_dace, pytest.mark.requires_gpu),
+        ),
+    ],
     ids=lambda p: p.short_id(),
 )
 def exec_alloc_descriptor(request):

--- a/tests/next_tests/unit_tests/conftest.py
+++ b/tests/next_tests/unit_tests/conftest.py
@@ -19,31 +19,11 @@ import dataclasses
 import pytest
 
 import gt4py.next as gtx
-from gt4py.next.iterator import runtime, transforms
+from gt4py.next.iterator import runtime
 from gt4py.next.program_processors import processor_interface as ppi
 
 
-try:
-    from gt4py.next.program_processors.runners import dace_iterator
-except ModuleNotFoundError as e:
-    if "dace" in str(e):
-        dace_iterator = None
-    else:
-        raise e
-
-
 import next_tests
-
-
-OPTIONAL_PROCESSORS = []
-if dace_iterator:
-    OPTIONAL_PROCESSORS.append((next_tests.definitions.OptionalProgramBackendId.DACE_CPU, True))
-    # TODO(havogt): update tests to use proper allocation
-    # OPTIONAL_PROCESSORS.append(
-    #     pytest.param(
-    #         (definitions.OptionalProgramBackendId.DACE_GPU, True), marks=pytest.mark.requires_gpu
-    #     )
-    # ),
 
 
 @pytest.fixture(
@@ -59,8 +39,16 @@ if dace_iterator:
         (next_tests.definitions.ProgramFormatterId.LISP_FORMATTER, False),
         (next_tests.definitions.ProgramFormatterId.ITIR_PRETTY_PRINTER, False),
         (next_tests.definitions.ProgramFormatterId.GTFN_CPP_FORMATTER, False),
-    ]
-    + OPTIONAL_PROCESSORS,
+        pytest.param(
+            (next_tests.definitions.OptionalProgramBackendId.DACE_CPU, True),
+            marks=pytest.mark.requires_dace,
+        ),
+        # TODO(havogt): update tests to use proper allocation
+        # pytest.param(
+        #     (next_tests.definitions.OptionalProgramBackendId.DACE_GPU, True),
+        #     marks=(pytest.mark.requires_dace, pytest.mark.requires_gpu),
+        # ),
+    ],
     ids=lambda p: p[0].short_id() if p[0] is not None else "None",
 )
 def program_processor(request) -> tuple[ppi.ProgramProcessor, bool]:

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/test_dace_fieldview.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/test_dace_fieldview.py
@@ -28,7 +28,7 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
 import numpy as np
 import pytest
 
-dace = pytest.importorskip("dace")
+pytestmark = pytest.mark.requires_dace
 
 
 N = 10


### PR DESCRIPTION
Start using `requires_dace` marker in next tests, same as cartesian tests already do.