### PR TITLE
style: Remove stale references to isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
   ## version = re.search('ruff==([0-9\.]*)', open("constraints.txt").read())[1]
   ## print(f"rev: v{version}")
   ##]]]
-  rev: v0.6.3
+  rev: v0.6.4
   ##[[[end]]]
   hooks:
     # Run the linter.
@@ -107,7 +107,7 @@ repos:
     - numpy==1.24.4
     - packaging==24.1
     - pybind11==2.13.5
-    - setuptools==74.1.0
+    - setuptools==74.1.2
     - tabulate==0.9.0
     - typing-extensions==4.12.2
     - xxhash==3.0.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -46,14 +46,14 @@ exceptiongroup==1.2.2     # via hypothesis, pytest
 execnet==2.1.1            # via pytest-cache, pytest-xdist
 executing==2.1.0          # via devtools, stack-data
 factory-boy==3.3.1        # via gt4py (pyproject.toml), pytest-factoryboy
-faker==28.1.0             # via factory-boy
+faker==28.4.1             # via factory-boy
 fastjsonschema==2.20.0    # via nbformat
 filelock==3.15.4          # via tox, virtualenv
 fonttools==4.53.1         # via matplotlib
 fparser==0.1.4            # via dace
 frozendict==2.4.4         # via gt4py (pyproject.toml)
 gridtools-cpp==2.3.4      # via gt4py (pyproject.toml)
-hypothesis==6.111.2       # via -r requirements-dev.in, gt4py (pyproject.toml)
+hypothesis==6.112.0       # via -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.6.0           # via pre-commit
 idna==3.8                 # via requests
 imagesize==1.4.1          # via sphinx
@@ -63,7 +63,6 @@ inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
 ipykernel==6.29.5         # via nbmake
 ipython==8.12.3           # via ipykernel
-isort==5.13.2             # via -r requirements-dev.in
 jedi==0.19.1              # via ipython
 jinja2==3.1.4             # via dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.23.0        # via nbformat
@@ -71,7 +70,7 @@ jsonschema-specifications==2023.12.1  # via jsonschema
 jupyter-client==8.6.2     # via ipykernel, nbclient
 jupyter-core==5.7.2       # via ipykernel, jupyter-client, nbformat
 jupytext==1.16.4          # via -r requirements-dev.in
-kiwisolver==1.4.5         # via matplotlib
+kiwisolver==1.4.7         # via matplotlib
 lark==1.2.2               # via gt4py (pyproject.toml)
 mako==1.3.5               # via gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via jupytext, mdit-py-plugins, rich
@@ -111,8 +110,8 @@ psutil==6.0.0             # via -r requirements-dev.in, ipykernel, pytest-xdist
 ptyprocess==0.7.0         # via pexpect
 pure-eval==0.2.3          # via stack-data
 pybind11==2.13.5          # via gt4py (pyproject.toml)
-pydantic==2.8.2           # via bump-my-version, pydantic-settings
-pydantic-core==2.20.1     # via pydantic
+pydantic==2.9.0           # via bump-my-version, pydantic-settings
+pydantic-core==2.23.2     # via pydantic
 pydantic-settings==2.4.0  # via bump-my-version
 pygments==2.18.0          # via -r requirements-dev.in, devtools, ipython, nbmake, rich, sphinx
 pyparsing==3.1.4          # via matplotlib
@@ -136,7 +135,7 @@ requests==2.32.3          # via sphinx
 rich==13.8.0              # via bump-my-version, rich-click
 rich-click==1.8.3         # via bump-my-version
 rpds-py==0.20.0           # via jsonschema, referencing
-ruff==0.6.3               # via -r requirements-dev.in
+ruff==0.6.4               # via -r requirements-dev.in
 scipy==1.10.1             # via gt4py (pyproject.toml)
 setuptools-scm==8.1.0     # via fparser
 six==1.16.0               # via asttokens, astunparse, python-dateutil
@@ -173,4 +172,4 @@ zipp==3.20.1              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2                 # via pip-tools, pipdeptree
-setuptools==74.1.0        # via gt4py (pyproject.toml), pip-tools, setuptools-scm
+setuptools==74.1.2        # via gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -70,7 +70,6 @@ frozendict==2.3
 gridtools-cpp==2.3.4
 hypothesis==6.0.0
 importlib-resources==5.0; python_version < "3.9"
-isort==5.10
 jax[cpu]==0.4.18; python_version >= "3.10"
 jinja2==3.0.0
 jupytext==1.14

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -66,7 +66,6 @@ frozendict==2.3
 gridtools-cpp==2.3.4
 hypothesis==6.0.0
 importlib-resources==5.0; python_version < "3.9"
