### PR TITLE
feat[next][dace]: GTIR-to-SDFG lowering of cast_ builtin

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_python_codegen.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_python_codegen.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 
@@ -79,12 +79,25 @@ MATH_BUILTINS_MAPPING = {
 }
 
 
-def format_builtin(bultin: str, *args: Any) -> str:
-    if bultin in MATH_BUILTINS_MAPPING:
-        fmt = MATH_BUILTINS_MAPPING[bultin]
+def builtin_cast(*args: Any) -> str:
+    val, target_type = args
+    return MATH_BUILTINS_MAPPING[target_type].format(val)
+
+
+GENERAL_BUILTIN_MAPPING: dict[str, Callable[[Any], str]] = {
+    "cast_": builtin_cast,
+}
+
+
+def format_builtin(builtin: str, *args: Any) -> str:
+    if builtin in MATH_BUILTINS_MAPPING:
+        fmt = MATH_BUILTINS_MAPPING[builtin]
+        return fmt.format(*args)
+    elif builtin in GENERAL_BUILTIN_MAPPING:
+        expr_func = GENERAL_BUILTIN_MAPPING[builtin]
+        return expr_func(*args)
     else:
-        raise NotImplementedError(f"'{bultin}' not implemented.")
-    return fmt.format(*args)
+        raise NotImplementedError(f"'{builtin}' not implemented.")
 
 
 class PythonCodegen(codegen.TemplatedGenerator):

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_tasklet.py
@@ -802,5 +802,8 @@ class LambdaToTasklet(eve.NodeVisitor):
 
     def visit_SymRef(self, node: gtir.SymRef) -> IteratorExpr | MemletExpr | SymbolExpr:
         param = str(node.id)
-        assert param in self.symbol_map
-        return self.symbol_map[param]
+        if param in self.symbol_map:
+            return self.symbol_map[param]
+        # if not in the lambda symbol map, this must be a symref to a builtin function
+        assert param in gtir_python_codegen.MATH_BUILTINS_MAPPING
+        return SymbolExpr(param, dace.string)


### PR DESCRIPTION
Add support to lower GTIR like:
`y @ c⟨ IDimₕ: [0, size) ⟩ ← as_fieldop(λ(a) → cast_(·a, float64), c⟨ IDimₕ: [0, size) ⟩)(x);`

Test case added.