### PR TITLE
ci[cartesian]: mypy warns about unused ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ allow_incomplete_defs = true
 allow_untyped_defs = true
 follow_imports = 'silent'
 module = 'gt4py.cartesian.*'
-warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
 ignore_errors = true

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -136,7 +136,7 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     }
     languages = {"computation": "cuda", "bindings": ["python"]}
     storage_info = gt_storage.layout.CUDALayout
-    PYEXT_GENERATOR_CLASS = CudaExtGenerator  # type: ignore
+    PYEXT_GENERATOR_CLASS = CudaExtGenerator
     MODULE_GENERATOR_CLASS = CUDAPyExtModuleGenerator
     GT_BACKEND_T = "gpu"
 

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -760,7 +760,7 @@ class DaCeCUDAPyExtModuleGenerator(DaCePyExtModuleGenerator, CUDAPyExtModuleGene
 
 class BaseDaceBackend(BaseGTBackend, CLIBackendMixin):
     GT_BACKEND_T = "dace"
-    PYEXT_GENERATOR_CLASS = DaCeExtGenerator  # type: ignore
+    PYEXT_GENERATOR_CLASS = DaCeExtGenerator
 
     def generate(self) -> Type[StencilObject]:
         self.check_options(self.builder.options)

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -126,7 +126,7 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
 
 class GTBaseBackend(BaseGTBackend, CLIBackendMixin):
     options = BaseGTBackend.GT_BACKEND_OPTS
-    PYEXT_GENERATOR_CLASS = GTExtGenerator  # type: ignore
+    PYEXT_GENERATOR_CLASS = GTExtGenerator
 
     def _generate_extension(self, uses_cuda: bool) -> Tuple[str, str]:
         return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=uses_cuda)

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -38,14 +38,14 @@ class GTCPreconditionError(eve.exceptions.EveError, RuntimeError):
     message_template = "GTC pass precondition error: [{info}]"
 
     def __init__(self, *, expected: str, **kwargs: Any) -> None:
-        super().__init__(expected=expected, **kwargs)  # type: ignore
+        super().__init__(expected=expected, **kwargs)
 
 
 class GTCPostconditionError(eve.exceptions.EveError, RuntimeError):
     message_template = "GTC pass postcondition error: [{info}]"
 
     def __init__(self, *, expected: str, **kwargs: Any) -> None:
-        super().__init__(expected=expected, **kwargs)  # type: ignore
+        super().__init__(expected=expected, **kwargs)
 
 
 class AssignmentKind(eve.StrEnum):
@@ -267,7 +267,7 @@ def verify_and_get_common_dtype(
 ) -> Optional[DataType]:
     assert len(exprs) > 0
     if all(e.dtype is not DataType.AUTO for e in exprs):
-        dtypes: List[DataType] = [e.dtype for e in exprs]  # type: ignore # guaranteed to be not None
+        dtypes: List[DataType] = [e.dtype for e in exprs]  # guaranteed to be not None
         dtype = dtypes[0]
         if strict:
             if all(dt == dtype for dt in dtypes):
@@ -908,7 +908,7 @@ def op_to_ufunc(
 @functools.lru_cache(maxsize=None)
 def typestr_to_data_type(typestr: str) -> DataType:
     if not isinstance(typestr, str) or len(typestr) < 3 or not typestr[2:].isnumeric():
-        return DataType.INVALID  # type: ignore
+        return DataType.INVALID
     table = {
         ("b", 1): DataType.BOOL,
         ("i", 1): DataType.INT8,
@@ -919,4 +919,4 @@ def typestr_to_data_type(typestr: str) -> DataType:
         ("f", 8): DataType.FLOAT64,
     }
     key = (typestr[1], int(typestr[2:]))
-    return table.get(key, DataType.INVALID)  # type: ignore
+    return table.get(key, DataType.INVALID)

--- a/src/gt4py/cartesian/gtc/cuir/cuir.py
+++ b/src/gt4py/cartesian/gtc/cuir/cuir.py
@@ -32,11 +32,11 @@ class Stmt(common.Stmt):
     pass
 
 
-class Literal(common.Literal, Expr):  # type: ignore
+class Literal(common.Literal, Expr):
     pass
 
 
-class ScalarAccess(common.ScalarAccess, Expr):  # type: ignore
+class ScalarAccess(common.ScalarAccess, Expr):
     pass
 
 
@@ -44,7 +44,7 @@ class VariableKOffset(common.VariableKOffset[Expr]):
     pass
 
 
-class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):  # type: ignore
+class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):
     pass
 
 
@@ -113,7 +113,7 @@ class TernaryOp(common.TernaryOp[Expr], Expr):
     _dtype_propagation = common.ternary_op_dtype_propagation(strict=True)
 
 
-class Cast(common.Cast[Expr], Expr):  # type: ignore
+class Cast(common.Cast[Expr], Expr):
     pass
 
 

--- a/src/gt4py/cartesian/gtc/dace/daceir.py
+++ b/src/gt4py/cartesian/gtc/dace/daceir.py
@@ -771,7 +771,7 @@ class TernaryOp(common.TernaryOp[Expr], Expr):
     _dtype_propagation = common.ternary_op_dtype_propagation(strict=True)
 
 
-class Cast(common.Cast[Expr], Expr):  # type: ignore
+class Cast(common.Cast[Expr], Expr):
     pass
 
 

--- a/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
@@ -420,8 +420,7 @@ class DaCeIRBuilder(eve.NodeTranslator):
         k_interval,
         **kwargs: Any,
     ):
