### PR TITLE
refactor[next]: fixed point transformation pass infrastructure

### DIFF
--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -14,7 +14,6 @@ import functools
 import operator
 from typing import Optional
 
-from gt4py import eve
 from gt4py.eve import utils as eve_utils
 from gt4py.next import common
 from gt4py.next.iterator import ir
@@ -23,6 +22,7 @@ from gt4py.next.iterator.ir_utils import (
     ir_makers as im,
     misc as ir_misc,
 )
+from gt4py.next.iterator.transforms.fixed_point_transformation import FixedPointTransformation
 from gt4py.next.iterator.transforms.inline_lambdas import InlineLambdas, inline_lambda
 from gt4py.next.iterator.type_system import inference as itir_type_inference
 from gt4py.next.type_system import type_info, type_specifications as ts
@@ -86,8 +86,8 @@ def _is_trivial_or_tuple_thereof_expr(node: ir.Node) -> bool:
 #  go through all available transformation and apply them. However the final result here still
 #  reads a little convoluted and is also different to how we write other transformations. We
 #  should revisit the pattern here and try to find a more general mechanism.
-@dataclasses.dataclass(frozen=True)
-class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CollapseTuple(FixedPointTransformation):
     """
     Simplifies `make_tuple`, `tuple_get` calls.
 
@@ -217,38 +217,16 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         node = self.generic_visit(node, **kwargs)
         return self.fp_transform(node, **kwargs)
 
-    def fp_transform(self, node: ir.Node, **kwargs) -> ir.Node:
-        while True:
-            new_node = self.transform(node, **kwargs)
-            if new_node is None:
-                break
-            assert new_node != node
-            node = new_node
-        return node
-
-    def transform(self, node: ir.Node, **kwargs) -> Optional[ir.Node]:
-        if not isinstance(node, ir.FunCall):
-            return None
-
-        for transformation in self.Flag:
-            if self.flags & transformation:
-                assert isinstance(transformation.name, str)
-                method = getattr(self, f"transform_{transformation.name.lower()}")
-                result = method(node, **kwargs)
-                if result is not None:
-                    assert (
-                        result is not node
-                    )  # transformation should have returned None, since nothing changed
-                    itir_type_inference.reinfer(result)
-                    return result
-        return None
-
     def transform_collapse_make_tuple_tuple_get(
         self, node: ir.FunCall, **kwargs
     ) -> Optional[ir.Node]:
-        if node.fun == ir.SymRef(id="make_tuple") and all(
-            isinstance(arg, ir.FunCall) and arg.fun == ir.SymRef(id="tuple_get")
-            for arg in node.args
+        if (
+            isinstance(node, ir.FunCall)
+            and node.fun == ir.SymRef(id="make_tuple")
+            and all(
+                isinstance(arg, ir.FunCall) and arg.fun == ir.SymRef(id="tuple_get")
+                for arg in node.args
+            )
         ):
             # `make_tuple(tuple_get(0, t), tuple_get(1, t), ..., tuple_get(N-1,t))` -> `t`
             assert isinstance(node.args[0], ir.FunCall)
@@ -275,7 +253,8 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         self, node: ir.FunCall, **kwargs
     ) -> Optional[ir.Node]:
         if (
-            node.fun == ir.SymRef(id="tuple_get")
+            isinstance(node, ir.FunCall)
+            and node.fun == ir.SymRef(id="tuple_get")
             and isinstance(node.args[1], ir.FunCall)
             and node.args[1].fun == ir.SymRef(id="make_tuple")
             and isinstance(node.args[0], ir.Literal)
@@ -291,11 +270,15 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         return None
 
     def transform_propagate_tuple_get(self, node: ir.FunCall, **kwargs) -> Optional[ir.Node]:
-        if node.fun == ir.SymRef(id="tuple_get") and isinstance(node.args[0], ir.Literal):
+        if (
+            isinstance(node, ir.FunCall)
+            and node.fun == ir.SymRef(id="tuple_get")
+            and isinstance(node.args[0], ir.Literal)
+        ):
             # TODO(tehrengruber): extend to general symbols as long as the tail call in the let
             #   does not capture
             # `tuple_get(i, let(...)(make_tuple()))` -> `let(...)(tuple_get(i, make_tuple()))`
-            if cpm.is_let(node.args[1]):
+            if isinstance(node, ir.FunCall) and cpm.is_let(node.args[1]):
                 idx, let_expr = node.args
                 return im.call(
                     im.lambda_(*let_expr.fun.params)(  # type: ignore[attr-defined]  # ensured by is_let
@@ -315,7 +298,7 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         return None
 
     def transform_letify_make_tuple_elements(self, node: ir.FunCall, **kwargs) -> Optional[ir.Node]:
-        if node.fun == ir.SymRef(id="make_tuple"):
+        if isinstance(node, ir.FunCall) and node.fun == ir.SymRef(id="make_tuple"):
             # `make_tuple(expr1, expr1)`
             # -> `let((_tuple_el_1, expr1), (_tuple_el_2, expr2))(make_tuple(_tuple_el_1, _tuple_el_2))`
             bound_vars: dict[ir.Sym, ir.Expr] = {}
@@ -335,7 +318,7 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         return None
 
     def transform_inline_trivial_make_tuple(self, node: ir.FunCall, **kwargs) -> Optional[ir.Node]:
-        if cpm.is_let(node):
+        if isinstance(node, ir.FunCall) and cpm.is_let(node):
             # `let(tup, make_tuple(trivial_expr1, trivial_expr2))(foo(tup))`
             #  -> `foo(make_tuple(trivial_expr1, trivial_expr2))`
             eligible_params = [_is_trivial_make_tuple_call(arg) for arg in node.args]
@@ -349,7 +332,7 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
             #  in local-view for now. Revisit.
             return None
 
-        if not cpm.is_call_to(node, "if_"):
+        if isinstance(node, ir.FunCall) and not cpm.is_call_to(node, "if_"):
             # TODO(tehrengruber): Only inline if type of branch value is a tuple.
             # Examples:
             # `(if cond then {1, 2} else {3, 4})[0]` -> `if cond then {1, 2}[0] else {3, 4}[0]`
@@ -391,7 +374,7 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         # `if True then {2, 1} else {4, 3}`. The examples in the comments below all refer to this
         # tuple reordering example here.
 
-        if cpm.is_call_to(node, "if_"):
+        if not isinstance(node, ir.FunCall) or cpm.is_call_to(node, "if_"):
             return None
 
         # The first argument that is eligible also transforms all remaining args (They will be
@@ -464,7 +447,7 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         return None
 
     def transform_propagate_nested_let(self, node: ir.FunCall, **kwargs) -> Optional[ir.Node]:
-        if cpm.is_let(node):
+        if isinstance(node, ir.FunCall) and cpm.is_let(node):
             # `let((a, let(b, 1)(a_val)))(a)`-> `let(b, 1)(let(a, a_val)(a))`
             outer_vars = {}
             inner_vars = {}
@@ -490,7 +473,7 @@ class CollapseTuple(eve.PreserveLocationVisitor, eve.NodeTranslator):
         return None
 
     def transform_inline_trivial_let(self, node: ir.FunCall, **kwargs) -> Optional[ir.Node]:
-        if cpm.is_let(node):
+        if isinstance(node, ir.FunCall) and cpm.is_let(node):
             if isinstance(node.fun.expr, ir.SymRef):  # type: ignore[attr-defined]  # ensured by is_let
                 # `let(a, 1)(a)` -> `1`
                 for arg_sym, arg in zip(node.fun.params, node.args):  # type: ignore[attr-defined]  # ensured by is_let

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -14,6 +14,7 @@ import functools
 import operator
 from typing import Optional
 
+from gt4py import eve
 from gt4py.eve import utils as eve_utils
 from gt4py.next import common
 from gt4py.next.iterator import ir
@@ -22,7 +23,7 @@ from gt4py.next.iterator.ir_utils import (
     ir_makers as im,
     misc as ir_misc,
 )
-from gt4py.next.iterator.transforms.fixed_point_transformation import FixedPointTransformation
+from gt4py.next.iterator.transforms import fixed_point_transformation
 from gt4py.next.iterator.transforms.inline_lambdas import InlineLambdas, inline_lambda
 from gt4py.next.iterator.type_system import inference as itir_type_inference
 from gt4py.next.type_system import type_info, type_specifications as ts
@@ -87,7 +88,9 @@ def _is_trivial_or_tuple_thereof_expr(node: ir.Node) -> bool:
 #  reads a little convoluted and is also different to how we write other transformations. We
 #  should revisit the pattern here and try to find a more general mechanism.
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class CollapseTuple(FixedPointTransformation):
+class CollapseTuple(
+    fixed_point_transformation.FixedPointTransformation, eve.PreserveLocationVisitor
+):
     """
     Simplifies `make_tuple`, `tuple_get` calls.
 