-isort==5.10
 jinja2==3.0.0
 jupytext==1.14
 lark==1.1.2

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,7 +11,6 @@ cogapp>=3.3
 coverage[toml]>=5.0
 darglint>=1.6
 hypothesis   # constraints in gt4py['testing']
-isort>=5.10
 jupytext>=1.14
 mypy>=1.0
 matplotlib>=3.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,14 +46,14 @@ exceptiongroup==1.2.2     # via -c constraints.txt, hypothesis, pytest
 execnet==2.1.1            # via -c constraints.txt, pytest-cache, pytest-xdist
 executing==2.1.0          # via -c constraints.txt, devtools, stack-data
 factory-boy==3.3.1        # via -c constraints.txt, gt4py (pyproject.toml), pytest-factoryboy
-faker==28.1.0             # via -c constraints.txt, factory-boy
+faker==28.4.1             # via -c constraints.txt, factory-boy
 fastjsonschema==2.20.0    # via -c constraints.txt, nbformat
 filelock==3.15.4          # via -c constraints.txt, tox, virtualenv
 fonttools==4.53.1         # via -c constraints.txt, matplotlib
 fparser==0.1.4            # via -c constraints.txt, dace
 frozendict==2.4.4         # via -c constraints.txt, gt4py (pyproject.toml)
 gridtools-cpp==2.3.4      # via -c constraints.txt, gt4py (pyproject.toml)
-hypothesis==6.111.2       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
+hypothesis==6.112.0       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.6.0           # via -c constraints.txt, pre-commit
 idna==3.8                 # via -c constraints.txt, requests
 imagesize==1.4.1          # via -c constraints.txt, sphinx
@@ -63,7 +63,6 @@ inflection==0.5.1         # via -c constraints.txt, pytest-factoryboy
 iniconfig==2.0.0          # via -c constraints.txt, pytest
 ipykernel==6.29.5         # via -c constraints.txt, nbmake
 ipython==8.12.3           # via -c constraints.txt, ipykernel
-isort==5.13.2             # via -c constraints.txt, -r requirements-dev.in
 jedi==0.19.1              # via -c constraints.txt, ipython
 jinja2==3.1.4             # via -c constraints.txt, dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.23.0        # via -c constraints.txt, nbformat
@@ -71,7 +70,7 @@ jsonschema-specifications==2023.12.1  # via -c constraints.txt, jsonschema
 jupyter-client==8.6.2     # via -c constraints.txt, ipykernel, nbclient
 jupyter-core==5.7.2       # via -c constraints.txt, ipykernel, jupyter-client, nbformat
 jupytext==1.16.4          # via -c constraints.txt, -r requirements-dev.in
-kiwisolver==1.4.5         # via -c constraints.txt, matplotlib
+kiwisolver==1.4.7         # via -c constraints.txt, matplotlib
 lark==1.2.2               # via -c constraints.txt, gt4py (pyproject.toml)
 mako==1.3.5               # via -c constraints.txt, gt4py (pyproject.toml)
 markdown-it-py==3.0.0     # via -c constraints.txt, jupytext, mdit-py-plugins, rich
@@ -111,8 +110,8 @@ psutil==6.0.0             # via -c constraints.txt, -r requirements-dev.in, ipyk
 ptyprocess==0.7.0         # via -c constraints.txt, pexpect
 pure-eval==0.2.3          # via -c constraints.txt, stack-data
 pybind11==2.13.5          # via -c constraints.txt, gt4py (pyproject.toml)
-pydantic==2.8.2           # via -c constraints.txt, bump-my-version, pydantic-settings
-pydantic-core==2.20.1     # via -c constraints.txt, pydantic
+pydantic==2.9.0           # via -c constraints.txt, bump-my-version, pydantic-settings
+pydantic-core==2.23.2     # via -c constraints.txt, pydantic
 pydantic-settings==2.4.0  # via -c constraints.txt, bump-my-version
 pygments==2.18.0          # via -c constraints.txt, -r requirements-dev.in, devtools, ipython, nbmake, rich, sphinx
 pyparsing==3.1.4          # via -c constraints.txt, matplotlib
@@ -136,7 +135,7 @@ requests==2.32.3          # via -c constraints.txt, sphinx
 rich==13.8.0              # via -c constraints.txt, bump-my-version, rich-click
 rich-click==1.8.3         # via -c constraints.txt, bump-my-version
 rpds-py==0.20.0           # via -c constraints.txt, jsonschema, referencing
