### PR TITLE
ci: GH200 test instability

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -31,12 +31,8 @@ stages:
   # Since the base image name is runtime dependent, we need to carry the value of it to
   # the following jobs via a dotenv file.
   before_script:
-  - DATA_TAG=`mktemp`
-  - cat $DOCKERFILE > $DATA_TAG
   # include build arguments in hash since we use a parameterized Docker file
-  - echo $DOCKER_BUILD_ARGS >> $DATA_TAG
-  - DOCKER_TAG=`sha256sum $DATA_TAG | head -c 16`
-  - rm -f $DATA_TAG
+  - DOCKER_TAG=`echo "$(cat $DOCKERFILE) $DOCKER_BUILD_ARGS" | sha256sum | head -c 16`
   - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/$ARCH/base/gt4py-ci:$DOCKER_TAG-$PYVERSION
   - echo "BASE_IMAGE_${PYVERSION_PREFIX}=$PERSIST_IMAGE_NAME" >> build.env
   artifacts:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -182,8 +182,9 @@ build_py38_image_x86_64:
   variables:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
-    # limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage
-    # observed gpu tests hang in combination with CUDA MPS
+    # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
+    # Another problem, observed in test stage, is that gpu tests hang in combination with CUDA MPS,
+    # when high test parallelism is used.
     NUM_PROCESSES: 16
 
 test_py311_x86_64:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -149,7 +149,7 @@ build_py38_image_x86_64:
   variables:
     CRAY_CUDA_MPS: 1
     SLURM_JOB_NUM_NODES: 1
-    SLURM_TIMELIMIT: 120
+    SLURM_TIMELIMIT: 30
     NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
 .test_helper_x86_64:
@@ -178,7 +178,8 @@ build_py38_image_x86_64:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
     # limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage
-    NUM_PROCESSES: 32
+    # observed also gpu tests to hang in combination with CUDA MPS
+    NUM_PROCESSES: 16
 
 test_py311_x86_64:
   extends: [.test_helper_x86_64]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -31,7 +31,12 @@ stages:
   # Since the base image name is runtime dependent, we need to carry the value of it to
   # the following jobs via a dotenv file.
   before_script:
-  - DOCKER_TAG=`sha256sum $DOCKERFILE | head -c 16`
+    - DATA_TAG=`mktemp`
+    - cat $DOCKERFILE > $DATA_TAG
+    # include build arguments in hash since we use a parameterized Docker file
+    - echo $DOCKER_BUILD_ARGS >> $DATA_TAG
+    - DOCKER_TAG=`sha256sum $DATA_TAG | head -c 16`
+    - rm -f $DATA_TAG
   - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/$ARCH/base/gt4py-ci:$DOCKER_TAG-$PYVERSION
   - echo "BASE_IMAGE_${PYVERSION_PREFIX}=$PERSIST_IMAGE_NAME" >> build.env
   artifacts:
@@ -149,7 +154,7 @@ build_py38_image_x86_64:
   variables:
     CRAY_CUDA_MPS: 1
     SLURM_JOB_NUM_NODES: 1
-    SLURM_TIMELIMIT: 30
+    SLURM_TIMELIMIT: 15
     NUM_PROCESSES: auto
     VIRTUALENV_SYSTEM_SITE_PACKAGES: 1
 .test_helper_x86_64:
@@ -178,7 +183,7 @@ build_py38_image_x86_64:
     # Grace-Hopper gpu architecture is not enabled by default in CUDA build
     CUDAARCHS: "90"
     # limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage
-    # observed also gpu tests to hang in combination with CUDA MPS
+    # observed gpu tests hang in combination with CUDA MPS
     NUM_PROCESSES: 16
 
 test_py311_x86_64:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -31,12 +31,12 @@ stages:
   # Since the base image name is runtime dependent, we need to carry the value of it to
   # the following jobs via a dotenv file.
   before_script:
-    - DATA_TAG=`mktemp`
-    - cat $DOCKERFILE > $DATA_TAG
-    # include build arguments in hash since we use a parameterized Docker file
-    - echo $DOCKER_BUILD_ARGS >> $DATA_TAG
-    - DOCKER_TAG=`sha256sum $DATA_TAG | head -c 16`
-    - rm -f $DATA_TAG
+  - DATA_TAG=`mktemp`
+  - cat $DOCKERFILE > $DATA_TAG
+  # include build arguments in hash since we use a parameterized Docker file
+  - echo $DOCKER_BUILD_ARGS >> $DATA_TAG
+  - DOCKER_TAG=`sha256sum $DATA_TAG | head -c 16`
+  - rm -f $DATA_TAG
   - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/$ARCH/base/gt4py-ci:$DOCKER_TAG-$PYVERSION
   - echo "BASE_IMAGE_${PYVERSION_PREFIX}=$PERSIST_IMAGE_NAME" >> build.env
   artifacts:


### PR DESCRIPTION
It was observed that the CI tests on GPU randomly hang, and eventually time out. In an attempt to make the CI stable on GH200 nodes, this PR proposes 2 changes:
- Reduce pytest parallelism, by lowering the num processes from 32 to 16 (note that GPU tests exploit CUDA MPS)
- Reduce the SLURM timeout, in order to early detect when jobs hang (longest job takes 10 min)

Additional change:
- Improve the hash on the Dockerfile for caching of base image: now also include the build arguments