--- a/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
+++ b/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
@@ -17,10 +17,26 @@ from gt4py.next.iterator.type_system import inference as itir_type_inference
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FixedPointTransformation(eve.PreserveLocationVisitor, eve.NodeTranslator):
-    Flag: ClassVar[Type[enum.Flag]]
-    flags: enum.Flag
+    """
+    Transformation pass that transforms until no transformation is applicable anymore.
+    """
+
+    #: Enum of all transformation (names). The transformations need to be defined as methods
+    #: named `transform_<NAME>`.
+    Transformation: ClassVar[Type[enum.Flag]]
+
+    #: All transformations enabled in this instance, e.g. `Transformation.T1 & Transformation.T2`.
+    #: Usually the default value is chosen to be all transformations.
+    enabled_transformations: enum.Flag
+
+    def visit(self, node: ir.Node, **kwargs) -> ir.Node:
+        node = super().visit(node, **kwargs)
+        return self.fp_transform(node, **kwargs)
 
     def fp_transform(self, node: ir.Node, **kwargs) -> ir.Node:
+        """
+        Transform node until a fixed point is reached, e.g. no transformation is applicable anymore.
+        """
         while True:
             new_node = self.transform(node, **kwargs)
             if new_node is None:
@@ -30,8 +46,15 @@ class FixedPointTransformation(eve.PreserveLocationVisitor, eve.NodeTranslator):
         return node
 
     def transform(self, node: ir.Node, **kwargs) -> Optional[ir.Node]:
