### PR TITLE
build: bump actions/download-artifacts v3 -> v4

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
     - name: Download wheel
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gt4py-dist
         path: dist
@@ -60,7 +60,7 @@ jobs:
       id-token: write
     steps:
     - name: Download wheel
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: gt4py-dist
         path: dist


### PR DESCRIPTION
## Description

Version 3 of actions/download-artifacts is deprecated since Nov 30 2024. Version 4 contains breaking changes to the backend architecture. We already switch upload to v4 (which was blocking PR merges). Download only happens when we release gt4py. It is thus not blocking and less pressing. We should nevertheless update.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests: N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder: N/A
