### PR TITLE
bug[next]: fix lowering of tuples of neighbors in conditionals

### DIFF
--- a/src/gt4py/next/ffront/foast_to_gtir.py
+++ b/src/gt4py/next/ffront/foast_to_gtir.py
@@ -366,7 +366,7 @@ class FieldOperatorLowering(eve.PreserveLocationVisitor, eve.NodeTranslator):
         ) -> itir.FunCall:
             return _map(
                 "if_",
-                (itir.SymRef(id=cond_symref_name, type=node.args[0].type), true_, false_),
+                (im.ref(cond_symref_name), true_, false_),
                 (node.args[0].type, *arg_types),
             )
 

--- a/src/gt4py/next/ffront/foast_to_itir.py
+++ b/src/gt4py/next/ffront/foast_to_itir.py
@@ -267,16 +267,16 @@ class FieldOperatorLowering(PreserveLocationVisitor, NodeTranslator):
         if node.op in [dialect_ast_enums.UnaryOperator.NOT, dialect_ast_enums.UnaryOperator.INVERT]:
             if dtype.kind != ts.ScalarKind.BOOL:
                 raise NotImplementedError(f"'{node.op}' is only supported on 'bool' arguments.")
-            return self._map("not_", node.operand)
+            return self._lower_and_map("not_", node.operand)
 
-        return self._map(
+        return self._lower_and_map(
             node.op.value,
             foast.Constant(value="0", type=dtype, location=node.location),
             node.operand,
         )
 
     def visit_BinOp(self, node: foast.BinOp, **kwargs: Any) -> itir.FunCall:
-        return self._map(node.op.value, node.left, node.right)
+        return self._lower_and_map(node.op.value, node.left, node.right)
 
     def visit_TernaryExpr(self, node: foast.TernaryExpr, **kwargs: Any) -> itir.FunCall:
         op = "if_"
@@ -296,7 +296,7 @@ class FieldOperatorLowering(PreserveLocationVisitor, NodeTranslator):
         )
 
     def visit_Compare(self, node: foast.Compare, **kwargs: Any) -> itir.FunCall:
-        return self._map(node.op.value, node.left, node.right)
+        return self._lower_and_map(node.op.value, node.left, node.right)
 
     def _visit_shift(self, node: foast.Call, **kwargs: Any) -> itir.Expr:
         current_expr = self.visit(node.func, **kwargs)
