### PR TITLE
bug[next]: fix lowering of `astype` on tuples containing scalars

### DIFF
--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -113,6 +113,7 @@ def process_elements(
         objs: The object whose elements are to be transformed.
         current_el_type: A type with the same structure as the elements of `objs`. The leaf-types
             are not used and thus not relevant.
+        with_type: If True, the last argument passed to `process_func` will be its type.
     """
     if isinstance(objs, itir.Expr):
         objs = (objs,)

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -113,6 +113,8 @@ def process_elements(
         objs: The object whose elements are to be transformed.
         current_el_type: A type with the same structure as the elements of `objs`. The leaf-types
             are not used and thus not relevant.
+        current_el_type: A type with the same structure as the elements of `objs`. Unless `with_type=True`
+            the leaf-types are not used and thus not relevant.
         with_type: If True, the last argument passed to `process_func` will be its type.
     """
     if isinstance(objs, itir.Expr):


### PR DESCRIPTION
The unpacked tuple will contain `as_fieldop`ed `cast_`s for fields, but direct `cast_`s for scalars.

Note: A similar change is not needed for `where` which also works on tuples in the `true` and `false` branches. The reason is that `mask` is required to be a `Field`, therefore `true` and `false` are promoted to `Field`s, too.