### PR TITLE
refactor[next]: Move symbolic domain utilities to seperate module

### DIFF
--- a/src/gt4py/next/iterator/ir_utils/domain_utils.py
+++ b/src/gt4py/next/iterator/ir_utils/domain_utils.py
@@ -1,0 +1,150 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from typing import Any, Literal, Mapping
+
+import gt4py.next as gtx
+from gt4py.next import common
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.ir_utils import ir_makers as im
+
+
+def _max_domain_sizes_by_location_type(offset_provider: Mapping[str, Any]) -> dict[str, int]:
+    """
+    Extract horizontal domain sizes from an `offset_provider`.
+
+    Considers the shape of the neighbor table to get the size of each `origin_axis` and the maximum
+    value inside the neighbor table to get the size of each `neighbor_axis`.
+    """
+    sizes = dict[str, int]()
+    for provider in offset_provider.values():
+        if isinstance(provider, gtx.NeighborTableOffsetProvider):
+            assert provider.origin_axis.kind == gtx.DimensionKind.HORIZONTAL
+            assert provider.neighbor_axis.kind == gtx.DimensionKind.HORIZONTAL
+            sizes[provider.origin_axis.value] = max(
+                sizes.get(provider.origin_axis.value, 0), provider.table.shape[0]
+            )
+            sizes[provider.neighbor_axis.value] = max(
+                sizes.get(provider.neighbor_axis.value, 0),
+                provider.table.max() + 1,  # type: ignore[attr-defined] # TODO(havogt): improve typing for NDArrayObject
+            )
+    return sizes
+
+
+@dataclasses.dataclass
+class SymbolicRange:
+    start: itir.Expr
+    stop: itir.Expr
+
+    def translate(self, distance: int) -> SymbolicRange:
+        return SymbolicRange(im.plus(self.start, distance), im.plus(self.stop, distance))
+
+
+@dataclasses.dataclass
+class SymbolicDomain:
+    grid_type: Literal["unstructured_domain", "cartesian_domain"]
+    ranges: dict[
+        common.Dimension, SymbolicRange
+    ]  # TODO(havogt): remove `AxisLiteral` by `Dimension` everywhere
+
+    @classmethod
+    def from_expr(cls, node: itir.Node) -> SymbolicDomain:
+        assert isinstance(node, itir.FunCall) and node.fun in [
+            im.ref("unstructured_domain"),
+            im.ref("cartesian_domain"),
+        ]
+
+        ranges: dict[common.Dimension, SymbolicRange] = {}
+        for named_range in node.args:
+            assert (
+                isinstance(named_range, itir.FunCall)
+                and isinstance(named_range.fun, itir.SymRef)
+                and named_range.fun.id == "named_range"
+            )
+            axis_literal, lower_bound, upper_bound = named_range.args
+            assert isinstance(axis_literal, itir.AxisLiteral)
+
+            ranges[common.Dimension(value=axis_literal.value, kind=axis_literal.kind)] = (
+                SymbolicRange(lower_bound, upper_bound)
+            )
+        return cls(node.fun.id, ranges)  # type: ignore[attr-defined]  # ensure by assert above
+
+    def as_expr(self) -> itir.FunCall:
+        converted_ranges: dict[common.Dimension | str, tuple[itir.Expr, itir.Expr]] = {
+            key: (value.start, value.stop) for key, value in self.ranges.items()
+        }
+        return im.domain(self.grid_type, converted_ranges)
+
+    def translate(
+        self: SymbolicDomain,
+        shift: tuple[itir.OffsetLiteral, ...],
+        offset_provider: common.OffsetProvider,
+    ) -> SymbolicDomain:
+        dims = list(self.ranges.keys())
+        new_ranges = {dim: self.ranges[dim] for dim in dims}
+        if len(shift) == 0:
+            return self
+        if len(shift) == 2:
+            off, val = shift
+            assert isinstance(off.value, str) and isinstance(val.value, int)
+            nbt_provider = offset_provider[off.value]
+            if isinstance(nbt_provider, common.Dimension):
+                current_dim = nbt_provider
+                # cartesian offset
+                new_ranges[current_dim] = SymbolicRange.translate(
+                    self.ranges[current_dim], val.value
+                )
+            elif isinstance(nbt_provider, common.Connectivity):
+                # unstructured shift
+                # note: ugly but cheap re-computation, but should disappear
+                horizontal_sizes = _max_domain_sizes_by_location_type(offset_provider)
+
+                old_dim = nbt_provider.origin_axis
+                new_dim = nbt_provider.neighbor_axis
+
+                assert new_dim not in new_ranges or old_dim == new_dim
+
+                # TODO(tehrengruber): Do we need symbolic sizes, e.g., for ICON?
+                new_range = SymbolicRange(
+                    im.literal("0", itir.INTEGER_INDEX_BUILTIN),
+                    im.literal(str(horizontal_sizes[new_dim.value]), itir.INTEGER_INDEX_BUILTIN),
+                )
+                new_ranges = dict(
+                    (dim, range_) if dim != old_dim else (new_dim, new_range)
+                    for dim, range_ in new_ranges.items()
+                )
+            else:
+                raise AssertionError()
+            return SymbolicDomain(self.grid_type, new_ranges)
+        elif len(shift) > 2:
+            return self.translate(shift[0:2], offset_provider).translate(shift[2:], offset_provider)
+        else:
+            raise AssertionError("Number of shifts must be a multiple of 2.")
+
+
+def domain_union(*domains: SymbolicDomain) -> SymbolicDomain:
+    """Return the (set) union of a list of domains."""
+    new_domain_ranges = {}
+    assert all(domain.grid_type == domains[0].grid_type for domain in domains)
+    assert all(domain.ranges.keys() == domains[0].ranges.keys() for domain in domains)
+    for dim in domains[0].ranges.keys():
+        start = functools.reduce(
+            lambda current_expr, el_expr: im.call("minimum")(current_expr, el_expr),
+            [domain.ranges[dim].start for domain in domains],
+        )
+        stop = functools.reduce(
+            lambda current_expr, el_expr: im.call("maximum")(current_expr, el_expr),
+            [domain.ranges[dim].stop for domain in domains],
+        )
+        new_domain_ranges[dim] = SymbolicRange(start, stop)
+
+    return SymbolicDomain(domains[0].grid_type, new_domain_ranges)

