### PR TITLE
fix[cartesian]: While loops inside conditions

### DIFF
--- a/src/gt4py/cartesian/gtc/numpy/oir_to_npir.py
+++ b/src/gt4py/cartesian/gtc/numpy/oir_to_npir.py
@@ -157,13 +157,12 @@ class OirToNpir(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
     def visit_While(
         self, node: oir.While, *, mask: Optional[npir.Expr] = None, **kwargs: Any
     ) -> npir.While:
-        cond = self.visit(node.cond, mask=mask, **kwargs)
+        cond_expr = self.visit(node.cond, **kwargs)
         if mask:
-            mask = npir.VectorLogic(op=common.LogicalOperator.AND, left=mask, right=cond)
-        else:
-            mask = cond
+            cond_expr = npir.VectorLogic(op=common.LogicalOperator.AND, left=mask, right=cond_expr)
+
         return npir.While(
-            cond=cond, body=utils.flatten_list(self.visit(node.body, mask=mask, **kwargs))
+            cond=cond_expr, body=utils.flatten_list(self.visit(node.body, mask=cond_expr, **kwargs))
         )
 
     def visit_HorizontalRestriction(

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_suites.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_suites.py
@@ -444,6 +444,36 @@ class TestRuntimeIfNestedDataDependent(gt_testing.StencilTestSuite):
         field_a += 1
 
 
+class TestRuntimeIfNestedWhile(gt_testing.StencilTestSuite):
+    """Test conditional while statements."""
+
+    dtypes = (np.float_,)
+    domain_range = [(1, 15), (1, 15), (1, 15)]
+    backends = ALL_BACKENDS
+    symbols = dict(
+        infield=gt_testing.field(in_range=(-1, 1), boundary=[(0, 0), (0, 0), (0, 0)]),
+        outfield=gt_testing.field(in_range=(-10, 10), boundary=[(0, 0), (0, 0), (0, 0)]),
+    )
+
+    def definition(infield, outfield):
+        with computation(PARALLEL), interval(...):
+            if infield < 10:
+                outfield = 1
+                done = False
+                while not done:
+                    outfield = 2
+                    done = True
+            else:
+                condition = True
+                while condition:
+                    outfield = 4
+                    condition = False
+                outfield = 3
+
+    def validation(infield, outfield, *, domain, origin, **kwargs):
+        outfield[...] = 2
+
+
 class TestTernaryOp(gt_testing.StencilTestSuite):
     dtypes = (np.float_,)
     domain_range = [(1, 15), (2, 15), (1, 15)]


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

This is a follow-up from PR https://github.com/GridTools/gt4py/pull/1630. It combines two things

1. In `oir_to_npir`, we fix conditional `while` loops in `numpy` backend. After PR 1630 these were stuck under certain conditions. Tests coverage extended.
2. In `gtir_to_oir`, we cleaned up the now unused `mask` parameter, which was pre-PR 1630 needed to pass down the mask information. With PR 1630 we actually removed the need for that parameter to be passed along because we properly nest the nested statements.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
