### PR TITLE
ci: Disable CI job for GH200

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -53,6 +53,8 @@ stages:
   variables:
     CUDA_VERSION: 12.4.1
     CUPY_PACKAGE: cupy-cuda12x
+  # TODO: enable CI job when Todi is back in operational state
+  when: manual
 
 build_py311_baseimage_x86_64:
   extends: .build_baseimage_x86_64


### PR DESCRIPTION
Todi vCluster is under maintenance, so the CI jobs on GH200 nodes are blocked. Disable automatic trigger for these jobs.