### PR TITLE
fix[cartesian]: Protect K write against dynamic access 

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1458,6 +1458,11 @@ class IRMaker(ast.NodeVisitor):
                                 message=f"Assignment to non-zero offsets in K is not available in {self.backend_name} for CUDA<12. Please update CUDA.",
                                 loc=nodes.Location.from_ast_node(t),
                             )
+                    if isinstance(spatial_offset[2], nodes.Expr):
+                        raise GTScriptSyntaxError(
+                            message=f"Assignment to non-zero offsets in K can only be done with literals, got {spatial_offset[2]}",
+                            loc=nodes.Location.from_ast_node(t),
+                        )
 
             if not self._is_known(name):
                 if name in self.temp_decls:

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -1429,6 +1429,21 @@ class TestAssignmentSyntax:
                 module=self.__class__.__name__,
             )
 
+        with pytest.raises(
+            gt_frontend.GTScriptSyntaxError,
+            match=r"Assignment to non-zero offsets in K can only be done with literals, got(.*)",
+        ):
+
+            def func(
+                in_field: gtscript.Field[np.float_],
+                out_field: gtscript.Field[np.float_],
+                index: int,
+            ):
+                with computation(FORWARD), interval(...):
+                    out_field[0, 0, index] = in_field
+
+            parse_definition(func, name=inspect.stack()[0][3], module=self.__class__.__name__)
+
     def test_return_to_subscript(self):
         @gtscript.function
         def func(a):


### PR DESCRIPTION
## Description

We allowed offset-writes in K in a previous PR e.g.
```python
out_field[0, 0, 1] = value
```
but we let open the possibility for the offset to be a dynamic value which would escape any extent analysis. E.g.
```python
index = value ** 29382938
out_field[0, 0, index] = other_value
```

The time might come where a legit case shows up and we could imagine introducing a mitigating strategy. Until that fateful day, we restrict access to literals.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
