### PR TITLE
bug[next]: Fix accept args

### DIFF
--- a/src/gt4py/next/iterator/type_system/inference.py
+++ b/src/gt4py/next/iterator/type_system/inference.py
@@ -32,66 +32,11 @@ def _is_representable_as_int(s: int | str) -> bool:
         return False
 
 
-def _is_compatible_type(type_a: ts.TypeSpec, type_b: ts.TypeSpec):
-    """
-    Predicate to determine if two types are compatible.
-
-    This function gracefully handles:
-     - iterators with unknown positions which are considered compatible to any other positions
-       of another iterator.
-     - iterators which are defined everywhere, i.e. empty defined dimensions
-    Beside that this function simply checks for equality of types.
-
-    >>> bool_type = ts.ScalarType(kind=ts.ScalarKind.BOOL)
-    >>> IDim = common.Dimension(value="IDim")
-    >>> type_on_i_of_i_it = it_ts.IteratorType(
-    ...     position_dims=[IDim], defined_dims=[IDim], element_type=bool_type
-    ... )
-    >>> type_on_undefined_of_i_it = it_ts.IteratorType(
-    ...     position_dims="unknown", defined_dims=[IDim], element_type=bool_type
-    ... )
-    >>> _is_compatible_type(type_on_i_of_i_it, type_on_undefined_of_i_it)
-    True
-
-    >>> JDim = common.Dimension(value="JDim")
-    >>> type_on_j_of_j_it = it_ts.IteratorType(
-    ...     position_dims=[JDim], defined_dims=[JDim], element_type=bool_type
-    ... )
-    >>> _is_compatible_type(type_on_i_of_i_it, type_on_j_of_j_it)
-    False
-    """
-    is_compatible = True
-
-    if isinstance(type_a, it_ts.IteratorType) and isinstance(type_b, it_ts.IteratorType):
-        if not any(el_type.position_dims == "unknown" for el_type in [type_a, type_b]):
-            is_compatible &= type_a.position_dims == type_b.position_dims
-        if type_a.defined_dims and type_b.defined_dims:
-            is_compatible &= type_a.defined_dims == type_b.defined_dims
-        is_compatible &= type_a.element_type == type_b.element_type
-    elif isinstance(type_a, ts.TupleType) and isinstance(type_b, ts.TupleType):
-        for el_type_a, el_type_b in zip(type_a.types, type_b.types, strict=True):
-            is_compatible &= _is_compatible_type(el_type_a, el_type_b)
-    elif isinstance(type_a, ts.FunctionType) and isinstance(type_b, ts.FunctionType):
-        for arg_a, arg_b in zip(type_a.pos_only_args, type_b.pos_only_args, strict=True):
-            is_compatible &= _is_compatible_type(arg_a, arg_b)
-        for arg_a, arg_b in zip(
-            type_a.pos_or_kw_args.values(), type_b.pos_or_kw_args.values(), strict=True
-        ):
-            is_compatible &= _is_compatible_type(arg_a, arg_b)
-        for arg_a, arg_b in zip(
-            type_a.kw_only_args.values(), type_b.kw_only_args.values(), strict=True
-        ):
-            is_compatible &= _is_compatible_type(arg_a, arg_b)
-        is_compatible &= _is_compatible_type(type_a.returns, type_b.returns)
-    else:
-        is_compatible &= type_info.is_concretizable(type_a, type_b)
-
-    return is_compatible
-
-
 def _set_node_type(node: itir.Node, type_: ts.TypeSpec) -> None:
     if node.type:
-        assert _is_compatible_type(node.type, type_), "Node already has a type which differs."
+        assert type_info.is_compatible_type(
+            node.type, type_
+        ), "Node already has a type which differs."
     node.type = type_
 
 
@@ -475,7 +420,7 @@ class ITIRTypeInference(eve.NodeTranslator):
         if isinstance(node, itir.Node):
             if isinstance(result, ts.TypeSpec):
                 if node.type and not isinstance(node.type, ts.DeferredType):
-                    assert _is_compatible_type(node.type, result)
+                    assert type_info.is_compatible_type(node.type, result)
                 node.type = result
             elif isinstance(result, ObservableTypeSynthesizer) or result is None:
                 pass

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from gt4py.eve.utils import XIterable, xiter
 from gt4py.next import common
+from gt4py.next.iterator.type_system import type_specifications as it_ts
 from gt4py.next.type_system import type_specifications as ts
 
 
@@ -432,6 +433,69 @@ def contains_local_field(type_: ts.TypeSpec) -> bool:
     )
 
 
