### PR TITLE
tests: fix name of license file configured in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ keywords = [
   'portable',
   'hpc'
 ]
-license = {file = 'LICENSE'}
+license = {file = 'LICENSE.txt'}
 name = 'gt4py'
 readme = 'README.md'
 requires-python = '>=3.8'


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

The license file configured in `pyproject.toml` was missing the `*.txt` extension, leading to warnings in tests.

Parent: https://github.com/GEOS-ESM/SMT-Nebulae/issues/89

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Tested locally and the warning is now gone. CI still runs as before.
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A