-ruff==0.6.3               # via -c constraints.txt, -r requirements-dev.in
+ruff==0.6.4               # via -c constraints.txt, -r requirements-dev.in
 setuptools-scm==8.1.0     # via -c constraints.txt, fparser
 six==1.16.0               # via -c constraints.txt, asttokens, astunparse, python-dateutil
 snowballstemmer==2.2.0    # via -c constraints.txt, sphinx
@@ -172,4 +171,4 @@ zipp==3.20.1              # via -c constraints.txt, importlib-metadata, importli
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2                 # via -c constraints.txt, pip-tools, pipdeptree
-setuptools==74.1.0        # via -c constraints.txt, gt4py (pyproject.toml), pip-tools, setuptools-scm
+setuptools==74.1.2        # via -c constraints.txt, gt4py (pyproject.toml), pip-tools, setuptools-scm

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -37,22 +37,22 @@ from typing_extensions import *  # type: ignore[assignment,no-redef]  # noqa: F4
 
 if _sys.version_info >= (3, 9):
     # Standard library already supports PEP 585 (Type Hinting Generics In Standard Collections)
-    from builtins import (  # type: ignore[assignment]  # isort:skip
-        tuple as Tuple,
-        list as List,
+    from builtins import (  # type: ignore[assignment]
         dict as Dict,
-        set as Set,
         frozenset as FrozenSet,
+        list as List,
+        set as Set,
+        tuple as Tuple,
         type as Type,
     )
-    from collections import (  # isort:skip
+    from collections import (
         ChainMap as ChainMap,
         Counter as Counter,
         OrderedDict as OrderedDict,
         defaultdict as defaultdict,
         deque as deque,
     )
-    from collections.abc import (  # isort:skip
+    from collections.abc import (
         AsyncGenerator as AsyncGenerator,
         AsyncIterable as AsyncIterable,
         AsyncIterator as AsyncIterator,
@@ -74,14 +74,14 @@ if _sys.version_info >= (3, 9):
         MutableSet as MutableSet,
         Reversible as Reversible,
         Sequence as Sequence,
+        Set as AbstractSet,
+        ValuesView as ValuesView,
     )
-    from collections.abc import Set as AbstractSet  # isort:skip
-    from collections.abc import ValuesView as ValuesView  # isort:skip
-    from contextlib import (  # isort:skip
+    from contextlib import (
         AbstractAsyncContextManager as AsyncContextManager,
+        AbstractContextManager as ContextManager,
     )
-    from contextlib import AbstractContextManager as ContextManager  # isort:skip
-    from re import Match as Match, Pattern as Pattern  # isort:skip
+    from re import Match as Match, Pattern as Pattern
 
 
 # These fallbacks are useful for public symbols not exported by default.
@@ -661,7 +661,10 @@ def infer_type(
                     arg_types.append(annotations.get(p.name, None) or Any)
                 elif p.kind == _inspect.Parameter.KEYWORD_ONLY:
                     kwonly_arg_types[p.name] = annotations.get(p.name, None) or Any
-                elif p.kind in (_inspect.Parameter.VAR_POSITIONAL, _inspect.Parameter.VAR_KEYWORD):
+                elif p.kind in (
+                    _inspect.Parameter.VAR_POSITIONAL,
+                    _inspect.Parameter.VAR_KEYWORD,
+                ):
                     raise TypeError("Variadic callables are not supported")
 
             result: Any = Callable[arg_types, return_type]

--- a/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_ffront_fvm_nabla.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_ffront_fvm_nabla.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 
-pytest.importorskip("atlas4py")  # isort: skip
+pytest.importorskip("atlas4py")
 
 from gt4py import next as gtx
 from gt4py.next import allocators, neighbor_sum

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_fvm_nabla.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_fvm_nabla.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 
-pytest.importorskip("atlas4py")  # isort: skip
+pytest.importorskip("atlas4py")
 
 import gt4py.next as gtx
 from gt4py.next.iterator import library


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

`isort` has been replaced by `ruff` in PR https://github.com/GridTools/gt4py/pull/1466.

_Note_ Removing `isort` means rebuilding the requirements, which updates a couple of unrelated (to the `isort` removal) dependencies.

_Note 2_ I also checked for `black` (formatter) and there are lingering references too. However, `black`  is actively used as formatter in code generation

https://github.com/GridTools/gt4py/blob/70dd7c34036e48c37f5047bf32573916836a4a35/src/gt4py/eve/codegen.py#L106

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
