### PR TITLE
fix[cartesian]: Verbose frontend error for bad call

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -459,7 +459,8 @@ class CallInliner(ast.NodeTransformer):
                     call_args[name] = ast.Constant(value=arg_infos[name])
         except Exception as ex:
             raise GTScriptSyntaxError(
-                message="Invalid call signature", loc=nodes.Location.from_ast_node(node)
+                message=f"Invalid call signature when calling {call_name}",
+                loc=nodes.Location.from_ast_node(node),
             ) from ex
 
         # Rename local names in subroutine to avoid conflicts with caller context names


### PR DESCRIPTION
When making a bad call to at a `gtscript.function` we add the function name in the error message for quick reference.