--- a/src/gt4py/next/iterator/transforms/infer_domain.py
+++ b/src/gt4py/next/iterator/transforms/infer_domain.py
@@ -29,12 +29,12 @@ DOMAIN: TypeAlias = domain_utils.SymbolicDomain | None | tuple["DOMAIN", ...]
 ACCESSED_DOMAINS: TypeAlias = dict[str, DOMAIN]
 
 
-def split_dict_by_key(pred: Callable, d: dict):
+def _split_dict_by_key(pred: Callable, d: dict):
     """
     Split dictionary into two based on predicate.
 
     >>> d = {1: "a", 2: "b", 3: "c", 4: "d"}
-    >>> split_dict_by_key(lambda k: k % 2 == 0, d)
+    >>> _split_dict_by_key(lambda k: k % 2 == 0, d)
     ({2: 'b', 4: 'd'}, {1: 'a', 3: 'c'})
     """
     a: dict = {}
@@ -45,7 +45,7 @@ def split_dict_by_key(pred: Callable, d: dict):
 
 
 # TODO(tehrengruber): Revisit whether we want to move this behaviour to `domain_utils.domain_union`.
-def domain_union_with_none(
+def _domain_union_with_none(
     *domains: domain_utils.SymbolicDomain | None,
 ) -> domain_utils.SymbolicDomain | None:
     filtered_domains: list[domain_utils.SymbolicDomain] = [d for d in domains if d is not None]
@@ -54,7 +54,7 @@ def domain_union_with_none(
     return domain_utils.domain_union(*filtered_domains)
 
 
-def canonicalize_domain_structure(d1: DOMAIN, d2: DOMAIN) -> tuple[DOMAIN, DOMAIN]:
+def _canonicalize_domain_structure(d1: DOMAIN, d2: DOMAIN) -> tuple[DOMAIN, DOMAIN]:
     """
     Given two domains or composites thereof, canonicalize their structure.
 
@@ -63,24 +63,24 @@ def canonicalize_domain_structure(d1: DOMAIN, d2: DOMAIN) -> tuple[DOMAIN, DOMAI
     specified.
 
     >>> domain = im.domain(common.GridType.CARTESIAN, {})
-    >>> canonicalize_domain_structure((domain,), (domain, domain)) == (
+    >>> _canonicalize_domain_structure((domain,), (domain, domain)) == (
     ...     (domain, None),
     ...     (domain, domain),
     ... )
     True
 
-    >>> canonicalize_domain_structure((domain, None), None) == ((domain, None), (None, None))
+    >>> _canonicalize_domain_structure((domain, None), None) == ((domain, None), (None, None))
     True
     """
     if d1 is None and isinstance(d2, tuple):
-        return canonicalize_domain_structure((None,) * len(d2), d2)
+        return _canonicalize_domain_structure((None,) * len(d2), d2)
     if d2 is None and isinstance(d1, tuple):
-        return canonicalize_domain_structure(d1, (None,) * len(d1))
+        return _canonicalize_domain_structure(d1, (None,) * len(d1))
     if isinstance(d1, tuple) and isinstance(d2, tuple):
         return tuple(
             zip(
                 *(
-                    canonicalize_domain_structure(el1, el2)
+                    _canonicalize_domain_structure(el1, el2)
                     for el1, el2 in itertools.zip_longest(d1, d2, fillvalue=None)
                 )
             )
@@ -95,15 +95,15 @@ def _merge_domains(
     new_domains = {**original_domains}
 
     for key, domain in additional_domains.items():
-        original_domain, domain = canonicalize_domain_structure(
+        original_domain, domain = _canonicalize_domain_structure(
             original_domains.get(key, None), domain
         )
-        new_domains[key] = tree_map(domain_union_with_none)(original_domain, domain)
+        new_domains[key] = tree_map(_domain_union_with_none)(original_domain, domain)
 
     return new_domains
 
 
-def extract_accessed_domains(
+def _extract_accessed_domains(
     stencil: itir.Expr,
     input_ids: list[str],
     target_domain: domain_utils.SymbolicDomain,
@@ -119,7 +119,7 @@ def extract_accessed_domains(
             for shift in shifts_list
         ]
         # `None` means field is never accessed
-        accessed_domains[in_field_id] = domain_union_with_none(
+        accessed_domains[in_field_id] = _domain_union_with_none(
             accessed_domains.get(in_field_id, None), *new_domains
         )
 
@@ -158,7 +158,7 @@ def infer_as_fieldop(
             raise ValueError(f"Unsupported expression of type '{type(in_field)}'.")
         input_ids.append(id_)
 
-    accessed_domains: ACCESSED_DOMAINS = extract_accessed_domains(
+    accessed_domains: ACCESSED_DOMAINS = _extract_accessed_domains(
         stencil, input_ids, target_domain, offset_provider
     )
 
@@ -197,7 +197,7 @@ def infer_let(
     )
 
     let_params = {param_sym.id for param_sym in let_expr.fun.params}
-    accessed_domains_let_args, accessed_domains_outer = split_dict_by_key(
+    accessed_domains_let_args, accessed_domains_outer = _split_dict_by_key(
         lambda k: k in let_params, accessed_domains
     )
 


### PR DESCRIPTION
Additionally some utility functions in the domain inference have been made private.