### PR TITLE
bug[next]: Enable test_ffront_lap again

### DIFF
--- a/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_laplacian.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_laplacian.py
@@ -89,14 +89,14 @@ def test_ffront_lap(cartesian_case):
     in_field = square(in_field)
     out_field = cases.allocate(cartesian_case, lap_program, "out_field")()
 
-    # cases.verify(
-    #     cartesian_case,
-    #     lap_program,
-    #     in_field,
-    #     out_field,
-    #     inout=out_field[1:-1, 1:-1],
-    #     ref=lap_ref(in_field.ndarray),
-    # )
+    cases.verify(
+        cartesian_case,
+        lap_program,
+        in_field,
+        out_field,
+        inout=out_field[1:-1, 1:-1],
+        ref=lap_ref(in_field.ndarray),
+    )
 
 
 def test_ffront_skewedlap(cartesian_case):


### PR DESCRIPTION
Not sure what happend here, but I somehow disabled this test in a previous PR and merged it in the end...