### PR TITLE
bug[next]: Fix ITIR program hash stability

### DIFF
--- a/src/gt4py/next/iterator/ir.py
+++ b/src/gt4py/next/iterator/ir.py
@@ -242,7 +242,9 @@ class Program(Node, ValidatedSymbolTableTrait):
     body: List[Stmt]
     implicit_domain: bool = False
 
-    _NODE_SYMBOLS_: ClassVar[List[Sym]] = [Sym(id=name) for name in GTIR_BUILTINS]
+    _NODE_SYMBOLS_: ClassVar[List[Sym]] = [
+        Sym(id=name) for name in sorted(GTIR_BUILTINS)
+    ]  # sorted for serialization stability
 
 
 # TODO(fthaler): just use hashable types in nodes (tuples instead of lists)


### PR DESCRIPTION
#1690 included a change to make the hash of an `itir.FencilDefinition` stable across multiple runs. This PR adopts the same change to an `itir.Program`,