### PR TITLE
refactor[cartesian]: Warn if GT4Py can't find DaCe

### DIFF
--- a/src/gt4py/cartesian/backend/__init__.py
+++ b/src/gt4py/cartesian/backend/__init__.py
@@ -6,6 +6,8 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from warnings import warn
+
 from .base import (
     REGISTRY,
     Backend,
@@ -16,13 +18,6 @@ from .base import (
     from_name,
     register,
 )
-
-
-try:
-    from .dace_backend import DaceCPUBackend, DaceGPUBackend
-except ImportError:
-    pass
-
 from .cuda_backend import CudaBackend
 from .gtcpp_backend import GTCpuIfirstBackend, GTCpuKfirstBackend, GTGpuBackend
 from .module_generator import BaseModuleGenerator
@@ -47,5 +42,12 @@ __all__ = [
 ]
 
 
-if "DaceCPUBackend" in globals():
+try:
+    from .dace_backend import DaceCPUBackend, DaceGPUBackend
+
     __all__ += ["DaceCPUBackend", "DaceGPUBackend"]
+except ImportError:
+    warn(
+        "GT4Py was unable to load DaCe. DaCe backends (`dace:cpu` and `dace:gpu`) will not be available.",
+        stacklevel=2,
+    )


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

DaCe backends are optional backends in the cartesian version of GT4Py. Currently, we silently drop support for DaCe backends if DaCe can't be imported. This can can happen because DaCe isn't available or for a couple other reasons (e.g. a circular import in the import path). With this PR we thus add a warning message allowing developers to easily figure out that/why DaCe backends are disabled.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