@@ -410,7 +410,7 @@ class FieldOperatorLowering(PreserveLocationVisitor, NodeTranslator):
 
         lowered_condition = self.visit(condition, **kwargs)
         return lowering_utils.process_elements(
-            lambda tv, fv, types: self._map2(
+            lambda tv, fv, types: _map(
                 "if_", (lowered_condition, tv, fv), (condition.type, *types)
             ),
             [self.visit(true_value, **kwargs), self.visit(false_value, **kwargs)],
@@ -424,7 +424,7 @@ class FieldOperatorLowering(PreserveLocationVisitor, NodeTranslator):
         return self.visit(node.args[0], **kwargs)
 
     def _visit_math_built_in(self, node: foast.Call, **kwargs: Any) -> itir.FunCall:
-        return self._map(self.visit(node.func, **kwargs), *node.args)
+        return self._lower_and_map(self.visit(node.func, **kwargs), *node.args)
 
     def _make_reduction_expr(
         self, node: foast.Call, op: str | itir.SymRef, init_expr: itir.Expr, **kwargs: Any
@@ -485,30 +485,28 @@ class FieldOperatorLowering(PreserveLocationVisitor, NodeTranslator):
     def visit_Constant(self, node: foast.Constant, **kwargs: Any) -> itir.Expr:
         return self._make_literal(node.value, node.type)
 
-    def _map(self, op: itir.Expr | str, *args: Any, **kwargs: Any) -> itir.FunCall:
-        lowered_args = [self.visit(arg, **kwargs) for arg in args]
-        if any(type_info.contains_local_field(arg.type) for arg in args):
-            lowered_args = [
-                promote_to_list(arg.type)(larg) for arg, larg in zip(args, lowered_args)
-            ]
-            op = im.call("map_")(op)
+    def _lower_and_map(self, op: itir.Expr | str, *args: Any, **kwargs: Any) -> itir.FunCall:
+        return _map(
+            op, tuple(self.visit(arg, **kwargs) for arg in args), tuple(arg.type for arg in args)
+        )
 
-        return im.promote_to_lifted_stencil(im.call(op))(*lowered_args)
 
-    def _map2(
-        self,
-        op: itir.Expr | str,
-        lowered_args: tuple,
-        original_arg_types: tuple[ts.TypeSpec, ...],
-    ) -> itir.FunCall:
-        if any(type_info.contains_local_field(arg_type) for arg_type in original_arg_types):
-            lowered_args = tuple(
-                promote_to_list(arg_type)(larg)
-                for arg_type, larg in zip(original_arg_types, lowered_args)
-            )
-            op = im.call("map_")(op)
+def _map(
+    op: itir.Expr | str,
+    lowered_args: tuple,
+    original_arg_types: tuple[ts.TypeSpec, ...],
+) -> itir.FunCall:
+    """
+    Mapping includes making the operation an lifted stencil (first kind of mapping), but also `itir.map_`ing lists.
+    """
+    if any(type_info.contains_local_field(arg_type) for arg_type in original_arg_types):
+        lowered_args = tuple(
+            promote_to_list(arg_type)(larg)
+            for arg_type, larg in zip(original_arg_types, lowered_args)
+        )
+        op = im.call("map_")(op)
 
-        return im.promote_to_lifted_stencil(im.call(op))(*lowered_args)
+    return im.promote_to_lifted_stencil(im.call(op))(*lowered_args)
 
 
 class FieldOperatorLoweringError(Exception): ...

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Iterable
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from gt4py.eve import utils as eve_utils
 from gt4py.next.ffront import type_info as ti_ffront
@@ -102,7 +102,7 @@ def process_elements(
     process_func: Callable[..., itir.Expr],
     objs: itir.Expr | Iterable[itir.Expr],
     current_el_type: ts.TypeSpec,
-    with_type: bool = False,
+    arg_types: Optional[ts.TypeSpec | Iterable[ts.TypeSpec]] = None,
 ) -> itir.FunCall:
     """
     Recursively applies a processing function to all primitive constituents of a tuple.
@@ -113,9 +113,9 @@ def process_elements(
         objs: The object whose elements are to be transformed.
         current_el_type: A type with the same structure as the elements of `objs`. The leaf-types
             are not used and thus not relevant.
-        current_el_type: A type with the same structure as the elements of `objs`. Unless `with_type=True`
-            the leaf-types are not used and thus not relevant.
-        with_type: If True, the last argument passed to `process_func` will be its type.
+        arg_types: If provided, a tuple of the type of each argument is passed to `process_func` as last argument.
+            Note, that `arg_types` might coincide with `(current_el_type,)*len(objs)`, but not necessarily,
+            in case of implicit broadcasts.
     """
     if isinstance(objs, itir.Expr):
         objs = (objs,)
@@ -125,7 +125,7 @@ def process_elements(
         process_func,
         tuple(im.ref(let_id) for let_id in let_ids),
         current_el_type,
-        with_type=with_type,
+        arg_types=arg_types,
     )
 
     return im.let(*(zip(let_ids, objs, strict=True)))(body)
@@ -138,7 +138,7 @@ def _process_elements_impl(
     process_func: Callable[..., itir.Expr],
     _current_el_exprs: Iterable[T],
     current_el_type: ts.TypeSpec,
-    with_type: bool,
+    arg_types: Optional[ts.TypeSpec | Iterable[ts.TypeSpec]],
 ) -> itir.Expr:
     if isinstance(current_el_type, ts.TupleType):
         result = im.make_tuple(
@@ -149,16 +149,16 @@ def _process_elements_impl(
                         im.tuple_get(i, current_el_expr) for current_el_expr in _current_el_exprs
                     ),
                     current_el_type.types[i],
-                    with_type=with_type,
+                    arg_types=tuple(arg_t.types[i] for arg_t in arg_types)  # type: ignore[union-attr] # guaranteed by the requirement that `current_el_type` and each element of `arg_types` have the same tuple structure
+                    if arg_types is not None
+                    else None,
                 )
                 for i in range(len(current_el_type.types))
             )
         )
-    elif type_info.contains_local_field(current_el_type):
-        raise NotImplementedError("Processing fields with local dimension is not implemented.")
     else:
-        if with_type:
-            result = process_func(*_current_el_exprs, current_el_type)
+        if arg_types is not None:
+            result = process_func(*_current_el_exprs, arg_types)
         else:
             result = process_func(*_current_el_exprs)
 

--- a/src/gt4py/next/ffront/lowering_utils.py
+++ b/src/gt4py/next/ffront/lowering_utils.py
@@ -102,7 +102,7 @@ def process_elements(
     process_func: Callable[..., itir.Expr],
     objs: itir.Expr | Iterable[itir.Expr],
     current_el_type: ts.TypeSpec,
-    arg_types: Optional[ts.TypeSpec | Iterable[ts.TypeSpec]] = None,
+    arg_types: Optional[Iterable[ts.TypeSpec]] = None,
 ) -> itir.FunCall:
     """
     Recursively applies a processing function to all primitive constituents of a tuple.
@@ -138,7 +138,7 @@ def _process_elements_impl(
     process_func: Callable[..., itir.Expr],
     _current_el_exprs: Iterable[T],
     current_el_type: ts.TypeSpec,
-    arg_types: Optional[ts.TypeSpec | Iterable[ts.TypeSpec]],
+    arg_types: Optional[Iterable[ts.TypeSpec]],
 ) -> itir.Expr:
     if isinstance(current_el_type, ts.TupleType):
         result = im.make_tuple(
@@ -149,7 +149,7 @@ def _process_elements_impl(
                         im.tuple_get(i, current_el_expr) for current_el_expr in _current_el_exprs
                     ),
                     current_el_type.types[i],
-                    arg_types=tuple(arg_t.types[i] for arg_t in arg_types)  # type: ignore[union-attr] # guaranteed by the requirement that `current_el_type` and each element of `arg_types` have the same tuple structure
+                    arg_types=tuple(arg_t.types[i] for arg_t in arg_types)  # type: ignore[attr-defined] # guaranteed by the requirement that `current_el_type` and each element of `arg_types` have the same tuple structure
                     if arg_types is not None
                     else None,
                 )

--- a/tests/next_tests/integration_tests/cases.py
+++ b/tests/next_tests/integration_tests/cases.py
@@ -69,6 +69,7 @@ IKFloatField: TypeAlias = gtx.Field[[IDim, KDim], np.float64]  # type: ignore [v
 IJKField: TypeAlias = gtx.Field[[IDim, JDim, KDim], np.int32]  # type: ignore [valid-type]
 IJKFloatField: TypeAlias = gtx.Field[[IDim, JDim, KDim], np.float64]  # type: ignore [valid-type]
 VField: TypeAlias = gtx.Field[[Vertex], np.int32]  # type: ignore [valid-type]
+VBoolField: TypeAlias = gtx.Field[[Vertex], bool]  # type: ignore [valid-type]
 EField: TypeAlias = gtx.Field[[Edge], np.int32]  # type: ignore [valid-type]
 CField: TypeAlias = gtx.Field[[Cell], np.int32]  # type: ignore [valid-type]
 EmptyField: TypeAlias = gtx.Field[[], np.int32]  # type: ignore [valid-type]

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -278,28 +278,34 @@ def test_reduction_expression_with_where_and_tuples(unstructured_case):
     )
 
 
-# @pytest.mark.uses_unstructured_shift
-# def test_reduction_expression_with_where_and_scalar(unstructured_case):
-#     @gtx.field_operator
-#     def testee(mask: cases.VBoolField, inp: cases.EField) -> cases.VField:
-#         return neighbor_sum(inp(V2E) + where(mask, inp(V2E), 1), axis=V2EDim)
+@pytest.mark.uses_unstructured_shift
+def test_reduction_expression_with_where_and_scalar(unstructured_case):
+    @gtx.field_operator
+    def testee(mask: cases.VBoolField, inp: cases.EField) -> cases.VField:
+        return neighbor_sum(inp(V2E) + where(mask, inp(V2E), 1), axis=V2EDim)
 
-#     v2e_table = unstructured_case.offset_provider["V2E"].table
+    v2e_table = unstructured_case.offset_provider["V2E"].table
 
-#     mask = unstructured_case.as_field(
-#         [Vertex], np.random.choice(a=[False, True], size=unstructured_case.default_sizes[Vertex])
-#     )
-#     inp = cases.allocate(unstructured_case, testee, "inp")()
-#     out = cases.allocate(unstructured_case, testee, cases.RETURN)()
+    mask = unstructured_case.as_field(
+        [Vertex], np.random.choice(a=[False, True], size=unstructured_case.default_sizes[Vertex])
+    )
+    inp = cases.allocate(unstructured_case, testee, "inp")()
+    out = cases.allocate(unstructured_case, testee, cases.RETURN)()
 
-#     cases.verify(
-#         unstructured_case,
-#         testee,
-#         mask,
-#         inp,
-#         out=out,
-#         ref=0,
-#     )
+    cases.verify(
+        unstructured_case,
+        testee,
+        mask,
+        inp,
+        out=out,
+        ref=np.sum(
+            inp.asnumpy()[v2e_table]
+            + np.where(np.expand_dims(mask.asnumpy(), 1), inp.asnumpy()[v2e_table], 1),
+            axis=1,
+            initial=0,
+            where=v2e_table != common._DEFAULT_SKIP_VALUE,
+        ),
+    )
 
 
 @pytest.mark.uses_tuple_returns

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -220,6 +220,88 @@ def test_reduction_with_common_expression(unstructured_case):
     )
 
 
+@pytest.mark.uses_unstructured_shift
+def test_reduction_expression_with_where(unstructured_case):
+    @gtx.field_operator
+    def testee(mask: cases.VBoolField, inp: cases.EField) -> cases.VField:
+        return neighbor_sum(where(mask, inp(V2E), inp(V2E)), axis=V2EDim)
+
+    v2e_table = unstructured_case.offset_provider["V2E"].table
+
+    mask = unstructured_case.as_field(
+        [Vertex], np.random.choice(a=[False, True], size=unstructured_case.default_sizes[Vertex])
+    )
+    inp = cases.allocate(unstructured_case, testee, "inp")()
+    out = cases.allocate(unstructured_case, testee, cases.RETURN)()
+
+    cases.verify(
+        unstructured_case,
+        testee,
+        mask,
+        inp,
+        out=out,
+        ref=np.sum(
+            inp.asnumpy()[v2e_table],
+            axis=1,
+            initial=0,
+            where=v2e_table != common._DEFAULT_SKIP_VALUE,
+        ),
+    )
+
+
+@pytest.mark.uses_unstructured_shift
+def test_reduction_expression_with_where_and_tuples(unstructured_case):
+    @gtx.field_operator
+    def testee(mask: cases.VBoolField, inp: cases.EField) -> cases.VField:
+        return neighbor_sum(where(mask, (inp(V2E), inp(V2E)), (inp(V2E), inp(V2E)))[1], axis=V2EDim)
+
+    v2e_table = unstructured_case.offset_provider["V2E"].table
+
+    mask = unstructured_case.as_field(
+        [Vertex], np.random.choice(a=[False, True], size=unstructured_case.default_sizes[Vertex])
+    )
+    inp = cases.allocate(unstructured_case, testee, "inp")()
+    out = cases.allocate(unstructured_case, testee, cases.RETURN)()
+
+    cases.verify(
+        unstructured_case,
+        testee,
+        mask,
+        inp,
+        out=out,
+        ref=np.sum(
+            inp.asnumpy()[v2e_table],
+            axis=1,
+            initial=0,
+            where=v2e_table != common._DEFAULT_SKIP_VALUE,
+        ),
+    )
+
+
+# @pytest.mark.uses_unstructured_shift
+# def test_reduction_expression_with_where_and_scalar(unstructured_case):
+#     @gtx.field_operator
+#     def testee(mask: cases.VBoolField, inp: cases.EField) -> cases.VField:
+#         return neighbor_sum(inp(V2E) + where(mask, inp(V2E), 1), axis=V2EDim)
+
+#     v2e_table = unstructured_case.offset_provider["V2E"].table
+
+#     mask = unstructured_case.as_field(
+#         [Vertex], np.random.choice(a=[False, True], size=unstructured_case.default_sizes[Vertex])
+#     )
+#     inp = cases.allocate(unstructured_case, testee, "inp")()
+#     out = cases.allocate(unstructured_case, testee, cases.RETURN)()
+
+#     cases.verify(
+#         unstructured_case,
+#         testee,
+#         mask,
+#         inp,
+#         out=out,
+#         ref=0,
+#     )
+
+
 @pytest.mark.uses_tuple_returns
 def test_conditional_nested_tuple(cartesian_case):
     @gtx.field_operator


### PR DESCRIPTION
Use the `_map` function in all cases where mapping of with as_fieldop/lifted stencil *and* mapping of lists is required.