### PR TITLE
feat[next]: Change interval syntax in ITIR pretty printer

### DIFF
--- a/src/gt4py/next/iterator/ir_utils/ir_makers.py
+++ b/src/gt4py/next/iterator/ir_utils/ir_makers.py
@@ -423,11 +423,11 @@ def domain(
     ...         },
     ...     )
     ... )
-    'c⟨ IDimₕ: [0, 10), JDimₕ: [0, 20) ⟩'
+    'c⟨ IDimₕ: [0, 10[, JDimₕ: [0, 20[ ⟩'
     >>> str(domain(common.GridType.CARTESIAN, {"IDim": (0, 10), "JDim": (0, 20)}))
-    'c⟨ IDimₕ: [0, 10), JDimₕ: [0, 20) ⟩'
+    'c⟨ IDimₕ: [0, 10[, JDimₕ: [0, 20[ ⟩'
     >>> str(domain(common.GridType.UNSTRUCTURED, {"IDim": (0, 10), "JDim": (0, 20)}))
-    'u⟨ IDimₕ: [0, 10), JDimₕ: [0, 20) ⟩'
+    'u⟨ IDimₕ: [0, 10[, JDimₕ: [0, 20[ ⟩'
     """
     if isinstance(grid_type, common.GridType):
         grid_type = f"{grid_type!s}_domain"

--- a/src/gt4py/next/iterator/pretty_parser.py
+++ b/src/gt4py/next/iterator/pretty_parser.py
@@ -84,7 +84,7 @@ GRAMMAR = """
     else_branch_seperator: "else"
     if_stmt: "if" "(" prec0 ")" "{" ( stmt )* "}" else_branch_seperator "{" ( stmt )* "}"
 
-    named_range: AXIS_LITERAL ":" "[" prec0 "," prec0 ")"
+    named_range: AXIS_LITERAL ":" "[" prec0 "," prec0 "["
     function_definition: ID_NAME "=" "λ(" ( SYM "," )* SYM? ")" "→" prec0 ";"
     declaration: ID_NAME "=" "temporary(" "domain=" prec0 "," "dtype=" TYPE_LITERAL ")" ";"
     stencil_closure: prec0 "←" "(" prec0 ")" "(" ( SYM_REF ", " )* SYM_REF ")" "@" prec0 ";"

--- a/src/gt4py/next/iterator/pretty_printer.py
+++ b/src/gt4py/next/iterator/pretty_printer.py
@@ -190,7 +190,7 @@ class PrettyPrinter(NodeTranslator):
             if fun_name == "named_range" and len(node.args) == 3:
                 # named_range(dim, start, stop) → dim: [star, stop)
                 dim, start, end = self.visit(node.args, prec=0)
-                res = self._hmerge(dim, [": ["], start, [", "], end, [")"])
+                res = self._hmerge(dim, [": ["], start, [", "], end, ["["])  # to get matching parenthesis of functions
                 return self._prec_parens(res, prec, PRECEDENCE["__call__"])
             if fun_name == "cartesian_domain" and len(node.args) >= 1:
                 # cartesian_domain(x, y, ...) → c{ x × y × ... } # noqa: RUF003 [ambiguous-unicode-character-comment]

--- a/src/gt4py/next/iterator/pretty_printer.py
+++ b/src/gt4py/next/iterator/pretty_printer.py
@@ -190,7 +190,9 @@ class PrettyPrinter(NodeTranslator):
             if fun_name == "named_range" and len(node.args) == 3:
                 # named_range(dim, start, stop) → dim: [star, stop)
                 dim, start, end = self.visit(node.args, prec=0)
-                res = self._hmerge(dim, [": ["], start, [", "], end, ["["])  # to get matching parenthesis of functions
+                res = self._hmerge(
+                    dim, [": ["], start, [", "], end, ["["]
+                )  # to get matching parenthesis of functions
                 return self._prec_parens(res, prec, PRECEDENCE["__call__"])
             if fun_name == "cartesian_domain" and len(node.args) >= 1:
                 # cartesian_domain(x, y, ...) → c{ x × y × ... } # noqa: RUF003 [ambiguous-unicode-character-comment]

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -85,8 +85,8 @@ class FuseAsFieldOp(eve.NodeTranslator):
     ...     im.ref("inp3", field_type),
     ... )
     >>> print(nested_as_fieldop)
