### PR TITLE
bug[next]: Fix implicit offset provider

### DIFF
--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -208,9 +208,10 @@ class Program:
         for param in params:
             if isinstance(param.type, ts.FieldType):
                 for dim in param.type.dims:
-                    implicit_offset_provider.update(
-                        {common.dimension_to_implicit_offset(dim.value): dim}
-                    )
+                    if dim.kind in (common.DimensionKind.HORIZONTAL, common.DimensionKind.VERTICAL):
+                        implicit_offset_provider.update(
+                            {common.dimension_to_implicit_offset(dim.value): dim}
+                        )
         return implicit_offset_provider
 
     def __call__(self, *args, offset_provider: dict[str, Dimension], **kwargs: Any) -> None:


### PR DESCRIPTION
#1484 introduced support for writing `field(I+1)`. The implicit offset providers we generate for this accidentally also included local dimensions, which broke e.g. Icon4Py with errors like:
```
                    if not dim.kind == common.DimensionKind.VERTICAL:
>                       raise ValueError(
                            "Mapping an offset to a horizontal dimension in unstructured is not allowed."
                        )
E                       ValueError: Mapping an offset to a horizontal dimension in unstructured is not allowed.
```
This PR fixes that by only including horizontal and vertical, but not local dimensions in the implicit offset providers.