### PR TITLE
bug[next]: Fix propagated symbols order stability across runs

### DIFF
--- a/src/gt4py/next/ffront/field_operator_ast.py
+++ b/src/gt4py/next/ffront/field_operator_ast.py
@@ -180,7 +180,7 @@ class IfStmt(Stmt):
     @datamodels.root_validator
     @classmethod
     def _collect_common_symbols(cls: type[IfStmt], instance: IfStmt) -> None:
-        common_symbol_names = (
+        common_symbol_names = sorted(  # sort is required to get stable results across runs
             instance.true_branch.annex.symtable.keys() & instance.false_branch.annex.symtable.keys()
         )
         instance.annex.propagated_symbols = {


### PR DESCRIPTION
If statements in FOAST have a special `propagated_symbols` annex attributed that contains all symbols that are defined and hence available outside of the if. The compuation of these symbols is based on a set operation whose order is not stable across runs. This PR fixes that by sorting them. Since behavior changes across runs are hard to test and we don't have any facilities for that no test is provided.