### PR TITLE
feat[next][dace]: Canonicalize GTIR to enable lowering to SDFG for special cases

### DIFF
--- a/src/gt4py/next/iterator/ir_utils/common_pattern_matcher.py
+++ b/src/gt4py/next/iterator/ir_utils/common_pattern_matcher.py
@@ -70,3 +70,7 @@ def is_call_to(node: itir.Node, fun: str | Iterable[str]) -> TypeGuard[itir.FunC
     return (
         isinstance(node, itir.FunCall) and isinstance(node.fun, itir.SymRef) and node.fun.id == fun
     )
+
+
+def is_ref_to(node, ref: str):
+    return isinstance(node, itir.SymRef) and node.id == ref

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
@@ -100,7 +100,7 @@ def _parse_fieldop_arg(
     if isinstance(arg.data_type, ts.ScalarType):
         return gtir_to_tasklet.MemletExpr(arg.data_node, sbs.Indices([0]))
     elif isinstance(arg.data_type, ts.FieldType):
-        indices: dict[gtx_common.Dimension, gtir_to_tasklet.IteratorIndexExpr] = {
+        indices: dict[gtx_common.Dimension, gtir_to_tasklet.ValueExpr] = {
             dim: gtir_to_tasklet.SymbolExpr(
                 dace_gtir_utils.get_map_variable(dim),
                 IteratorIndexDType,
@@ -179,7 +179,6 @@ def translate_as_field_op(
 
     # add local storage to compute the field operator over the given domain
     domain = dace_gtir_utils.get_domain(domain_expr)
-    assert isinstance(node.type, ts.FieldType)
 
     if cpm.is_applied_reduce(stencil_expr.expr):
         if reduce_identity is not None:
@@ -188,7 +187,7 @@ def translate_as_field_op(
         # the reduce identity value is used to fill the skip values in neighbors list
         _, _, reduce_identity = gtir_to_tasklet.get_reduce_params(stencil_expr.expr)
 
-    # first visit the list of arguments and build a symbol map
+    # visit the list of arguments to be passed to the lambda expression
     stencil_args = [
         _parse_fieldop_arg(arg, sdfg, state, sdfg_builder, domain, reduce_identity)
         for arg in node.args
@@ -197,7 +196,7 @@ def translate_as_field_op(
     # represent the field operator as a mapped tasklet graph, which will range over the field domain
     taskgen = gtir_to_tasklet.LambdaToTasklet(sdfg, state, sdfg_builder, reduce_identity)
     input_connections, output_expr = taskgen.visit(stencil_expr, args=stencil_args)
-    assert isinstance(output_expr, gtir_to_tasklet.ValueExpr)
+    assert isinstance(output_expr, gtir_to_tasklet.TempExpr)
     output_desc = output_expr.node.desc(sdfg)
 
     # retrieve the tasklet node which writes the result
@@ -409,7 +408,7 @@ def translate_literal(
     sdfg: dace.SDFG,
     state: dace.SDFGState,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
-    reduce_identity: Optional[gtir_to_tasklet.SymbolExpr],
+    reduce_identity: Optional[gtir_to_tasklet.SymbolExpr] = None,
 ) -> FieldopResult:
     """Generates the dataflow subgraph for a `ir.Literal` node."""
     assert isinstance(node, gtir.Literal)

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
@@ -196,7 +196,7 @@ def translate_as_field_op(
     # represent the field operator as a mapped tasklet graph, which will range over the field domain
     taskgen = gtir_to_tasklet.LambdaToTasklet(sdfg, state, sdfg_builder, reduce_identity)
     input_connections, output_expr = taskgen.visit(stencil_expr, args=stencil_args)
-    assert isinstance(output_expr, gtir_to_tasklet.TempExpr)
+    assert isinstance(output_expr, gtir_to_tasklet.DataExpr)
     output_desc = output_expr.node.desc(sdfg)
 
     # retrieve the tasklet node which writes the result

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
@@ -408,7 +408,7 @@ def translate_literal(
     sdfg: dace.SDFG,
     state: dace.SDFGState,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
-    reduce_identity: Optional[gtir_to_tasklet.SymbolExpr] = None,
+    reduce_identity: Optional[gtir_to_tasklet.SymbolExpr],
 ) -> FieldopResult:
     """Generates the dataflow subgraph for a `ir.Literal` node."""
     assert isinstance(node, gtir.Literal)

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_sdfg.py
@@ -642,7 +642,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
 
 
 def build_sdfg_from_gtir(
-    program: gtir.Program,
+    ir: gtir.Program,
     offset_provider: gtx_common.OffsetProvider,
 ) -> dace.SDFG:
     """
@@ -653,15 +653,16 @@ def build_sdfg_from_gtir(
     As a final step, it runs the `simplify` pass to ensure that the SDFG is in the DaCe canonical form.
 
     Arguments:
-        program: The GTIR program node to be lowered to SDFG
+        ir: The GTIR program node to be lowered to SDFG
         offset_provider: The definitions of offset providers used by the program node
 
     Returns:
         An SDFG in the DaCe canonical form (simplified)
     """
-    program = gtir_type_inference.infer(program, offset_provider=offset_provider)
+    ir = gtir_type_inference.infer(ir, offset_provider=offset_provider)
+    ir = dace_gtir_utils.patch_gtir(ir)
     sdfg_genenerator = GTIRToSDFG(offset_provider)
-    sdfg = sdfg_genenerator.visit(program)
+    sdfg = sdfg_genenerator.visit(ir)
     assert isinstance(sdfg, dace.SDFG)
 
     gtx_transformations.gt_simplify(sdfg)

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_tasklet.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_to_tasklet.py
@@ -45,7 +45,7 @@ class SymbolExpr:
 
 
 @dataclasses.dataclass(frozen=True)
-class ValueExpr:
+class TempExpr:
     """Result of the computation implemented by a tasklet node."""
 
     node: dace.nodes.AccessNode
@@ -60,7 +60,7 @@ InputConnection: TypeAlias = tuple[
     Optional[str],
 ]
 
-IteratorIndexExpr: TypeAlias = MemletExpr | SymbolExpr | ValueExpr
+ValueExpr: TypeAlias = MemletExpr | SymbolExpr | TempExpr
 
 
 @dataclasses.dataclass(frozen=True)
@@ -80,7 +80,7 @@ class IteratorExpr:
 
     field: dace.nodes.AccessNode
     dimensions: list[gtx_common.Dimension]
-    indices: dict[gtx_common.Dimension, IteratorIndexExpr]
+    indices: dict[gtx_common.Dimension, ValueExpr]
 
 
 DACE_REDUCTION_MAPPING: dict[str, dace.dtypes.ReductionType] = {
@@ -193,7 +193,7 @@ class LambdaToTasklet(eve.NodeVisitor):
         dtype: dace.typeclass,
         src_node: dace.nodes.Tasklet,
         src_connector: str,
-    ) -> ValueExpr:
+    ) -> TempExpr:
         temp_name = self.sdfg.temp_data_name()
         self.sdfg.add_scalar(temp_name, dtype, transient=True)
         data_type = dace_utils.as_scalar_type(str(dtype.as_numpy_dtype()))
@@ -205,9 +205,9 @@ class LambdaToTasklet(eve.NodeVisitor):
             None,
             dace.Memlet(data=temp_name, subset="0"),
         )
-        return ValueExpr(temp_node, data_type)
+        return TempExpr(temp_node, data_type)
 
-    def _visit_deref(self, node: gtir.FunCall) -> MemletExpr | ValueExpr:
+    def _visit_deref(self, node: gtir.FunCall) -> ValueExpr:
         """
         Visit a `deref` node, which represents dereferencing of an iterator.
         The iterator is the argument of this node.
@@ -226,26 +226,26 @@ class LambdaToTasklet(eve.NodeVisitor):
         IndexConnectorFmt: Final = "__index_{dim}"
 
         assert len(node.args) == 1
-        it = self.visit(node.args[0])
+        arg_expr = self.visit(node.args[0])
 
-        if isinstance(it, IteratorExpr):
-            field_desc = it.field.desc(self.sdfg)
-            assert len(field_desc.shape) == len(it.dimensions)
-            if all(isinstance(index, SymbolExpr) for index in it.indices.values()):
+        if isinstance(arg_expr, IteratorExpr):
+            field_desc = arg_expr.field.desc(self.sdfg)
+            assert len(field_desc.shape) == len(arg_expr.dimensions)
+            if all(isinstance(index, SymbolExpr) for index in arg_expr.indices.values()):
                 # when all indices are symblic expressions, we can perform direct field access through a memlet
                 field_subset = sbs.Range(
-                    (it.indices[dim].value, it.indices[dim].value, 1)  # type: ignore[union-attr]
-                    if dim in it.indices
+                    (arg_expr.indices[dim].value, arg_expr.indices[dim].value, 1)  # type: ignore[union-attr]
+                    if dim in arg_expr.indices
                     else (0, size - 1, 1)
-                    for dim, size in zip(it.dimensions, field_desc.shape)
+                    for dim, size in zip(arg_expr.dimensions, field_desc.shape)
                 )
-                return MemletExpr(it.field, field_subset)
+                return MemletExpr(arg_expr.field, field_subset)
 
             else:
                 # we use a tasklet to dereference an iterator when one or more indices are the result of some computation,
                 # either indirection through connectivity table or dynamic cartesian offset.
-                assert all(dim in it.indices for dim in it.dimensions)
-                field_indices = [(dim, it.indices[dim]) for dim in it.dimensions]
+                assert all(dim in arg_expr.indices for dim in arg_expr.dimensions)
+                field_indices = [(dim, arg_expr.indices[dim]) for dim in arg_expr.dimensions]
                 index_connectors = [
                     IndexConnectorFmt.format(dim=dim.value)
                     for dim, index in field_indices
@@ -268,7 +268,7 @@ class LambdaToTasklet(eve.NodeVisitor):
                 )
                 # add new termination point for the field parameter
                 self._add_entry_memlet_path(
-                    it.field,
+                    arg_expr.field,
                     sbs.Range.from_array(field_desc),
                     deref_node,
                     "field",
@@ -285,7 +285,7 @@ class LambdaToTasklet(eve.NodeVisitor):
                             deref_connector,
                         )
 
-                    elif isinstance(index_expr, ValueExpr):
+                    elif isinstance(index_expr, TempExpr):
                         self._add_edge(
                             index_expr.node,
                             None,
@@ -296,14 +296,13 @@ class LambdaToTasklet(eve.NodeVisitor):
                     else:
                         assert isinstance(index_expr, SymbolExpr)
 
-                dtype = it.field.desc(self.sdfg).dtype
+                dtype = arg_expr.field.desc(self.sdfg).dtype
                 return self._get_tasklet_result(dtype, deref_node, "val")
 
         else:
-            assert isinstance(it, MemletExpr)
-            return it
+            return arg_expr
 
-    def _visit_neighbors(self, node: gtir.FunCall) -> ValueExpr:
+    def _visit_neighbors(self, node: gtir.FunCall) -> TempExpr:
         assert len(node.args) == 2
 
         assert isinstance(node.args[0], gtir.OffsetLiteral)
@@ -429,9 +428,9 @@ class LambdaToTasklet(eve.NodeVisitor):
         )
 
         assert isinstance(node.type, gtir_ts.ListType)
-        return ValueExpr(neighbors_node, node.type)
+        return TempExpr(neighbors_node, node.type)
 
-    def _visit_reduce(self, node: gtir.FunCall) -> ValueExpr:
+    def _visit_reduce(self, node: gtir.FunCall) -> TempExpr:
         op_name, reduce_init, reduce_identity = get_reduce_params(node)
         dtype = reduce_identity.dtype
 
@@ -447,7 +446,7 @@ class LambdaToTasklet(eve.NodeVisitor):
             # ensure that we leave the visitor in the same state as we entered
             self.reduce_identity = prev_reduce_identity
 
-        assert isinstance(input_expr, MemletExpr | ValueExpr)
+        assert isinstance(input_expr, MemletExpr | TempExpr)
         input_desc = input_expr.node.desc(self.sdfg)
         assert isinstance(input_desc, dace.data.Array)
 
@@ -487,7 +486,7 @@ class LambdaToTasklet(eve.NodeVisitor):
             dace.Memlet(data=temp_name, subset="0"),
         )
         assert isinstance(node.type, ts.ScalarType)
-        return ValueExpr(temp_node, node.type)
+        return TempExpr(temp_node, node.type)
 
     def _split_shift_args(
         self, args: list[gtir.Expr]
@@ -518,11 +517,11 @@ class LambdaToTasklet(eve.NodeVisitor):
         return offset_provider_arg, offset_value_arg, it
 
     def _make_cartesian_shift(
-        self, it: IteratorExpr, offset_dim: gtx_common.Dimension, offset_expr: IteratorIndexExpr
+        self, it: IteratorExpr, offset_dim: gtx_common.Dimension, offset_expr: ValueExpr
     ) -> IteratorExpr:
         """Implements cartesian shift along one dimension."""
         assert offset_dim in it.dimensions
-        new_index: SymbolExpr | ValueExpr
+        new_index: SymbolExpr | TempExpr
         assert offset_dim in it.indices
         index_expr = it.indices[offset_dim]
         if isinstance(index_expr, SymbolExpr) and isinstance(offset_expr, SymbolExpr):
@@ -563,7 +562,7 @@ class LambdaToTasklet(eve.NodeVisitor):
                         dynamic_offset_tasklet,
                         input_connector,
                     )
-                elif isinstance(input_expr, ValueExpr):
+                elif isinstance(input_expr, TempExpr):
                     self._add_edge(
                         input_expr.node,
                         None,
@@ -588,10 +587,10 @@ class LambdaToTasklet(eve.NodeVisitor):
 
     def _make_dynamic_neighbor_offset(
         self,
-        offset_expr: MemletExpr | ValueExpr,
+        offset_expr: MemletExpr | TempExpr,
         offset_table_node: dace.nodes.AccessNode,
         origin_index: SymbolExpr,
-    ) -> ValueExpr:
+    ) -> TempExpr:
         """
         Implements access to neighbor connectivity table by means of a tasklet node.
 
@@ -635,7 +634,7 @@ class LambdaToTasklet(eve.NodeVisitor):
         it: IteratorExpr,
         connectivity: gtx_common.Connectivity,
         offset_table_node: dace.nodes.AccessNode,
-        offset_expr: IteratorIndexExpr,
+        offset_expr: ValueExpr,
     ) -> IteratorExpr:
         """Implements shift in unstructured domain by means of a neighbor table."""
         assert connectivity.neighbor_axis in it.dimensions
@@ -702,7 +701,7 @@ class LambdaToTasklet(eve.NodeVisitor):
                 it, offset_provider, offset_table_node, offset_expr
             )
 
-    def visit_FunCall(self, node: gtir.FunCall) -> IteratorExpr | MemletExpr | ValueExpr:
+    def visit_FunCall(self, node: gtir.FunCall) -> IteratorExpr | ValueExpr:
         if cpm.is_call_to(node, "deref"):
             return self._visit_deref(node)
 
@@ -719,10 +718,10 @@ class LambdaToTasklet(eve.NodeVisitor):
             assert isinstance(node.fun, gtir.SymRef)
 
         node_internals = []
-        node_connections: dict[str, MemletExpr | ValueExpr] = {}
+        node_connections: dict[str, MemletExpr | TempExpr] = {}
         for i, arg in enumerate(node.args):
             arg_expr = self.visit(arg)
-            if isinstance(arg_expr, MemletExpr | ValueExpr):
+            if isinstance(arg_expr, MemletExpr | TempExpr):
                 # the argument value is the result of a tasklet node or direct field access
                 connector = f"__inp_{i}"
                 node_connections[connector] = arg_expr
@@ -745,7 +744,7 @@ class LambdaToTasklet(eve.NodeVisitor):
         )
 
         for connector, arg_expr in node_connections.items():
-            if isinstance(arg_expr, ValueExpr):
+            if isinstance(arg_expr, TempExpr):
                 self._add_edge(
                     arg_expr.node,
                     None,
@@ -768,11 +767,11 @@ class LambdaToTasklet(eve.NodeVisitor):
 
     def visit_Lambda(
         self, node: gtir.Lambda, args: list[IteratorExpr | MemletExpr | SymbolExpr]
-    ) -> tuple[list[InputConnection], ValueExpr]:
+    ) -> tuple[list[InputConnection], TempExpr]:
         for p, arg in zip(node.params, args, strict=True):
             self.symbol_map[str(p.id)] = arg
-        output_expr: MemletExpr | SymbolExpr | ValueExpr = self.visit(node.expr)
-        if isinstance(output_expr, ValueExpr):
+        output_expr: MemletExpr | SymbolExpr | TempExpr = self.visit(node.expr)
+        if isinstance(output_expr, TempExpr):
             return self.input_connections, output_expr
 
         if isinstance(output_expr, MemletExpr):

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/utility.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import dace
 
+from gt4py import eve
 from gt4py.next import common as gtx_common
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm
@@ -106,3 +107,40 @@ def get_tuple_type(data: tuple[Any, ...]) -> ts.TupleType:
     return ts.TupleType(
         types=[get_tuple_type(d) if isinstance(d, tuple) else d.data_type for d in data]
     )
+
+
+def patch_gtir(ir: gtir.Program) -> gtir.Program:
+    """
+    Make the IR comply with the requirements of lowering to SDFG.
+
+    Applies canonicalization of as_fieldop expressions as well as some temporary workarounds.
+    """
+
+    class PatchGTIR(eve.PreserveLocationVisitor, eve.NodeTranslator):
+        def visit_FunCall(self, node: gtir.FunCall) -> gtir.Node:
+            if cpm.is_applied_as_fieldop(node):
+                assert isinstance(node.fun, gtir.FunCall)
+                assert isinstance(node.type, ts.FieldType)
+
+                # Handle the case of fieldop without domain. This case should never happen, but domain
+                # inference currently produces this kind of nodes for unreferenced tuple fields.
+                # TODO(tehrengruber): remove this workaround once domain ineference supports this case
+                if len(node.fun.args) == 1:
+                    return gtir.Literal(value="0", type=node.type.dtype)
+
+                assert len(node.fun.args) == 2
+                stencil = node.fun.args[0]
+
+                # Canonicalize as_fieldop: always expect a lambda expression.
+                # Here we replace the call to deref with a lambda expression without arguments.
+                if cpm.is_ref_to(stencil, "deref"):
+                    node.fun.args[0] = gtir.Lambda(
+                        expr=gtir.FunCall(fun=stencil, args=node.args), params=[]
+                    )
+                    node.args = []
+
+            node.args = [self.visit(arg) for arg in node.args]
+            node.fun = self.visit(node.fun)
+            return node
+
+    return PatchGTIR().visit(ir)

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/utility.py
@@ -111,9 +111,10 @@ def get_tuple_type(data: tuple[Any, ...]) -> ts.TupleType:
 
 def patch_gtir(ir: gtir.Program) -> gtir.Program:
     """
-    Make the IR comply with the requirements of lowering to SDFG.
+    Make the IR compliant with the requirements of lowering to SDFG.
 
     Applies canonicalization of as_fieldop expressions as well as some temporary workarounds.
+    This allows to lower the IR to SDFG for some special cases.
     """
 
     class PatchGTIR(eve.PreserveLocationVisitor, eve.NodeTranslator):
@@ -132,7 +133,7 @@ def patch_gtir(ir: gtir.Program) -> gtir.Program:
                 stencil = node.fun.args[0]
 
                 # Canonicalize as_fieldop: always expect a lambda expression.
-                # Here we replace the call to deref with a lambda expression without arguments.
+                # Here we replace the call to deref with a lambda expression and empty arguments list.
                 if cpm.is_ref_to(stencil, "deref"):
                     node.fun.args[0] = gtir.Lambda(
                         expr=gtir.FunCall(fun=stencil, args=node.args), params=[]

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -100,10 +100,36 @@ def make_mesh_symbols(mesh: MeshDescriptor):
     )
 
 
-def test_gtir_cast():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
+def test_gtir_broadcast():
+    val = np.random.rand()
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
+    testee = gtir.Program(
+        id="gtir_broadcast",
+        function_definitions=[],
+        params=[
+            gtir.Sym(id="x", type=IFTYPE),
+            gtir.Sym(id="size", type=SIZE_TYPE),
+        ],
+        declarations=[],
+        body=[
+            gtir.SetAt(
+                expr=im.as_fieldop("deref", domain)(val),
+                domain=domain,
+                target=gtir.SymRef(id="x"),
+            )
+        ],
     )
+
+    a = np.empty(N, dtype=np.float64)
+
+    sdfg = dace_backend.build_sdfg_from_gtir(testee, CARTESIAN_OFFSETS)
+
+    sdfg(a, **FSYMBOLS)
+    np.testing.assert_array_equal(a, val)
+
+
+def test_gtir_cast():
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     IFTYPE_FLOAT32 = ts.FieldType(IFTYPE.dims, dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT32))
     IFTYPE_BOOL = ts.FieldType(IFTYPE.dims, dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL))
     testee = gtir.Program(
@@ -141,9 +167,7 @@ def test_gtir_cast():
 
 
 def test_gtir_copy_self():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 1, 2)
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (1, 2)})
     testee = gtir.Program(
         id="gtir_copy_self",
         function_definitions=[],
@@ -171,9 +195,7 @@ def test_gtir_copy_self():
 
 
 def test_gtir_tuple_swap():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="gtir_tuple_swap",
         function_definitions=[],
@@ -205,9 +227,7 @@ def test_gtir_tuple_swap():
 
 
 def test_gtir_tuple_args():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="gtir_tuple_args",
         function_definitions=[],
@@ -255,9 +275,7 @@ def test_gtir_tuple_args():
 
 
 def test_gtir_tuple_expr():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="gtir_tuple_expr",
         function_definitions=[],
@@ -298,9 +316,7 @@ def test_gtir_tuple_expr():
 
 
 def test_gtir_tuple_return():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="gtir_tuple_return",
         function_definitions=[],
@@ -346,9 +362,7 @@ def test_gtir_tuple_return():
 
 
 def test_gtir_tuple_target():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="gtir_tuple_target",
         function_definitions=[],
@@ -379,9 +393,7 @@ def test_gtir_tuple_target():
 
 
 def test_gtir_update():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     stencil1 = im.as_fieldop(
         im.lambda_("a")(im.plus(im.deref("a"), 0 - 1.0)),
         domain,
@@ -415,9 +427,7 @@ def test_gtir_update():
 
 
 def test_gtir_sum2():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="sum_2fields",
         function_definitions=[],
@@ -448,9 +458,7 @@ def test_gtir_sum2():
 
 
 def test_gtir_sum2_sym():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="sum_2fields_sym",
         function_definitions=[],
@@ -479,9 +487,7 @@ def test_gtir_sum2_sym():
 
 
 def test_gtir_sum3():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     stencil1 = im.op_as_fieldop("plus", domain)(
         "x",
         im.op_as_fieldop("plus", domain)("y", "w"),
@@ -525,9 +531,7 @@ def test_gtir_sum3():
 
 
 def test_gtir_cond():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="cond_2sums",
         function_definitions=[],
@@ -571,9 +575,7 @@ def test_gtir_cond():
 
 
 def test_gtir_cond_with_tuple_return():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="cond_with_tuple_return",
         function_definitions=[],
@@ -623,9 +625,7 @@ def test_gtir_cond_with_tuple_return():
 
 
 def test_gtir_cond_nested():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="cond_nested",
         function_definitions=[],
@@ -668,12 +668,14 @@ def test_gtir_cond_nested():
 def test_gtir_cartesian_shift_left():
     DELTA = 3.0
     OFFSET = 1
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(
-            gtir.AxisLiteral(value=IDim.value),
-            0,
-            im.minus(gtir.SymRef(id="size"), gtir.Literal(value=str(OFFSET), type=SIZE_TYPE)),
-        )
+    domain = im.domain(
+        gtx_common.GridType.CARTESIAN,
+        ranges={
+            IDim: (
+                0,
+                im.minus(gtir.SymRef(id="size"), gtir.Literal(value=str(OFFSET), type=SIZE_TYPE)),
+            ),
+        },
     )
 
     # cartesian shift with literal integer offset
@@ -769,9 +771,7 @@ def test_gtir_cartesian_shift_left():
 def test_gtir_cartesian_shift_right():
     DELTA = 3.0
     OFFSET = 1
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), OFFSET, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (OFFSET, "size")})
 
     # cartesian shift with literal integer offset
     stencil1_inlined = im.as_fieldop(
@@ -864,13 +864,25 @@ def test_gtir_cartesian_shift_right():
 def test_gtir_connectivity_shift():
     C2E_neighbor_idx = 2
     E2V_neighbor_idx = 1
-    cv_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Cell.value), 0, "ncells"),
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
+    edge_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Edge: (0, "nedges"),
+        },
     )
