### PR TITLE
fix[next]: Bugfix in dace-ITIR backend: use canonical name for field shape symbol

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/itir_to_sdfg.py
@@ -15,6 +15,7 @@ from dace.sdfg.state import LoopRegion
 import gt4py.eve as eve
 from gt4py.next import Dimension, DimensionKind
 from gt4py.next.common import Connectivity
+from gt4py.next.ffront import fbuiltins as gtx_fbuiltins
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir import Expr, FunCall, Literal, Sym, SymRef
 from gt4py.next.program_processors.runners.dace_common import utility as dace_utils
@@ -103,7 +104,7 @@ def _make_array_shape_and_strides(
     tuple(shape, strides)
         The output tuple fields are arrays of dace symbolic expressions.
     """
-    dtype = dace.int32
+    dtype = dace.dtype_to_typeclass(gtx_fbuiltins.IndexType)
     sorted_dims = dace_utils.get_sorted_dims(dims) if sort_dims else list(enumerate(dims))
     neighbor_tables = dace_utils.filter_connectivities(offset_provider)
     shape = [

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -14,6 +14,7 @@ import dace
 import gt4py.next.iterator.ir as itir
 from gt4py import eve
 from gt4py.next.common import Connectivity
+from gt4py.next.ffront import fbuiltins as gtx_fbuiltins
 from gt4py.next.program_processors.runners.dace_common import utility as dace_utils
 
 
@@ -132,7 +133,7 @@ def unique_var_name():
 
 
 def new_array_symbols(name: str, ndim: int) -> tuple[list[dace.symbol], list[dace.symbol]]:
-    dtype = dace.int64
+    dtype = dace.dtype_to_typeclass(gtx_fbuiltins.IndexType)
     shape = [dace.symbol(dace_utils.field_size_symbol_name(name, i), dtype) for i in range(ndim)]
     strides = [
         dace.symbol(dace_utils.field_stride_symbol_name(name, i), dtype) for i in range(ndim)

--- a/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_iterator/utility.py
@@ -133,8 +133,10 @@ def unique_var_name():
 
 def new_array_symbols(name: str, ndim: int) -> tuple[list[dace.symbol], list[dace.symbol]]:
     dtype = dace.int64
-    shape = [dace.symbol(unique_name(f"{name}_shape{i}"), dtype) for i in range(ndim)]
-    strides = [dace.symbol(unique_name(f"{name}_stride{i}"), dtype) for i in range(ndim)]
+    shape = [dace.symbol(dace_utils.field_size_symbol_name(name, i), dtype) for i in range(ndim)]
+    strides = [
+        dace.symbol(dace_utils.field_stride_symbol_name(name, i), dtype) for i in range(ndim)
+    ]
     return shape, strides
 
 


### PR DESCRIPTION
Shape and stride symbols are expected to match a canonical string pattern. This PR adopts the canonical pattern in ITIR dace backend.

Note: it solves an issue encountered in dace orchestration tests.