### PR TITLE
fix[next][dace]: Initialization of partially written test array

### DIFF
--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -1270,7 +1270,7 @@ def test_gtir_let_lambda():
     )
 
     a = np.random.rand(N)
-    b = np.empty_like(a)
+    b = np.random.rand(N)
     ref = np.concatenate((b[0:1], a[1 : N - 1] * 8, b[N - 1 : N]))
 
     sdfg = dace_backend.build_sdfg_from_gtir(testee, {})


### PR DESCRIPTION
Fix test case for GTIR-to-DaCe lowering: partially written array needs to be initialized in order to support element-by-element comparison. Previously the array was filled with `NaN`.