### PR TITLE
fix[next][dace]: enable subdomain in let-statements

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_common/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/utility.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import enum
 import re
 from typing import Any, Final, Mapping, Optional, Sequence
 
@@ -21,9 +20,6 @@ from gt4py.next.type_system import type_specifications as ts
 
 # regex to match the symbols for field shape and strides
 FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile("__.+_(size|stride)_\d+")
-
-# symbol types used for field memory layout
-FieldSymbol = enum.Enum("FieldSymbol", ["size", "stride"])
 
 
 def as_scalar_type(typestr: str) -> ts.ScalarType:
@@ -39,16 +35,12 @@ def connectivity_identifier(name: str) -> str:
     return f"connectivity_{name}"
 
 
-def _field_symbol_name(field_name: str, axis: int, suffix: FieldSymbol) -> str:
-    return f"__{field_name}_{suffix.name}_{axis}"
-
-
 def field_size_symbol_name(field_name: str, axis: int) -> str:
-    return _field_symbol_name(field_name, axis, FieldSymbol.size)
+    return f"__{field_name}_size_{axis}"
 
 
 def field_stride_symbol_name(field_name: str, axis: int) -> str:
-    return _field_symbol_name(field_name, axis, FieldSymbol.stride)
+    return f"__{field_name}_stride_{axis}"
 
 
 def is_field_symbol(name: str) -> bool:

--- a/src/gt4py/next/program_processors/runners/dace_common/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/utility.py
@@ -20,10 +20,10 @@ from gt4py.next.type_system import type_specifications as ts
 
 
 # regex to match the symbols for field shape and strides
-FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile("__.+_(offset|size|stride)_\d+")
+FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile("__.+_(size|stride)_\d+")
 
 # symbol types used for field memory layout
-FieldSymbol = enum.Enum("FieldSymbol", ["offset", "size", "stride"])
+FieldSymbol = enum.Enum("FieldSymbol", ["size", "stride"])
 
 
 def as_scalar_type(typestr: str) -> ts.ScalarType:
@@ -41,10 +41,6 @@ def connectivity_identifier(name: str) -> str:
 
 def _field_symbol_name(field_name: str, axis: int, suffix: FieldSymbol) -> str:
     return f"__{field_name}_{suffix.name}_{axis}"
-
-
-def field_offset_symbol_name(field_name: str, axis: int) -> str:
-    return _field_symbol_name(field_name, axis, FieldSymbol.offset)
 
 
 def field_size_symbol_name(field_name: str, axis: int) -> str:

--- a/src/gt4py/next/program_processors/runners/dace_common/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/utility.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import enum
 import re
 from typing import Any, Final, Mapping, Optional, Sequence
 
@@ -19,7 +20,10 @@ from gt4py.next.type_system import type_specifications as ts
 
 
 # regex to match the symbols for field shape and strides
-FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile("__.+_(size|stride)_\d+")
+FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile("__.+_(offset|size|stride)_\d+")
+
+# symbol types used for field memory layout
+FieldSymbol = enum.Enum("FieldSymbol", ["offset", "size", "stride"])
 
 
 def as_scalar_type(typestr: str) -> ts.ScalarType:
@@ -35,12 +39,20 @@ def connectivity_identifier(name: str) -> str:
     return f"connectivity_{name}"
 
 
+def _field_symbol_name(field_name: str, axis: int, suffix: FieldSymbol) -> str:
+    return f"__{field_name}_{suffix.name}_{axis}"
+
+
+def field_offset_symbol_name(field_name: str, axis: int) -> str:
+    return _field_symbol_name(field_name, axis, FieldSymbol.offset)
+
+
 def field_size_symbol_name(field_name: str, axis: int) -> str:
-    return f"__{field_name}_size_{axis}"
+    return _field_symbol_name(field_name, axis, FieldSymbol.size)
 
 
 def field_stride_symbol_name(field_name: str, axis: int) -> str:
-    return f"__{field_name}_stride_{axis}"
+    return _field_symbol_name(field_name, axis, FieldSymbol.stride)
 
 
 def is_field_symbol(name: str) -> bool:

