### PR TITLE
ci: disable x86-targets (DaintXC) in CSCS CI-Ext

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -51,6 +51,7 @@ stages:
     CUPY_VERSION: 13.3.0
     UBUNTU_VERSION: 22.04
 
+# prefix the x86_64 config with dot in order to not execute it
 .build_py311_baseimage_x86_64:
   extends: .build_baseimage_x86_64
   variables:
@@ -60,6 +61,7 @@ build_py311_baseimage_aarch64:
   variables:
     <<: *py311
 
+# prefix the x86_64 config with dot in order to not execute it
 .build_py310_baseimage_x86_64:
   extends: .build_baseimage_x86_64
   variables:
@@ -83,6 +85,7 @@ build_py310_baseimage_aarch64:
 .build_image_aarch64:
   extends: [.container-builder-cscs-gh200, .build_image]
 
+# prefix the x86_64 config with dot in order to not execute it
 .build_py311_image_x86_64:
   extends: .build_image_x86_64
   needs: [build_py311_baseimage_x86_64]
@@ -94,6 +97,7 @@ build_py311_image_aarch64:
   variables:
     <<: *py311
 
+# prefix the x86_64 config with dot in order to not execute it
 .build_py310_image_x86_64:
   extends: .build_image_x86_64
   needs: [build_py310_baseimage_x86_64]
@@ -149,6 +153,7 @@ build_py310_image_aarch64:
     # when high test parallelism is used.
     NUM_PROCESSES: 16
 
+# prefix the x86_64 config with dot in order to not execute it
 .test_py311_x86_64:
   extends: [.test_helper_x86_64]
   needs: [build_py311_image_x86_64]
@@ -160,6 +165,7 @@ test_py311_aarch64:
   variables:
     <<: *py311
 
+# prefix the x86_64 config with dot in order to not execute it
 .test_py310_x86_64:
   extends: [.test_helper_x86_64]
   needs: [build_py310_image_x86_64]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -51,7 +51,7 @@ stages:
     CUPY_VERSION: 13.3.0
     UBUNTU_VERSION: 22.04
 
-build_py311_baseimage_x86_64:
+.build_py311_baseimage_x86_64:
   extends: .build_baseimage_x86_64
   variables:
     <<: *py311
@@ -60,7 +60,7 @@ build_py311_baseimage_aarch64:
   variables:
     <<: *py311
 
-build_py310_baseimage_x86_64:
+.build_py310_baseimage_x86_64:
   extends: .build_baseimage_x86_64
   variables:
     <<: *py310
@@ -83,7 +83,7 @@ build_py310_baseimage_aarch64:
 .build_image_aarch64:
   extends: [.container-builder-cscs-gh200, .build_image]
 
-build_py311_image_x86_64:
+.build_py311_image_x86_64:
   extends: .build_image_x86_64
   needs: [build_py311_baseimage_x86_64]
   variables:
@@ -94,7 +94,7 @@ build_py311_image_aarch64:
   variables:
     <<: *py311
 
-build_py310_image_x86_64:
+.build_py310_image_x86_64:
   extends: .build_image_x86_64
   needs: [build_py310_baseimage_x86_64]
   variables:
@@ -149,7 +149,7 @@ build_py310_image_aarch64:
     # when high test parallelism is used.
     NUM_PROCESSES: 16
 
-test_py311_x86_64:
+.test_py311_x86_64:
   extends: [.test_helper_x86_64]
   needs: [build_py311_image_x86_64]
   variables:
@@ -160,7 +160,7 @@ test_py311_aarch64:
   variables:
     <<: *py311
 
-test_py310_x86_64:
+.test_py310_x86_64:
   extends: [.test_helper_x86_64]
   needs: [build_py310_image_x86_64]
   variables:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -51,21 +51,19 @@ stages:
     CUPY_VERSION: 13.3.0
     UBUNTU_VERSION: 22.04
 
-# prefix the x86_64 config with dot in order to not execute it
-.build_py311_baseimage_x86_64:
-  extends: .build_baseimage_x86_64
-  variables:
-    <<: *py311
+# build_py311_baseimage_x86_64:
+#   extends: .build_baseimage_x86_64
+#   variables:
+#     <<: *py311
 build_py311_baseimage_aarch64:
   extends: .build_baseimage_aarch64
   variables:
     <<: *py311
 
-# prefix the x86_64 config with dot in order to not execute it
-.build_py310_baseimage_x86_64:
-  extends: .build_baseimage_x86_64
-  variables:
-    <<: *py310
+# build_py310_baseimage_x86_64:
+#   extends: .build_baseimage_x86_64
+#   variables:
+#     <<: *py310
 build_py310_baseimage_aarch64:
   extends: .build_baseimage_aarch64
   variables:
@@ -85,24 +83,22 @@ build_py310_baseimage_aarch64:
 .build_image_aarch64:
   extends: [.container-builder-cscs-gh200, .build_image]
 
-# prefix the x86_64 config with dot in order to not execute it
-.build_py311_image_x86_64:
-  extends: .build_image_x86_64
-  needs: [build_py311_baseimage_x86_64]
-  variables:
-    <<: *py311
+# build_py311_image_x86_64:
+#   extends: .build_image_x86_64
+#   needs: [build_py311_baseimage_x86_64]
+#   variables:
+#     <<: *py311
 build_py311_image_aarch64:
   extends: .build_image_aarch64
   needs: [build_py311_baseimage_aarch64]
   variables:
     <<: *py311
 
-# prefix the x86_64 config with dot in order to not execute it
-.build_py310_image_x86_64:
-  extends: .build_image_x86_64
-  needs: [build_py310_baseimage_x86_64]
-  variables:
-    <<: *py310
+# build_py310_image_x86_64:
+#   extends: .build_image_x86_64
+#   needs: [build_py310_baseimage_x86_64]
+#   variables:
+#     <<: *py310
 build_py310_image_aarch64:
   extends: .build_image_aarch64
   needs: [build_py310_baseimage_aarch64]
@@ -153,24 +149,22 @@ build_py310_image_aarch64:
     # when high test parallelism is used.
     NUM_PROCESSES: 16
 
-# prefix the x86_64 config with dot in order to not execute it
-.test_py311_x86_64:
-  extends: [.test_helper_x86_64]
-  needs: [build_py311_image_x86_64]
-  variables:
-    <<: *py311
+# test_py311_x86_64:
+#   extends: [.test_helper_x86_64]
+#   needs: [build_py311_image_x86_64]
+#   variables:
+#     <<: *py311
 test_py311_aarch64:
   extends: [.test_helper_aarch64]
   needs: [build_py311_image_aarch64]
   variables:
     <<: *py311
 
-# prefix the x86_64 config with dot in order to not execute it
-.test_py310_x86_64:
-  extends: [.test_helper_x86_64]
-  needs: [build_py310_image_x86_64]
-  variables:
-    <<: *py310
+# test_py310_x86_64:
+#   extends: [.test_helper_x86_64]
+#   needs: [build_py310_image_x86_64]
+#   variables:
+#     <<: *py310
 test_py310_aarch64:
   extends: [.test_helper_aarch64]
   needs: [build_py310_image_aarch64]


### PR DESCRIPTION
Disable x86-targets (DaintXC) in CSCS CI-Ext, since DaintXC has been decommissioned.
We only disable but still keep the x86 configuration in case in future we need to set it up on a Alps vCluster.