-        for transformation in self.Flag:
-            if self.flags & transformation:
+        """
+        Transform node once.
+
+        Execute transformations until one is applicable. As soon as a transformation occured
+        the function will return the transformed node. Note that the transformation itself
+        may call other transformations on child nodes again.
+        """
+        for transformation in self.Transformation:
+            if self.enabled_transformations & transformation:
                 assert isinstance(transformation.name, str)
                 method = getattr(self, f"transform_{transformation.name.lower()}")
                 result = method(node, **kwargs)

--- a/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
+++ b/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
@@ -16,7 +16,7 @@ from gt4py.next.iterator.type_system import inference as itir_type_inference
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class FixedPointTransformation(eve.PreserveLocationVisitor, eve.NodeTranslator):
+class FixedPointTransformation(eve.NodeTranslator):
     """
     Transformation pass that transforms until no transformation is applicable anymore.
     """

--- a/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
+++ b/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
@@ -1,0 +1,44 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dataclasses
+import enum
+from typing import ClassVar, Optional, Type
+
+from gt4py import eve
+from gt4py.next.iterator import ir
+from gt4py.next.iterator.type_system import inference as itir_type_inference
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FixedPointTransformation(eve.PreserveLocationVisitor, eve.NodeTranslator):
+    Flag: ClassVar[Type[enum.Flag]]
+    flags: enum.Flag
+
+    def fp_transform(self, node: ir.Node, **kwargs) -> ir.Node:
+        while True:
+            new_node = self.transform(node, **kwargs)
+            if new_node is None:
+                break
+            assert new_node != node
+            node = new_node
+        return node
+
+    def transform(self, node: ir.Node, **kwargs) -> Optional[ir.Node]:
+        for transformation in self.Flag:
+            if self.flags & transformation:
+                assert isinstance(transformation.name, str)
+                method = getattr(self, f"transform_{transformation.name.lower()}")
+                result = method(node, **kwargs)
+                if result is not None:
+                    assert (
+                        result is not node
+                    )  # transformation should have returned None, since nothing changed
+                    itir_type_inference.reinfer(result)
+                    return result
+        return None

