### PR TITLE
build: Bump gridtools-cpp to 2.3.7 in preparation of #1648

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
   ## version = re.search('ruff==([0-9\.]*)', open("constraints.txt").read())[1]
   ## print(f"rev: v{version}")
   ##]]]
-  rev: v0.7.2
+  rev: v0.7.3
   ##[[[end]]]
   hooks:
     # Run the linter.
@@ -97,14 +97,14 @@ repos:
     - boltons==24.1.0
     - cached-property==2.0.1
     - click==8.1.7
-    - cmake==3.30.5
+    - cmake==3.31.0.1
     - cytoolz==1.0.0
     - deepdiff==8.0.1
     - devtools==0.12.2
     - diskcache==5.6.3
     - factory-boy==3.3.1
     - frozendict==2.4.6
-    - gridtools-cpp==2.3.6
+    - gridtools-cpp==2.3.7
     - importlib-resources==6.4.5
     - jinja2==3.1.4
     - lark==1.2.2
@@ -112,7 +112,7 @@ repos:
     - nanobind==2.2.0
     - ninja==1.11.1.1
     - numpy==1.24.4
-    - packaging==24.1
+    - packaging==24.2
     - pybind11==2.13.6
     - setuptools==75.3.0
     - tabulate==0.9.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -25,7 +25,7 @@ chardet==5.2.0            # via tox
 charset-normalizer==3.4.0  # via requests
 clang-format==19.1.3      # via -r requirements-dev.in, gt4py (pyproject.toml)
 click==8.1.7              # via black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
-cmake==3.30.5             # via gt4py (pyproject.toml)
+cmake==3.31.0.1           # via gt4py (pyproject.toml)
 cogapp==3.4.1             # via -r requirements-dev.in
 colorama==0.4.6           # via tox
 comm==0.2.2               # via ipykernel
@@ -35,7 +35,7 @@ cycler==0.12.1            # via matplotlib
 cytoolz==1.0.0            # via gt4py (pyproject.toml)
 dace==0.16.1              # via gt4py (pyproject.toml)
 darglint==1.8.1           # via -r requirements-dev.in
-debugpy==1.8.7            # via ipykernel
+debugpy==1.8.8            # via ipykernel
 decorator==5.1.1          # via ipython
 deepdiff==8.0.1           # via gt4py (pyproject.toml)
 devtools==0.12.2          # via gt4py (pyproject.toml)
@@ -55,7 +55,7 @@ fparser==0.1.4            # via dace
 frozendict==2.4.6         # via gt4py (pyproject.toml)
 gitdb==4.0.11             # via gitpython
 gitpython==3.1.43         # via tach
-gridtools-cpp==2.3.6      # via gt4py (pyproject.toml)
+gridtools-cpp==2.3.7      # via gt4py (pyproject.toml)
 hypothesis==6.113.0       # via -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.6.1           # via pre-commit
 idna==3.10                # via requests
@@ -66,7 +66,7 @@ inflection==0.5.1         # via pytest-factoryboy
 iniconfig==2.0.0          # via pytest
 ipykernel==6.29.5         # via nbmake
 ipython==8.12.3           # via ipykernel
-jedi==0.19.1              # via ipython
+jedi==0.19.2              # via ipython
 jinja2==3.1.4             # via dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.23.0        # via nbformat
 jsonschema-specifications==2023.12.1  # via jsonschema
@@ -95,7 +95,7 @@ ninja==1.11.1.1           # via gt4py (pyproject.toml)
 nodeenv==1.9.1            # via pre-commit
 numpy==1.24.4             # via contourpy, dace, gt4py (pyproject.toml), matplotlib, scipy
 orderly-set==5.2.2        # via deepdiff
-packaging==24.1           # via black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
+packaging==24.2           # via black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
 parso==0.8.4              # via jedi
 pathspec==0.12.1          # via black
 pexpect==4.9.0            # via ipython
@@ -139,7 +139,7 @@ requests==2.32.3          # via sphinx
 rich==13.9.4              # via bump-my-version, rich-click, tach
 rich-click==1.8.3         # via bump-my-version
 rpds-py==0.20.1           # via jsonschema, referencing
-ruff==0.7.2               # via -r requirements-dev.in
+ruff==0.7.3               # via -r requirements-dev.in
 scipy==1.10.1             # via gt4py (pyproject.toml)
 setuptools-scm==8.1.0     # via fparser
 six==1.16.0               # via asttokens, astunparse, python-dateutil
