### PR TITLE
test[next]: Disable iterator tests on DaCe GTIR backend

### DIFF
--- a/tests/next_tests/unit_tests/conftest.py
+++ b/tests/next_tests/unit_tests/conftest.py
@@ -60,15 +60,6 @@ program_processor = pytest.fixture(
         (next_tests.definitions.ProgramFormatterId.LISP_FORMATTER, False),
         (next_tests.definitions.ProgramFormatterId.ITIR_PRETTY_PRINTER, False),
         (next_tests.definitions.ProgramFormatterId.GTFN_CPP_FORMATTER, False),
-        pytest.param(
-            (next_tests.definitions.OptionalProgramBackendId.DACE_CPU, True),
-            marks=pytest.mark.requires_dace,
-        ),
-        # TODO(havogt): update tests to use proper allocation
-        # pytest.param(
-        #     (next_tests.definitions.OptionalProgramBackendId.DACE_GPU, True),
-        #     marks=(pytest.mark.requires_dace, pytest.mark.requires_gpu),
-        # ),
     ],
     ids=lambda p: p[0].short_id() if p[0] is not None else "None",
 )


### PR DESCRIPTION
There are 2 places where the `program_processor` fixture used in tests is configured:
```
tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
tests/next_tests/unit_tests/conftest.py
```

and there are four DaCe backends:
```
    DACE_CPU = "gt4py.next.program_processors.runners.dace.run_dace_cpu"
    DACE_GPU = "gt4py.next.program_processors.runners.dace.run_dace_gpu"
    DACE_CPU_NO_OPT = "gt4py.next.program_processors.runners.dace.run_dace_cpu_noopt"
    DACE_GPU_NO_OPT = "gt4py.next.program_processors.runners.dace.run_dace_gpu_noopt"
```

The `DACE_CPU` and `DACE_GPU` backends will be the default backends, that also apply the DaCe optimization pipeline. However, these backends are disabled for now because we are awaiting #1639.

The `DACE_CPU_NO_OPT` and `DACE_GPU_NO_OPT` apply the lowering to SDFG but do not run the optimization pipeline. These backends are currently enabled in GT4Py tests.

However, we observed failures in some iterator tests controlled by the `program_processor` fixture in `tests/next_tests/unit_tests/conftest.py`, once `DACE_CPU` is enabled. In this PR, we are disabling such tests: we will address these issues in a separate PR.