### PR TITLE
feat[dace]: Custom SDFG inline pass

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/__init__.py
@@ -12,7 +12,7 @@ Please also see [ADR0018](https://github.com/GridTools/gt4py/tree/main/docs/deve
 that explains the general structure and requirements on the SDFGs.
 """
 
-from .auto_opt import gt_auto_optimize, gt_set_iteration_order, gt_simplify
+from .auto_opt import gt_auto_optimize, gt_inline_nested_sdfg, gt_set_iteration_order, gt_simplify
 from .gpu_utils import GPUSetBlockSize, gt_gpu_transformation, gt_set_gpu_blocksize
 from .loop_blocking import LoopBlocking
 from .map_orderer import MapIterationOrder
@@ -29,6 +29,7 @@ __all__ = [
     "SerialMapPromoterGPU",
     "gt_auto_optimize",
     "gt_gpu_transformation",
+    "gt_inline_nested_sdfg",
     "gt_set_iteration_order",
     "gt_set_gpu_blocksize",
     "gt_simplify",

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/__init__.py
@@ -12,7 +12,13 @@ Please also see [ADR0018](https://github.com/GridTools/gt4py/tree/main/docs/deve
 that explains the general structure and requirements on the SDFGs.
 """
 
-from .auto_opt import gt_auto_optimize, gt_inline_nested_sdfg, gt_set_iteration_order, gt_simplify
+from .auto_opt import (
+    GT_SIMPLIFY_DEFAULT_SKIP_SET,
+    gt_auto_optimize,
+    gt_inline_nested_sdfg,
+    gt_set_iteration_order,
+    gt_simplify,
+)
 from .gpu_utils import GPUSetBlockSize, gt_gpu_transformation, gt_set_gpu_blocksize
 from .loop_blocking import LoopBlocking
 from .map_orderer import MapIterationOrder
@@ -21,6 +27,7 @@ from .map_serial_fusion import SerialMapFusion
 
 
 __all__ = [
+    "GT_SIMPLIFY_DEFAULT_SKIP_SET",
     "GPUSetBlockSize",
     "LoopBlocking",
     "MapIterationOrder",

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/auto_opt.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/auto_opt.py
@@ -35,19 +35,19 @@ def gt_simplify(
     sdfg: dace.SDFG,
     validate: bool = True,
     validate_all: bool = False,
-    skip: Iterable[str] = GT_SIMPLIFY_DEFAULT_SKIP_SET,
+    skip: Optional[Iterable[str]] = None,
 ) -> Any:
     """Performs simplifications on the SDFG in place.
 
     Instead of calling `sdfg.simplify()` directly, you should use this function,
     as it is specially tuned for GridTool based SDFGs.
 
-    By default this function will run the normal DaCe simplify pass, but skip
-    passes listed in `GT_SIMPLIFY_DEFAULT_SKIP_SET`. If `skip` is given it will
-    not be modified, i.e. `GT_SIMPLIFY_DEFAULT_SKIP_SET` is not added by default.
+    This function runs the DaCe simplification pass, but the following passes are
+    replaced:
+    - `InlineSDFGs`: Instead `gt_inline_nested_sdfg()` will be called.
 
-    Passes that are replaced:
-    - `InlineSDFGs`: Instead the `gt_inline_nested_sdfg()` will be used.
+    Furthermore, by default, or if `None` is passed fro `skip` the passes listed in
+    `GT_SIMPLIFY_DEFAULT_SKIP_SET` will be skipped.
 
     Args:
         sdfg: The SDFG to optimize.
@@ -57,7 +57,7 @@ def gt_simplify(
             to `GT_SIMPLIFY_DEFAULT_SKIP_SET`.
     """
     # Ensure that `skip` is a `set`
-    skip = set(skip)
+    skip = GT_SIMPLIFY_DEFAULT_SKIP_SET if skip is None else set(skip)
 
     if "InlineSDFGs" not in skip:
         gt_inline_nested_sdfg(
@@ -72,7 +72,7 @@ def gt_simplify(
         validate=validate,
         validate_all=validate_all,
         verbose=False,
-        skip=set(skip) | {"InlineSDFGs"},
+        skip=(skip | {"InlineSDFGs"}),
     ).apply_pass(sdfg, {})
 
 

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/auto_opt.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/transformations/auto_opt.py
@@ -35,7 +35,7 @@ def gt_simplify(
     sdfg: dace.SDFG,
     validate: bool = True,
     validate_all: bool = False,
-    skip: Optional[Iterable[str]] = GT_SIMPLIFY_DEFAULT_SKIP_SET,
+    skip: Iterable[str] = GT_SIMPLIFY_DEFAULT_SKIP_SET,
 ) -> Any:
     """Performs simplifications on the SDFG in place.
 
@@ -43,12 +43,11 @@ def gt_simplify(
     as it is specially tuned for GridTool based SDFGs.
 
     By default this function will run the normal DaCe simplify pass, but skip
-    passes listed in `GT_SIMPLIFY_DEFAULT_SKIP_SET`. If `skip` is passed it
-    will be forwarded to DaCe, i.e. `GT_SIMPLIFY_DEFAULT_SKIP_SET` are not
-    added automatically.
+    passes listed in `GT_SIMPLIFY_DEFAULT_SKIP_SET`. If `skip` is given it will
+    not be modified, i.e. `GT_SIMPLIFY_DEFAULT_SKIP_SET` is not added by default.
 
     Passes that are replaced:
-    - Instead of `InlineSDFGs` the function will run `gt_inline_nested_sdfg()`.
+    - `InlineSDFGs`: Instead the `gt_inline_nested_sdfg()` will be used.
 
     Args:
         sdfg: The SDFG to optimize.
@@ -57,8 +56,8 @@ def gt_simplify(
         skip: List of simplify passes that should not be applied, defaults
             to `GT_SIMPLIFY_DEFAULT_SKIP_SET`.
     """
-    if skip is None:
-        skip = set()
+    # Ensure that `skip` is a `set`
+    skip = set(skip)
 
     if "InlineSDFGs" not in skip:
         gt_inline_nested_sdfg(
@@ -116,7 +115,7 @@ def gt_inline_nested_sdfg(
 
     The function uses DaCe's `InlineSDFG` transformation, the same used in simplify.
     However, before the inline transformation is run the function will run some
-    cleaning passes that allows inlining nested SDFG.
+    cleaning passes that allows inlining nested SDFGs.
     As a side effect, the function will split stages into more states.
 
     Args:


### PR DESCRIPTION
Added a custom pass for inlining SDFG.
The function builds upon the traditional inline pass (`InlineSDFG`), however, before it is run some cleaning steps are preformed (`PruneConectors` and `PruneSymbols`) which increase the likelihood that the inlining can be done.
The cost is that state fusing is performed.

Also the `gt_simplify()` function is modified, instead of the build in behaviour it will only run the GT4Py specific one.
This behaviour can not be changed.


