### PR TITLE
feat[next][dace]: Cleanup scalar args

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
@@ -611,7 +611,7 @@ def translate_scalar_expr(
     connectors = []
     scalar_expr_args = []
 
-    for arg_expr in node.args:
+    for i, arg_expr in enumerate(node.args):
         visit_expr = True
         if isinstance(arg_expr, gtir.SymRef):
             try:
@@ -635,7 +635,7 @@ def translate_scalar_expr(
             )
             if not (isinstance(arg, Field) and isinstance(arg.data_type, ts.ScalarType)):
                 raise ValueError(f"Invalid argument to scalar expression {arg_expr}.")
-            param = f"__in_{arg.data_node.data}"
+            param = f"__arg{i}"
             args.append(arg.data_node)
             connectors.append(param)
             scalar_expr_args.append(gtir.SymRef(id=param))

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_builtin_translators.py
@@ -481,13 +481,12 @@ def _get_data_nodes(
         sym_node = state.add_access(sym_name)
         return Field(sym_node, sym_type)
     elif isinstance(sym_type, ts.ScalarType):
-        if sym_name in sdfg.arrays:
-            # access the existing scalar container
-            sym_node = state.add_access(sym_name)
-        else:
+        if sym_name in sdfg.symbols:
             sym_node = _get_symbolic_value(
                 sdfg, state, sdfg_builder, sym_name, sym_type, temp_name=f"__{sym_name}"
             )
+        else:
+            sym_node = state.add_access(sym_name)
         return Field(sym_node, sym_type)
     elif isinstance(sym_type, ts.TupleType):
         tuple_fields = dace_gtir_utils.get_tuple_fields(sym_name, sym_type)

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_dataflow.py
@@ -939,7 +939,7 @@ class LambdaToDataflow(eve.NodeVisitor):
             arg_expr = self.visit(arg)
             if isinstance(arg_expr, MemletExpr | DataExpr):
                 # the argument value is the result of a tasklet node or direct field access
-                connector = f"__inp_{i}"
+                connector = f"__arg{i}"
                 node_connections[connector] = arg_expr
                 node_internals.append(connector)
             else:

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
@@ -261,10 +261,6 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
 
         Returns:
             A list of array nodes containing the result fields.
-
-        TODO: Do we need to return the GT4Py `FieldType`/`ScalarType`? It is needed
-        in case the transient arrays containing the expression result are not guaranteed
-        to have the same memory layout as the target array.
         """
         result = self.visit(node, sdfg=sdfg, head_state=head_state, reduce_identity=None)
 

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
@@ -37,7 +37,7 @@ from gt4py.next.program_processors.runners.dace_fieldview import (
 from gt4py.next.type_system import type_specifications as ts, type_translation as tt
 
 
-GTIR_DOMAIN_DEFAULT_SYMBOLS: Final[set[str]] = {
+GTIR_DOMAIN_SYMBOLS: Final[set[str]] = {
     "horizontal_start",
     "horizontal_end",
     "vertical_start",
@@ -222,13 +222,13 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             dtype = dace_utils.as_dace_type(symbol_type)
             # Scalar program arguments are represented as scalar data in the SDFG;
             # the exception are program arguments used for symbolic domain expressions,
-            # listed in `GTIR_DOMAIN_DEFAULT_SYMBOLS`, and those used for symbolic
-            # array shape and strides.
+            # listed in `GTIR_DOMAIN_SYMBOLS`, and those used for symbolic array
+            # shape and strides.
             # The field size is sometimes passed as a scalar argument to the program,
             # so we have to check if the shape symbol was already allocated by
             # `_make_array_shape_and_strides`. We assume that the scalar argument
             # for field size always follows the field argument.
-            if name in GTIR_DOMAIN_DEFAULT_SYMBOLS:
+            if name in GTIR_DOMAIN_SYMBOLS:
                 sdfg.add_symbol(name, dtype)
             elif dace_utils.is_field_symbol(name):
                 if name in sdfg.symbols:

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import itertools
-from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Final, Iterable, List, Optional, Protocol, Sequence, Set, Tuple, Union
 
 import dace
 
@@ -26,7 +26,7 @@ from gt4py.eve import concepts
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm
-from gt4py.next.iterator.transforms import prune_casts as ir_prune_casts
+from gt4py.next.iterator.transforms import prune_casts as ir_prune_casts, symbol_ref_utils
 from gt4py.next.iterator.type_system import inference as gtir_type_inference
 from gt4py.next.program_processors.runners.dace_common import utility as dace_utils
 from gt4py.next.program_processors.runners.dace_fieldview import (
@@ -35,6 +35,18 @@ from gt4py.next.program_processors.runners.dace_fieldview import (
     utility as dace_gtir_utils,
 )
 from gt4py.next.type_system import type_specifications as ts, type_translation as tt
+
+
+GTIR_DOMAIN_DEFAULT_SYMBOLS: Final[set[str]] = {
+    "horizontal_start",
+    "horizontal_end",
+    "vertical_start",
+    "vertical_end",
+}
+"""
+Set of IR symbols that are passed as gt4py scalar arguments but we have to represent
+in the SDFG as dace symbols, because they are used in domain symbolic expressions.
+"""
 
 
 class DataflowBuilder(Protocol):
@@ -175,7 +187,6 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         name: str,
         symbol_type: ts.DataType,
         transient: bool = True,
-        is_tuple_member: bool = False,
     ) -> list[tuple[str, ts.DataType]]:
         """
         Add storage for data containers used in the SDFG. For fields, it allocates dace arrays,
@@ -195,9 +206,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             for tname, tsymbol_type in dace_gtir_utils.get_tuple_fields(
                 name, symbol_type, flatten=True
             ):
-                tuple_fields.extend(
-                    self._add_storage(sdfg, tname, tsymbol_type, transient, is_tuple_member=True)
-                )
+                tuple_fields.extend(self._add_storage(sdfg, tname, tsymbol_type, transient))
             return tuple_fields
 
         elif isinstance(symbol_type, ts.FieldType):
@@ -211,17 +220,23 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
 
         elif isinstance(symbol_type, ts.ScalarType):
             dtype = dace_utils.as_dace_type(symbol_type)
-            # Scalar arguments passed to the program are represented as symbols in DaCe SDFG;
-            # the exception are members of tuple arguments, that are represented as scalar containers.
-            # The field size is sometimes passed as scalar argument to the program, so we have to
-            # check if the shape symbol was already allocated by `_make_array_shape_and_strides`.
-            # We assume that the scalar argument for field size always follows the field argument.
-            if is_tuple_member:
-                sdfg.add_scalar(name, dtype, transient=transient)
-            elif name in sdfg.symbols:
-                assert sdfg.symbols[name].dtype == dtype
-            else:
+            # Scalar program arguments are represented as scalar data in the SDFG;
+            # the exception are program arguments used for symbolic domain expressions,
+            # listed in `GTIR_DOMAIN_DEFAULT_SYMBOLS`, and those used for symbolic
+            # array shape and strides.
+            # The field size is sometimes passed as a scalar argument to the program,
+            # so we have to check if the shape symbol was already allocated by
+            # `_make_array_shape_and_strides`. We assume that the scalar argument
+            # for field size always follows the field argument.
+            if name in GTIR_DOMAIN_DEFAULT_SYMBOLS:
                 sdfg.add_symbol(name, dtype)
+            elif dace_utils.is_field_symbol(name):
+                if name in sdfg.symbols:
+                    assert sdfg.symbols[name].dtype == dtype
+                else:
+                    sdfg.add_symbol(name, dtype)
+            else:
+                sdfg.add_scalar(name, dtype, transient=transient)
 
             return [(name, symbol_type)]
 
@@ -490,7 +505,10 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         ]
 
         # inherit symbols from parent scope but eventually override with local symbols
-        lambda_symbols = self.global_symbols | {
+        lambda_symbols = {
+            sym: self.global_symbols[sym]
+            for sym in symbol_ref_utils.collect_symbol_refs(node.expr, self.global_symbols.keys())
+        } | {
             pname: dace_gtir_utils.get_tuple_type(arg) if isinstance(arg, tuple) else arg.data_type
             for pname, arg in lambda_args_mapping
         }

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -219,6 +219,7 @@ def test_scalar_tuple_arg(unstructured_case):
 
 
 @pytest.mark.uses_tuple_args
+@pytest.mark.uses_zero_dimensional_fields
 def test_zero_dim_tuple_arg(unstructured_case):
     @gtx.field_operator
     def testee(

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_execution.py
@@ -219,7 +219,6 @@ def test_scalar_tuple_arg(unstructured_case):
 
 
 @pytest.mark.uses_tuple_args
-@pytest.mark.uses_zero_dimensional_fields
 def test_zero_dim_tuple_arg(unstructured_case):
     @gtx.field_operator
     def testee(

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -819,9 +819,7 @@ def test_gtir_cartesian_shift_left():
 
         sdfg = dace_backend.build_sdfg_from_gtir(testee, CARTESIAN_OFFSETS)
 
-        FSYMBOLS_tmp = FSYMBOLS.copy()
-        FSYMBOLS_tmp["__x_offset_stride_0"] = 1
-        sdfg(a, a_offset, b, **FSYMBOLS_tmp)
+        sdfg(a, a_offset, b, **FSYMBOLS, __x_offset_size_0=N, __x_offset_stride_0=1)
         assert np.allclose(a[OFFSET:] + DELTA, b[:-OFFSET])
 
 
@@ -914,7 +912,7 @@ def test_gtir_cartesian_shift_right():
 
         sdfg = dace_backend.build_sdfg_from_gtir(testee, CARTESIAN_OFFSETS)
 
-        sdfg(a, a_offset, b, **FSYMBOLS, __x_offset_stride_0=1)
+        sdfg(a, a_offset, b, **FSYMBOLS, __x_offset_size_0=N, __x_offset_stride_0=1)
         assert np.allclose(a[:-OFFSET] + DELTA, b[OFFSET:])
 
 
@@ -1072,7 +1070,9 @@ def test_gtir_connectivity_shift():
             __ev_field_size_1=SIMPLE_MESH.num_vertices,
             __ev_field_stride_0=SIMPLE_MESH.num_vertices,
             __ev_field_stride_1=1,
+            __c2e_offset_size_0=SIMPLE_MESH.num_cells,
             __c2e_offset_stride_0=1,
+            __e2v_offset_size_0=SIMPLE_MESH.num_edges,
             __e2v_offset_stride_0=1,
         )
         assert np.allclose(ce, ref)
@@ -1590,6 +1590,41 @@ def test_gtir_let_lambda():
 
     sdfg(a, b, **FSYMBOLS)
     assert np.allclose(b, ref)
+
+
+def test_gtir_let_lambda_scalar_expression():
+    domain = im.domain(gtx_common.GridType.CARTESIAN, ranges={IDim: (0, "size")})
+    testee = gtir.Program(
+        id="let_lambda_scalar_expression",
+        function_definitions=[],
+        params=[
+            gtir.Sym(id="a", type=IFTYPE.dtype),
+            gtir.Sym(id="b", type=IFTYPE.dtype),
+            gtir.Sym(id="x", type=IFTYPE),
+            gtir.Sym(id="y", type=IFTYPE),
+            gtir.Sym(id="size", type=SIZE_TYPE),
+        ],
+        declarations=[],
+        body=[
+            gtir.SetAt(
+                expr=im.let("tmp", im.multiplies_("a", "b"))(
+                    im.op_as_fieldop("multiplies", domain)("x", im.multiplies_("tmp", "tmp"))
+                ),
+                domain=domain,
+                target=gtir.SymRef(id="y"),
+            )
+        ],
+    )
+
+    a = np.random.rand()
+    b = np.random.rand()
+    c = np.random.rand(N)
+    d = np.empty_like(c)
+
+    sdfg = dace_backend.build_sdfg_from_gtir(testee, {})
+
+    sdfg(a, b, c, d, **FSYMBOLS)
+    assert np.allclose(d, (a * a * b * b * c))
 
 
 def test_gtir_let_lambda_with_connectivity():

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -1757,9 +1757,9 @@ def test_gtir_if_scalars():
         body=[
             gtir.SetAt(
                 expr=im.let("f", im.tuple_get(0, "x"))(
-                    im.let("y", im.tuple_get(1, "x"))(
-                        im.let("y_0", im.tuple_get(0, "y"))(
-                            im.let("y_1", im.tuple_get(1, "y"))(
+                    im.let("g", im.tuple_get(1, "x"))(
+                        im.let("y_0", im.tuple_get(0, "g"))(
+                            im.let("y_1", im.tuple_get(1, "g"))(
                                 im.op_as_fieldop("plus", domain)(
                                     "f",
                                     im.if_(


### PR DESCRIPTION
This PR simplifies the representation of program scalar arguments in the SDFG: instead of promoting them to symbols, we represent them as scalar data. Scalar to symbol promotion is a transformation pass available in DaCe that should be applied after lowering to SDFG, eventually.

Additional changes:
- Fixes a problem in naming of input connectors for scalar expression tasklets: the connector name cannot match the argument name, otherwise we cannot pass the same value to two connectors in expressions like `out = tmp * tmp`.
- Only propagate to lambda scope the symbols that are referenced.