### PR TITLE
refactor[cartesian]: Enable MaskInlining in gt4yp - DaCe bridge

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -42,7 +42,6 @@ from gt4py.cartesian.gtc.dace.utils import array_dimensions, replace_strides
 from gt4py.cartesian.gtc.gtir_to_oir import GTIRToOIR
 from gt4py.cartesian.gtc.passes.gtir_k_boundary import compute_k_boundary
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
-from gt4py.cartesian.gtc.passes.oir_optimizations.inlining import MaskInlining
 from gt4py.cartesian.gtc.passes.oir_optimizations.utils import compute_fields_extents
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.cartesian.utils import shash
@@ -353,7 +352,7 @@ class SDFGManager:
             except FileNotFoundError:
                 base_oir = GTIRToOIR().visit(self.builder.gtir)
                 oir_pipeline = self.builder.options.backend_opts.get(
-                    "oir_pipeline", DefaultPipeline(skip=[MaskInlining])
+                    "oir_pipeline", DefaultPipeline()
                 )
                 oir_node = oir_pipeline.run(base_oir)
                 sdfg = OirSDFGBuilder().visit(oir_node)


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

`MaskInlining`  will be a key feature of the improved gt4py / DaCe bridge as envisioned in https://github.com/GEOS-ESM/NDSL/issues/53, which will propagate more control flow elements from gt4py to DaCe. We thus want to make sure if `MaskInlining` itself is posing any problems. We tracked the git history of this explicit exclude back to PR https://github.com/GridTools/gt4py/pull/300, which not only added the npir backend, but also refactored how pipeline stages are defined. Previous to this PR optimization passes to be specified explicitly and the PR changed this to an exclude list. It looks like the `MaskInlining` pass was added after the list of optimization passes was formed and thus excluded (to keep the list constant). From this history we thus don't expect `MaskInlining`  to break anything.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