-        # skip type checking due to https://github.com/python/mypy/issues/5485
-        extent = global_ctx.library_node.get_extents(node)  # type: ignore
+        extent = global_ctx.library_node.get_extents(node)
         decls = [self.visit(decl, **kwargs) for decl in node.declarations]
         targets: Set[str] = set()
         stmts = [

--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp.py
@@ -31,11 +31,11 @@ class Offset(common.CartesianOffset):
     pass
 
 
-class Literal(common.Literal, Expr):  # type: ignore
+class Literal(common.Literal, Expr):
     pass
 
 
-class LocalAccess(common.ScalarAccess, Expr):  # type: ignore
+class LocalAccess(common.ScalarAccess, Expr):
     pass
 
 
@@ -43,7 +43,7 @@ class VariableKOffset(common.VariableKOffset[Expr]):
     pass
 
 
-class AccessorRef(common.FieldAccess[Expr, VariableKOffset], Expr):  # type: ignore
+class AccessorRef(common.FieldAccess[Expr, VariableKOffset], Expr):
     pass
 
 
@@ -88,7 +88,7 @@ class NativeFuncCall(common.NativeFuncCall[Expr], Expr):
     _dtype_propagation = common.native_func_call_dtype_propagation(strict=True)
 
 
-class Cast(common.Cast[Expr], Expr):  # type: ignore
+class Cast(common.Cast[Expr], Expr):
     pass
 
 

--- a/src/gt4py/cartesian/gtc/gtir.py
+++ b/src/gt4py/cartesian/gtc/gtir.py
@@ -43,7 +43,7 @@ class BlockStmt(common.BlockStmt[Stmt], Stmt):
     pass
 
 
-class Literal(common.Literal, Expr):  # type: ignore
+class Literal(common.Literal, Expr):
     pass
 
 
@@ -51,11 +51,11 @@ class VariableKOffset(common.VariableKOffset[Expr]):
     pass
 
 
-class ScalarAccess(common.ScalarAccess, Expr):  # type: ignore
+class ScalarAccess(common.ScalarAccess, Expr):
     pass
 
 
-class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):  # type: ignore
+class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):
     pass
 
 
@@ -163,7 +163,7 @@ class TernaryOp(common.TernaryOp[Expr], Expr):
     _dtype_propagation = common.ternary_op_dtype_propagation(strict=False)
 
 
-class Cast(common.Cast[Expr], Expr):  # type: ignore
+class Cast(common.Cast[Expr], Expr):
     pass
 
 

--- a/src/gt4py/cartesian/gtc/oir.py
+++ b/src/gt4py/cartesian/gtc/oir.py
@@ -33,11 +33,11 @@ class Stmt(common.Stmt):
     pass
 
 
-class Literal(common.Literal, Expr):  # type: ignore
+class Literal(common.Literal, Expr):
     pass
 
 
-class ScalarAccess(common.ScalarAccess, Expr):  # type: ignore
+class ScalarAccess(common.ScalarAccess, Expr):
     pass
 
 
@@ -45,7 +45,7 @@ class VariableKOffset(common.VariableKOffset[Expr]):
     pass
 
 
-class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):  # type: ignore
+class FieldAccess(common.FieldAccess[Expr, VariableKOffset], Expr):
     pass
 
 
@@ -88,7 +88,7 @@ class TernaryOp(common.TernaryOp[Expr], Expr):
     _dtype_propagation = common.ternary_op_dtype_propagation(strict=True)
 
 
-class Cast(common.Cast[Expr], Expr):  # type: ignore
+class Cast(common.Cast[Expr], Expr):
     pass
 
 

--- a/src/gt4py/cartesian/gtc/passes/gtir_upcaster.py
+++ b/src/gt4py/cartesian/gtc/passes/gtir_upcaster.py
@@ -24,7 +24,7 @@ def _upcast_node(target_dtype: DataType, node: Expr) -> Expr:
 
 def _upcast_nodes(*exprs: Expr, upcasting_rule: Callable) -> Iterator[Expr]:
     assert all(e.dtype for e in exprs)
-    dtypes: List[DataType] = [e.dtype for e in exprs]  # type: ignore # guaranteed to be not None
+    dtypes: List[DataType] = [e.dtype for e in exprs]  # guaranteed to be not None
     target_dtypes = upcasting_rule(*dtypes)
     return iter(_upcast_node(target_dtype, arg) for target_dtype, arg in zip(target_dtypes, exprs))
 

--- a/src/gt4py/cartesian/stencil_builder.py
+++ b/src/gt4py/cartesian/stencil_builder.py
@@ -58,10 +58,7 @@ class StencilBuilder:
         frontend: Optional[Type[FrontendType]] = None,
     ):
         self._definition = definition_func
-        # type ignore explanation: Attribclass generated init not recognized by mypy
-        self.options = options or BuildOptions(  # type: ignore
-            **self.default_options_dict(definition_func)
-        )
+        self.options = options or BuildOptions(**self.default_options_dict(definition_func))
         backend = backend or "numpy"
         backend = gt4pyc.backend.from_name(backend) if isinstance(backend, str) else backend
         if backend is None:

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -513,7 +513,7 @@ class StencilObject(abc.ABC):
                     *((0,) * len(field_info.data_dims)),
                 )
             elif (info_origin := getattr(array_infos.get(name), "origin", None)) is not None:
-                origin[name] = info_origin  # type: ignore
+                origin[name] = info_origin
             else:
                 origin[name] = (0,) * field_info.ndim
 


### PR DESCRIPTION
## Description

`mypy` was configured not to report unused ignores in `gt4py.cartesian`. I could remove all unused ignores without any problem and thus removed this extra configuration. From now on, unused ignores will be reported.

This is work towards https://github.com/GEOS-ESM/SMT-Nebulae/issues/89.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
   `mypy` is happy with the change.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
