### PR TITLE
test[dace]: Add skip rules for dace optional dependency

### DIFF
--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/conftest.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/conftest.py
@@ -9,16 +9,8 @@
 from typing import Any, Optional, Sequence, Union, overload, Literal, Generator
 
 import pytest
-import dace
-import copy
-import numpy as np
-from dace.sdfg import nodes as dace_nodes
-from dace.transformation import dataflow as dace_dataflow
 
-from gt4py.next import common as gtx_common
-from gt4py.next.program_processors.runners.dace_fieldview import (
-    transformations as gtx_transformations,
-)
+dace = pytest.importorskip("dace")
 
 
 @pytest.fixture()

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_gpu_utils.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_gpu_utils.py
@@ -19,7 +19,7 @@ from gt4py.next.program_processors.runners.dace_fieldview.transformations import
 )
 from . import util
 
-pytestmark = pytest.mark.usefixtures("set_dace_settings")
+pytestmark = [pytest.mark.requires_dace, pytest.mark.usefixtures("set_dace_settings")]
 
 
 def _get_trivial_gpu_promotable(

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_loop_blocking.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_loop_blocking.py
@@ -19,7 +19,7 @@ from gt4py.next.program_processors.runners.dace_fieldview import (
 )
 from . import util
 
-pytestmark = pytest.mark.usefixtures("set_dace_settings")
+pytestmark = [pytest.mark.requires_dace, pytest.mark.usefixtures("set_dace_settings")]
 
 
 def _get_simple_sdfg() -> tuple[dace.SDFG, Callable[[np.ndarray, np.ndarray], np.ndarray]]:

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_map_fusion.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_map_fusion.py
@@ -21,7 +21,7 @@ from gt4py.next.program_processors.runners.dace_fieldview import (
 )
 from . import util
 
-pytestmark = pytest.mark.usefixtures("set_dace_settings")
+pytestmark = [pytest.mark.requires_dace, pytest.mark.usefixtures("set_dace_settings")]
 
 
 def _make_serial_sdfg_1(

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_serial_map_promoter.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace/transformation_tests/test_serial_map_promoter.py
@@ -20,7 +20,7 @@ from gt4py.next.program_processors.runners.dace_fieldview import (
 from . import util
 
 
-pytestmark = pytest.mark.usefixtures("set_dace_settings")
+pytestmark = [pytest.mark.requires_dace, pytest.mark.usefixtures("set_dace_settings")]
 
 
 def test_serial_map_promotion():

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/test_dace.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/test_dace.py
@@ -25,6 +25,7 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
     exec_alloc_descriptor,
 )
 
+pytestmark = pytest.mark.requires_dace
 compiled_sdfg = pytest.importorskip("dace.codegen.compiled_sdfg")
 
 

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/test_dace_fieldview.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/test_dace_fieldview.py
@@ -17,8 +17,6 @@ import functools
 from gt4py.next import common as gtx_common
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import ir_makers as im
-from gt4py.next.iterator.type_system import type_specifications as gtir_ts
-from gt4py.next.program_processors.runners import dace_fieldview as dace_backend
 from gt4py.next.type_system import type_specifications as ts
 from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils import (
     Cell,
@@ -34,6 +32,7 @@ import numpy as np
 import pytest
 
 pytestmark = pytest.mark.requires_dace
+dace_backend = pytest.importorskip("gt4py.next.program_processors.runners.dace_fieldview")
 
 
 N = 10


### PR DESCRIPTION
Tests that depend on dace should check if dace is installed, because dace is an optional dependency. Error detected in spack-c2sm CI where dace is not installed.
Additionally, added `requires_dace` marker to filter the testcases.