### PR TITLE
fix[next][dace]: remove unused connectivities

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace_common/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/utility.py
@@ -18,12 +18,13 @@ from gt4py.next.iterator import ir as gtir
 from gt4py.next.type_system import type_specifications as ts
 
 
-# regex to match the symbols for field shape and strides
-FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile(r"__.+_(size|stride)_\d+")
-
-
 # arrays for connectivity tables use the following prefix
 CONNECTIVITY_INDENTIFIER_PREFIX: Final[str] = "connectivity_"
+CONNECTIVITY_INDENTIFIER_RE: Final[re.Pattern] = re.compile(r"^connectivity_(.+)$")
+
+
+# regex to match the symbols for field shape and strides
+FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile(r"__.+_(size|stride)_\d+")
 
 
 def as_dace_type(type_: ts.ScalarType) -> dace.typeclass:
@@ -55,11 +56,13 @@ def connectivity_identifier(name: str) -> str:
     return f"{CONNECTIVITY_INDENTIFIER_PREFIX}{name}"
 
 
-def is_connectivity(name: str, datadesc: dace.data.Data) -> bool:
-    is_array = isinstance(datadesc, dace.data.Array) and (
-        not isinstance(datadesc, (dace.data.ArrayReference, dace.data.ArrayView))
-    )
-    return is_array and name.startswith(CONNECTIVITY_INDENTIFIER_PREFIX)
+def is_connectivity_identifier(
+    name: str, offset_provider_type: gtx_common.OffsetProviderType
+) -> bool:
+    m = CONNECTIVITY_INDENTIFIER_RE.match(name)
+    if m is None:
+        return False
+    return m[1] in offset_provider_type
 
 
 def field_symbol_name(field_name: str, axis: int, sym: Literal["size", "stride"]) -> str:

--- a/src/gt4py/next/program_processors/runners/dace_common/utility.py
+++ b/src/gt4py/next/program_processors/runners/dace_common/utility.py
@@ -22,6 +22,10 @@ from gt4py.next.type_system import type_specifications as ts
 FIELD_SYMBOL_RE: Final[re.Pattern] = re.compile(r"__.+_(size|stride)_\d+")
 
 
+# arrays for connectivity tables use the following prefix
+CONNECTIVITY_INDENTIFIER_PREFIX: Final[str] = "connectivity_"
+
+
 def as_dace_type(type_: ts.ScalarType) -> dace.typeclass:
     """Converts GT4Py scalar type to corresponding DaCe type."""
     if type_.kind == ts.ScalarKind.BOOL:
@@ -48,7 +52,14 @@ def as_itir_type(dtype: dace.typeclass) -> ts.ScalarType:
 
 
 def connectivity_identifier(name: str) -> str:
-    return f"connectivity_{name}"
+    return f"{CONNECTIVITY_INDENTIFIER_PREFIX}{name}"
+
+
+def is_connectivity(name: str, datadesc: dace.data.Data) -> bool:
+    is_array = isinstance(datadesc, dace.data.Array) and (
+        not isinstance(datadesc, (dace.data.ArrayReference, dace.data.ArrayView))
+    )
+    return is_array and name.startswith(CONNECTIVITY_INDENTIFIER_PREFIX)
 
 
 def field_symbol_name(field_name: str, axis: int, sym: Literal["size", "stride"]) -> str:

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_dataflow.py
@@ -401,7 +401,7 @@ class LambdaToDataflow(eve.NodeVisitor):
                 view_shape = tuple(desc.shape[i] for i in local_dim_indices)
                 view_strides = tuple(desc.strides[i] for i in local_dim_indices)
             view, _ = self.sdfg.add_view(
-                f"{field.dc_node.data}_view",
+                f"view_{field.dc_node.data}",
                 view_shape,
                 desc.dtype,
                 strides=view_strides,

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
@@ -474,9 +474,11 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             unused_connectivities = [
                 data
                 for data, datadesc in nsdfg.arrays.items()
-                if dace_utils.is_connectivity(data, datadesc) and datadesc.transient
+                if dace_utils.is_connectivity_identifier(data, self.offset_provider_type)
+                and datadesc.transient
             ]
             for data in unused_connectivities:
+                assert isinstance(nsdfg.arrays[data], dace.data.Array)
                 nsdfg.arrays.pop(data)
 
         # Create the call signature for the SDFG.

--- a/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace_fieldview/gtir_sdfg.py
@@ -469,6 +469,16 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             head_state._debuginfo = dace_utils.debug_info(stmt, default=sdfg.debuginfo)
             head_state = self.visit(stmt, sdfg=sdfg, state=head_state)
 
+        # remove unused connectivity tables (by design, arrays are marked as non-transient when they are used)
+        for nsdfg in sdfg.all_sdfgs_recursive():
+            unused_connectivities = [
+                data
+                for data, datadesc in nsdfg.arrays.items()
+                if dace_utils.is_connectivity(data, datadesc) and datadesc.transient
+            ]
+            for data in unused_connectivities:
+                nsdfg.arrays.pop(data)
+
         # Create the call signature for the SDFG.
         #  Only the arguments required by the GT4Py program, i.e. `node.params`, are added
         #  as positional arguments. The implicit arguments, such as the offset providers or


### PR DESCRIPTION
By design, the arrays for connectivity tables are initially created as transient and marked as non-transient during the lowering when they are used. At the end of lowering to SDFG, the unused connectivities (still transient arrays) should be removed.