--- a/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
+++ b/src/gt4py/next/iterator/transforms/fixed_point_transformation.py
@@ -29,9 +29,9 @@ class FixedPointTransformation(eve.PreserveLocationVisitor, eve.NodeTranslator):
     #: Usually the default value is chosen to be all transformations.
     enabled_transformations: enum.Flag
 
-    def visit(self, node: ir.Node, **kwargs) -> ir.Node:
+    def visit(self, node, **kwargs):
         node = super().visit(node, **kwargs)
-        return self.fp_transform(node, **kwargs)
+        return self.fp_transform(node, **kwargs) if isinstance(node, ir.Node) else node
 
     def fp_transform(self, node: ir.Node, **kwargs) -> ir.Node:
         """

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -76,7 +76,7 @@ def apply_common_transforms(
     # required in order to get rid of expressions without a domain (e.g. when a tuple element is never accessed)
     ir = CollapseTuple.apply(
         ir,
-        flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
         uids=collapse_tuple_uids,
         offset_provider_type=offset_provider_type,
     )  # type: ignore[assignment]  # always an itir.Program
@@ -98,7 +98,7 @@ def apply_common_transforms(
         # is constant-folded the surrounding tuple_get calls can be removed.
         inlined = CollapseTuple.apply(
             inlined,
-            flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+            enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
             uids=collapse_tuple_uids,
             offset_provider_type=offset_provider_type,
         )  # type: ignore[assignment]  # always an itir.Program
@@ -136,7 +136,7 @@ def apply_common_transforms(
             ir,
             ignore_tuple_size=True,
             uids=collapse_tuple_uids,
-            flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+            enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
             offset_provider_type=offset_provider_type,
         )  # type: ignore[assignment]  # always an itir.Program
 
@@ -176,7 +176,7 @@ def apply_fieldview_transforms(
     ir = InlineLambdas.apply(ir, opcount_preserving=True, force_inline_lambda_args=True)
     ir = CollapseTuple.apply(
         ir,
-        flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
         offset_provider_type=common.offset_provider_to_type(offset_provider),
     )  # type: ignore[assignment] # type is still `itir.Program`
     ir = inline_dynamic_shifts.InlineDynamicShifts.apply(

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -76,7 +76,7 @@ def apply_common_transforms(
     # required in order to get rid of expressions without a domain (e.g. when a tuple element is never accessed)
     ir = CollapseTuple.apply(
         ir,
-        enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         uids=collapse_tuple_uids,
         offset_provider_type=offset_provider_type,
     )  # type: ignore[assignment]  # always an itir.Program
@@ -98,7 +98,7 @@ def apply_common_transforms(
         # is constant-folded the surrounding tuple_get calls can be removed.
         inlined = CollapseTuple.apply(
             inlined,
-            enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+            enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
             uids=collapse_tuple_uids,
             offset_provider_type=offset_provider_type,
         )  # type: ignore[assignment]  # always an itir.Program
@@ -136,7 +136,7 @@ def apply_common_transforms(
             ir,
             ignore_tuple_size=True,
             uids=collapse_tuple_uids,
-            enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+            enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
             offset_provider_type=offset_provider_type,
         )  # type: ignore[assignment]  # always an itir.Program
 
@@ -176,7 +176,7 @@ def apply_fieldview_transforms(
     ir = InlineLambdas.apply(ir, opcount_preserving=True, force_inline_lambda_args=True)
     ir = CollapseTuple.apply(
         ir,
-        enabled_transformations=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         offset_provider_type=common.offset_provider_to_type(offset_provider),
     )  # type: ignore[assignment] # type is still `itir.Program`
     ir = inline_dynamic_shifts.InlineDynamicShifts.apply(

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -19,7 +19,7 @@ def test_simple_make_tuple_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -37,7 +37,7 @@ def test_nested_make_tuple_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -53,7 +53,7 @@ def test_different_tuples_make_tuple_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -67,7 +67,7 @@ def test_incompatible_order_make_tuple_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -79,7 +79,7 @@ def test_incompatible_size_make_tuple_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -91,7 +91,7 @@ def test_merged_with_smaller_outer_size_make_tuple_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         ignore_tuple_size=True,
-        flags=CollapseTuple.Flag.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -104,7 +104,7 @@ def test_simple_tuple_get_make_tuple():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.COLLAPSE_TUPLE_GET_MAKE_TUPLE,
+        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_TUPLE_GET_MAKE_TUPLE,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -117,7 +117,7 @@ def test_propagate_tuple_get():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.PROPAGATE_TUPLE_GET,
+        enabled_transformations=CollapseTuple.Transformation.PROPAGATE_TUPLE_GET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -135,7 +135,7 @@ def test_letify_make_tuple_elements():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.LETIFY_MAKE_TUPLE_ELEMENTS,
+        enabled_transformations=CollapseTuple.Transformation.LETIFY_MAKE_TUPLE_ELEMENTS,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -149,7 +149,7 @@ def test_letify_make_tuple_with_trivial_elements():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.LETIFY_MAKE_TUPLE_ELEMENTS,
+        enabled_transformations=CollapseTuple.Transformation.LETIFY_MAKE_TUPLE_ELEMENTS,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -163,7 +163,7 @@ def test_inline_trivial_make_tuple():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.INLINE_TRIVIAL_MAKE_TUPLE,
+        enabled_transformations=CollapseTuple.Transformation.INLINE_TRIVIAL_MAKE_TUPLE,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -182,7 +182,7 @@ def test_propagate_to_if_on_tuples():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -199,8 +199,8 @@ def test_propagate_to_if_on_tuples_with_let():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=True,
-        flags=CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES
-        | CollapseTuple.Flag.LETIFY_MAKE_TUPLE_ELEMENTS,
+        enabled_transformations=CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES
+        | CollapseTuple.Transformation.LETIFY_MAKE_TUPLE_ELEMENTS,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -213,7 +213,7 @@ def test_propagate_nested_lift():
     actual = CollapseTuple.apply(
         testee,
         remove_letified_make_tuple_elements=False,
-        flags=CollapseTuple.Flag.PROPAGATE_NESTED_LET,
+        enabled_transformations=CollapseTuple.Transformation.PROPAGATE_NESTED_LET,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -249,7 +249,7 @@ def test_if_make_tuple_reorder_cps():
     expected = im.if_(True, im.make_tuple(2, 1), im.make_tuple(4, 3))
     actual = CollapseTuple.apply(
         testee,
-        flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -275,7 +275,7 @@ def test_nested_if_make_tuple_reorder_cps():
     )
     actual = CollapseTuple.apply(
         testee,
-        flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -291,7 +291,7 @@ def test_if_make_tuple_reorder_cps_nested():
     expected = im.if_(True, im.make_tuple(2, 1, 1), im.make_tuple(4, 3, 3))
     actual = CollapseTuple.apply(
         testee,
-        flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )
@@ -306,7 +306,7 @@ def test_if_make_tuple_reorder_cps_external():
     expected = im.if_(True, im.make_tuple(external_ref, 2, 1), im.make_tuple(external_ref, 4, 3))
     actual = CollapseTuple.apply(
         testee,
-        flags=~CollapseTuple.Flag.PROPAGATE_TO_IF_ON_TUPLES,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
         allow_undeclared_symbols=True,
         within_stencil=False,
     )


### PR DESCRIPTION
Executing transformations until a fixed point is reached, i.e., not transformation is applicable anymore is a common pattern encountered in many passes. The `CollapseTuple` pass already contained some infrastructure / utilities for this purpose. Since we now want to use the same approach in `ConstantFolding` and `FieldOpFusion`, they are extracted into a common base class here.

This is essentially a step into the direction of a more general pass manager that allows composition of transformations. It is very hard to design something on the scratch board that fulfills all needs we have in the various transformations. The idea is to extend the capabilities of this class step-by-step to cover more and more transformation use-cases such that more passes can use this infrastructure until we can eventually evaluate how dissimilar passes can be composed, e.g. CollapseTuple and ConstantFolding.

Edit @tehrengruber