@@ -159,7 +159,7 @@ stack-data==0.6.3         # via ipython
 stdlib-list==0.10.0       # via tach
 sympy==1.12.1             # via dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via gt4py (pyproject.toml)
-tach==0.14.2              # via -r requirements-dev.in
+tach==0.14.3              # via -r requirements-dev.in
 tomli==2.0.2 ; python_version < "3.11"  # via -r requirements-dev.in, black, build, coverage, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tach, tox
 tomli-w==1.0.0            # via tach
 tomlkit==0.13.2           # via bump-my-version
@@ -174,7 +174,7 @@ virtualenv==20.27.1       # via pre-commit, tox
 wcmatch==10.0             # via bump-my-version
 wcwidth==0.2.13           # via prompt-toolkit
 websockets==13.1          # via dace
-wheel==0.44.0             # via astunparse, pip-tools
+wheel==0.45.0             # via astunparse, pip-tools
 xxhash==3.0.0             # via gt4py (pyproject.toml)
 zipp==3.20.2              # via importlib-metadata, importlib-resources
 

--- a/min-extra-requirements-test.txt
+++ b/min-extra-requirements-test.txt
@@ -68,7 +68,7 @@ devtools==0.6
 diskcache==5.6.3
 factory-boy==3.3.0
 frozendict==2.3
-gridtools-cpp==2.3.6
+gridtools-cpp==2.3.7
 hypothesis==6.0.0
 importlib-resources==5.0; python_version < "3.9"
 jax[cpu]==0.4.18; python_version >= "3.10"

--- a/min-requirements-test.txt
+++ b/min-requirements-test.txt
@@ -64,7 +64,7 @@ devtools==0.6
 diskcache==5.6.3
 factory-boy==3.3.0
 frozendict==2.3
-gridtools-cpp==2.3.6
+gridtools-cpp==2.3.7
 hypothesis==6.0.0
 importlib-resources==5.0; python_version < "3.9"
 jinja2==3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   'diskcache>=5.6.3',
   'factory-boy>=3.3.0',
   'frozendict>=2.3',
-  'gridtools-cpp>=2.3.6,==2.*',
+  'gridtools-cpp>=2.3.7,==2.*',
   "importlib-resources>=5.0;python_version<'3.9'",
   'jinja2>=3.0.0',
   'lark>=1.1.2',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ chardet==5.2.0            # via -c constraints.txt, tox
 charset-normalizer==3.4.0  # via -c constraints.txt, requests
 clang-format==19.1.3      # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
 click==8.1.7              # via -c constraints.txt, black, bump-my-version, gt4py (pyproject.toml), pip-tools, rich-click
-cmake==3.30.5             # via -c constraints.txt, gt4py (pyproject.toml)
+cmake==3.31.0.1           # via -c constraints.txt, gt4py (pyproject.toml)
 cogapp==3.4.1             # via -c constraints.txt, -r requirements-dev.in
 colorama==0.4.6           # via -c constraints.txt, tox
 comm==0.2.2               # via -c constraints.txt, ipykernel
@@ -35,7 +35,7 @@ cycler==0.12.1            # via -c constraints.txt, matplotlib
 cytoolz==1.0.0            # via -c constraints.txt, gt4py (pyproject.toml)
 dace==0.16.1              # via -c constraints.txt, gt4py (pyproject.toml)
 darglint==1.8.1           # via -c constraints.txt, -r requirements-dev.in
-debugpy==1.8.7            # via -c constraints.txt, ipykernel
+debugpy==1.8.8            # via -c constraints.txt, ipykernel
 decorator==5.1.1          # via -c constraints.txt, ipython
 deepdiff==8.0.1           # via -c constraints.txt, gt4py (pyproject.toml)
 devtools==0.12.2          # via -c constraints.txt, gt4py (pyproject.toml)
@@ -55,7 +55,7 @@ fparser==0.1.4            # via -c constraints.txt, dace
 frozendict==2.4.6         # via -c constraints.txt, gt4py (pyproject.toml)
 gitdb==4.0.11             # via -c constraints.txt, gitpython
 gitpython==3.1.43         # via -c constraints.txt, tach