-    ce_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Cell.value), 0, "ncells"),
-        im.call("named_range")(gtir.AxisLiteral(value=Edge.value), 0, "nedges"),
+    ce_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Cell: (0, "ncells"),
+            Edge: (0, "nedges"),
+        },
+    )
+    cv_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Cell: (0, "ncells"),
+            Vertex: (0, "nvertices"),
+        },
     )
 
     # apply shift 2 times along different dimensions
@@ -944,12 +956,7 @@ def test_gtir_connectivity_shift():
     )(
         "ev_field",
         "c2e_offset",
-        im.op_as_fieldop(
-            "plus",
-            im.call("unstructured_domain")(
-                im.call("named_range")(gtir.AxisLiteral(value=Edge.value), 0, "nedges"),
-            ),
-        )("e2v_offset", 0),
+        im.op_as_fieldop("plus", edge_domain)("e2v_offset", 0),
     )
 
     CE_FTYPE = ts.FieldType(dims=[Cell, Edge], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
@@ -1022,11 +1029,17 @@ def test_gtir_connectivity_shift():
 def test_gtir_connectivity_shift_chain():
     E2V_neighbor_idx = 1
     V2E_neighbor_idx = 2
-    edge_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Edge.value), 0, "nedges")
+    edge_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Edge: (0, "nedges"),
+        },
     )
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices")
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
     testee = gtir.Program(
         id="connectivity_shift_chain",
@@ -1085,8 +1098,11 @@ def test_gtir_neighbors_as_input():
     # FIXME[#1582](edopao): Enable testcase when type inference is working
     pytest.skip("Field of lists not fully supported by GTIR type inference")
     init_value = np.random.rand()
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
     testee = gtir.Program(
         id="neighbors_as_input",
@@ -1144,16 +1160,18 @@ def test_gtir_neighbors_as_input():
 def test_gtir_neighbors_as_output():
     # FIXME[#1582](edopao): Enable testcase when type inference is working
     pytest.skip("Field of lists not fully supported by GTIR type inference")
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
+    v2e_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+            V2EDim: (0, SIMPLE_MESH_OFFSET_PROVIDER["V2E"].max_neighbors),
+        },
     )
