### PR TITLE
feat[cartesian]: Absolute k indexation

### DIFF
--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -561,7 +561,8 @@ class DefIRToGTIR(IRNodeVisitor):
         self, offset: Dict[str, Union[int, Expr, AbsoluteKIndex]], **kwargs: Any
     ) -> Union[common.CartesianOffset, gtir.VariableKOffset]:
         if isinstance(offset, AbsoluteKIndex):
-            return gtir.AbsoluteKIndex(k=offset.k)
+            k_to_gtir = self.visit(offset.k)
+            return gtir.AbsoluteKIndex(k=k_to_gtir)
         k_val = offset.get("K", 0)
         if isinstance(k_val, numbers.Integral):
             return common.CartesianOffset(i=offset.get("I", 0), j=offset.get("J", 0), k=k_val)

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -24,6 +24,7 @@ from gt4py.cartesian.frontend.nodes import (
     Assign,
     AxisBound,
     AxisInterval,
+    AbsoluteKIndex,
     BinaryOperator,
     BinOpExpr,
     BlockStmt,
@@ -557,12 +558,14 @@ class DefIRToGTIR(IRNodeVisitor):
         )
 
     def transform_offset(
-        self, offset: Dict[str, Union[int, Expr]], **kwargs: Any
+        self, offset: Dict[str, Union[int, Expr, AbsoluteKIndex]], **kwargs: Any
     ) -> Union[common.CartesianOffset, gtir.VariableKOffset]:
+        if isinstance(offset, AbsoluteKIndex):
+            return gtir.AbsoluteKIndex(k=offset.k)
         k_val = offset.get("K", 0)
         if isinstance(k_val, numbers.Integral):
             return common.CartesianOffset(i=offset.get("I", 0), j=offset.get("J", 0), k=k_val)
         elif isinstance(k_val, Expr):
             return gtir.VariableKOffset(k=self.visit(k_val, **kwargs))
         else:
-            raise TypeError("Unrecognized vertical offset type")
+            raise TypeError("Unrecognized vertical indexing type")

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1140,8 +1140,7 @@ class IRMaker(ast.NodeVisitor):
                     f", given {index_nodes[0].args}",
                     loc=node,
                 )
-
-            return nodes.AbsoluteKIndex(k=ast.literal_eval(index_nodes[0].args[0]))
+            return nodes.AbsoluteKIndex(k=self.visit(index_nodes[0].args[0]))
 
         # Determine if we are using the new-style axis syntax, or the old style.
         # If this is parsing a data index, this should be fine and will return False.
@@ -1189,10 +1188,10 @@ class IRMaker(ast.NodeVisitor):
                     if len(field_axes) != len(index):
                         ro_field_message = ""
                         if len(field_axes) == 0:
-                            ro_field_message = f"Did you mean .A{index}?"
+                            ro_field_message = f"Did you mean absolute indexing via .A{index}?"
                         raise GTScriptSyntaxError(
-                            f"Incorrect offset specification detected. Found {index}, "
-                            f"but the field has dimensions ({', '.join(field_axes)}). "
+                            f"Incorrect offset specification detected for {result.name}. "
+                            f"Found index={index}, but {result.name} field has dimensions ({', '.join(field_axes)}). "
                             f"{ro_field_message}"
                         )
                     result.offset = {axis: value for axis, value in zip(field_axes, index)}

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -336,9 +336,17 @@ class VarRef(Ref):
 
 
 @attribclass
+class AbsoluteKIndex(Expr):
+    """See gtc.common.AbsoluteKIndex"""
+
+    k = attribute(of=Any)
+    func_name = "K_at"
+
+
+@attribclass
 class FieldRef(Ref):
     name = attribute(of=str)
-    offset = attribute(of=DictOf[str, UnionOf[int, Expr]])
+    offset = attribute(of=DictOf[str, UnionOf[int, Expr, AbsoluteKIndex]])
     data_index = attribute(of=ListOf[Expr], factory=list)
     loc = attribute(of=Location, optional=True)
 

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -119,7 +119,7 @@ class DataType(eve.IntEnum):
         return self == self.BOOL
 
     def isinteger(self):
-        return self in (self.INT8, self.INT32, self.INT64)
+        return self in (self.INT8, self.INT16, self.INT32, self.INT64)
 
     def isfloat(self):
         return self in (self.FLOAT32, self.FLOAT64)

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import enum
 import functools
 import typing
