### PR TITLE
style[cartesian]: Remove unused optional keyword arguments

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
@@ -417,7 +417,6 @@ class DaCeIRBuilder(eve.NodeTranslator):
         global_ctx: DaCeIRBuilder.GlobalContext,
         iteration_ctx: DaCeIRBuilder.IterationContext,
         symbol_collector: DaCeIRBuilder.SymbolCollector,
-        loop_order,
         k_interval,
         **kwargs: Any,
     ):
@@ -723,7 +722,6 @@ class DaCeIRBuilder(eve.NodeTranslator):
         scope_nodes,
         item: Loop,
         *,
-        global_ctx: DaCeIRBuilder.GlobalContext,
         iteration_ctx: DaCeIRBuilder.IterationContext,
         symbol_collector: DaCeIRBuilder.SymbolCollector,
         **kwargs: Any,

--- a/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
@@ -521,7 +521,6 @@ class DaCeIRBuilder(eve.NodeTranslator):
         self,
         node: oir.VerticalLoopSection,
         *,
-        loop_order,
         iteration_ctx: DaCeIRBuilder.IterationContext,
         global_ctx: DaCeIRBuilder.GlobalContext,
         symbol_collector: DaCeIRBuilder.SymbolCollector,
@@ -545,7 +544,6 @@ class DaCeIRBuilder(eve.NodeTranslator):
             iteration_ctx=iteration_ctx,
             global_ctx=global_ctx,
             symbol_collector=symbol_collector,
-            loop_order=loop_order,
             k_interval=node.interval,
             **kwargs,
         )
@@ -838,7 +836,6 @@ class DaCeIRBuilder(eve.NodeTranslator):
         sections = flatten_list(
             self.generic_visit(
                 node.sections,
-                loop_order=node.loop_order,
                 global_ctx=global_ctx,
                 iteration_ctx=iteration_ctx,
                 symbol_collector=symbol_collector,


### PR DESCRIPTION
## Description

These two keyword arguments aren't used in the function. Since the two functions have a "catch-all" `*kwargs` at the end of the argument list, we can safely delete the unused keyword arguments.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
`mypy` and/or existing tests would complain if these changes weren't appropriate
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
N/A
