### PR TITLE
build: use frozen dependencies when running mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
   hooks:
   - id: mypy
     name: mypy static type checker
-    entry: uv run mypy --no-install-types src/
+    entry: uv run --frozen mypy --no-install-types src/
     language: system
     types_or: [python, pyi]
     pass_filenames: false


### PR DESCRIPTION
... otherwise it might update `uv.lock` which will create a pre-commit error because of changed files. See also https://github.com/astral-sh/uv/issues/10845