### PR TITLE
test[cartesian]: Increased coverage for horizontal regions

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
@@ -13,6 +13,8 @@ from gt4py.cartesian.gtscript import (
     __INLINED,
     BACKWARD,
     FORWARD,
+    I,
+    J,
     PARALLEL,
     acos,
     acosh,
@@ -28,6 +30,7 @@ from gt4py.cartesian.gtscript import (
     exp,
     floor,
     gamma,
+    horizontal,
     interval,
     isfinite,
     isinf,
@@ -35,6 +38,7 @@ from gt4py.cartesian.gtscript import (
     log,
     log10,
     mod,
+    region,
     sin,
     sinh,
     sqrt,
@@ -402,3 +406,23 @@ def two_optional_fields(
             out_a = out_a + dt * phys_tend_a
         if __INLINED(PHYS_TEND_B):
             out_b = out_b + dt * phys_tend_b
+
+
+@register
+def horizontal_regions(field_in: Field3D, field_out: Field3D):
+    with computation(PARALLEL), interval(...):
+        with horizontal(region[I[0] : I[2], J[0] : J[2]], region[I[-3] : I[-1], J[-3] : J[-1]]):
+            field_out = field_in + 1.0
+
+        with horizontal(region[I[0] : I[2], J[-3] : J[-1]], region[I[-3] : I[-1], J[0] : J[2]]):
+            field_out = field_in - 1.0
+
+
+@register
+def horizontal_region_with_conditional(field_in: Field3D, field_out: Field3D):
+    with computation(PARALLEL), interval(...):
+        with horizontal(region[I[0] : I[2], J[0] : J[2]], region[I[-3] : I[-1], J[-3] : J[-1]]):
+            if field_in > 0:
+                field_out = field_in + 1.0
+            else:
+                field_out = 0


### PR DESCRIPTION
## Description

Working on the gt4py/dace bridge showed that code coverage for horizontal regions is low. In particular (code generation) tests for conditionals inside horizontal regions were missing.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
Added test cases.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
N/A