-    as_fieldop(λ(__arg0, __arg1) → ·__arg0 + ·__arg1, c⟨ IDimₕ: [0, 1) ⟩)(
-      as_fieldop(λ(__arg0, __arg1) → ·__arg0 × ·__arg1, c⟨ IDimₕ: [0, 1) ⟩)(inp1, inp2), inp3
+    as_fieldop(λ(__arg0, __arg1) → ·__arg0 + ·__arg1, c⟨ IDimₕ: [0, 1[ ⟩)(
+      as_fieldop(λ(__arg0, __arg1) → ·__arg0 × ·__arg1, c⟨ IDimₕ: [0, 1[ ⟩)(inp1, inp2), inp3
     )
     >>> print(
     ...     FuseAsFieldOp.apply(

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -93,7 +93,7 @@ class FuseAsFieldOp(eve.NodeTranslator):
     ...         nested_as_fieldop, offset_provider_type={}, allow_undeclared_symbols=True
     ...     )
     ... )
-    as_fieldop(λ(inp1, inp2, inp3) → ·inp1 × ·inp2 + ·inp3, c⟨ IDimₕ: [0, 1) ⟩)(inp1, inp2, inp3)
+    as_fieldop(λ(inp1, inp2, inp3) → ·inp1 × ·inp2 + ·inp3, c⟨ IDimₕ: [0, 1[ ⟩)(inp1, inp2, inp3)
     """  # noqa: RUF002  # ignore ambiguous multiplication character
 
     uids: eve_utils.UIDGenerator

--- a/src/gt4py/next/iterator/transforms/inline_fundefs.py
+++ b/src/gt4py/next/iterator/transforms/inline_fundefs.py
@@ -59,7 +59,7 @@ def prune_unreferenced_fundefs(program: itir.Program) -> itir.Program:
     >>> print(prune_unreferenced_fundefs(program))
     testee(inp, out) {
       fun1 = λ(a) → ·a;
-      out @ c⟨ IDimₕ: [0, 10) ⟩ ← fun1(inp);
+      out @ c⟨ IDimₕ: [0, 10[ ⟩ ← fun1(inp);
     }
     """
     fun_names = [fun.id for fun in program.function_definitions]

--- a/tests/next_tests/unit_tests/iterator_tests/test_pretty_parser.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_pretty_parser.py
@@ -127,7 +127,7 @@ def test_make_tuple():
 
 
 def test_named_range_horizontal():
-    testee = "IDimₕ: [x, y)"
+    testee = "IDimₕ: [x, y["
     expected = ir.FunCall(
         fun=ir.SymRef(id="named_range"),
         args=[ir.AxisLiteral(value="IDim"), ir.SymRef(id="x"), ir.SymRef(id="y")],
@@ -137,7 +137,7 @@ def test_named_range_horizontal():
 
 
 def test_named_range_vertical():
-    testee = "IDimᵥ: [x, y)"
+    testee = "IDimᵥ: [x, y["
     expected = ir.FunCall(
         fun=ir.SymRef(id="named_range"),
         args=[

--- a/tests/next_tests/unit_tests/iterator_tests/test_pretty_printer.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_pretty_printer.py
@@ -233,7 +233,7 @@ def test_named_range_horizontal():
         fun=ir.SymRef(id="named_range"),
         args=[ir.AxisLiteral(value="IDim"), ir.SymRef(id="x"), ir.SymRef(id="y")],
     )
-    expected = "IDimₕ: [x, y)"
+    expected = "IDimₕ: [x, y["
     actual = pformat(testee)
     assert actual == expected
 


### PR DESCRIPTION
We currently use `)` in the pretty printer to express an open interval. This is quite cumbersome when debugging the IR because it breaks matching parenthesis in the editor of functions and calls, e.g. when does a function start and end.  This PR simply uses `[` instead.