### PR TITLE
ci[cartesian]: disable test_K_offset_write on gt:gpu backend

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -583,7 +583,7 @@ def test_K_offset_write(backend):
     if backend == "cuda":
         pytest.skip("cuda K-offset write generates bad code")
 
-    if backend == "dace:gpu":
+    if backend in ["gt:gpu", "dace:gpu"]:
         pytest.skip(
             f"{backend} backend is not capable of K offset write, bug remains unsolved: https://github.com/GridTools/gt4py/issues/1684"
         )


### PR DESCRIPTION
Found other test failures related to #1684, see:
https://cicd-ext-mw.cscs.ch/ci/job/result/4525297225819146/42923301/8859517219?iid=10296 