### PR TITLE
ci: use actions/checkout@v4 and actions/setup-python@v5

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: 'pip'
@@ -24,4 +24,4 @@ jobs:
           **/pyproject.toml
           **/constraints.txt
           **/requirements-dev.txt
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,7 +14,7 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install C++ libraries
       if: ${{ matrix.os == 'macos-latest' }}
       shell: bash

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -42,7 +42,7 @@ jobs:
         mv boost_1_76_0/boost boost/include/
         echo "BOOST_ROOT=${PWD}/boost" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Install pypa/build

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build Python distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         tox-factor: [internal, dace]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install boost
       shell: bash
       run: |

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -40,7 +40,7 @@ jobs:
         mv boost_1_76_0/boost boost/include/
         echo "BOOST_ROOT=${PWD}/boost" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         tox-factor: [internal, dace]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install boost
       shell: bash
       run: |

--- a/.github/workflows/test-eve.yml
+++ b/.github/workflows/test-eve.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/test-eve.yml
+++ b/.github/workflows/test-eve.yml
@@ -28,7 +28,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -27,7 +27,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install C++ libraries
       if: ${{ matrix.os == 'macos-latest' }}
       shell: bash

--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         sudo apt install libboost-dev
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -20,7 +20,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/test-storage.yml
+++ b/.github/workflows/test-storage.yml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-storage.yml
+++ b/.github/workflows/test-storage.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'


### PR DESCRIPTION
## Description

This PR updates the GitHub Actions (GHA) workflows to use `actions/checkout@v4` instead of `v3` (or `v2`  in the cartesian case) and `actions/setup-python@v5`. Development for `actions/checkout@v3` and `actions/setup-python@v4` stopped ~1 year ago and GH is currently enforcing newer node versions than the one that these actions were designed with, leading to the following warnings

![image](https://github.com/user-attachments/assets/52924274-a00c-451c-a5a3-810fba1e6b27)
_warnings in next workflows_

![image](https://github.com/user-attachments/assets/af7f0027-f6d1-4998-a28a-c76c13dcaebb)
_warnings in cartesian workflows_

`deploy_release` action was following `actions/checkout@master`. Was this on purpose? Happy to revert if so. Unless there's a good reason, I suggest to keep all actions pinned at ideally the same major version.

`pre-commit/action` was updated to keep its dependencies up to date and avoid transitive warnings similar to the ones above.

No changes made to currently disabled workflows, i.e. the ones under `.github/workflows/_disabled/`.

Parent: https://github.com/GEOS-ESM/SMT-Nebulae/issues/89

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  CI is running as before - just with fewer warnings.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
