### PR TITLE
style[cartesian]: readability improvements and more type hints

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -123,6 +123,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
             state.add_edge(
                 access_node, None, library_node, "__in_" + field, dace.Memlet(field, subset=subset)
             )
+
         for field in access_collection.write_fields():
             access_node = state.add_access(field, debuginfo=dace.DebugInfo(0))
             library_node.add_out_connector("__out_" + field)
@@ -130,8 +131,6 @@ class OirSDFGBuilder(eve.NodeVisitor):
             state.add_edge(
                 library_node, "__out_" + field, access_node, None, dace.Memlet(field, subset=subset)
             )
-
-        return
 
     def visit_Stencil(self, node: oir.Stencil, **kwargs):
         ctx = OirSDFGBuilder.SDFGContext(stencil=node)

--- a/src/gt4py/cartesian/gtc/dace/utils.py
+++ b/src/gt4py/cartesian/gtc/dace/utils.py
@@ -40,7 +40,7 @@ def array_dimensions(array: dace.data.Array):
     return dims
 
 
-def replace_strides(arrays, get_layout_map):
+def replace_strides(arrays: List[dace.data.Array], get_layout_map) -> Dict[str, str]:
     symbol_mapping = {}
     for array in arrays:
         dims = array_dimensions(array)

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -421,7 +421,7 @@ def test_nested_while_loop(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_mask_with_offset_written_in_conditional(backend):
-    @gtscript.stencil(backend, externals={"mord": 5})
+    @gtscript.stencil(backend)
     def stencil(outp: gtscript.Field[np.float_]):
         with computation(PARALLEL), interval(...):
             cond = True


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsytem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

This PR detaches a couple of cleanups in the dace backend from the [in-progress gt4py/dace bridge](https://github.com/GridTools/gt4py/compare/main...romanc:gt4py:romanc/bridge-on-top-of-cleanups): mostly readability improvements and some easy type hints. There's also the occasional unused variable / argument in here.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A: mypy is happy with the new type hints
- [ ] Important design decisions have been documented in the approriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A

/cc @twicki @FlorianDeconinck I've been reading more code "outside my comfort zone" today leading to this small cleanup PR