### PR TITLE
test[cartesian]: Unskip blocked DaCe tests after DaCe upgrade

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -366,9 +366,6 @@ def test_input_order(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_variable_offsets(backend):
-    if backend == "dace:cpu":
-        pytest.skip("Internal compiler error in GitHub action container")
-
     @gtscript.stencil(backend=backend)
     def stencil_ij(
         in_field: gtscript.Field[np.float_],
@@ -391,9 +388,6 @@ def test_variable_offsets(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_variable_offsets_and_while_loop(backend):
-    if backend == "dace:cpu":
-        pytest.skip("Internal compiler error in GitHub action container")
-
     @gtscript.stencil(backend=backend)
     def stencil(
         pe1: gtscript.Field[np.float_],

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_suites.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_suites.py
@@ -738,29 +738,10 @@ class TestReadOutsideKInterval3(gt_testing.StencilTestSuite):
         field_out[:, :, 0] = field_in[:, :, 0]
 
 
-def _skip_dace_cpu_gcc_error(backends):
-    paramtype = type(pytest.param())
-    res = []
-    for b in backends:
-        if isinstance(b, paramtype) and b.values[0] == "dace:cpu":
-            res.append(
-                pytest.param(
-                    *b.values,
-                    marks=[
-                        *b.marks,
-                        pytest.mark.skip("Internal compiler error in GitHub action container"),
-                    ],
-                )
-            )
-        else:
-            res.append(b)
-    return res
-
-
 class TestVariableKRead(gt_testing.StencilTestSuite):
     dtypes = {"field_in": np.float32, "field_out": np.float32, "index": np.int32}
     domain_range = [(2, 2), (2, 2), (2, 8)]
-    backends = _skip_dace_cpu_gcc_error(ALL_BACKENDS)
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(-10, 10), axes="IJK", boundary=[(0, 0), (0, 0), (0, 0)]
@@ -782,7 +763,7 @@ class TestVariableKRead(gt_testing.StencilTestSuite):
 class TestVariableKAndReadOutside(gt_testing.StencilTestSuite):
     dtypes = {"field_in": np.float64, "field_out": np.float64, "index": np.int32}
     domain_range = [(2, 2), (2, 2), (2, 8)]
-    backends = _skip_dace_cpu_gcc_error(ALL_BACKENDS)
+    backends = ALL_BACKENDS
     symbols = {
         "field_in": gt_testing.field(
             in_range=(0.1, 10), axes="IJK", boundary=[(0, 0), (0, 0), (1, 0)]


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

A couple of tests were skipped in the DaCe backend with issue https://github.com/GridTools/gt4py/issues/1084 because they were throwing compiler errors. Current versions of DaCe can handle these cases again. Re-enabling the test cases. CI confirms (so far) that there aren't any issues anymore.

/cc @FlorianDeconinck as discussed.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