--- a/src/gt4py/next/program_processors/runners/dace_common/workflow.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/workflow.py
@@ -121,7 +121,7 @@ def convert_args(
             # the arguments list has to be reconstructed.
             for i, (arg_name, arg_type) in enumerate(inp.sdfg_arglist):
                 if isinstance(arg_type, dace.data.Array):
-                    assert arg_name in kwargs, f"Argument '{arg_name}' not found."
+                    assert arg_name in kwargs, f"argument '{arg_name}' not found."
                     data_ptr = get_array_interface_ptr(kwargs[arg_name], arg_type.storage)
                     assert isinstance(last_call_args[i], ctypes.c_void_p)
                     if last_call_args[i].value != data_ptr:
@@ -138,7 +138,7 @@ def convert_args(
                         # shape and strides of arrays are supposed not to change, and can therefore be omitted
                         assert dace_utils.is_field_symbol(
                             arg_name
-                        ), f"Argument '{arg_name}' not found."
+                        ), f"argument '{arg_name}' not found."
 
             if use_fast_call:
                 return sdfg_program.fast_call(*sdfg_program._lastargs)

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
@@ -120,8 +120,12 @@ def _create_temporary_field(
     field_dims = list(domain_dims)
     # It should be enough to allocate an array with shape (upper_bound - lower_bound)
     # but this would require to use array offset for compensate for the start index.
-    # Array offset is known to cause issues to SDFG inlining. Besides, map fusion will
-    # in any case eliminate most of transient arrays.
+    # Suppose that a field operator executes on domain [2,N-2], the dace array to store
+    # the result only needs size (N-4), but this would require to compensate all array
+    # accesses with offset -2 (which corresponds to -lower_bound). Instead, we choose
+    # to allocate (N-2), leaving positions [0:2] unused. The reason is that array offset
+    # is known to cause issues to SDFG inlining. Besides, map fusion will in any case
+    # eliminate most of transient arrays.
     field_shape = list(domain_ubs)
 
     if isinstance(output_desc, dace.data.Array):

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
@@ -564,5 +564,5 @@ def build_sdfg_from_gtir(
     sdfg = sdfg_genenerator.visit(program)
     assert isinstance(sdfg, dace.SDFG)
 
-    gtx_transformations.gt_simplify(sdfg)
+    gtx_transformations.gt_simplify(sdfg, skip=["InlineSDFGs"])
     return sdfg

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
@@ -37,9 +37,6 @@ from gt4py.next.program_processors.runners.dace_fieldview import (
 from gt4py.next.type_system import type_specifications as ts, type_translation as tt
 
 
-FIELD_SYMBOL_DTYPE = dace.int32
-
-
 class DataflowBuilder(Protocol):
     """Visitor interface to build a dataflow subgraph."""
 
@@ -146,7 +143,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         Returns:
             Two lists of symbols, one for the shape and the other for the strides of the array.
         """
-        dtype = FIELD_SYMBOL_DTYPE
+        dtype = dace.int32
         neighbor_tables = dace_common_util.filter_connectivities(self.offset_provider)
         shape = [
             (

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -1231,6 +1231,9 @@ def test_gtir_let_lambda():
     domain = im.call("cartesian_domain")(
         im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
     )
+    subdomain = im.call("cartesian_domain")(
+        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 1, im.minus("size", 1))
+    )
     testee = gtir.Program(
         id="let_lambda",
         function_definitions=[],
@@ -1246,21 +1249,21 @@ def test_gtir_let_lambda():
                 # `x2` is a let-lambda expression representing `x * 4`
                 #  - note that the let-symbol `x2` is used twice, in a nested let-expression, to test aliasing of the symbol
                 # `x3` is a let-lambda expression simply accessing `x` field symref
-                expr=im.let("x1", im.op_as_fieldop("multiplies", domain)(3.0, "x"))(
+                expr=im.let("x1", im.op_as_fieldop("multiplies", subdomain)(3.0, "x"))(
                     im.let(
                         "x2",
                         im.let("x2", im.op_as_fieldop("multiplies", domain)(2.0, "x"))(
-                            im.op_as_fieldop("plus", domain)("x2", "x2")
+                            im.op_as_fieldop("plus", subdomain)("x2", "x2")
                         ),
                     )(
                         im.let("x3", "x")(
-                            im.op_as_fieldop("plus", domain)(
-                                "x1", im.op_as_fieldop("plus", domain)("x2", "x3")
+                            im.op_as_fieldop("plus", subdomain)(
+                                "x1", im.op_as_fieldop("plus", subdomain)("x2", "x3")
                             )
                         )
                     )
                 ),
-                domain=domain,
+                domain=subdomain,
                 target=gtir.SymRef(id="y"),
             )
         ],
@@ -1268,11 +1271,12 @@ def test_gtir_let_lambda():
 
     a = np.random.rand(N)
     b = np.empty_like(a)
+    ref = np.concatenate((b[0:1], a[1 : N - 1] * 8, b[N - 1 : N]))
 
     sdfg = dace_backend.build_sdfg_from_gtir(testee, {})
 
     sdfg(a, b, **FSYMBOLS)
-    assert np.allclose(b, a * 8)
+    assert np.allclose(b, ref)
 
 
 def test_gtir_let_lambda_with_connectivity():


### PR DESCRIPTION
This PR fixes the lowering of let-statements with fields defined on sub-domain. The previous implementation was allocating dace array with the exact domain of the computation, eventually not starting from index 0. This required the use of offsets in dace arrays to compensate for the start index. There were two problems with this: 1) in the lowering from GTIR to SDFG because the array offsets were not correctly propagated across nested SDFGs for let-statements; and 2) the use of array offsets caused issue to SDFG-inlining pass. In order to reduce the overall complexity, this PR proposes to remove the usage of array offsets and therefore always allocate temporary fields starting from index 0.