+import numbers
 from typing import (
     Any,
     ClassVar,
@@ -331,6 +332,31 @@ class VariableKOffset(eve.GenericNode, Generic[ExprT]):
             raise ValueError("Variable vertical index must be an integer expression")
 
 
+class AbsoluteKIndex(eve.GenericNode, Generic[ExprT]):
+    """Access a field with absolute K
+
+    Restrictions:
+    - Centered I/J
+    - No data dimensions
+    - Read-only
+    """
+
+    k: Union[int, ExprT]
+
+    def to_dict(self) -> Dict[str, Optional[int]]:
+        return {"i": 0, "j": 0, "k": None}
+
+    @datamodels.validator("k")
+    def offset_expr_is_int(self, attribute: datamodels.Attribute, value: Any) -> None:
+        if isinstance(value, numbers.Real):
+            if not isinstance(value, int):
+                raise ValueError("Absolute vertical index literal must be an integer")
+        else:
+            value = typing.cast(Expr, value)
+            if value.dtype is not DataType.AUTO and not value.dtype.isinteger():
+                raise ValueError("Absolute vertical index must be an integer expression")
+
+
 class ScalarAccess(LocNode):
     name: eve.Coerced[eve.SymbolRef]
     kind: ExprKind = ExprKind.SCALAR
@@ -338,7 +364,7 @@ class ScalarAccess(LocNode):
 
 class FieldAccess(eve.GenericNode, Generic[ExprT, VariableKOffsetT]):
     name: eve.Coerced[eve.SymbolRef]
-    offset: Union[CartesianOffset, VariableKOffsetT]
+    offset: Union[CartesianOffset, VariableKOffsetT, AbsoluteKIndex]
     data_index: List[ExprT] = eve.field(default_factory=list)
     kind: ExprKind = ExprKind.FIELD
 

--- a/src/gt4py/cartesian/gtc/dace/daceir.py
+++ b/src/gt4py/cartesian/gtc/dace/daceir.py
@@ -738,7 +738,22 @@ class VariableKOffset(common.VariableKOffset[Expr]):
 
 
 class IndexAccess(common.FieldAccess, Expr):
-    offset: Optional[Union[common.CartesianOffset, VariableKOffset, common.AbsoluteKIndex]]
+    offset: Optional[
+        Union[
+            common.CartesianOffset,
+            VariableKOffset,
+            common.AbsoluteKIndex,
+            Literal,
+            ScalarAccess,  # For field index
+        ]
+    ]
+
+    @datamodels.validator("offset")
+    def offset_is_integer(self, attribute: datamodels.Attribute, v: Expr) -> None:
+        if (isinstance(v, ScalarAccess) or isinstance(v, Literal)) and not v.dtype.isinteger():
+            raise ValueError(
+                f"Index access, when ScalarAcces/Literal, must be an integer, got {v.dtype}."
+            )
 
 
 class AssignStmt(common.AssignStmt[Union[ScalarAccess, IndexAccess], Expr], Stmt):

--- a/src/gt4py/cartesian/gtc/dace/daceir.py
+++ b/src/gt4py/cartesian/gtc/dace/daceir.py
@@ -738,7 +738,7 @@ class VariableKOffset(common.VariableKOffset[Expr]):
 
 
 class IndexAccess(common.FieldAccess, Expr):
-    offset: Optional[Union[common.CartesianOffset, VariableKOffset]]
+    offset: Optional[Union[common.CartesianOffset, VariableKOffset, common.AbsoluteKIndex]]
 
 
 class AssignStmt(common.AssignStmt[Union[ScalarAccess, IndexAccess], Expr], Stmt):

--- a/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
@@ -355,8 +355,20 @@ class DaCeIRBuilder(eve.NodeTranslator):
             )
             name = get_tasklet_symbol(node.name, node.offset, is_target=is_target)
             if node.data_index:
+                if isinstance(node.offset, common.AbsoluteKIndex):
+                    raise RuntimeError("Absolute K indexing cannot work with data index")
                 res = dcir.IndexAccess(
-                    name=name, offset=None, data_index=node.data_index, dtype=node.dtype
+                    name=name,
+                    offset=None,
+                    data_index=node.data_index,
+                    dtype=node.dtype,
+                )
+            elif isinstance(node.offset, common.AbsoluteKIndex):
+                res = dcir.IndexAccess(
+                    name=name,
+                    offset=node.offset,
+                    data_index=[],
+                    dtype=node.dtype,
                 )
             else:
                 res = dcir.ScalarAccess(name=name, dtype=node.dtype)

