### PR TITLE
bug[next]: extract scalar value with correct dtype

### DIFF
--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -148,7 +148,7 @@ class NdArrayField(
             raise ValueError(
                 f"'as_scalar' is only valid on 0-dimensional 'Field's, got a {self.domain.ndim}-dimensional 'Field'."
             )
-        return self.ndarray.item()
+        return self.ndarray[()] if self.array_ns == np else cp.asnumpy(self.ndarray)[()]
 
     @property
     def codomain(self) -> type[core_defs.ScalarT]:

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -148,7 +148,8 @@ class NdArrayField(
             raise ValueError(
                 f"'as_scalar' is only valid on 0-dimensional 'Field's, got a {self.domain.ndim}-dimensional 'Field'."
             )
-        return self.ndarray[()] if self.array_ns == np else cp.asnumpy(self.ndarray)[()]
+        # note: `.item()` will return a Python type, therefore we use indexing with an empty tuple
+        return self.asnumpy()[()]  # type: ignore[return-value] # should be ensured by the 0-d check
 
     @property
     def codomain(self) -> type[core_defs.ScalarT]:

--- a/src/gt4py/next/program_processors/runners/dace_common/dace_backend.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/dace_backend.py
@@ -28,11 +28,7 @@ def _convert_arg(arg: Any, sdfg_param: str, use_field_canonical_representation: 
         return arg
     if len(arg.domain.dims) == 0:
         # Pass zero-dimensional fields as scalars.
-        # We need to extract the scalar value from the 0d numpy array without changing its type.
-        # Note that 'ndarray.item()' always transforms the numpy scalar to a python scalar,
-        # which may change its precision. To avoid this, we use here the empty tuple as index
-        # for 'ndarray.__getitem__()'.
-        return arg.ndarray[()]
+        return arg.as_scalar()
     # field domain offsets are not supported
     non_zero_offsets = [
         (dim, dim_range)

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -264,6 +264,16 @@ def test_binary_operations_with_intersection(binary_arithmetic_op, dims, expecte
     assert np.allclose(op_result.ndarray, expected_result)
 
 
+def test_as_scalar(nd_array_implementation):
+    testee = common._field(
+        nd_array_implementation.asarray(42.0, dtype=np.float32), domain=common.Domain()
+    )
+
+    result = testee.as_scalar()
+    assert result == 42.0
+    assert isinstance(result, np.float32)
+
+
 def product_nd_array_implementation_params():
     for xp1 in nd_array_field._nd_array_implementations:
         for xp2 in nd_array_field._nd_array_implementations:
@@ -639,7 +649,6 @@ def test_absolute_indexing_value_return():
 
     named_index = (NamedIndex(D0, 12), NamedIndex(D1, 6))
     assert isinstance(field, common.Field)
-    value = field[named_index]
 
     assert isinstance(value, common.Field)
     assert value.as_scalar() == 21

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -649,6 +649,7 @@ def test_absolute_indexing_value_return():
 
     named_index = (NamedIndex(D0, 12), NamedIndex(D1, 6))
     assert isinstance(field, common.Field)
+    value = field[named_index]
 
     assert isinstance(value, common.Field)
     assert value.as_scalar() == 21


### PR DESCRIPTION
credits to @egparedes for this pattern and realizing that `item()` decays to a python type.