### PR TITLE
refactor[next]: ranaming of dace_utils module

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_common/dace_backend.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/dace_backend.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from gt4py.next import common as gtx_common
 
-from . import utility as dace_util
+from . import utility as dace_utils
 
 
 try:
@@ -40,7 +40,7 @@ def _convert_arg(arg: Any, sdfg_param: str, use_field_canonical_representation: 
     if not use_field_canonical_representation:
         return arg.ndarray
     # the canonical representation requires alphabetical ordering of the dimensions in field domain definition
-    sorted_dims = dace_util.get_sorted_dims(arg.domain.dims)
+    sorted_dims = dace_utils.get_sorted_dims(arg.domain.dims)
     ndim = len(sorted_dims)
     dim_indices = [dim_index for dim_index, _ in sorted_dims]
     if isinstance(arg.ndarray, np.ndarray):
@@ -122,9 +122,9 @@ def get_sdfg_conn_args(
     device = dace.DeviceType.GPU if on_gpu else dace.DeviceType.CPU
 
     connectivity_args = {}
-    for offset, connectivity in dace_util.filter_connectivities(offset_provider).items():
+    for offset, connectivity in dace_utils.filter_connectivities(offset_provider).items():
         assert isinstance(connectivity, gtx_common.NeighborTable)
-        param = dace_util.connectivity_identifier(offset)
+        param = dace_utils.connectivity_identifier(offset)
         if param in sdfg.arrays:
             connectivity_args[param] = _ensure_is_on_device(connectivity.table, device)
 

--- a/src/gt4py/next/program_processors/runners/dace_common/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/utility.py
@@ -22,6 +22,21 @@ from gt4py.next.type_system import type_specifications as ts
 FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile("__.+_(size|stride)_\d+")
 
 
+def as_dace_type(type_: ts.ScalarType) -> dace.typeclass:
+    """Converts GT4Py scalar type to corresponding DaCe type."""
+    if type_.kind == ts.ScalarKind.BOOL:
+        return dace.bool_
+    elif type_.kind == ts.ScalarKind.INT32:
+        return dace.int32
+    elif type_.kind == ts.ScalarKind.INT64:
+        return dace.int64
+    elif type_.kind == ts.ScalarKind.FLOAT32:
+        return dace.float32
+    elif type_.kind == ts.ScalarKind.FLOAT64:
+        return dace.float64
+    raise ValueError(f"Scalar type '{type_}' not supported.")
+
+
 def as_scalar_type(typestr: str) -> ts.ScalarType:
     """Obtain GT4Py scalar type from generic numpy string representation."""
     try:

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
@@ -26,12 +26,12 @@ from gt4py.next import common as gtx_common
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm
 from gt4py.next.iterator.type_system import inference as gtir_type_inference
-from gt4py.next.program_processors.runners.dace_common import utility as dace_common_util
+from gt4py.next.program_processors.runners.dace_common import utility as dace_utils
 from gt4py.next.program_processors.runners.dace_fieldview import (
     gtir_builtin_translators,
     gtir_to_tasklet,
     transformations as gtx_transformations,
-    utility as dace_fieldview_util,
+    utility as dace_gtir_utils,
 )
 from gt4py.next.type_system import type_specifications as ts, type_translation as tt
 
@@ -143,17 +143,17 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             Two lists of symbols, one for the shape and the other for the strides of the array.
         """
         dtype = dace.int32
-        neighbor_tables = dace_common_util.filter_connectivities(self.offset_provider)
+        neighbor_tables = dace_utils.filter_connectivities(self.offset_provider)
         shape = [
             (
                 neighbor_tables[dim.value].max_neighbors
                 if dim.kind == gtx_common.DimensionKind.LOCAL
-                else dace.symbol(dace_common_util.field_size_symbol_name(name, i), dtype)
+                else dace.symbol(dace_utils.field_size_symbol_name(name, i), dtype)
             )
             for i, dim in enumerate(dims)
         ]
         strides = [
-            dace.symbol(dace_common_util.field_stride_symbol_name(name, i), dtype)
+            dace.symbol(dace_utils.field_stride_symbol_name(name, i), dtype)
             for i in range(len(dims))
         ]
         return shape, strides
@@ -170,13 +170,14 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         and have to be passed as array arguments to the SDFG.
         """
         if isinstance(symbol_type, ts.FieldType):
-            dtype = dace_fieldview_util.as_dace_type(symbol_type.dtype)
+            dtype = dace_utils.as_dace_type(symbol_type.dtype)
             # use symbolic shape, which allows to invoke the program with fields of different size;
             # and symbolic strides, which enables decoupling the memory layout from generated code.
             sym_shape, sym_strides = self._make_array_shape_and_strides(name, symbol_type.dims)
             sdfg.add_array(name, sym_shape, dtype, strides=sym_strides, transient=transient)
         elif isinstance(symbol_type, ts.ScalarType):
-            dtype = dace_fieldview_util.as_dace_type(symbol_type)
+            assert isinstance(symbol_type, ts.ScalarType)
+            dtype = dace_utils.as_dace_type(symbol_type)
             # Scalar arguments passed to the program are represented as symbols in DaCe SDFG.
             # The field size is sometimes passed as scalar argument to the program, so we have to
             # check if the shape symbol was already allocated by `_make_array_shape_and_strides`.
@@ -239,7 +240,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             self.global_symbols[pname] = param.type
 
         # add SDFG storage for connectivity tables
-        for offset, offset_provider in dace_common_util.filter_connectivities(
+        for offset, offset_provider in dace_utils.filter_connectivities(
             self.offset_provider
         ).items():
             scalar_kind = tt.get_scalar_kind(offset_provider.index_type)
@@ -252,7 +253,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             # the tables that are actually used. This way, we avoid adding SDFG arguments for
             # the connectivity tables that are not used. The remaining unused transient arrays
             # are removed by the dace simplify pass.
-            self._add_storage(sdfg, dace_common_util.connectivity_identifier(offset), type_)
+            self._add_storage(sdfg, dace_utils.connectivity_identifier(offset), type_)
 
     def visit_Program(self, node: gtir.Program) -> dace.SDFG:
         """Translates `ir.Program` to `dace.SDFG`.
@@ -267,7 +268,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             raise NotImplementedError("Functions expected to be inlined as lambda calls.")
 
         sdfg = dace.SDFG(node.id)
-        sdfg.debuginfo = dace_common_util.debug_info(node, default=sdfg.debuginfo)
+        sdfg.debuginfo = dace_utils.debug_info(node, default=sdfg.debuginfo)
         entry_state = sdfg.add_state("program_entry", is_start_block=True)
 
         # declarations of temporaries result in transient array definitions in the SDFG
@@ -287,7 +288,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         for i, stmt in enumerate(node.body):
             # include `debuginfo` only for `ir.Program` and `ir.Stmt` nodes: finer granularity would be too messy
             head_state = sdfg.add_state_after(head_state, f"stmt_{i}")
-            head_state._debuginfo = dace_common_util.debug_info(stmt, default=sdfg.debuginfo)
+            head_state._debuginfo = dace_utils.debug_info(stmt, default=sdfg.debuginfo)
             self.visit(stmt, sdfg=sdfg, state=head_state)
 
         # Create the call signature for the SDFG.
@@ -313,7 +314,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         target_nodes = self._visit_expression(stmt.target, sdfg, state)
 
         # convert domain expression to dictionary to ease access to dimension boundaries
-        domain = dace_fieldview_util.get_domain_ranges(stmt.domain)
+        domain = dace_gtir_utils.get_domain_ranges(stmt.domain)
 
         for expr_node, target_node in zip(expr_nodes, target_nodes, strict=True):
             target_array = sdfg.arrays[target_node.data]
@@ -421,8 +422,8 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         )
 
         connectivity_arrays = {
-            dace_common_util.connectivity_identifier(offset)
-            for offset in dace_common_util.filter_connectivities(self.offset_provider)
+            dace_utils.connectivity_identifier(offset)
+            for offset in dace_utils.filter_connectivities(self.offset_provider)
         }
         nsdfg_symbols_mapping: dict[str, dace.symbolic.SymExpr] = {}
 
@@ -461,7 +462,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             inputs=set(input_memlets.keys()),
             outputs=set(node.data for node, _ in lambda_nodes),
             symbol_mapping=nsdfg_symbols_mapping,
-            debuginfo=dace_common_util.debug_info(node, default=sdfg.debuginfo),
+            debuginfo=dace_utils.debug_info(node, default=sdfg.debuginfo),
         )
 
         for connector, memlet in input_memlets.items():

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/utility.py
@@ -13,34 +13,7 @@ import dace
 from gt4py.next import common as gtx_common
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm
-from gt4py.next.iterator.type_system import type_specifications as gtir_ts
 from gt4py.next.program_processors.runners.dace_fieldview import gtir_python_codegen
-from gt4py.next.type_system import type_specifications as ts
-
-
-def as_dace_type(type_: ts.TypeSpec) -> dace.typeclass:
-    """Converts GT4Py scalar type to corresponding DaCe type."""
-    if isinstance(type_, ts.ScalarType):
-        scalar_type = type_
-    elif isinstance(type_, gtir_ts.ListType):
-        assert isinstance(type_.element_type, ts.ScalarType)
-        scalar_type = type_.element_type
-    else:
-        raise NotImplementedError
-
-    match scalar_type.kind:
-        case ts.ScalarKind.BOOL:
-            return dace.bool_
-        case ts.ScalarKind.INT32:
-            return dace.int32
-        case ts.ScalarKind.INT64:
-            return dace.int64
-        case ts.ScalarKind.FLOAT32:
-            return dace.float32
-        case ts.ScalarKind.FLOAT64:
-            return dace.float64
-        case _:
-            raise ValueError(f"Scalar type '{scalar_type}' not supported.")
 
 
 def get_domain(

--- a/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/__init__.py
@@ -26,11 +26,10 @@ from gt4py.next.ffront import decorator
 from gt4py.next.iterator import transforms as itir_transforms
 from gt4py.next.iterator.transforms import program_to_fencil
 from gt4py.next.iterator.type_system import inference as itir_type_inference
-from gt4py.next.program_processors.runners.dace_common import utility as dace_common_util
+from gt4py.next.program_processors.runners.dace_common import utility as dace_utils
 from gt4py.next.type_system import type_specifications as ts
 
 from .itir_to_sdfg import ItirToSDFG
-from .utility import as_dace_type
 
 
 def preprocess_program(
@@ -260,31 +259,27 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
 
         # Define DaCe symbols
         connectivity_table_size_symbols = {
-            dace_common_util.field_size_symbol_name(
-                dace_common_util.connectivity_identifier(k), axis
+            dace_utils.field_size_symbol_name(
+                dace_utils.connectivity_identifier(k), axis
             ): dace.symbol(
-                dace_common_util.field_size_symbol_name(
-                    dace_common_util.connectivity_identifier(k), axis
-                )
+                dace_utils.field_size_symbol_name(dace_utils.connectivity_identifier(k), axis)
             )
             for k, v in offset_provider.items()  # type: ignore[union-attr]
             for axis in [0, 1]
             if hasattr(v, "table")
-            and dace_common_util.connectivity_identifier(k) in self.sdfg_closure_vars["sdfg.arrays"]
+            and dace_utils.connectivity_identifier(k) in self.sdfg_closure_vars["sdfg.arrays"]
         }
 
         connectivity_table_stride_symbols = {
-            dace_common_util.field_stride_symbol_name(
-                dace_common_util.connectivity_identifier(k), axis
+            dace_utils.field_stride_symbol_name(
+                dace_utils.connectivity_identifier(k), axis
             ): dace.symbol(
-                dace_common_util.field_stride_symbol_name(
-                    dace_common_util.connectivity_identifier(k), axis
-                )
+                dace_utils.field_stride_symbol_name(dace_utils.connectivity_identifier(k), axis)
             )
             for k, v in offset_provider.items()  # type: ignore[union-attr]
             for axis in [0, 1]
             if hasattr(v, "table")
-            and dace_common_util.connectivity_identifier(k) in self.sdfg_closure_vars["sdfg.arrays"]
+            and dace_utils.connectivity_identifier(k) in self.sdfg_closure_vars["sdfg.arrays"]
         }
 
         symbols = {**connectivity_table_size_symbols, **connectivity_table_stride_symbols}
@@ -294,32 +289,29 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
             for k, v in offset_provider.items():  # type: ignore[union-attr]
                 if not hasattr(v, "table"):
                     continue
-                if (
-                    dace_common_util.connectivity_identifier(k)
-                    in self.sdfg_closure_vars["sdfg.arrays"]
-                ):
+                if dace_utils.connectivity_identifier(k) in self.sdfg_closure_vars["sdfg.arrays"]:
                     Program.connectivity_tables_data_descriptors["storage"] = (
                         self.sdfg_closure_vars[
                             "sdfg.arrays"
-                        ][dace_common_util.connectivity_identifier(k)].storage
+                        ][dace_utils.connectivity_identifier(k)].storage
                     )
                     break
 
         # Build the closure dictionary
         closure_dict = {}
         for k, v in offset_provider.items():  # type: ignore[union-attr]
-            conn_id = dace_common_util.connectivity_identifier(k)
+            conn_id = dace_utils.connectivity_identifier(k)
             if hasattr(v, "table") and conn_id in self.sdfg_closure_vars["sdfg.arrays"]:
                 if conn_id not in Program.connectivity_tables_data_descriptors:
                     Program.connectivity_tables_data_descriptors[conn_id] = dace.data.Array(
                         dtype=dace.int64 if v.index_type == np.int64 else dace.int32,
                         shape=[
-                            symbols[dace_common_util.field_size_symbol_name(conn_id, 0)],
-                            symbols[dace_common_util.field_size_symbol_name(conn_id, 1)],
+                            symbols[dace_utils.field_size_symbol_name(conn_id, 0)],
+                            symbols[dace_utils.field_size_symbol_name(conn_id, 1)],
                         ],
                         strides=[
-                            symbols[dace_common_util.field_stride_symbol_name(conn_id, 0)],
-                            symbols[dace_common_util.field_stride_symbol_name(conn_id, 1)],
+                            symbols[dace_utils.field_stride_symbol_name(conn_id, 0)],
+                            symbols[dace_utils.field_stride_symbol_name(conn_id, 1)],
                         ],
                         storage=Program.connectivity_tables_data_descriptors["storage"],
                     )
@@ -337,7 +329,7 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
 def _crosscheck_dace_parsing(dace_parsed_args: list[Any], gt4py_program_args: list[Any]) -> bool:
     for dace_parsed_arg, gt4py_program_arg in zip(dace_parsed_args, gt4py_program_args):
         if isinstance(dace_parsed_arg, dace.data.Scalar):
-            assert dace_parsed_arg.dtype == as_dace_type(gt4py_program_arg)
+            assert dace_parsed_arg.dtype == dace_utils.as_dace_type(gt4py_program_arg)
         elif isinstance(
             dace_parsed_arg, (bool, int, float, str, np.bool_, np.integer, np.floating, np.str_)
         ):  # compile-time constant scalar
@@ -353,7 +345,7 @@ def _crosscheck_dace_parsing(dace_parsed_args: list[Any], gt4py_program_args: li
         elif isinstance(dace_parsed_arg, dace.data.Array):
             assert isinstance(gt4py_program_arg, ts.FieldType)
             assert len(dace_parsed_arg.shape) == len(gt4py_program_arg.dims)
-            assert dace_parsed_arg.dtype == as_dace_type(gt4py_program_arg.dtype)
+            assert dace_parsed_arg.dtype == dace_utils.as_dace_type(gt4py_program_arg.dtype)
         elif isinstance(
             dace_parsed_arg, (dace.data.Structure, dict, OrderedDict)
         ):  # offset_provider

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -14,28 +14,13 @@ import dace
 import gt4py.next.iterator.ir as itir
 from gt4py import eve
 from gt4py.next.common import Connectivity
-from gt4py.next.program_processors.runners.dace_common import utility as dace_common_util
-from gt4py.next.type_system import type_specifications as ts
-
-
-def as_dace_type(type_: ts.ScalarType) -> dace.dtypes.typeclass:
-    if type_.kind == ts.ScalarKind.BOOL:
-        return dace.bool_
-    elif type_.kind == ts.ScalarKind.INT32:
-        return dace.int32
-    elif type_.kind == ts.ScalarKind.INT64:
-        return dace.int64
-    elif type_.kind == ts.ScalarKind.FLOAT32:
-        return dace.float32
-    elif type_.kind == ts.ScalarKind.FLOAT64:
-        return dace.float64
-    raise ValueError(f"Scalar type '{type_}' not supported.")
+from gt4py.next.program_processors.runners.dace_common import utility as dace_utils
 
 
 def get_used_connectivities(
     node: itir.Node, offset_provider: Mapping[str, Any]
 ) -> dict[str, Connectivity]:
-    connectivities = dace_common_util.filter_connectivities(offset_provider)
+    connectivities = dace_utils.filter_connectivities(offset_provider)
     offset_dims = set(eve.walk_values(node).if_isinstance(itir.OffsetLiteral).getattr("value"))
     return {offset: connectivities[offset] for offset in offset_dims if offset in connectivities}
 


### PR DESCRIPTION
This is a pure refactoring PR, that applies the following changes in dace backends:
- renamed alias of `dace_common.utility` module: `dace_util` -> `dace_utils`
- renamed alias of `dace_common.utility` module: `dace_common_util` -> `dace_utils`
- renamed alias of `dace_fieldview.utility` module: `dace_fieldview_util` -> `dace_gtir_utils`
- moved method `as_dace_type` to `dace_common.utility`