-gridtools-cpp==2.3.6      # via -c constraints.txt, gt4py (pyproject.toml)
+gridtools-cpp==2.3.7      # via -c constraints.txt, gt4py (pyproject.toml)
 hypothesis==6.113.0       # via -c constraints.txt, -r requirements-dev.in, gt4py (pyproject.toml)
 identify==2.6.1           # via -c constraints.txt, pre-commit
 idna==3.10                # via -c constraints.txt, requests
@@ -66,7 +66,7 @@ inflection==0.5.1         # via -c constraints.txt, pytest-factoryboy
 iniconfig==2.0.0          # via -c constraints.txt, pytest
 ipykernel==6.29.5         # via -c constraints.txt, nbmake
 ipython==8.12.3           # via -c constraints.txt, ipykernel
-jedi==0.19.1              # via -c constraints.txt, ipython
+jedi==0.19.2              # via -c constraints.txt, ipython
 jinja2==3.1.4             # via -c constraints.txt, dace, gt4py (pyproject.toml), sphinx
 jsonschema==4.23.0        # via -c constraints.txt, nbformat
 jsonschema-specifications==2023.12.1  # via -c constraints.txt, jsonschema
@@ -95,7 +95,7 @@ ninja==1.11.1.1           # via -c constraints.txt, gt4py (pyproject.toml)
 nodeenv==1.9.1            # via -c constraints.txt, pre-commit
 numpy==1.24.4             # via -c constraints.txt, contourpy, dace, gt4py (pyproject.toml), matplotlib
 orderly-set==5.2.2        # via -c constraints.txt, deepdiff
-packaging==24.1           # via -c constraints.txt, black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
+packaging==24.2           # via -c constraints.txt, black, build, gt4py (pyproject.toml), ipykernel, jupytext, matplotlib, pipdeptree, pyproject-api, pytest, pytest-factoryboy, setuptools-scm, sphinx, tox
 parso==0.8.4              # via -c constraints.txt, jedi
 pathspec==0.12.1          # via -c constraints.txt, black
 pexpect==4.9.0            # via -c constraints.txt, ipython
@@ -139,7 +139,7 @@ requests==2.32.3          # via -c constraints.txt, sphinx
 rich==13.9.4              # via -c constraints.txt, bump-my-version, rich-click, tach
 rich-click==1.8.3         # via -c constraints.txt, bump-my-version
 rpds-py==0.20.1           # via -c constraints.txt, jsonschema, referencing
-ruff==0.7.2               # via -c constraints.txt, -r requirements-dev.in
+ruff==0.7.3               # via -c constraints.txt, -r requirements-dev.in
 setuptools-scm==8.1.0     # via -c constraints.txt, fparser
 six==1.16.0               # via -c constraints.txt, asttokens, astunparse, python-dateutil
 smmap==5.0.1              # via -c constraints.txt, gitdb
@@ -158,7 +158,7 @@ stack-data==0.6.3         # via -c constraints.txt, ipython
 stdlib-list==0.10.0       # via -c constraints.txt, tach
 sympy==1.12.1             # via -c constraints.txt, dace, gt4py (pyproject.toml)
 tabulate==0.9.0           # via -c constraints.txt, gt4py (pyproject.toml)
-tach==0.14.2              # via -c constraints.txt, -r requirements-dev.in
+tach==0.14.3              # via -c constraints.txt, -r requirements-dev.in
 tomli==2.0.2 ; python_version < "3.11"  # via -c constraints.txt, -r requirements-dev.in, black, build, coverage, jupytext, mypy, pip-tools, pyproject-api, pytest, setuptools-scm, tach, tox
 tomli-w==1.0.0            # via -c constraints.txt, tach
 tomlkit==0.13.2           # via -c constraints.txt, bump-my-version
@@ -173,7 +173,7 @@ virtualenv==20.27.1       # via -c constraints.txt, pre-commit, tox
 wcmatch==10.0             # via -c constraints.txt, bump-my-version
 wcwidth==0.2.13           # via -c constraints.txt, prompt-toolkit
 websockets==13.1          # via -c constraints.txt, dace
-wheel==0.44.0             # via -c constraints.txt, astunparse, pip-tools
+wheel==0.45.0             # via -c constraints.txt, astunparse, pip-tools
 xxhash==3.0.0             # via -c constraints.txt, gt4py (pyproject.toml)
 zipp==3.20.2              # via -c constraints.txt, importlib-metadata, importlib-resources
 


### PR DESCRIPTION
#1648 exposed a compilation problem with nvcc which has been fixed in https://github.com/GridTools/gridtools/pull/1811 included in gridtools 2.3.7.