+# TODO(tehrengruber): This function has specializations on Iterator types, which are not part of
+#  the general / shared type system. This functionality should be moved to the iterator-only
+#  type system, but we need some sort of multiple dispatch for that.
+# TODO(tehrengruber): Should this have a direction like is_concretizable?
+def is_compatible_type(type_a: ts.TypeSpec, type_b: ts.TypeSpec) -> bool:
+    """
+    Predicate to determine if two types are compatible.
+
+    This function gracefully handles:
+     - iterators with unknown positions which are considered compatible to any other positions
+       of another iterator.
+     - iterators which are defined everywhere, i.e. empty defined dimensions
+    Beside that this function simply checks for equality of types.
+
+    >>> bool_type = ts.ScalarType(kind=ts.ScalarKind.BOOL)
+    >>> IDim = common.Dimension(value="IDim")
+    >>> type_on_i_of_i_it = it_ts.IteratorType(
+    ...     position_dims=[IDim], defined_dims=[IDim], element_type=bool_type
+    ... )
+    >>> type_on_undefined_of_i_it = it_ts.IteratorType(
+    ...     position_dims="unknown", defined_dims=[IDim], element_type=bool_type
+    ... )
+    >>> is_compatible_type(type_on_i_of_i_it, type_on_undefined_of_i_it)
+    True
+
+    >>> JDim = common.Dimension(value="JDim")
+    >>> type_on_j_of_j_it = it_ts.IteratorType(
+    ...     position_dims=[JDim], defined_dims=[JDim], element_type=bool_type
+    ... )
+    >>> is_compatible_type(type_on_i_of_i_it, type_on_j_of_j_it)
+    False
+    """
+    is_compatible = True
+
+    if isinstance(type_a, it_ts.IteratorType) and isinstance(type_b, it_ts.IteratorType):
+        if not any(el_type.position_dims == "unknown" for el_type in [type_a, type_b]):
+            is_compatible &= type_a.position_dims == type_b.position_dims
+        if type_a.defined_dims and type_b.defined_dims:
+            is_compatible &= type_a.defined_dims == type_b.defined_dims
+        is_compatible &= type_a.element_type == type_b.element_type
+    elif isinstance(type_a, ts.TupleType) and isinstance(type_b, ts.TupleType):
+        if len(type_a.types) != len(type_b.types):
+            return False
+        for el_type_a, el_type_b in zip(type_a.types, type_b.types, strict=True):
+            is_compatible &= is_compatible_type(el_type_a, el_type_b)
+    elif isinstance(type_a, ts.FunctionType) and isinstance(type_b, ts.FunctionType):
+        for arg_a, arg_b in zip(type_a.pos_only_args, type_b.pos_only_args, strict=True):
+            is_compatible &= is_compatible_type(arg_a, arg_b)
+        for arg_a, arg_b in zip(
+            type_a.pos_or_kw_args.values(), type_b.pos_or_kw_args.values(), strict=True
+        ):
+            is_compatible &= is_compatible_type(arg_a, arg_b)
+        for arg_a, arg_b in zip(
+            type_a.kw_only_args.values(), type_b.kw_only_args.values(), strict=True
+        ):
+            is_compatible &= is_compatible_type(arg_a, arg_b)
+        is_compatible &= is_compatible_type(type_a.returns, type_b.returns)
+    else:
+        is_compatible &= is_concretizable(type_a, type_b)
+
+    return is_compatible
+
+
 def is_concretizable(symbol_type: ts.TypeSpec, to_type: ts.TypeSpec) -> bool:
     """
     Check if ``symbol_type`` can be concretized to ``to_type``.
@@ -725,11 +789,7 @@ def function_signature_incompatibilities_func(
     for i, (a_arg, b_arg) in enumerate(
         zip(list(func_type.pos_only_args) + list(func_type.pos_or_kw_args.values()), args)
     ):
-        if (
-            b_arg is not UNDEFINED_ARG
-            and a_arg != b_arg
-            and not is_concretizable(a_arg, to_type=b_arg)
-        ):
+        if b_arg is not UNDEFINED_ARG and a_arg != b_arg and not is_compatible_type(a_arg, b_arg):
             if i < len(func_type.pos_only_args):
                 arg_repr = f"{_number_to_ordinal_number(i + 1)} argument"
             else:
@@ -739,7 +799,7 @@ def function_signature_incompatibilities_func(
     for kwarg in set(func_type.kw_only_args.keys()) & set(kwargs.keys()):
         if (a_kwarg := func_type.kw_only_args[kwarg]) != (
             b_kwarg := kwargs[kwarg]
-        ) and not is_concretizable(a_kwarg, to_type=b_kwarg):
+        ) and not is_compatible_type(a_kwarg, b_kwarg):
             yield f"Expected keyword argument '{kwarg}' to be of type '{func_type.kw_only_args[kwarg]}', got '{kwargs[kwarg]}'."
 
 

--- a/tests/next_tests/unit_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_type_deduction.py
@@ -1,0 +1,414 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import re
+from typing import Optional, Pattern
+
+import pytest
+
+import gt4py.next.ffront.type_specifications
+from gt4py.next import (
+    Dimension,
+    DimensionKind,
+    Field,
+    FieldOffset,
+    astype,
+    broadcast,
+    common,
+    errors,
+    float32,
+    float64,
+    int32,
+    int64,
+    neighbor_sum,
+    where,
+)
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
+from gt4py.next.ffront.experimental import as_offset
+from gt4py.next.ffront.func_to_foast import FieldOperatorParser
+from gt4py.next.type_system import type_info, type_specifications as ts
+
+TDim = Dimension("TDim")  # Meaningless dimension, used for tests.
+
+
+def test_unpack_assign():
+    def unpack_explicit_tuple(
+        a: Field[[TDim], float64], b: Field[[TDim], float64]
+    ) -> tuple[Field[[TDim], float64], Field[[TDim], float64]]:
+        tmp_a, tmp_b = (a, b)
+        return tmp_a, tmp_b
+
+    parsed = FieldOperatorParser.apply_to_function(unpack_explicit_tuple)
+
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp_a", 0)].type == ts.FieldType(
+        dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None)
+    )
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp_b", 0)].type == ts.FieldType(
+        dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None)
+    )
+
+
+def test_assign_tuple():
+    def temp_tuple(a: Field[[TDim], float64], b: Field[[TDim], int64]):
+        tmp = a, b
+        return tmp
+
+    parsed = FieldOperatorParser.apply_to_function(temp_tuple)
+
+    assert parsed.body.annex.symtable[ssa.unique_name("tmp", 0)].type == ts.TupleType(
+        types=[
+            ts.FieldType(dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None)),
+            ts.FieldType(dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64, shape=None)),
+        ]
+    )
+
+
+def test_adding_bool():
+    """Expect an error when using arithmetic on bools."""
+
+    def add_bools(a: Field[[TDim], bool], b: Field[[TDim], bool]):
+        return a + b
+
+    with pytest.raises(
+        errors.DSLError, match=(r"Type 'Field\[\[TDim\], bool\]' can not be used in operator '\+'.")
+    ):
+        _ = FieldOperatorParser.apply_to_function(add_bools)
+
+
+def test_binop_nonmatching_dims():
+    """Binary operations can only work when both fields have the same dimensions."""
+    X = Dimension("X")
+    Y = Dimension("Y")
+
+    def nonmatching(a: Field[[X], float64], b: Field[[Y], float64]):
+        return a + b
+
+    with pytest.raises(
+        errors.DSLError,
+        match=(
+            r"Could not promote 'Field\[\[X], float64\]' and 'Field\[\[Y\], float64\]' to common type in call to +."
+        ),
+    ):
+        _ = FieldOperatorParser.apply_to_function(nonmatching)
+
+
+def test_bitopping_float():
+    def float_bitop(a: Field[[TDim], float], b: Field[[TDim], float]):
+        return a & b
+
+    with pytest.raises(
+        errors.DSLError,
+        match=(r"Type 'Field\[\[TDim\], float64\]' can not be used in operator '\&'."),
+    ):
+        _ = FieldOperatorParser.apply_to_function(float_bitop)
+
+
+def test_signing_bool():
+    def sign_bool(a: Field[[TDim], bool]):
+        return -a
+
+    with pytest.raises(
+        errors.DSLError,
+        match=r"Incompatible type for unary operator '\-': 'Field\[\[TDim\], bool\]'.",
+    ):
+        _ = FieldOperatorParser.apply_to_function(sign_bool)
+
+
+def test_notting_int():
+    def not_int(a: Field[[TDim], int64]):
+        return not a
+
+    with pytest.raises(
+        errors.DSLError,
+        match=r"Incompatible type for unary operator 'not': 'Field\[\[TDim\], int64\]'.",
+    ):
+        _ = FieldOperatorParser.apply_to_function(not_int)
+
+
+@pytest.fixture
+def premap_setup():
+    X = Dimension("X")
+    Y = Dimension("Y")
+    Y2XDim = Dimension("Y2X", kind=DimensionKind.LOCAL)
+    Y2X = FieldOffset("Y2X", source=X, target=(Y, Y2XDim))
+    return X, Y, Y2XDim, Y2X
+
+
+def test_premap(premap_setup):
+    X, Y, Y2XDim, Y2X = premap_setup
+
+    def premap_fo(bar: Field[[X], int64]) -> Field[[Y], int64]:
+        return bar(Y2X[0])
+
+    parsed = FieldOperatorParser.apply_to_function(premap_fo)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[Y], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)
+    )
+
+
+def test_premap_nbfield(premap_setup):
+    X, Y, Y2XDim, Y2X = premap_setup
+
+    def premap_fo(bar: Field[[X], int64]) -> Field[[Y, Y2XDim], int64]:
+        return bar(Y2X)
+
+    parsed = FieldOperatorParser.apply_to_function(premap_fo)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[Y, Y2XDim], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)
+    )
+
+
+def test_premap_reduce(premap_setup):
+    X, Y, Y2XDim, Y2X = premap_setup
+
+    def premap_fo(bar: Field[[X], int32]) -> Field[[Y], int32]:
+        return 2 * neighbor_sum(bar(Y2X), axis=Y2XDim)
+
+    parsed = FieldOperatorParser.apply_to_function(premap_fo)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[Y], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)
+    )
+
+
+def test_premap_reduce_sparse(premap_setup):
+    X, Y, Y2XDim, Y2X = premap_setup
+
+    def premap_fo(bar: Field[[Y, Y2XDim], int32]) -> Field[[Y], int32]:
+        return 5 * neighbor_sum(bar, axis=Y2XDim)
+
+    parsed = FieldOperatorParser.apply_to_function(premap_fo)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[Y], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)
+    )
+
+
+def test_mismatched_literals():
+    def mismatched_lit() -> Field[[TDim], "float32"]:
+        return float32("1.0") + float64("1.0")
+
+    with pytest.raises(
+        errors.DSLError,
+        match=(r"Could not promote 'float32' and 'float64' to common type in call to +."),
+    ):
+        _ = FieldOperatorParser.apply_to_function(mismatched_lit)
+
+
+def test_broadcast_multi_dim():
+    ADim = Dimension("ADim")
+    BDim = Dimension("BDim")
+    CDim = Dimension("CDim")
+
+    def simple_broadcast(a: Field[[ADim], float64]):
+        return broadcast(a, (ADim, BDim, CDim))
+
+    parsed = FieldOperatorParser.apply_to_function(simple_broadcast)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[ADim, BDim, CDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+    )
+
+
+def test_broadcast_disjoint():
+    ADim = Dimension("ADim")
+    BDim = Dimension("BDim")
+    CDim = Dimension("CDim")
+
+    def disjoint_broadcast(a: Field[[ADim], float64]):
+        return broadcast(a, (BDim, CDim))
+
+    with pytest.raises(errors.DSLError, match=r"expected broadcast dimension\(s\) \'.*\' missing"):
+        _ = FieldOperatorParser.apply_to_function(disjoint_broadcast)
+
+
+def test_broadcast_badtype():
+    ADim = Dimension("ADim")
+    BDim = "BDim"
+    CDim = Dimension("CDim")
+
+    def badtype_broadcast(a: Field[[ADim], float64]):
+        return broadcast(a, (BDim, CDim))
+
+    with pytest.raises(
+        errors.DSLError, match=r"expected all broadcast dimensions to be of type 'Dimension'."
+    ):
+        _ = FieldOperatorParser.apply_to_function(badtype_broadcast)
+
+
+def test_where_dim():
+    ADim = Dimension("ADim")
+    BDim = Dimension("BDim")
+
+    def simple_where(a: Field[[ADim], bool], b: Field[[ADim, BDim], float64]):
+        return where(a, b, 9.0)
+
+    parsed = FieldOperatorParser.apply_to_function(simple_where)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[ADim, BDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+    )
+
+
+def test_where_broadcast_dim():
+    ADim = Dimension("ADim")
+
+    def simple_where(a: Field[[ADim], bool]):
+        return where(a, 5.0, 9.0)
+
+    parsed = FieldOperatorParser.apply_to_function(simple_where)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+    )
+
+
+def test_where_tuple_dim():
+    ADim = Dimension("ADim")
+
+    def tuple_where(a: Field[[ADim], bool], b: Field[[ADim], float64]):
+        return where(a, ((5.0, 9.0), (b, 6.0)), ((8.0, b), (5.0, 9.0)))
+
+    parsed = FieldOperatorParser.apply_to_function(tuple_where)
+
+    assert parsed.body.stmts[0].value.type == ts.TupleType(
+        types=[
+            ts.TupleType(
+                types=[
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                ]
+            ),
+            ts.TupleType(
+                types=[
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                ]
+            ),
+        ]
+    )
+
+
+def test_where_bad_dim():
+    ADim = Dimension("ADim")
+
+    def bad_dim_where(a: Field[[ADim], bool], b: Field[[ADim], float64]):
+        return where(a, ((5.0, 9.0), (b, 6.0)), b)
+
+    with pytest.raises(errors.DSLError, match=r"Return arguments need to be of same type"):
+        _ = FieldOperatorParser.apply_to_function(bad_dim_where)
+
+
+def test_where_mixed_dims():
+    ADim = Dimension("ADim")
+    BDim = Dimension("BDim")
+
+    def tuple_where_mix_dims(
+        a: Field[[ADim], bool], b: Field[[ADim], float64], c: Field[[ADim, BDim], float64]
+    ):
+        return where(a, ((c, 9.0), (b, 6.0)), ((8.0, b), (5.0, 9.0)))
+
+    parsed = FieldOperatorParser.apply_to_function(tuple_where_mix_dims)
+
+    assert parsed.body.stmts[0].value.type == ts.TupleType(
+        types=[
+            ts.TupleType(
+                types=[
+                    ts.FieldType(
+                        dims=[ADim, BDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
+                    ),
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                ]
+            ),
+            ts.TupleType(
+                types=[
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
+                ]
+            ),
+        ]
+    )
+
+
+def test_astype_dtype():
+    def simple_astype(a: Field[[TDim], float64]):
+        return astype(a, bool)
+
+    parsed = FieldOperatorParser.apply_to_function(simple_astype)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL)
+    )
+
+
+def test_astype_wrong_dtype():
+    def simple_astype(a: Field[[TDim], float64]):
+        # we just use broadcast here, but anything with type function is fine
+        return astype(a, broadcast)
+
+    with pytest.raises(
+        errors.DSLError,
+        match=r"Invalid call to 'astype': second argument must be a scalar type, got.",
+    ):
+        _ = FieldOperatorParser.apply_to_function(simple_astype)
+
+
+def test_astype_wrong_value_type():
+    def simple_astype(a: Field[[TDim], float64]):
+        # we just use broadcast here but anything that is not a field, scalar or tuple thereof works
+        return astype(broadcast, bool)
+
+    with pytest.raises(errors.DSLError) as exc_info:
+        _ = FieldOperatorParser.apply_to_function(simple_astype)
+
+    assert (
+        re.search("Expected 1st argument to be of type", exc_info.value.__cause__.args[0])
+        is not None
+    )
+
+
+def test_mod_floats():
+    def modulo_floats(inp: Field[[TDim], float]):
+        return inp % 3.0
+
+    with pytest.raises(errors.DSLError, match=r"Type 'float64' can not be used in operator '%'"):
+        _ = FieldOperatorParser.apply_to_function(modulo_floats)
+
+
+def test_undefined_symbols():
+    def return_undefined():
+        return undefined_symbol
+
+    with pytest.raises(errors.DSLError, match="Undeclared symbol"):
+        _ = FieldOperatorParser.apply_to_function(return_undefined)
+
+
+def test_as_offset_dim():
+    ADim = Dimension("ADim")
+    BDim = Dimension("BDim")
+    Boff = FieldOffset("Boff", source=BDim, target=(BDim,))
+
+    def as_offset_dim(a: Field[[ADim, BDim], float], b: Field[[ADim], int]):
+        return a(as_offset(Boff, b))
+
+    with pytest.raises(errors.DSLError, match=f"not in list of offset field dimensions"):
+        _ = FieldOperatorParser.apply_to_function(as_offset_dim)
+
+
+def test_as_offset_dtype():
+    ADim = Dimension("ADim")
+    BDim = Dimension("BDim")
+    Boff = FieldOffset("Boff", source=BDim, target=(BDim,))
+
+    def as_offset_dtype(a: Field[[ADim, BDim], float], b: Field[[BDim], float]):
+        return a(as_offset(Boff, b))
+
+    with pytest.raises(errors.DSLError, match=f"expected integer for offset field dtype"):
+        _ = FieldOperatorParser.apply_to_function(as_offset_dtype)

--- a/tests/next_tests/unit_tests/test_type_system.py
+++ b/tests/next_tests/unit_tests/test_type_system.py
@@ -11,28 +11,13 @@ from typing import Optional, Pattern
 
 import pytest
 
-import gt4py.next.ffront.type_specifications
 from gt4py.next import (
     Dimension,
     DimensionKind,
-    Field,
-    FieldOffset,
-    astype,
-    broadcast,
-    common,
-    errors,
-    float32,
-    float64,
-    int32,
-    int64,
-    neighbor_sum,
-    where,
 )
-from gt4py.next.ffront.ast_passes import single_static_assign as ssa
-from gt4py.next.ffront.experimental import as_offset
-from gt4py.next.ffront.func_to_foast import FieldOperatorParser
 from gt4py.next.type_system import type_info, type_specifications as ts
-
+from gt4py.next.ffront import type_specifications as ts_ffront
+from gt4py.next.iterator.type_system import type_specifications as ts_it
 
 TDim = Dimension("TDim")  # Meaningless dimension, used for tests.
 
@@ -107,7 +92,7 @@ def callable_type_info_cases():
     unary_tuple_arg_func_type = ts.FunctionType(
         pos_only_args=[tuple_type], pos_or_kw_args={}, kw_only_args={}, returns=ts.VoidType()
     )
-    fieldop_type = gt4py.next.ffront.type_specifications.FieldOperatorType(
+    fieldop_type = ts_ffront.FieldOperatorType(
         definition=ts.FunctionType(
             pos_only_args=[field_type, float_type],
             pos_or_kw_args={},
@@ -115,7 +100,7 @@ def callable_type_info_cases():
             returns=field_type,
         )
     )
-    scanop_type = gt4py.next.ffront.type_specifications.ScanOperatorType(
+    scanop_type = ts_ffront.ScanOperatorType(
         axis=KDim,
         definition=ts.FunctionType(
             pos_only_args=[],
@@ -124,7 +109,7 @@ def callable_type_info_cases():
             returns=float_type,
         ),
     )
-    tuple_scanop_type = gt4py.next.ffront.type_specifications.ScanOperatorType(
+    tuple_scanop_type = ts_ffront.ScanOperatorType(
         axis=KDim,
         definition=ts.FunctionType(
             pos_only_args=[],
@@ -367,6 +352,22 @@ def callable_type_info_cases():
             ],
             ts.FieldType(dims=[IDim, JDim, KDim], dtype=float_type),
         ),
+        (
+            ts.FunctionType(
+                pos_only_args=[
+                    ts_it.IteratorType(
+                        position_dims="unknown", defined_dims=[], element_type=float_type
+                    ),
+                ],
+                pos_or_kw_args={},
+                kw_only_args={},
+                returns=ts.VoidType(),
+            ),
+            [ts_it.IteratorType(position_dims=[IDim], defined_dims=[], element_type=float_type)],
+            {},
+            [],
+            ts.VoidType(),
+        ),
     ]
 
 
@@ -408,381 +409,3 @@ def test_return_type(
     accepts_args = type_info.accepts_args(func_type, with_args=args, with_kwargs=kwargs)
     if accepts_args:
         assert type_info.return_type(func_type, with_args=args, with_kwargs=kwargs) == return_type
-
-
-def test_unpack_assign():
-    def unpack_explicit_tuple(
-        a: Field[[TDim], float64], b: Field[[TDim], float64]
-    ) -> tuple[Field[[TDim], float64], Field[[TDim], float64]]:
-        tmp_a, tmp_b = (a, b)
-        return tmp_a, tmp_b
-
-    parsed = FieldOperatorParser.apply_to_function(unpack_explicit_tuple)
-
-    assert parsed.body.annex.symtable[ssa.unique_name("tmp_a", 0)].type == ts.FieldType(
-        dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None)
-    )
-    assert parsed.body.annex.symtable[ssa.unique_name("tmp_b", 0)].type == ts.FieldType(
-        dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None)
-    )
-
-
-def test_assign_tuple():
-    def temp_tuple(a: Field[[TDim], float64], b: Field[[TDim], int64]):
-        tmp = a, b
-        return tmp
-
-    parsed = FieldOperatorParser.apply_to_function(temp_tuple)
-
-    assert parsed.body.annex.symtable[ssa.unique_name("tmp", 0)].type == ts.TupleType(
-        types=[
-            ts.FieldType(dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64, shape=None)),
-            ts.FieldType(dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64, shape=None)),
-        ]
-    )
-
-
-def test_adding_bool():
-    """Expect an error when using arithmetic on bools."""
-
-    def add_bools(a: Field[[TDim], bool], b: Field[[TDim], bool]):
-        return a + b
-
-    with pytest.raises(
-        errors.DSLError, match=(r"Type 'Field\[\[TDim\], bool\]' can not be used in operator '\+'.")
-    ):
-        _ = FieldOperatorParser.apply_to_function(add_bools)
-
-
-def test_binop_nonmatching_dims():
-    """Binary operations can only work when both fields have the same dimensions."""
-    X = Dimension("X")
-    Y = Dimension("Y")
-
-    def nonmatching(a: Field[[X], float64], b: Field[[Y], float64]):
-        return a + b
-
-    with pytest.raises(
-        errors.DSLError,
-        match=(
-            r"Could not promote 'Field\[\[X], float64\]' and 'Field\[\[Y\], float64\]' to common type in call to +."
-        ),
-    ):
-        _ = FieldOperatorParser.apply_to_function(nonmatching)
-
-
-def test_bitopping_float():
-    def float_bitop(a: Field[[TDim], float], b: Field[[TDim], float]):
-        return a & b
-
-    with pytest.raises(
-        errors.DSLError,
-        match=(r"Type 'Field\[\[TDim\], float64\]' can not be used in operator '\&'."),
-    ):
-        _ = FieldOperatorParser.apply_to_function(float_bitop)
-
-
-def test_signing_bool():
-    def sign_bool(a: Field[[TDim], bool]):
-        return -a
-
-    with pytest.raises(
-        errors.DSLError,
-        match=r"Incompatible type for unary operator '\-': 'Field\[\[TDim\], bool\]'.",
-    ):
-        _ = FieldOperatorParser.apply_to_function(sign_bool)
-
-
-def test_notting_int():
-    def not_int(a: Field[[TDim], int64]):
-        return not a
-
-    with pytest.raises(
-        errors.DSLError,
-        match=r"Incompatible type for unary operator 'not': 'Field\[\[TDim\], int64\]'.",
-    ):
-        _ = FieldOperatorParser.apply_to_function(not_int)
-
-
-@pytest.fixture
-def premap_setup():
-    X = Dimension("X")
-    Y = Dimension("Y")
-    Y2XDim = Dimension("Y2X", kind=DimensionKind.LOCAL)
-    Y2X = FieldOffset("Y2X", source=X, target=(Y, Y2XDim))
-    return X, Y, Y2XDim, Y2X
-
-
-def test_premap(premap_setup):
-    X, Y, Y2XDim, Y2X = premap_setup
-
-    def premap_fo(bar: Field[[X], int64]) -> Field[[Y], int64]:
-        return bar(Y2X[0])
-
-    parsed = FieldOperatorParser.apply_to_function(premap_fo)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[Y], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)
-    )
-
-
-def test_premap_nbfield(premap_setup):
-    X, Y, Y2XDim, Y2X = premap_setup
-
-    def premap_fo(bar: Field[[X], int64]) -> Field[[Y, Y2XDim], int64]:
-        return bar(Y2X)
-
-    parsed = FieldOperatorParser.apply_to_function(premap_fo)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[Y, Y2XDim], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)
-    )
-
-
-def test_premap_reduce(premap_setup):
-    X, Y, Y2XDim, Y2X = premap_setup
-
-    def premap_fo(bar: Field[[X], int32]) -> Field[[Y], int32]:
-        return 2 * neighbor_sum(bar(Y2X), axis=Y2XDim)
-
-    parsed = FieldOperatorParser.apply_to_function(premap_fo)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[Y], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)
-    )
-
-
-def test_premap_reduce_sparse(premap_setup):
-    X, Y, Y2XDim, Y2X = premap_setup
-
-    def premap_fo(bar: Field[[Y, Y2XDim], int32]) -> Field[[Y], int32]:
-        return 5 * neighbor_sum(bar, axis=Y2XDim)
-
-    parsed = FieldOperatorParser.apply_to_function(premap_fo)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[Y], dtype=ts.ScalarType(kind=ts.ScalarKind.INT32)
-    )
-
-
-def test_mismatched_literals():
-    def mismatched_lit() -> Field[[TDim], "float32"]:
-        return float32("1.0") + float64("1.0")
-
-    with pytest.raises(
-        errors.DSLError,
-        match=(r"Could not promote 'float32' and 'float64' to common type in call to +."),
-    ):
-        _ = FieldOperatorParser.apply_to_function(mismatched_lit)
-
-
-def test_broadcast_multi_dim():
-    ADim = Dimension("ADim")
-    BDim = Dimension("BDim")
-    CDim = Dimension("CDim")
-
-    def simple_broadcast(a: Field[[ADim], float64]):
-        return broadcast(a, (ADim, BDim, CDim))
-
-    parsed = FieldOperatorParser.apply_to_function(simple_broadcast)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[ADim, BDim, CDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
-    )
-
-
-def test_broadcast_disjoint():
-    ADim = Dimension("ADim")
-    BDim = Dimension("BDim")
-    CDim = Dimension("CDim")
-
-    def disjoint_broadcast(a: Field[[ADim], float64]):
-        return broadcast(a, (BDim, CDim))
-
-    with pytest.raises(errors.DSLError, match=r"expected broadcast dimension\(s\) \'.*\' missing"):
-        _ = FieldOperatorParser.apply_to_function(disjoint_broadcast)
-
-
-def test_broadcast_badtype():
-    ADim = Dimension("ADim")
-    BDim = "BDim"
-    CDim = Dimension("CDim")
-
-    def badtype_broadcast(a: Field[[ADim], float64]):
-        return broadcast(a, (BDim, CDim))
-
-    with pytest.raises(
-        errors.DSLError, match=r"expected all broadcast dimensions to be of type 'Dimension'."
-    ):
-        _ = FieldOperatorParser.apply_to_function(badtype_broadcast)
-
-
-def test_where_dim():
-    ADim = Dimension("ADim")
-    BDim = Dimension("BDim")
-
-    def simple_where(a: Field[[ADim], bool], b: Field[[ADim, BDim], float64]):
-        return where(a, b, 9.0)
-
-    parsed = FieldOperatorParser.apply_to_function(simple_where)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[ADim, BDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
-    )
-
-
-def test_where_broadcast_dim():
-    ADim = Dimension("ADim")
-
-    def simple_where(a: Field[[ADim], bool]):
-        return where(a, 5.0, 9.0)
-
-    parsed = FieldOperatorParser.apply_to_function(simple_where)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
-    )
-
-
-def test_where_tuple_dim():
-    ADim = Dimension("ADim")
-
-    def tuple_where(a: Field[[ADim], bool], b: Field[[ADim], float64]):
-        return where(a, ((5.0, 9.0), (b, 6.0)), ((8.0, b), (5.0, 9.0)))
-
-    parsed = FieldOperatorParser.apply_to_function(tuple_where)
-
-    assert parsed.body.stmts[0].value.type == ts.TupleType(
-        types=[
-            ts.TupleType(
-                types=[
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                ]
-            ),
-            ts.TupleType(
-                types=[
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                ]
-            ),
-        ]
-    )
-
-
-def test_where_bad_dim():
-    ADim = Dimension("ADim")
-
-    def bad_dim_where(a: Field[[ADim], bool], b: Field[[ADim], float64]):
-        return where(a, ((5.0, 9.0), (b, 6.0)), b)
-
-    with pytest.raises(errors.DSLError, match=r"Return arguments need to be of same type"):
-        _ = FieldOperatorParser.apply_to_function(bad_dim_where)
-
-
-def test_where_mixed_dims():
-    ADim = Dimension("ADim")
-    BDim = Dimension("BDim")
-
-    def tuple_where_mix_dims(
-        a: Field[[ADim], bool], b: Field[[ADim], float64], c: Field[[ADim, BDim], float64]
-    ):
-        return where(a, ((c, 9.0), (b, 6.0)), ((8.0, b), (5.0, 9.0)))
-
-    parsed = FieldOperatorParser.apply_to_function(tuple_where_mix_dims)
-
-    assert parsed.body.stmts[0].value.type == ts.TupleType(
-        types=[
-            ts.TupleType(
-                types=[
-                    ts.FieldType(
-                        dims=[ADim, BDim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)
-                    ),
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                ]
-            ),
-            ts.TupleType(
-                types=[
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                    ts.FieldType(dims=[ADim], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64)),
-                ]
-            ),
-        ]
-    )
-
-
-def test_astype_dtype():
-    def simple_astype(a: Field[[TDim], float64]):
-        return astype(a, bool)
-
-    parsed = FieldOperatorParser.apply_to_function(simple_astype)
-
-    assert parsed.body.stmts[0].value.type == ts.FieldType(
-        dims=[TDim], dtype=ts.ScalarType(kind=ts.ScalarKind.BOOL)
-    )
-
-
-def test_astype_wrong_dtype():
-    def simple_astype(a: Field[[TDim], float64]):
-        # we just use broadcast here, but anything with type function is fine
-        return astype(a, broadcast)
-
-    with pytest.raises(
-        errors.DSLError,
-        match=r"Invalid call to 'astype': second argument must be a scalar type, got.",
-    ):
-        _ = FieldOperatorParser.apply_to_function(simple_astype)
-
-
-def test_astype_wrong_value_type():
-    def simple_astype(a: Field[[TDim], float64]):
-        # we just use broadcast here but anything that is not a field, scalar or tuple thereof works
-        return astype(broadcast, bool)
-
-    with pytest.raises(errors.DSLError) as exc_info:
-        _ = FieldOperatorParser.apply_to_function(simple_astype)
-
-    assert (
-        re.search("Expected 1st argument to be of type", exc_info.value.__cause__.args[0])
-        is not None
-    )
-
-
-def test_mod_floats():
-    def modulo_floats(inp: Field[[TDim], float]):
-        return inp % 3.0
-
-    with pytest.raises(errors.DSLError, match=r"Type 'float64' can not be used in operator '%'"):
-        _ = FieldOperatorParser.apply_to_function(modulo_floats)
-
-
-def test_undefined_symbols():
-    def return_undefined():
-        return undefined_symbol
-
-    with pytest.raises(errors.DSLError, match="Undeclared symbol"):
-        _ = FieldOperatorParser.apply_to_function(return_undefined)
-
-
-def test_as_offset_dim():
-    ADim = Dimension("ADim")
-    BDim = Dimension("BDim")
-    Boff = FieldOffset("Boff", source=BDim, target=(BDim,))
-
-    def as_offset_dim(a: Field[[ADim, BDim], float], b: Field[[ADim], int]):
-        return a(as_offset(Boff, b))
-
-    with pytest.raises(errors.DSLError, match=f"not in list of offset field dimensions"):
-        _ = FieldOperatorParser.apply_to_function(as_offset_dim)
-
-
-def test_as_offset_dtype():
-    ADim = Dimension("ADim")
-    BDim = Dimension("BDim")
-    Boff = FieldOffset("Boff", source=BDim, target=(BDim,))
-
-    def as_offset_dtype(a: Field[[ADim, BDim], float], b: Field[[BDim], float]):
-        return a(as_offset(Boff, b))
-
-    with pytest.raises(errors.DSLError, match=f"expected integer for offset field dtype"):
-        _ = FieldOperatorParser.apply_to_function(as_offset_dtype)


### PR DESCRIPTION
`type_info.accept_args` is used in the iterator type inference to check if a node with type `ts.FunctionType` is callable for a given set of arguments [here](https://github.com/GridTools/gt4py/blob/764ef5098078b327d086c4e06db357b45b046669/src/gt4py/next/iterator/type_system/inference.py#L237). This failed when the function type had an iterator argument with `position_dims="unknown"`. This PR promotes the `_is_compatible_type` function from the iterator type inference to a shared function available in all type systems and switches `accept_args` (or more precisely `function_signature_incompatibilities_func`) to use that function instead of `is_concretizable`.

Additionally this PR contains a small cleanup of the type deduction / type system tests:
- `test_type_deduction.py` was moved from integration to unit tests (as it only contains unit tests).
- All type system tests are moved from `test_type_deduction.py` as they are not specific to the frontend type deduction.