--- a/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
@@ -366,7 +366,14 @@ class DaCeIRBuilder(eve.NodeTranslator):
             elif isinstance(node.offset, common.AbsoluteKIndex):
                 res = dcir.IndexAccess(
                     name=name,
-                    offset=node.offset,
+                    offset=self.visit(
+                        node.offset.k,
+                        is_target=is_target,
+                        targets=targets,
+                        var_offset_fields=var_offset_fields,
+                        K_write_with_offset=K_write_with_offset,
+                        **kwargs,
+                    ),
                     data_index=[],
                     dtype=node.dtype,
                 )

--- a/src/gt4py/cartesian/gtc/dace/expansion/tasklet_codegen.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/tasklet_codegen.py
@@ -67,7 +67,7 @@ class TaskletCodegen(eve.codegen.TemplatedGenerator, eve.VisitorWithSymbolTableT
         return self._visit_offset(node, **kwargs)
 
     def visit_AbsoluteKIndex(self, node: common.AbsoluteKIndex, **kwargs):
-        idx = self.visit(node.k)
+        idx = self.visit(self.visit(node.k))
         return str(idx)
 
     def visit_IndexAccess(

--- a/src/gt4py/cartesian/gtc/dace/expansion/tasklet_codegen.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/tasklet_codegen.py
@@ -66,6 +66,10 @@ class TaskletCodegen(eve.codegen.TemplatedGenerator, eve.VisitorWithSymbolTableT
     def visit_VariableKOffset(self, node: common.CartesianOffset, **kwargs):
         return self._visit_offset(node, **kwargs)
 
+    def visit_AbsoluteKIndex(self, node: common.AbsoluteKIndex, **kwargs):
+        idx = self.visit(node.k)
+        return str(idx)
+
     def visit_IndexAccess(
         self,
         node: dcir.IndexAccess,

--- a/src/gt4py/cartesian/gtc/dace/utils.py
+++ b/src/gt4py/cartesian/gtc/dace/utils.py
@@ -232,10 +232,17 @@ class AccessInfoCollector(eve.NodeVisitor):
         grid_subset,
         is_write,
     ) -> dcir.FieldAccessInfo:
+        """Compute how the field get accessed on the grid"""
+
         # Check we have expression offsets in K
         # OR write offsets in K
+        # OR absolute indexing in K
         offset = [offset_node.to_dict()[k] for k in "ijk"]
-        if isinstance(offset_node, oir.VariableKOffset) or (offset[2] != 0 and is_write):
+        if (
+            isinstance(offset_node, oir.VariableKOffset)
+            or (offset[2] != 0 and is_write)
+            or isinstance(offset_node, oir.AbsoluteKIndex)
+        ):
             variable_offset_axes = [dcir.Axis.K]
         else:
             variable_offset_axes = []

--- a/src/gt4py/cartesian/gtc/gtir.py
+++ b/src/gt4py/cartesian/gtc/gtir.py
@@ -51,6 +51,12 @@ class VariableKOffset(common.VariableKOffset[Expr]):
     pass
 
 
+class AbsoluteKIndex(common.AbsoluteKIndex[Expr]):
+    """See gtc.common.AbsoluteKIndex"""
+
+    pass
+
+
 class ScalarAccess(common.ScalarAccess, Expr):  # type: ignore
     pass
 
@@ -83,14 +89,26 @@ class ParAssignStmt(common.AssignStmt[FieldAccess, Expr], Stmt):
     ) -> None:
         if isinstance(instance.left, FieldAccess):
             offset_reads = (
-                eve.walk_values(instance.right)
-                .filter(_cartesian_fieldaccess)
-                .filter(lambda acc: acc.offset.i != 0 or acc.offset.j != 0)
-                .getattr("name")
-                .to_set()
-            ) | eve.walk_values(instance.right).filter(_variablek_fieldaccess).getattr(
-                "name"
-            ).to_set()
+                (
+                    eve.walk_values(instance.right)
+                    .filter(_cartesian_fieldaccess)
+                    .filter(lambda acc: acc.offset.i != 0 or acc.offset.j != 0)
+                    .getattr("name")
+                    .to_set()
+                )
+                | (
+                    eve.walk_values(instance.right)
+                    .filter(_absolutekindex_fieldaccess)
+                    .getattr("name")
+                    .to_set()
+                )
+                | (
+                    eve.walk_values(instance.right)
+                    .filter(_variablek_fieldaccess)
+                    .getattr("name")
+                    .to_set()
+                )
+            )
             if instance.left.name in offset_reads:
                 raise ValueError("Self-assignment with offset is illegal.")
 
@@ -246,11 +264,27 @@ class Stencil(LocNode, eve.ValidatedSymbolTableTrait):
 
 
 def _cartesian_fieldaccess(node) -> bool:
-    return isinstance(node, FieldAccess) and not isinstance(node.offset, VariableKOffset)
+    return (
+        isinstance(node, FieldAccess)
+        and not isinstance(node.offset, VariableKOffset)
+        and not isinstance(node.offset, AbsoluteKIndex)
+    )
 
 
 def _variablek_fieldaccess(node) -> bool:
-    return isinstance(node, FieldAccess) and isinstance(node.offset, VariableKOffset)
+    return (
+        isinstance(node, FieldAccess)
+        and isinstance(node.offset, VariableKOffset)
+        and not isinstance(node.offset, AbsoluteKIndex)
+    )
+
+
+def _absolutekindex_fieldaccess(node) -> bool:
+    return (
+        isinstance(node, FieldAccess)
+        and isinstance(node.offset, AbsoluteKIndex)
+        and not isinstance(node.offset, VariableKOffset)
+    )
 
 
 # TODO(havogt): either move to eve or will be removed in the attr-based eve if a List[Node] is represented as a CollectionNode

--- a/src/gt4py/cartesian/gtc/gtir_to_oir.py
+++ b/src/gt4py/cartesian/gtc/gtir_to_oir.py
@@ -66,6 +66,9 @@ class GTIRToOIR(eve.NodeTranslator):
             loc=node.loc,
         )
 
