### PR TITLE
[POC] ci: Leverage `base_python` to enforce python version running tox

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -107,7 +107,7 @@ jobs:
       run: |
         pyversion=${{ matrix.python-version }}
         pyversion_no_dot=${pyversion//./}
-        tox run -e ${pyversion_no_dot} -m test-${{ matrix.tox-module-factor }}-cpu
+        tox run -x testenv.base_python=py${pyversion_no_dot} -m test-${{ matrix.tox-module-factor }}-cpu
     - name: Notify slack
       if: ${{ failure() }}
       env:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -105,7 +105,9 @@ jobs:
         NUM_PROCESSES: auto
         ENV_REQUIREMENTS_FILE: ${{ matrix.requirements-file }}
       run: |
-        tox run --skip-missing-interpreters -m test-${{ matrix.tox-module-factor }}-cpu
+        pyversion=${{ matrix.python-version }}
+        pyversion_no_dot=${pyversion//./}
+        tox run -e ${pyversion_no_dot} -m test-${{ matrix.tox-module-factor }}-cpu
     - name: Notify slack
       if: ${{ failure() }}
       env:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
 
   ## COMMENTED OUT: only for testing CI action changes
-  # pull_request:
-  #   branches:
-  #   - main
+  pull_request:
+    branches:
+    - main
   ## END
 
 jobs:

--- a/tox.ini
+++ b/tox.ini
@@ -2,28 +2,16 @@
 requires =
     tox>=4.2
     virtualenv>20.2
-envlist =
-    cartesian-py{310}-{internal,dace}-{cpu}
-    eve-py{310}
-    next-py{310}-{nomesh,atlas}-{cpu}
-    storage-py{310}-{internal,dace}-{cpu}
-    # docs
 labels =
-    test-cartesian-cpu = cartesian-py38-internal-cpu, cartesian-internal-py39-cpu, \
-    cartesian-internal-py310-cpu, cartesian-py311-internal-cpu, \
-    cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu, cartesian-py311-dace-cpu
-    test-eve-cpu = eve-py38, eve-py39, eve-py310, eve-py311
-    test-next-cpu = next-py310-nomesh-cpu, next-py311-nomesh-cpu, next-py310-atlas-cpu, next-py311-atlas-cpu
-    test-storage-cpu = storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, storage-py311-internal-cpu, \
-    storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu, storage-py311-dace-cpu
-    test-cpu = cartesian-py38-internal-cpu, cartesian-py39-internal-cpu, cartesian-py310-internal-cpu, cartesian-py311-internal-cpu, \
-    cartesian-py38-dace-cpu, cartesian-py39-dace-cpu, cartesian-py310-dace-cpu, cartesian-py311-dace-cpu, \
-    eve-py38, eve-py39, eve-py310, eve-py311, \
-    next-py310-nomesh-cpu, next-py311-nomesh-cpu, next-py310-atlas-cpu, next-py311-atlas-cpu, \
-    storage-py38-internal-cpu, storage-py39-internal-cpu, storage-py310-internal-cpu, storage-py311-internal-cpu, \
-    storage-py38-dace-cpu, storage-py39-dace-cpu, storage-py310-dace-cpu, storage-py311-dace-cpu
+    test-bla = bla-bar, bla-foo
+    test-cartesian-cpu = cartesian-internal-cpu, cartesian-dace-cpu
+    test-eve-cpu = eve
+    test-next-cpu = next-nomesh-cpu, next-atlas-cpu
+    test-storage-cpu = storage-internal-cpu, storage-dace-cpu
+    test-cpu = cartesian-internal-cpu, cartesian-dace-cpu, eve, next-nomesh-cpu, next-atlas-cpu, storage-internal-cpu, storage-dace-cpu
 
 [testenv]
+base_python = py310
 deps = -r {tox_root}{/}{env:ENV_REQUIREMENTS_FILE:requirements-dev.txt}
 constrain_package_deps = true
 use_frozen_constraints = true
@@ -41,8 +29,13 @@ set_env =
     PYTEST_ADDOPTS = --color=auto --instafail
     PYTHONWARNINGS = {env:PYTHONWARNINGS:ignore:Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*:UserWarning,ignore:Field View Program:UserWarning}
 
+[testenv:bla-{foo,bar}]
+description = Run bla tests
+commands =
+    python --version
+
 # -- Primary tests --
-[testenv:cartesian-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
+[testenv:cartesian-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.cartesian' tests
 pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH, CXX, CC, OPENMP_CPPFLAGS, OPENMP_LDFLAGS, PIP_USER, PYTHONUSERBASE
 allowlist_externals =
@@ -65,13 +58,13 @@ commands =
 #     coverage json --rcfile=setup.cfg
 #     coverage html --rcfile=setup.cfg --show-contexts
 
-[testenv:eve-py{38,39,310,311}]
+[testenv:eve]
 description = Run 'gt4py.eve' tests
 commands =
     python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} {posargs} tests{/}eve_tests
     python -m pytest --doctest-modules src{/}gt4py{/}eve
 
-[testenv:next-py{310,311}-{nomesh,atlas}-{cpu,cuda,cuda11x,cuda12x}]
+[testenv:next-{nomesh,atlas}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.next' tests
 pass_env = {[testenv]pass_env}, BOOST_ROOT, BOOST_HOME, CUDA_HOME, CUDA_PATH
 deps =
@@ -89,7 +82,7 @@ commands =
         " {posargs} tests{/}next_tests
     pytest --doctest-modules src{/}gt4py{/}next
 
-[testenv:storage-py{38,39,310,311}-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
+[testenv:storage-{internal,dace}-{cpu,cuda,cuda11x,cuda12x}]
 description = Run 'gt4py.storage' tests
 commands =
     python -m pytest --cache-clear -v -n {env:NUM_PROCESSES:1} -m "\
@@ -99,7 +92,7 @@ commands =
     # pytest doctest-modules {posargs} src{/}gt4py{/}storage
 
 # -- Secondary tests --
-[testenv:notebooks-py{310,311}]
+[testenv:notebooks]
 description = Run notebooks
 commands_pre =
     jupytext docs/user/next/QuickstartGuide.md --to .ipynb
@@ -111,8 +104,8 @@ commands =
     python -m pytest --nbmake docs/user/next/advanced -v -n {env:NUM_PROCESSES:1}
     python -m pytest --nbmake examples -v -n {env:NUM_PROCESSES:1}
 
-# -- Other artefacts --
-[testenv:dev-py{38,39,310,311}{-atlas,}]
+# -- Other artifacts --
+[testenv:dev-atlas]
 description = Initialize development environment for gt4py
 deps =
     -r {tox_root}{/}requirements-dev.txt
@@ -144,10 +137,10 @@ set_env =
 [testenv:requirements-{base,py38,py39,py310,py311}]
 description =
     base: Update pinned development requirements
-    py38: Update requirements for testing a specific python version
-    py39: Update requirements for testing a specific python version
-    py310: Update requirements for testing a specific python version
-    py311: Update requirements for testing a specific python version
+    py38: Update requirements for testing with python version 3.8
+    py39: Update requirements for testing with python version 3.9
+    py310: Update requirements for testing with python version 3.10
+    py311: Update requirements for testing with python version 3.11
 base_python =
     base: py38
     py38: py38


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsystem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

POC: leverage `tox`' `base_python` setting to ensure we are running (on CI) with the expected python version.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
