### PR TITLE
WIP: test[cartesian]: Treat warnigns as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ keywords = [
   'portable',
   'hpc'
 ]
-license = {file = 'LICENSE'}
+license = {file = 'LICENSE.txt'}
 name = 'gt4py'
 readme = 'README.md'
 requires-python = '>=3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ allowlist_externals =
     ldd
     rm
 commands =
-    python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "\
+    python -m pytest --cache-clear -Werror -v -n {env:NUM_PROCESSES:1} -m "\
             internal: not requires_dace \
             dace: requires_dace \
             cpu: and not requires_gpu \


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

In our on-going efforts to productize ndsl, treat warnings as errors in cartesian tests.

This was triggered by PR https://github.com/GridTools/gt4py/pull/1709, where the deprecation warning was only seen by chance and we weren't aware of changes in DaCe.

Two sources of warnings stand out from local testing

- [x] Fixed: license file wasn't configured correctly, which issued a warning in almost any test
- [ ] To be discussed: deprecation of `__INLINED` keyword in gt4py, see issues https://github.com/GridTools/gt4py/issues/1068 and https://github.com/GridTools/gt4py/issues/1012 for context and an initial discussion.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