+    def visit_AbsoluteKIndex(self, node: gtir.AbsoluteKIndex) -> oir.AbsoluteKIndex:
+        return oir.AbsoluteKIndex(k=self.visit(node.k))
+
     def visit_VariableKOffset(self, node: gtir.VariableKOffset) -> oir.VariableKOffset:
         return oir.VariableKOffset(k=self.visit(node.k))
 

--- a/src/gt4py/cartesian/gtc/numpy/npir.py
+++ b/src/gt4py/cartesian/gtc/numpy/npir.py
@@ -118,11 +118,17 @@ class VarKOffset(common.VariableKOffset[Expr]):
     pass
 
 
+class AbsoluteKIndex(common.AbsoluteKIndex[Expr]):
+    """See gtc.common.AbsoluteKIndex"""
+
+    pass
+
+
 class FieldSlice(VectorLValue):
     name: eve.Coerced[eve.SymbolRef]
     i_offset: int
     j_offset: int
-    k_offset: Union[int, VarKOffset]
+    k_offset: Union[int, VarKOffset, AbsoluteKIndex]
     data_index: List[Expr] = eve.field(default_factory=list)
     kind: common.ExprKind = common.ExprKind.FIELD
 

--- a/src/gt4py/cartesian/gtc/numpy/oir_to_npir.py
+++ b/src/gt4py/cartesian/gtc/numpy/oir_to_npir.py
@@ -78,6 +78,11 @@ class OirToNpir(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
     ) -> Tuple[int, int, eve.Node]:
         return 0, 0, npir.VarKOffset(k=self.visit(node.k, **kwargs))
 
+    def visit_AbsoluteKIndex(
+        self, node: oir.AbsoluteKIndex, **kwargs: Any
+    ) -> Tuple[int, int, Union[int, eve.Node]]:
+        return 0, 0, npir.AbsoluteKIndex(k=self.visit(node.k, **kwargs))
+
     def visit_FieldAccess(self, node: oir.FieldAccess, **kwargs: Any) -> npir.FieldSlice:
         i_offset, j_offset, k_offset = self.visit(node.offset, **kwargs)
         data_index = [self.visit(index, **kwargs) for index in node.data_index]

