### PR TITLE
ci: fix boost install in cartesian and daily ci plan

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -34,13 +34,6 @@ jobs:
       shell: bash
       run: |
         sudo apt install libboost-dev
-        wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz
-        echo 7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca boost_1_76_0.tar.gz > boost_hash.txt
-        sha256sum -c boost_hash.txt
-        tar xzf boost_1_76_0.tar.gz
-        mkdir -p boost/include
-        mv boost_1_76_0/boost boost/include/
-        echo "BOOST_ROOT=${PWD}/boost" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -29,16 +29,16 @@ jobs:
         tox-factor: [internal, dace]
     steps:
     - uses: actions/checkout@v4
-    - name: Install boost
+    - name: Install C++ libraries
+      if: ${{ matrix.os == 'macos-latest' }}
       shell: bash
       run: |
-        wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz
-        echo 7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca boost_1_76_0.tar.gz > boost_hash.txt
-        sha256sum -c boost_hash.txt
-        tar xzf boost_1_76_0.tar.gz
-        mkdir -p boost/include
-        mv boost_1_76_0/boost boost/include/
-        echo "BOOST_ROOT=${PWD}/boost" >> $GITHUB_ENV
+        brew install boost
+    - name: Install C++ libraries
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      shell: bash
+      run: |
+        sudo apt install libboost-dev
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -30,15 +30,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install C++ libraries
-      if: ${{ matrix.os == 'macos-latest' }}
-      shell: bash
-      run: |
-        brew install boost
-    - name: Install C++ libraries
       if: ${{ matrix.os == 'ubuntu-latest' }}
       shell: bash
       run: |
         sudo apt install libboost-dev
+        echo "BOOST_ROOT=/usr/include" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -35,6 +35,8 @@ jobs:
       run: |
         sudo apt install libboost-dev
         echo "BOOST_ROOT=/usr/include" >> $GITHUB_ENV
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -30,13 +30,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install C++ libraries
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       shell: bash
       run: |
         sudo apt install libboost-dev
-        echo "BOOST_ROOT=/usr/include" >> $GITHUB_ENV
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Boost download link expired, but actually no custom boost (header) installation is required.