### PR TITLE
style[cartesian]: fixing typos

### DIFF
--- a/src/gt4py/cartesian/backend/module_generator.py
+++ b/src/gt4py/cartesian/backend/module_generator.py
@@ -62,8 +62,6 @@ _args_data_cache: Dict[StencilID, ModuleData] = {}
 def make_args_data_from_gtir(pipeline: GtirPipeline) -> ModuleData:
     """
     Compute module data containing information about stencil arguments from gtir.
-
-    This is no longer compatible with the legacy backends.
     """
     if pipeline.stencil_id in _args_data_cache:
         return _args_data_cache[pipeline.stencil_id]
@@ -142,7 +140,7 @@ class BaseModuleGenerator(abc.ABC):
         """
         Generate source code for a Python module containing a StencilObject.
 
-        A possible reaosn for extending is processing additional kwargs,
+        A possible reason for extending is processing additional kwargs,
         using a different template might require completely overriding.
         """
         if builder:

--- a/src/gt4py/cartesian/caching.py
+++ b/src/gt4py/cartesian/caching.py
@@ -61,7 +61,7 @@ class CachingStrategy(abc.ABC):
         """
         Generate the cache info dict.
 
-        Backend specific additions can be added via a hook propery on the backend instance.
+        Backend specific additions can be added via a hook properly on the backend instance.
         Override :py:meth:`gt4py.backend.base.Backend.extra_cache_info` to store extra
         info.
         """

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -130,7 +130,6 @@ storing a reference to the piece of source code which originated the node.
                       parameters: List[VarDecl],
                       computations: List[ComputationBlock],
                       [externals: Dict[str, Any], sources: Dict[str, str]])
-
 """
 
 from __future__ import annotations

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -60,7 +60,7 @@ class AssignmentKind(eve.StrEnum):
 
 @enum.unique
 class UnaryOperator(eve.StrEnum):
-    """Unary operator indentifier."""
+    """Unary operator identifier."""
 
     POS = "+"
     NEG = "-"

--- a/src/gt4py/cartesian/gtc/cuir/cuir_codegen.py
+++ b/src/gt4py/cartesian/gtc/cuir/cuir_codegen.py
@@ -592,7 +592,7 @@ class CUIRCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
     @classmethod
     def apply(cls, root: LeafNode, **kwargs: Any) -> str:
         if not isinstance(root, cuir.Program):
-            raise ValueError("apply() requires gtcpp.Progam root node")
+            raise ValueError("apply() requires gtcpp.Program root node")
         generated_code = super().apply(root, **kwargs)
         if kwargs.get("format_source", True):
             generated_code = codegen.format_source("cpp", generated_code, style="LLVM")

--- a/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
@@ -74,7 +74,6 @@ class StencilComputationExpansion(dace.library.ExpandTransformation):
         * change connector names to match inner array name (before expansion prefixed to satisfy uniqueness)
         * change in- and out-edges' subsets so that they have the same shape as the corresponding array inside
         * determine the domain size based on edges to StencilComputation
-
         """
         # change connector names
         for in_edge in parent_state.in_edges(node):

--- a/src/gt4py/cartesian/gtc/definitions.py
+++ b/src/gt4py/cartesian/gtc/definitions.py
@@ -118,7 +118,7 @@ class NumericTuple(tuple):
         return self._apply(self._broadcast(other), operator.add)
 
     def __sub__(self, other):
-        """Element-wise substraction."""
+        """Element-wise subtraction."""
         return self._apply(self._broadcast(other), operator.sub)
 
     def __mul__(self, other):
@@ -335,7 +335,7 @@ class FrameTuple(tuple):
         return self._apply(self._broadcast(other), lambda a, b: a + b)
 
     def __sub__(self, other):
-        """Element-wise substraction."""
+        """Element-wise subtraction."""
         return self._apply(self._broadcast(other), lambda a, b: a - b)
 
     def __and__(self, other):

--- a/src/gt4py/cartesian/gtc/gtir_to_oir.py
+++ b/src/gt4py/cartesian/gtc/gtir_to_oir.py
@@ -22,7 +22,6 @@ def validate_stencil_memory_accesses(node: oir.Stencil) -> oir.Stencil:
     at the OIR level. This is similar to the check at the gtir level for read-with-offset
     and writes, but more complete because it involves extent analysis, so it catches
     indirect read-with-offset through temporaries.
-
     """
 
     def _writes(node: oir.Stencil) -> Set[str]:

--- a/src/gt4py/cartesian/gtc/passes/oir_optimizations/caches.py
+++ b/src/gt4py/cartesian/gtc/passes/oir_optimizations/caches.py
@@ -39,7 +39,6 @@ are replaced by just a few registers.
 Note that filling and flushing k-caches can always be replaced by a local
 (non-filling or flushing) k-cache plus additional filling and flushing
 statements.
-
 """
 
 
@@ -261,7 +260,7 @@ class FillFlushToLocalKCaches(eve.NodeTranslator, eve.VisitorWithSymbolTableTrai
     For each cached field, the following actions are performed:
     1. A new locally-k-cached temporary is introduced.
     2. All accesses to the original field are replaced by accesses to this temporary.
-    3. Loop sections are split where necessary to allow single-level loads whereever possible.
+    3. Loop sections are split where necessary to allow single-level loads wherever possible.
     3. Fill statements from the original field to the temporary are introduced.
     4. Flush statements from the temporary to the original field are introduced.
     """

--- a/src/gt4py/cartesian/gtscript_imports.py
+++ b/src/gt4py/cartesian/gtscript_imports.py
@@ -23,13 +23,12 @@ Usage Example
     gtscript_imports.enable(
         search_path=[<path1>, <path2>, ...],  # for allowing only in search_path
         generate_path=<mybuildpath>,  # for generating python modules in a specific dir
-        in_source=False,  # set True to generate python modules next to gtscfipt files
+        in_source=False,  # set True to generate python modules next to gtscript files
     )
 
     # scoped usage
     with gtscript_imports.enabled():
         import ...
-
 """
 
 import importlib

--- a/src/gt4py/cartesian/testing/suites.py
+++ b/src/gt4py/cartesian/testing/suites.py
@@ -534,7 +534,7 @@ class StencilTestSuite(metaclass=SuiteMeta):
         # call implementation
         implementation(**test_values, origin=origin, domain=domain, exec_info=exec_info)
 
-        # for validation data, data is cropped to actually touched domain, so that origin offseting
+        # for validation data, data is cropped to actually touched domain, so that origin offsetting
         # does not have to be implemented for every test suite. This is done based on info
         # specified in test suite
         cropped_validation_values = {}

--- a/src/gt4py/eve/__init__.py
+++ b/src/gt4py/eve/__init__.py
@@ -21,7 +21,6 @@ on some of the previous ones):
   7. visitors
   8. traits
   9. codegen
-
 """
 
 from __future__ import annotations

--- a/src/gt4py/eve/datamodels/__init__.py
+++ b/src/gt4py/eve/datamodels/__init__.py
@@ -104,7 +104,6 @@ Examples:
     >>> CustomModel(3, 2)
     Instance 1 == 1.5
     CustomModel(value=1.5)
-
 """
 
 from . import core as core, validators as validators  # imported but unused


### PR DESCRIPTION
## Description

Fixing typos (in comments) in the cartesian part of the codebase. No code was touched.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests: N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder: N/A