--- a/src/gt4py/cartesian/gtc/oir.py
+++ b/src/gt4py/cartesian/gtc/oir.py
@@ -45,6 +45,12 @@ class VariableKOffset(common.VariableKOffset[Expr]):
     pass
 
 
+class AbsoluteKIndex(common.AbsoluteKIndex[Expr]):
+    """See gtc.common.AbsoluteKIndex"""
+
+    pass
+
+
 class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):  # type: ignore
     pass
 

--- a/src/gt4py/cartesian/gtc/passes/gtir_k_boundary.py
+++ b/src/gt4py/cartesian/gtc/passes/gtir_k_boundary.py
@@ -46,7 +46,9 @@ class KBoundaryVisitor(eve.NodeVisitor):
     ):
         boundary = field_boundaries[node.name]
         interval = vloop.interval
-        if not isinstance(node.offset, gtir.VariableKOffset):
+        if not isinstance(node.offset, gtir.VariableKOffset) and not isinstance(
+            node.offset, gtir.AbsoluteKIndex
+        ):
             if interval.start.level == LevelMarker.START and (
                 include_center_interval or interval.end.level == LevelMarker.START
             ):

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -61,6 +61,11 @@ MATH_BUILTINS = {
     "trunc",
 }
 
+builtins_and_inline_ignore = {
+    "compile_assert",
+    "K_at",
+}
+
 builtins = {
     "I",
     "J",
@@ -82,11 +87,11 @@ builtins = {
     "__gtscript__",
     "__externals__",
     "__INLINED",
-    "compile_assert",
     *MATH_BUILTINS,
+    *builtins_and_inline_ignore,
 }
 
-IGNORE_WHEN_INLINING = {*MATH_BUILTINS, "compile_assert"}
+IGNORE_WHEN_INLINING = {*MATH_BUILTINS, *builtins_and_inline_ignore}
 
 __all__ = [*list(builtins), "function", "stencil", "lazy_stencil"]
 
@@ -595,6 +600,12 @@ JK = (J, K)
 
 IJK = (I, J, K)
 """Tuple of axes I, J, K."""
+
+
+def K_at(value: int):
+    """Stub function used to implement absolute
+    K indexing"""
+    raise RuntimeError("`K_at` stub function only, do not call.")
 
 
 def mask_from_axes(axes):

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -27,6 +27,7 @@ from gt4py.cartesian.gtscript import (
     I,
     J,
     K,
+    K_at,
     abs,
     asin,
     compile_assert,
@@ -1822,3 +1823,42 @@ class TestAnnotations:
         assert "wb" in annotations
         assert annotations["wb"] == int
         assert len(annotations) == 6
+
+
+class TestAbsoluteIndex:
+    def test_good_syntax(self):
+        def definition_func(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
+            with computation(PARALLEL), interval(...):
+                out_field = in_field[K_at(0)] + in_field[K_at(1)]
+
+        parse_definition(
+            definition_func, name=inspect.stack()[0][3], module=self.__class__.__name__
+        )
+
+    def test_bad_syntax_specifying_I_J_legacy(self):
+        def definition_func(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
+            with computation(PARALLEL), interval(...):
+                out_field = in_field[0, 0, K_at(0)]
+
+        with pytest.raises(
+            gt_frontend.GTScriptSyntaxError, match=r".*Absolute K Index wrong syntax.*"
+        ):
+            parse_definition(
+                definition_func,
+                name=inspect.stack()[0][3],
+                module=self.__class__.__name__,
+            )
+
+    def test_bad_syntax_specifying_I_J_axis(self):
+        def definition_func(in_field: gtscript.Field[float], out_field: gtscript.Field[float]):
+            with computation(PARALLEL), interval(...):
+                out_field = in_field[I + 1, K_at(0)]
+
+        with pytest.raises(
+            gt_frontend.GTScriptSyntaxError, match=r".*Absolute K Index wrong syntax.*"
+        ):
+            parse_definition(
+                definition_func,
+                name=inspect.stack()[0][3],
+                module=self.__class__.__name__,
+            )


### PR DESCRIPTION
Syntax: `field[K_at(...)]
Backends:  `numpy` and `dace:cpu`

Can index with literals, parameters, externals and fields.

ToDo:
- change syntax to `field.at(K=...)`
- more protection & test for unwanted syntax (I, J in particular)