### PR TITLE
refactor[cartesian]: Minor cleanup in backends

### DIFF
--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -141,7 +141,7 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     GT_BACKEND_T = "gpu"
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
-        return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=True)
+        return self.make_extension(uses_cuda=True)
 
     def generate(self) -> Type[StencilObject]:
         self.check_options(self.builder.options)

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -794,7 +794,7 @@ class DaceCPUBackend(BaseDaceBackend):
     options = BaseGTBackend.GT_BACKEND_OPTS
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
-        return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=False)
+        return self.make_extension(uses_cuda=False)
 
 
 @register
@@ -815,4 +815,4 @@ class DaceGPUBackend(BaseDaceBackend):
     options = {**BaseGTBackend.GT_BACKEND_OPTS, "device_sync": {"versioning": True, "type": bool}}
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
-        return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=True)
+        return self.make_extension(uses_cuda=True)

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -510,7 +510,7 @@ auto ${name}(const std::array<gt::uint_t, 3>& domain) {
                     lines = lines[0:i] + cuda_code.split("\n") + lines[i + 1 :]
                     break
 
-        def keep_line(line):
+        def keep_line(line: str) -> bool:
             line = line.strip()
             if line == '#include "../../include/hash.h"':
                 return False
@@ -520,11 +520,7 @@ auto ${name}(const std::array<gt::uint_t, 3>& domain) {
                 return False
             return True
 
-        lines = filter(keep_line, lines)
-        generated_code = "\n".join(lines)
-        if builder.options.format_source:
-            generated_code = codegen.format_source("cpp", generated_code, style="LLVM")
-        return generated_code
+        return "\n".join(filter(keep_line, lines))
 
     @classmethod
     def apply(cls, stencil_ir: gtir.Stencil, builder: StencilBuilder, sdfg: dace.SDFG):

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -129,7 +129,7 @@ class GTBaseBackend(BaseGTBackend, CLIBackendMixin):
     PYEXT_GENERATOR_CLASS = GTExtGenerator
 
     def _generate_extension(self, uses_cuda: bool) -> Tuple[str, str]:
-        return self.make_extension(stencil_ir=self.builder.gtir, uses_cuda=uses_cuda)
+        return self.make_extension(uses_cuda=uses_cuda)
 
     def generate(self) -> Type[StencilObject]:
         self.check_options(self.builder.options)

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend_api.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend_api.py
@@ -79,7 +79,7 @@ def test_generate_bindings(backend, tmp_path):
         )
     else:
         # assumption: only gt backends support python bindings for other languages than python
-        result = builder.backend.generate_bindings("python", stencil_ir=builder.gtir)
+        result = builder.backend.generate_bindings("python")
         assert "init_1_src" in result
-        srcs = result["init_1_src"]
-        assert "bindings.cpp" in srcs or "bindings.cu" in srcs
+        sources = result["init_1_src"]
+        assert "bindings.cpp" in sources or "bindings.cu" in sources


### PR DESCRIPTION
## Description

I was reading a lot of code around DaCe/gt-codegen when debugging the new DaCe/gt4py bridge. This PR combines three cleanup commits:

- Always get stencil_ir from builder in GTBaseBackends. I've found no usage of `stencil_ir` being anything else than `self.build.gtir` if it was explicitly passed as an argument at all. There's thus no need to pass around `self.build.gtir` as long as we stay in the same class hierarchy.
- Avoid unnecessary indenting in generated code. Generated code is optionally formatted, but even if not, we can make sure the code doesn't look too ugly.
- Avoid double formatting of source code (if gt4py/dace is configured to do so). No need for formatting intermediate code parts because it's formatted anyway at the end.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Updated test accordingly.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