-    v2e_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
-        im.call("named_range")(
-            gtir.AxisLiteral(value=V2EDim.value),
-            0,
-            SIMPLE_MESH_OFFSET_PROVIDER["V2E"].max_neighbors,
-        ),
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
     testee = gtir.Program(
         id="neighbors_as_output",
@@ -1197,8 +1215,11 @@ def test_gtir_neighbors_as_output():
 
 def test_gtir_reduce():
     init_value = np.random.rand()
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
     stencil_inlined = im.call(
         im.call("as_fieldop")(
@@ -1265,8 +1286,11 @@ def test_gtir_reduce():
 
 def test_gtir_reduce_with_skip_values():
     init_value = np.random.rand()
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
     stencil_inlined = im.call(
         im.call("as_fieldop")(
@@ -1337,16 +1361,11 @@ def test_gtir_reduce_dot_product():
     # FIXME[#1582](edopao): Enable testcase when type inference is working
     pytest.skip("Field of lists not fully supported as a type in GTIR yet")
     init_value = np.random.rand()
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
-    )
-    v2e_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
-        im.call("named_range")(
-            gtir.AxisLiteral(value=V2EDim.value),
-            0,
-            SIMPLE_MESH_OFFSET_PROVIDER["V2E"].max_neighbors,
-        ),
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
 
     testee = gtir.Program(
@@ -1405,8 +1424,11 @@ def test_gtir_reduce_dot_product():
 
 def test_gtir_reduce_with_cond_neighbors():
     init_value = np.random.rand()
-    vertex_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Vertex.value), 0, "nvertices"),
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Vertex: (0, "nvertices"),
+        },
     )
     testee = gtir.Program(
         id="reduce_with_cond_neighbors",
@@ -1488,12 +1510,8 @@ def test_gtir_reduce_with_cond_neighbors():
 
 
 def test_gtir_let_lambda():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
-    subdomain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 1, im.minus("size", 1))
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
+    subdomain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (1, im.minus("size", 1))})
     testee = gtir.Program(
         id="let_lambda",
         function_definitions=[],
@@ -1542,8 +1560,11 @@ def test_gtir_let_lambda():
 def test_gtir_let_lambda_with_connectivity():
     C2E_neighbor_idx = 1
     C2V_neighbor_idx = 2
-    cell_domain = im.call("unstructured_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=Cell.value), 0, "ncells"),
+    cell_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED,
+        ranges={
+            Cell: (0, "ncells"),
+        },
     )
 
     connectivity_C2E = SIMPLE_MESH_OFFSET_PROVIDER["C2E"]
@@ -1607,9 +1628,7 @@ def test_gtir_let_lambda_with_connectivity():
 
 
 def test_gtir_let_lambda_with_cond():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="let_lambda_with_cond",
         function_definitions=[],
@@ -1647,9 +1666,7 @@ def test_gtir_let_lambda_with_cond():
 
 
 def test_gtir_let_lambda_with_tuple():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="let_lambda_with_tuple",
         function_definitions=[],
@@ -1693,9 +1710,7 @@ def test_gtir_let_lambda_with_tuple():
 
 
 def test_gtir_if_scalars():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="if_scalars",
         function_definitions=[],
@@ -1750,9 +1765,7 @@ def test_gtir_if_scalars():
 
 
 def test_gtir_if_values():
-    domain = im.call("cartesian_domain")(
-        im.call("named_range")(gtir.AxisLiteral(value=IDim.value), 0, "size")
-    )
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
     testee = gtir.Program(
         id="if_values",
         function_definitions=[],

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -864,12 +864,7 @@ def test_gtir_cartesian_shift_right():
 def test_gtir_connectivity_shift():
     C2E_neighbor_idx = 2
     E2V_neighbor_idx = 1
-    edge_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Edge: (0, "nedges"),
-        },
-    )
+    edge_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Edge: (0, "nedges")})
     ce_domain = im.domain(
         gtx_common.GridType.UNSTRUCTURED,
         ranges={
@@ -1029,18 +1024,8 @@ def test_gtir_connectivity_shift():
 def test_gtir_connectivity_shift_chain():
     E2V_neighbor_idx = 1
     V2E_neighbor_idx = 2
-    edge_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Edge: (0, "nedges"),
-        },
-    )
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    edge_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Edge: (0, "nedges")})
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
     testee = gtir.Program(
         id="connectivity_shift_chain",
         function_definitions=[],
@@ -1098,12 +1083,7 @@ def test_gtir_neighbors_as_input():
     # FIXME[#1582](edopao): Enable testcase when type inference is working
     pytest.skip("Field of lists not fully supported by GTIR type inference")
     init_value = np.random.rand()
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
     testee = gtir.Program(
         id="neighbors_as_input",
         function_definitions=[],
@@ -1167,12 +1147,7 @@ def test_gtir_neighbors_as_output():
             V2EDim: (0, SIMPLE_MESH_OFFSET_PROVIDER["V2E"].max_neighbors),
         },
     )
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
     testee = gtir.Program(
         id="neighbors_as_output",
         function_definitions=[],
@@ -1215,12 +1190,7 @@ def test_gtir_neighbors_as_output():
 
 def test_gtir_reduce():
     init_value = np.random.rand()
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
     stencil_inlined = im.call(
         im.call("as_fieldop")(
             im.lambda_("it")(
@@ -1286,12 +1256,7 @@ def test_gtir_reduce():
 
 def test_gtir_reduce_with_skip_values():
     init_value = np.random.rand()
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
     stencil_inlined = im.call(
         im.call("as_fieldop")(
             im.lambda_("it")(
@@ -1361,12 +1326,7 @@ def test_gtir_reduce_dot_product():
     # FIXME[#1582](edopao): Enable testcase when type inference is working
     pytest.skip("Field of lists not fully supported as a type in GTIR yet")
     init_value = np.random.rand()
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
 
     testee = gtir.Program(
         id="reduce_dot_product",
@@ -1424,12 +1384,7 @@ def test_gtir_reduce_dot_product():
 
 def test_gtir_reduce_with_cond_neighbors():
     init_value = np.random.rand()
-    vertex_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Vertex: (0, "nvertices"),
-        },
-    )
+    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
     testee = gtir.Program(
         id="reduce_with_cond_neighbors",
         function_definitions=[],
@@ -1560,12 +1515,7 @@ def test_gtir_let_lambda():
 def test_gtir_let_lambda_with_connectivity():
     C2E_neighbor_idx = 1
     C2V_neighbor_idx = 2
-    cell_domain = im.domain(
-        gtx_common.GridType.UNSTRUCTURED,
-        ranges={
-            Cell: (0, "ncells"),
-        },
-    )
+    cell_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Cell: (0, "ncells")})
 
     connectivity_C2E = SIMPLE_MESH_OFFSET_PROVIDER["C2E"]
     assert isinstance(connectivity_C2E, gtx_common.NeighborTable)


### PR DESCRIPTION
Introduce a utility function `patch_gtir` that makes the IR compliant with the requirements of lowering to SDFG:

- Add support for `as_fieldop` expressions that broadcast a scalar value on a field:
```
as_fieldop(deref, u⟨ Cellₕ: [horizontal_start, horizontal_end), Kᵥ: [vertical_start, vertical_end) ⟩)(
  0.0
)
```

- Add support for GTIR workaround in domain inference, where the domain is not inferred on the tuple fields that are not referenced.

Additionally, apply some refactoring:
- Use `im.domain` to construct the domain in gtir-to-sdfg tests.
- Rename `ValueExpr` to `TempExpr` and `IteratorIndexExpr` to `ValueExpr`