### PR TITLE
refactor[cartesian]: unexpanded sdfg cleanups

### DIFF
--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -84,7 +84,7 @@ class Backend(abc.ABC):
     #: Backend-specific storage parametrization:
     #:
     #:  - "alignment": in bytes
-    #:  - "device": "cpu" | "gpu"
+    #:  - "device": StorageDevice.CPU | StorageDevice.GPU
     #:  - "layout_map": callback converting a mask to a layout
     #:  - "is_optimal_layout": callback checking if a storage has compatible layout
     storage_info: ClassVar[gt_storage.layout.LayoutInfo]

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -151,10 +151,6 @@ def _pre_expand_transformations(gtir_pipeline: GtirPipeline, sdfg: dace.SDFG, la
         sdfg.add_state(gtir_pipeline.gtir.name)
         return sdfg
 
-    for array in sdfg.arrays.values():
-        if array.transient:
-            array.lifetime = dace.AllocationLifetime.Persistent
-
     sdfg.simplify(validate=False)
 
     _set_expansion_orders(sdfg)

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -47,7 +47,7 @@ from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.cartesian.utils import shash
 from gt4py.eve import codegen
 from gt4py.eve.codegen import MakoTemplate as as_mako
-from gt4py.storage.cartesian.layout import StorageDevice
+from gt4py.storage.cartesian.layout import is_cuda_device
 
 
 if TYPE_CHECKING:
@@ -409,7 +409,7 @@ class DaCeExtGenerator(BackendCodegen):
             stencil_ir, sdfg, module_name=self.module_name, backend=self.backend
         )
 
-        bindings_ext = "cu" if self.backend.storage_info["device"] == StorageDevice.GPU else "cpp"
+        bindings_ext = "cu" if is_cuda_device(self.backend.storage_info) else "cpp"
         sources = {
             "computation": {"computation.hpp": implementation},
             "bindings": {f"bindings.{bindings_ext}": bindings},
@@ -664,7 +664,7 @@ class DaCeBindingsCodegen:
                     "py::{pybind_type} {name}, std::array<gt::int_t,{ndim}> {name}_origin".format(
                         pybind_type=(
                             "object"
-                            if self.backend.storage_info["device"] == StorageDevice.GPU
+                            if is_cuda_device(self.backend.storage_info["device"])
                             else "buffer"
                         ),
                         name=name,
@@ -767,14 +767,7 @@ class BaseDaceBackend(BaseGTBackend, CLIBackendMixin):
 class DaceCPUBackend(BaseDaceBackend):
     name = "dace:cpu"
     languages = {"computation": "c++", "bindings": ["python"]}
-    storage_info = {
-        "alignment": 1,
-        "device": StorageDevice.CPU,
-        "layout_map": gt_storage.layout.layout_maker_factory((0, 1, 2)),
-        "is_optimal_layout": gt_storage.layout.layout_checker_factory(
-            gt_storage.layout.layout_maker_factory((0, 1, 2))
-        ),
-    }
+    storage_info = gt_storage.layout.DaceCPULayout
     MODULE_GENERATOR_CLASS = DaCePyExtModuleGenerator
 
     options = BaseGTBackend.GT_BACKEND_OPTS
@@ -789,14 +782,7 @@ class DaceGPUBackend(BaseDaceBackend):
 
     name = "dace:gpu"
     languages = {"computation": "cuda", "bindings": ["python"]}
-    storage_info = {
-        "alignment": 32,
-        "device": StorageDevice.GPU,
-        "layout_map": gt_storage.layout.layout_maker_factory((2, 1, 0)),
-        "is_optimal_layout": gt_storage.layout.layout_checker_factory(
-            gt_storage.layout.layout_maker_factory((2, 1, 0))
-        ),
-    }
+    storage_info = gt_storage.layout.DaceGPULayout
     MODULE_GENERATOR_CLASS = DaCeCUDAPyExtModuleGenerator
     options = {**BaseGTBackend.GT_BACKEND_OPTS, "device_sync": {"versioning": True, "type": bool}}
 

--- a/src/gt4py/cartesian/backend/dace_stencil_object.py
+++ b/src/gt4py/cartesian/backend/dace_stencil_object.py
@@ -24,9 +24,10 @@ from gt4py.cartesian.backend.dace_backend import freeze_origin_domain_sdfg
 from gt4py.cartesian.definitions import AccessKind, DomainInfo, FieldInfo
 from gt4py.cartesian.stencil_object import ArgsInfo, FrozenStencil, StencilObject
 from gt4py.cartesian.utils import shash
+from gt4py.storage.cartesian.layout import StorageDevice
 
 
-def _extract_array_infos(field_args, device) -> Dict[str, Optional[ArgsInfo]]:
+def _extract_array_infos(field_args, device: StorageDevice) -> Dict[str, Optional[ArgsInfo]]:
     return {
         name: ArgsInfo(
             array=arg,

--- a/src/gt4py/cartesian/backend/dace_stencil_object.py
+++ b/src/gt4py/cartesian/backend/dace_stencil_object.py
@@ -20,14 +20,14 @@ import dace.frontend.python.common
 from dace.frontend.python.common import SDFGClosure, SDFGConvertible
 
 from gt4py import cartesian as gt4pyc
+from gt4py._core.definitions import DeviceType
 from gt4py.cartesian.backend.dace_backend import freeze_origin_domain_sdfg
 from gt4py.cartesian.definitions import AccessKind, DomainInfo, FieldInfo
 from gt4py.cartesian.stencil_object import ArgsInfo, FrozenStencil, StencilObject
 from gt4py.cartesian.utils import shash
-from gt4py.storage.cartesian.layout import StorageDevice
 
 
-def _extract_array_infos(field_args, device: StorageDevice) -> Dict[str, Optional[ArgsInfo]]:
+def _extract_array_infos(field_args, device: DeviceType) -> Dict[str, Optional[ArgsInfo]]:
     return {
         name: ArgsInfo(
             array=arg,

--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -23,6 +23,7 @@ from gt4py.cartesian.gtc import gtir
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
 from gt4py.cartesian.gtc.passes.oir_pipeline import OirPipeline
 from gt4py.eve.codegen import MakoTemplate as as_mako
+from gt4py.storage.cartesian.layout import StorageDevice
 
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ def pybuffer_to_sid(
     domain_ndim = domain_dim_flags.count(True)
     sid_ndim = domain_ndim + data_ndim
 
-    as_sid = "as_cuda_sid" if backend.storage_info["device"] == "gpu" else "as_sid"
+    as_sid = "as_cuda_sid" if backend.storage_info["device"] == StorageDevice.GPU else "as_sid"
 
     sid_def = """gt::{as_sid}<{ctype}, {sid_ndim},
         gt::integral_constant<int, {unique_index}>>({name})""".format(

--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -23,7 +23,7 @@ from gt4py.cartesian.gtc import gtir
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
 from gt4py.cartesian.gtc.passes.oir_pipeline import OirPipeline
 from gt4py.eve.codegen import MakoTemplate as as_mako
-from gt4py.storage.cartesian.layout import StorageDevice
+from gt4py.storage.cartesian.layout import is_cuda_device
 
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ def pybuffer_to_sid(
     domain_ndim = domain_dim_flags.count(True)
     sid_ndim = domain_ndim + data_ndim
 
-    as_sid = "as_cuda_sid" if backend.storage_info["device"] == StorageDevice.GPU else "as_sid"
+    as_sid = "as_cuda_sid" if is_cuda_device(backend.storage_info) else "as_sid"
 
     sid_def = """gt::{as_sid}<{ctype}, {sid_ndim},
         gt::integral_constant<int, {unique_index}>>({name})""".format(

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -25,6 +25,7 @@ from gt4py.cartesian.gtc.gtir_to_oir import GTIRToOIR
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.eve import codegen
+from gt4py.storage.cartesian.layout import StorageDevice
 
 from .gtc_common import BaseGTBackend, CUDAPyExtModuleGenerator
 
@@ -85,7 +86,9 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
             if kwargs["external_arg"]:
                 return "py::{pybind_type} {name}, std::array<gt::int_t,{sid_ndim}> {name}_origin".format(
                     pybind_type=(
-                        "object" if self.backend.storage_info["device"] == "gpu" else "buffer"
+                        "object"
+                        if self.backend.storage_info["device"] == StorageDevice.GPU
+                        else "buffer"
                     ),
                     name=node.name,
                     sid_ndim=sid_ndim,

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -25,7 +25,7 @@ from gt4py.cartesian.gtc.gtir_to_oir import GTIRToOIR
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.eve import codegen
-from gt4py.storage.cartesian.layout import StorageDevice
+from gt4py.storage.cartesian.layout import is_gpu_device
 
 from .gtc_common import BaseGTBackend, CUDAPyExtModuleGenerator
 
@@ -86,9 +86,7 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
             if kwargs["external_arg"]:
                 return "py::{pybind_type} {name}, std::array<gt::int_t,{sid_ndim}> {name}_origin".format(
                     pybind_type=(
-                        "object"
-                        if self.backend.storage_info["device"] == StorageDevice.GPU
-                        else "buffer"
+                        "object" if is_gpu_device(self.backend.storage_info) else "buffer"
                     ),
                     name=node.name,
                     sid_ndim=sid_ndim,

--- a/src/gt4py/cartesian/gtc/dace/constants.py
+++ b/src/gt4py/cartesian/gtc/dace/constants.py
@@ -1,0 +1,15 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+from typing import Final
+
+
+# StencilComputation in/out connector prefixes
+CONNECTOR_PREFIX_IN: Final = "__in_"
+CONNECTOR_PREFIX_OUT: Final = "__out_"

--- a/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
@@ -18,6 +18,7 @@ import dace.subsets
 import sympy
 
 from gt4py.cartesian.gtc.dace import daceir as dcir
+from gt4py.cartesian.gtc.dace.constants import CONNECTOR_PREFIX_IN, CONNECTOR_PREFIX_OUT
 from gt4py.cartesian.gtc.dace.expansion.daceir_builder import DaCeIRBuilder
 from gt4py.cartesian.gtc.dace.expansion.sdfg_builder import StencilComputationSDFGBuilder
 
@@ -77,11 +78,11 @@ class StencilComputationExpansion(dace.library.ExpandTransformation):
         """
         # change connector names
         for in_edge in parent_state.in_edges(node):
-            assert in_edge.dst_conn.startswith("__in_")
-            in_edge.dst_conn = in_edge.dst_conn[len("__in_") :]
+            assert in_edge.dst_conn.startswith(CONNECTOR_PREFIX_IN)
+            in_edge.dst_conn = in_edge.dst_conn.removeprefix(CONNECTOR_PREFIX_IN)
         for out_edge in parent_state.out_edges(node):
-            assert out_edge.src_conn.startswith("__out_")
-            out_edge.src_conn = out_edge.src_conn[len("__out_") :]
+            assert out_edge.src_conn.startswith(CONNECTOR_PREFIX_OUT)
+            out_edge.src_conn = out_edge.src_conn.removeprefix(CONNECTOR_PREFIX_OUT)
 
         # union input and output subsets
         subsets = {}
@@ -125,9 +126,13 @@ class StencilComputationExpansion(dace.library.ExpandTransformation):
     ) -> Dict[str, dace.data.Data]:
         parent_arrays: Dict[str, dace.data.Data] = {}
         for edge in (e for e in parent_state.in_edges(node) if e.dst_conn is not None):
-            parent_arrays[edge.dst_conn[len("__in_") :]] = parent_sdfg.arrays[edge.data.data]
+            parent_arrays[edge.dst_conn.removeprefix(CONNECTOR_PREFIX_IN)] = parent_sdfg.arrays[
+                edge.data.data
+            ]
         for edge in (e for e in parent_state.out_edges(node) if e.src_conn is not None):
-            parent_arrays[edge.src_conn[len("__out_") :]] = parent_sdfg.arrays[edge.data.data]
+            parent_arrays[edge.src_conn.removeprefix(CONNECTOR_PREFIX_OUT)] = parent_sdfg.arrays[
+                edge.data.data
+            ]
         return parent_arrays
 
     @staticmethod

--- a/src/gt4py/cartesian/gtc/dace/expansion/sdfg_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/sdfg_builder.py
@@ -20,9 +20,8 @@ import dace.subsets
 from gt4py import eve
 from gt4py.cartesian.gtc.dace import daceir as dcir
 from gt4py.cartesian.gtc.dace.expansion.tasklet_codegen import TaskletCodegen
-from gt4py.cartesian.gtc.dace.expansion.utils import get_dace_debuginfo
 from gt4py.cartesian.gtc.dace.symbol_utils import data_type_to_dace_typeclass
-from gt4py.cartesian.gtc.dace.utils import make_dace_subset
+from gt4py.cartesian.gtc.dace.utils import get_dace_debuginfo, make_dace_subset
 
 
 class StencilComputationSDFGBuilder(eve.VisitorWithSymbolTableTrait):
@@ -268,13 +267,13 @@ class StencilComputationSDFGBuilder(eve.VisitorWithSymbolTableTrait):
             for memlet in computation.read_memlets:
                 if memlet.field not in read_acc_and_conn:
                     read_acc_and_conn[memlet.field] = (
-                        sdfg_ctx.state.add_access(memlet.field, debuginfo=dace.DebugInfo(0)),
+                        sdfg_ctx.state.add_access(memlet.field),
                         None,
                     )
             for memlet in computation.write_memlets:
                 if memlet.field not in write_acc_and_conn:
                     write_acc_and_conn[memlet.field] = (
-                        sdfg_ctx.state.add_access(memlet.field, debuginfo=dace.DebugInfo(0)),
+                        sdfg_ctx.state.add_access(memlet.field),
                         None,
                     )
             node_ctx = StencilComputationSDFGBuilder.NodeContext(
@@ -298,7 +297,7 @@ class StencilComputationSDFGBuilder(eve.VisitorWithSymbolTableTrait):
             dtype=data_type_to_dace_typeclass(node.dtype),
             storage=node.storage.to_dace_storage(),
             transient=node.name not in non_transients,
-            debuginfo=dace.DebugInfo(0),
+            debuginfo=get_dace_debuginfo(node),
         )
 
     def visit_SymbolDecl(
@@ -343,7 +342,6 @@ class StencilComputationSDFGBuilder(eve.VisitorWithSymbolTableTrait):
                 inputs=node.input_connectors,
                 outputs=node.output_connectors,
                 symbol_mapping=symbol_mapping,
-                debuginfo=dace.DebugInfo(0),
             )
             self.visit(
                 node.read_memlets,

--- a/src/gt4py/cartesian/gtc/dace/expansion/utils.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/utils.py
@@ -10,11 +10,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 
-import dace
-import dace.data
-import dace.library
-import dace.subsets
-
 from gt4py import eve
 from gt4py.cartesian.gtc import common, oir
 from gt4py.cartesian.gtc.dace import daceir as dcir
@@ -23,15 +18,6 @@ from gt4py.cartesian.gtc.definitions import Extent
 
 if TYPE_CHECKING:
     from gt4py.cartesian.gtc.dace.nodes import StencilComputation
-
-
-def get_dace_debuginfo(node: common.LocNode):
-    if node.loc is not None:
-        return dace.dtypes.DebugInfo(
-            node.loc.line, node.loc.column, node.loc.line, node.loc.column, node.loc.filename
-        )
-    else:
-        return dace.dtypes.DebugInfo(0)
 
 
 class HorizontalIntervalRemover(eve.NodeTranslator):

--- a/src/gt4py/cartesian/gtc/dace/nodes.py
+++ b/src/gt4py/cartesian/gtc/dace/nodes.py
@@ -23,11 +23,11 @@ from dace import library
 from gt4py.cartesian.gtc import common, oir
 from gt4py.cartesian.gtc.dace import daceir as dcir
 from gt4py.cartesian.gtc.dace.expansion.expansion import StencilComputationExpansion
+from gt4py.cartesian.gtc.dace.expansion.utils import HorizontalExecutionSplitter
+from gt4py.cartesian.gtc.dace.expansion_specification import ExpansionItem, make_expansion_order
+from gt4py.cartesian.gtc.dace.utils import get_dace_debuginfo
 from gt4py.cartesian.gtc.definitions import Extent
 from gt4py.cartesian.gtc.oir import Decl, FieldDecl, VerticalLoop, VerticalLoopSection
-
-from .expansion.utils import HorizontalExecutionSplitter, get_dace_debuginfo
-from .expansion_specification import ExpansionItem, make_expansion_order
 
 
 def _set_expansion_order(

--- a/src/gt4py/cartesian/gtc/dace/nodes.py
+++ b/src/gt4py/cartesian/gtc/dace/nodes.py
@@ -119,6 +119,7 @@ class StencilComputation(library.LibraryNode):
         extents: Optional[Dict[int, Extent]] = None,
         declarations: Optional[Dict[str, Decl]] = None,
         expansion_order=None,
+        device: Optional[dace.DeviceType] = None,
         *args,
         **kwargs,
     ):
@@ -137,6 +138,7 @@ class StencilComputation(library.LibraryNode):
             self.oir_node = typing.cast(PickledDataclassProperty, oir_node)
             self.extents = extents_dict  # type: ignore
             self.declarations = declarations  # type: ignore
+            self.device = device
             self.symbol_mapping = {
                 decl.name: dace.symbol(
                     decl.name,

--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -20,7 +20,11 @@ from gt4py import eve
 from gt4py.cartesian.gtc.dace import daceir as dcir
 from gt4py.cartesian.gtc.dace.nodes import StencilComputation
 from gt4py.cartesian.gtc.dace.symbol_utils import data_type_to_dace_typeclass
-from gt4py.cartesian.gtc.dace.utils import compute_dcir_access_infos, make_dace_subset
+from gt4py.cartesian.gtc.dace.utils import (
+    compute_dcir_access_infos,
+    get_dace_debuginfo,
+    make_dace_subset,
+)
 from gt4py.cartesian.gtc.definitions import Extent
 from gt4py.cartesian.gtc.passes.oir_optimizations.utils import (
     AccessCollector,
@@ -115,7 +119,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
         access_collection = AccessCollector.apply(node)
 
         for field in access_collection.read_fields():
-            access_node = state.add_access(field, debuginfo=dace.DebugInfo(0))
+            access_node = state.add_access(field, debuginfo=get_dace_debuginfo(declarations[field]))
             library_node.add_in_connector("__in_" + field)
             subset = ctx.make_input_dace_subset(node, field)
             state.add_edge(
@@ -123,7 +127,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
             )
 
         for field in access_collection.write_fields():
-            access_node = state.add_access(field, debuginfo=dace.DebugInfo(0))
+            access_node = state.add_access(field, debuginfo=get_dace_debuginfo(declarations[field]))
             library_node.add_out_connector("__out_" + field)
             subset = ctx.make_output_dace_subset(node, field)
             state.add_edge(
@@ -146,7 +150,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                     ],
                     dtype=data_type_to_dace_typeclass(param.dtype),
                     transient=False,
-                    debuginfo=dace.DebugInfo(0),
+                    debuginfo=get_dace_debuginfo(param),
                 )
             else:
                 ctx.sdfg.add_symbol(param.name, stype=data_type_to_dace_typeclass(param.dtype))
@@ -164,7 +168,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                 ],
                 dtype=data_type_to_dace_typeclass(decl.dtype),
                 transient=True,
-                debuginfo=dace.DebugInfo(0),
+                debuginfo=get_dace_debuginfo(decl),
             )
         self.generic_visit(node, ctx=ctx)
         ctx.sdfg.validate()

--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Literal
+from typing import Dict
 
 import dace
 import dace.properties
@@ -31,16 +31,17 @@ from gt4py.cartesian.gtc.passes.oir_optimizations.utils import (
     AccessCollector,
     compute_horizontal_block_extents,
 )
+from gt4py.storage.cartesian.layout import StorageDevice
 
 
-transient_storage_per_device: Dict[Literal["cpu", "gpu"], dace.StorageType] = {
-    "cpu": dace.StorageType.Default,
-    "gpu": dace.StorageType.GPU_Global,
+transient_storage_per_device: Dict[StorageDevice, dace.StorageType] = {
+    StorageDevice.CPU: dace.StorageType.Default,
+    StorageDevice.GPU: dace.StorageType.GPU_Global,
 }
 
-device_type_per_device: Dict[Literal["cpu", "gpu"], dace.DeviceType] = {
-    "cpu": dace.DeviceType.CPU,
-    "gpu": dace.DeviceType.GPU,
+device_type_per_device: Dict[StorageDevice, dace.DeviceType] = {
+    StorageDevice.CPU: dace.DeviceType.CPU,
+    StorageDevice.GPU: dace.DeviceType.GPU,
 }
 
 
@@ -114,7 +115,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
         node: oir.VerticalLoop,
         *,
         ctx: OirSDFGBuilder.SDFGContext,
-        device: Literal["cpu", "gpu"],
+        device: StorageDevice,
     ) -> None:
         declarations = {
             acc.name: ctx.decls[acc.name]
@@ -155,7 +156,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                 library_node, connector_name, access_node, None, dace.Memlet(field, subset=subset)
             )
 
-    def visit_Stencil(self, node: oir.Stencil, *, device: Literal["cpu", "gpu"]) -> dace.SDFG:
+    def visit_Stencil(self, node: oir.Stencil, *, device: StorageDevice) -> dace.SDFG:
         ctx = OirSDFGBuilder.SDFGContext(node)
         for param in node.params:
             if isinstance(param, oir.FieldDecl):

--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -171,6 +171,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                 ],
                 dtype=data_type_to_dace_typeclass(decl.dtype),
                 transient=True,
+                lifetime=dace.AllocationLifetime.Persistent,
                 debuginfo=get_dace_debuginfo(decl),
             )
         self.generic_visit(node, ctx=ctx)

--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -93,9 +93,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                 global_access_info, local_access_info, self.decls[field].data_dims
             )
 
-    def visit_VerticalLoop(
-        self, node: oir.VerticalLoop, *, ctx: OirSDFGBuilder.SDFGContext, **kwargs
-    ):
+    def visit_VerticalLoop(self, node: oir.VerticalLoop, *, ctx: OirSDFGBuilder.SDFGContext):
         declarations = {
             acc.name: ctx.decls[acc.name]
             for acc in node.walk_values().if_isinstance(oir.FieldAccess, oir.ScalarAccess)
@@ -132,7 +130,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                 library_node, "__out_" + field, access_node, None, dace.Memlet(field, subset=subset)
             )
 
-    def visit_Stencil(self, node: oir.Stencil, **kwargs):
+    def visit_Stencil(self, node: oir.Stencil):
         ctx = OirSDFGBuilder.SDFGContext(stencil=node)
         for param in node.params:
             if isinstance(param, oir.FieldDecl):

--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -17,6 +17,7 @@ import dace.subsets
 
 import gt4py.cartesian.gtc.oir as oir
 from gt4py import eve
+from gt4py._core.definitions import DeviceType
 from gt4py.cartesian.gtc.dace import daceir as dcir
 from gt4py.cartesian.gtc.dace.constants import CONNECTOR_PREFIX_IN, CONNECTOR_PREFIX_OUT
 from gt4py.cartesian.gtc.dace.nodes import StencilComputation
@@ -31,17 +32,16 @@ from gt4py.cartesian.gtc.passes.oir_optimizations.utils import (
     AccessCollector,
     compute_horizontal_block_extents,
 )
-from gt4py.storage.cartesian.layout import StorageDevice
 
 
-transient_storage_per_device: Dict[StorageDevice, dace.StorageType] = {
-    StorageDevice.CPU: dace.StorageType.Default,
-    StorageDevice.GPU: dace.StorageType.GPU_Global,
+transient_storage_per_device: Dict[DeviceType, dace.StorageType] = {
+    DeviceType.CPU: dace.StorageType.Default,
+    DeviceType.CUDA: dace.StorageType.GPU_Global,
 }
 
-device_type_per_device: Dict[StorageDevice, dace.DeviceType] = {
-    StorageDevice.CPU: dace.DeviceType.CPU,
-    StorageDevice.GPU: dace.DeviceType.GPU,
+device_type_per_device: Dict[DeviceType, dace.DeviceType] = {
+    DeviceType.CPU: dace.DeviceType.CPU,
+    DeviceType.CUDA: dace.DeviceType.GPU,
 }
 
 
@@ -115,7 +115,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
         node: oir.VerticalLoop,
         *,
         ctx: OirSDFGBuilder.SDFGContext,
-        device: StorageDevice,
+        device: DeviceType,
     ) -> None:
         declarations = {
             acc.name: ctx.decls[acc.name]
@@ -156,7 +156,7 @@ class OirSDFGBuilder(eve.NodeVisitor):
                 library_node, connector_name, access_node, None, dace.Memlet(field, subset=subset)
             )
 
-    def visit_Stencil(self, node: oir.Stencil, *, device: StorageDevice) -> dace.SDFG:
+    def visit_Stencil(self, node: oir.Stencil, *, device: DeviceType) -> dace.SDFG:
         ctx = OirSDFGBuilder.SDFGContext(node)
         for param in node.params:
             if isinstance(param, oir.FieldDecl):

--- a/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_dace.py
@@ -18,6 +18,7 @@ import dace.subsets
 import gt4py.cartesian.gtc.oir as oir
 from gt4py import eve
 from gt4py.cartesian.gtc.dace import daceir as dcir
+from gt4py.cartesian.gtc.dace.constants import CONNECTOR_PREFIX_IN, CONNECTOR_PREFIX_OUT
 from gt4py.cartesian.gtc.dace.nodes import StencilComputation
 from gt4py.cartesian.gtc.dace.symbol_utils import data_type_to_dace_typeclass
 from gt4py.cartesian.gtc.dace.utils import (
@@ -120,18 +121,20 @@ class OirSDFGBuilder(eve.NodeVisitor):
 
         for field in access_collection.read_fields():
             access_node = state.add_access(field, debuginfo=get_dace_debuginfo(declarations[field]))
-            library_node.add_in_connector("__in_" + field)
+            connector_name = f"{CONNECTOR_PREFIX_IN}{field}"
+            library_node.add_in_connector(connector_name)
             subset = ctx.make_input_dace_subset(node, field)
             state.add_edge(
-                access_node, None, library_node, "__in_" + field, dace.Memlet(field, subset=subset)
+                access_node, None, library_node, connector_name, dace.Memlet(field, subset=subset)
             )
 
         for field in access_collection.write_fields():
             access_node = state.add_access(field, debuginfo=get_dace_debuginfo(declarations[field]))
-            library_node.add_out_connector("__out_" + field)
+            connector_name = f"{CONNECTOR_PREFIX_OUT}{field}"
+            library_node.add_out_connector(connector_name)
             subset = ctx.make_output_dace_subset(node, field)
             state.add_edge(
-                library_node, "__out_" + field, access_node, None, dace.Memlet(field, subset=subset)
+                library_node, connector_name, access_node, None, dace.Memlet(field, subset=subset)
             )
 
     def visit_Stencil(self, node: oir.Stencil):

--- a/src/gt4py/cartesian/gtc/dace/utils.py
+++ b/src/gt4py/cartesian/gtc/dace/utils.py
@@ -23,6 +23,15 @@ from gt4py.cartesian.gtc.dace import daceir as dcir
 from gt4py.cartesian.gtc.passes.oir_optimizations.utils import compute_horizontal_block_extents
 
 
+def get_dace_debuginfo(node: common.LocNode) -> dace.dtypes.DebugInfo:
+    if node.loc is None:
+        return dace.dtypes.DebugInfo(0)
+
+    return dace.dtypes.DebugInfo(
+        node.loc.line, node.loc.column, node.loc.line, node.loc.column, node.loc.filename
+    )
+
+
 def array_dimensions(array: dace.data.Array):
     dims = [
         any(

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -22,9 +22,9 @@ import numpy as np
 import gt4py.cartesian.gtc.utils as gtc_utils
 import gt4py.storage.cartesian.utils as storage_utils
 from gt4py import cartesian as gt4pyc
+from gt4py._core.definitions import DeviceType
 from gt4py.cartesian.definitions import AccessKind, DomainInfo, FieldInfo, ParameterInfo
 from gt4py.cartesian.gtc.definitions import Index, Shape
-from gt4py.storage.cartesian.layout import StorageDevice
 
 
 try:
@@ -52,7 +52,7 @@ def _compute_domain_origin_cache_key(
 
 @dataclass
 class ArgsInfo:
-    device: StorageDevice
+    device: DeviceType
     array: FieldType
     original_object: Optional[Any] = None
     origin: Optional[Tuple[int, ...]] = None
@@ -60,7 +60,7 @@ class ArgsInfo:
 
 
 def _extract_array_infos(
-    field_args: Dict[str, Optional[FieldType]], device: StorageDevice
+    field_args: Dict[str, Optional[FieldType]], device: DeviceType
 ) -> Dict[str, Optional[ArgsInfo]]:
     array_infos: Dict[str, Optional[ArgsInfo]] = {}
     for name, arg in field_args.items():

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -15,7 +15,7 @@ import time
 from dataclasses import dataclass
 from numbers import Number
 from pickle import dumps
-from typing import Any, Callable, ClassVar, Dict, Literal, Optional, Tuple, Union, cast
+from typing import Any, Callable, ClassVar, Dict, Optional, Tuple, Union, cast
 
 import numpy as np
 
@@ -24,6 +24,7 @@ import gt4py.storage.cartesian.utils as storage_utils
 from gt4py import cartesian as gt4pyc
 from gt4py.cartesian.definitions import AccessKind, DomainInfo, FieldInfo, ParameterInfo
 from gt4py.cartesian.gtc.definitions import Index, Shape
+from gt4py.storage.cartesian.layout import StorageDevice
 
 
 try:
@@ -51,7 +52,7 @@ def _compute_domain_origin_cache_key(
 
 @dataclass
 class ArgsInfo:
-    device: str
+    device: StorageDevice
     array: FieldType
     original_object: Optional[Any] = None
     origin: Optional[Tuple[int, ...]] = None
@@ -59,7 +60,7 @@ class ArgsInfo:
 
 
 def _extract_array_infos(
-    field_args: Dict[str, Optional[FieldType]], device: Literal["cpu", "gpu"]
+    field_args: Dict[str, Optional[FieldType]], device: StorageDevice
 ) -> Dict[str, Optional[ArgsInfo]]:
     array_infos: Dict[str, Optional[ArgsInfo]] = {}
     for name, arg in field_args.items():

--- a/src/gt4py/cartesian/testing/suites.py
+++ b/src/gt4py/cartesian/testing/suites.py
@@ -24,6 +24,7 @@ from gt4py.cartesian.definitions import AccessKind, FieldInfo
 from gt4py.cartesian.gtc.definitions import Boundary, CartesianSpace, Index, Shape
 from gt4py.cartesian.stencil_object import StencilObject
 from gt4py.storage.cartesian import utils as storage_utils
+from gt4py.storage.cartesian.layout import StorageDevice
 
 from .input_strategies import (
     SymbolKind,
@@ -206,7 +207,10 @@ class SuiteMeta(type):
                 )
 
                 marks = test["marks"].copy()
-                if gt4pyc.backend.from_name(test["backend"]).storage_info["device"] == "gpu":
+                if (
+                    gt4pyc.backend.from_name(test["backend"]).storage_info["device"]
+                    == StorageDevice.GPU
+                ):
                     marks.append(pytest.mark.requires_gpu)
                 # Run generation and implementation tests in the same group to ensure
                 # (thread-) safe parallelization of stencil tests.
@@ -240,7 +244,10 @@ class SuiteMeta(type):
                 )
 
                 marks = test["marks"].copy()
-                if gt4pyc.backend.from_name(test["backend"]).storage_info["device"] == "gpu":
+                if (
+                    gt4pyc.backend.from_name(test["backend"]).storage_info["device"]
+                    == StorageDevice.GPU
+                ):
                     marks.append(pytest.mark.requires_gpu)
                 # Run generation and implementation tests in the same group to ensure
                 # (thread-) safe parallelization of stencil tests.

--- a/src/gt4py/cartesian/testing/suites.py
+++ b/src/gt4py/cartesian/testing/suites.py
@@ -24,7 +24,7 @@ from gt4py.cartesian.definitions import AccessKind, FieldInfo
 from gt4py.cartesian.gtc.definitions import Boundary, CartesianSpace, Index, Shape
 from gt4py.cartesian.stencil_object import StencilObject
 from gt4py.storage.cartesian import utils as storage_utils
-from gt4py.storage.cartesian.layout import StorageDevice
+from gt4py.storage.cartesian.layout import is_gpu_device
 
 from .input_strategies import (
     SymbolKind,
@@ -207,10 +207,7 @@ class SuiteMeta(type):
                 )
 
                 marks = test["marks"].copy()
-                if (
-                    gt4pyc.backend.from_name(test["backend"]).storage_info["device"]
-                    == StorageDevice.GPU
-                ):
+                if is_gpu_device(gt4pyc.backend.from_name(test["backend"]).storage_info):
                     marks.append(pytest.mark.requires_gpu)
                 # Run generation and implementation tests in the same group to ensure
                 # (thread-) safe parallelization of stencil tests.
@@ -244,10 +241,7 @@ class SuiteMeta(type):
                 )
 
                 marks = test["marks"].copy()
-                if (
-                    gt4pyc.backend.from_name(test["backend"]).storage_info["device"]
-                    == StorageDevice.GPU
-                ):
+                if is_gpu_device(gt4pyc.backend.from_name(test["backend"]).storage_info):
                     marks.append(pytest.mark.requires_gpu)
                 # Run generation and implementation tests in the same group to ensure
                 # (thread-) safe parallelization of stencil tests.

--- a/src/gt4py/storage/cartesian/interface.py
+++ b/src/gt4py/storage/cartesian/interface.py
@@ -13,6 +13,7 @@ from typing import Optional, Sequence, Union
 
 import numpy as np
 
+from gt4py._core.definitions import DeviceType
 from gt4py.storage import allocators
 from gt4py.storage.cartesian import layout, utils as storage_utils
 
@@ -81,10 +82,14 @@ def empty(
     _error_on_invalid_preset(backend)
     storage_info = layout.from_name(backend)
     assert storage_info is not None
-    if storage_info["device"] == layout.StorageDevice.GPU:
+    if storage_info["device"] == DeviceType.CUDA:
         allocate_f = storage_utils.allocate_gpu
-    else:
+    elif storage_info["device"] == DeviceType.CPU:
         allocate_f = storage_utils.allocate_cpu
+    else:
+        raise ValueError(
+            f"Allocation is only defined for DeviceTypes {DeviceType.CPU} (CPU) and {DeviceType.CUDA} (CUDA). Got {storage_info['device']} instead."
+        )
 
     aligned_index, shape, dtype, dimensions = storage_utils.normalize_storage_spec(
         aligned_index, shape, dtype, dimensions

--- a/src/gt4py/storage/cartesian/interface.py
+++ b/src/gt4py/storage/cartesian/interface.py
@@ -81,7 +81,7 @@ def empty(
     _error_on_invalid_preset(backend)
     storage_info = layout.from_name(backend)
     assert storage_info is not None
-    if storage_info["device"] == "gpu":
+    if storage_info["device"] == layout.StorageDevice.GPU:
         allocate_f = storage_utils.allocate_gpu
     else:
         allocate_f = storage_utils.allocate_cpu

--- a/src/gt4py/storage/cartesian/layout.py
+++ b/src/gt4py/storage/cartesian/layout.py
@@ -6,13 +6,13 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Final,
-    Literal,
     Optional,
     Sequence,
     Tuple,
@@ -30,9 +30,14 @@ if TYPE_CHECKING:
         cp = None
 
 
+class StorageDevice(Enum):
+    CPU = 1
+    GPU = 2
+
+
 class LayoutInfo(TypedDict):
     alignment: int  # measured in bytes
-    device: Literal["cpu", "gpu"]
+    device: StorageDevice
     layout_map: Callable[[Tuple[str, ...]], Tuple[Optional[int], ...]]
     is_optimal_layout: Callable[[Any, Tuple[str, ...]], bool]
 
@@ -136,7 +141,7 @@ def make_cuda_layout_map(dimensions: Tuple[str, ...]) -> Tuple[Optional[int], ..
 
 NaiveCPULayout: Final[LayoutInfo] = {
     "alignment": 1,
-    "device": "cpu",
+    "device": StorageDevice.CPU,
     "layout_map": lambda axes: tuple(i for i in range(len(axes))),
     "is_optimal_layout": lambda *_: True,
 }
@@ -144,7 +149,7 @@ register("naive_cpu", NaiveCPULayout)
 
 CPUIFirstLayout: Final[LayoutInfo] = {
     "alignment": 8,
-    "device": "cpu",
+    "device": StorageDevice.CPU,
     "layout_map": make_gtcpu_ifirst_layout_map,
     "is_optimal_layout": layout_checker_factory(make_gtcpu_ifirst_layout_map),
 }
@@ -153,7 +158,7 @@ register("cpu_ifirst", CPUIFirstLayout)
 
 CPUKFirstLayout: Final[LayoutInfo] = {
     "alignment": 1,
-    "device": "cpu",
+    "device": StorageDevice.CPU,
     "layout_map": make_gtcpu_kfirst_layout_map,
     "is_optimal_layout": layout_checker_factory(make_gtcpu_kfirst_layout_map),
 }
@@ -162,7 +167,7 @@ register("cpu_kfirst", CPUKFirstLayout)
 
 CUDALayout: Final[LayoutInfo] = {
     "alignment": 32,
-    "device": "gpu",
+    "device": StorageDevice.GPU,
     "layout_map": make_cuda_layout_map,
     "is_optimal_layout": layout_checker_factory(make_cuda_layout_map),
 }

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -22,7 +22,6 @@ from gt4py._core import definitions as core_defs
 from gt4py.cartesian import config as gt_config
 from gt4py.eve.extended_typing import ArrayInterface, CUDAArrayInterface
 from gt4py.storage import allocators
-from gt4py.storage.cartesian.layout import StorageDevice
 
 
 try:
@@ -183,16 +182,18 @@ def cpu_copy(array: Union[np.ndarray, "cp.ndarray"]) -> np.ndarray:
         return np.array(array)
 
 
-def asarray(array: FieldLike, *, device: Optional[StorageDevice] = None) -> np.ndarray | cp.ndarray:
+def asarray(
+    array: FieldLike, *, device: Optional[core_defs.DeviceType] = None
+) -> np.ndarray | cp.ndarray:
     if hasattr(array, "ndarray"):
         # extract the buffer from a gt4py.next.Field
         # TODO(havogt): probably `Field` should provide the array interface methods when applicable
         array = array.ndarray
 
     xp = None
-    if device == StorageDevice.CPU:
+    if device == core_defs.DeviceType.CPU:
         xp = np
-    elif device == StorageDevice.GPU:
+    elif device == core_defs.DeviceType.CUDA:
         assert cp is not None
         xp = cp
     elif not device:

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -22,6 +22,7 @@ from gt4py._core import definitions as core_defs
 from gt4py.cartesian import config as gt_config
 from gt4py.eve.extended_typing import ArrayInterface, CUDAArrayInterface
 from gt4py.storage import allocators
+from gt4py.storage.cartesian.layout import StorageDevice
 
 
 try:
@@ -182,18 +183,16 @@ def cpu_copy(array: Union[np.ndarray, "cp.ndarray"]) -> np.ndarray:
         return np.array(array)
 
 
-def asarray(
-    array: FieldLike, *, device: Literal["cpu", "gpu", None] = None
-) -> np.ndarray | cp.ndarray:
+def asarray(array: FieldLike, *, device: Optional[StorageDevice] = None) -> np.ndarray | cp.ndarray:
     if hasattr(array, "ndarray"):
         # extract the buffer from a gt4py.next.Field
         # TODO(havogt): probably `Field` should provide the array interface methods when applicable
         array = array.ndarray
 
     xp = None
-    if device == "cpu":
+    if device == StorageDevice.CPU:
         xp = np
-    elif device == "gpu":
+    elif device == StorageDevice.GPU:
         assert cp is not None
         xp = cp
     elif not device:

--- a/tach.toml
+++ b/tach.toml
@@ -16,6 +16,7 @@ depends_on = [
 [[modules]]
 path = "gt4py.cartesian"
 depends_on = [
+    { path = "gt4py._core" }, # romanc: to be removed again (unless absolutely necessary)
     { path = "gt4py.eve" },
     { path = "gt4py.storage" },
 ]

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -19,13 +19,13 @@ import numpy as np
 import pytest
 
 from gt4py import cartesian as gt4pyc
+from gt4py._core.definitions import DeviceType
 from gt4py.cartesian import utils as gt_utils
-from gt4py.storage.cartesian.layout import StorageDevice
 
 
 def _backend_name_as_param(name):
     marks = []
-    if gt4pyc.backend.from_name(name).storage_info["device"] == StorageDevice.GPU:
+    if gt4pyc.backend.from_name(name).storage_info["device"] == DeviceType.CUDA:
         marks.append(pytest.mark.requires_gpu)
     if "dace" in name:
         marks.append(pytest.mark.requires_dace)
@@ -35,7 +35,7 @@ def _backend_name_as_param(name):
 _ALL_BACKEND_NAMES = list(gt4pyc.backend.REGISTRY.keys())
 
 
-def _get_backends_with_storage_info(storage_device: StorageDevice):
+def _get_backends_with_storage_info(storage_device: DeviceType):
     res = []
     for name in _ALL_BACKEND_NAMES:
         backend = gt4pyc.backend.from_name(name)
@@ -45,8 +45,8 @@ def _get_backends_with_storage_info(storage_device: StorageDevice):
     return res
 
 
-CPU_BACKENDS = _get_backends_with_storage_info(StorageDevice.CPU)
-GPU_BACKENDS = _get_backends_with_storage_info(StorageDevice.GPU)
+CPU_BACKENDS = _get_backends_with_storage_info(DeviceType.CPU)
+GPU_BACKENDS = _get_backends_with_storage_info(DeviceType.CUDA)
 ALL_BACKENDS = CPU_BACKENDS + GPU_BACKENDS
 
 _PERFORMANCE_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name not in ("numpy", "cuda")]
@@ -62,7 +62,7 @@ def get_array_library(backend: str):
     """Return device ready array maker library"""
     backend_cls = gt4pyc.backend.from_name(backend)
     assert backend_cls is not None
-    if backend_cls.storage_info["device"] == StorageDevice.GPU:
+    if backend_cls.storage_info["device"] == DeviceType.CUDA:
         assert cp is not None
         return cp
     else:

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -20,11 +20,12 @@ import pytest
 
 from gt4py import cartesian as gt4pyc
 from gt4py.cartesian import utils as gt_utils
+from gt4py.storage.cartesian.layout import StorageDevice
 
 
 def _backend_name_as_param(name):
     marks = []
-    if gt4pyc.backend.from_name(name).storage_info["device"] == "gpu":
+    if gt4pyc.backend.from_name(name).storage_info["device"] == StorageDevice.GPU:
         marks.append(pytest.mark.requires_gpu)
     if "dace" in name:
         marks.append(pytest.mark.requires_dace)
@@ -34,18 +35,18 @@ def _backend_name_as_param(name):
 _ALL_BACKEND_NAMES = list(gt4pyc.backend.REGISTRY.keys())
 
 
-def _get_backends_with_storage_info(storage_info_kind: str):
+def _get_backends_with_storage_info(storage_device: StorageDevice):
     res = []
     for name in _ALL_BACKEND_NAMES:
         backend = gt4pyc.backend.from_name(name)
         if not getattr(backend, "disabled", False):
-            if backend.storage_info["device"] == storage_info_kind:
+            if backend.storage_info["device"] == storage_device:
                 res.append(_backend_name_as_param(name))
     return res
 
 
-CPU_BACKENDS = _get_backends_with_storage_info("cpu")
-GPU_BACKENDS = _get_backends_with_storage_info("gpu")
+CPU_BACKENDS = _get_backends_with_storage_info(StorageDevice.CPU)
+GPU_BACKENDS = _get_backends_with_storage_info(StorageDevice.GPU)
 ALL_BACKENDS = CPU_BACKENDS + GPU_BACKENDS
 
 _PERFORMANCE_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name not in ("numpy", "cuda")]
@@ -61,7 +62,7 @@ def get_array_library(backend: str):
     """Return device ready array maker library"""
     backend_cls = gt4pyc.backend.from_name(backend)
     assert backend_cls is not None
-    if backend_cls.storage_info["device"] == "gpu":
+    if backend_cls.storage_info["device"] == StorageDevice.GPU:
         assert cp is not None
         return cp
     else:

--- a/tests/storage_tests/unit_tests/test_interface.py
+++ b/tests/storage_tests/unit_tests/test_interface.py
@@ -11,6 +11,8 @@ import hypothesis.strategies as hyp_st
 import numpy as np
 import pytest
 
+from gt4py.storage.cartesian.layout import StorageDevice
+
 
 try:
     import cupy as cp
@@ -23,12 +25,14 @@ from gt4py.storage.cartesian.utils import allocate_cpu, allocate_gpu, normalize_
 
 
 CPU_LAYOUTS = [
-    name for name, info in gt4py.storage.layout.REGISTRY.items() if info["device"] == "cpu"
+    name
+    for name, info in gt4py.storage.layout.REGISTRY.items()
+    if info["device"] == StorageDevice.CPU
 ]
 GPU_LAYOUTS = [
     pytest.param(name, marks=pytest.mark.requires_gpu)
     for name, info in gt4py.storage.layout.REGISTRY.items()
-    if info["device"] == "gpu"
+    if info["device"] == StorageDevice.GPU
 ]
 
 try:

--- a/tests/storage_tests/unit_tests/test_interface.py
+++ b/tests/storage_tests/unit_tests/test_interface.py
@@ -11,7 +11,7 @@ import hypothesis.strategies as hyp_st
 import numpy as np
 import pytest
 
-from gt4py.storage.cartesian.layout import StorageDevice
+from gt4py._core.definitions import DeviceType
 
 
 try:
@@ -25,14 +25,12 @@ from gt4py.storage.cartesian.utils import allocate_cpu, allocate_gpu, normalize_
 
 
 CPU_LAYOUTS = [
-    name
-    for name, info in gt4py.storage.layout.REGISTRY.items()
-    if info["device"] == StorageDevice.CPU
+    name for name, info in gt4py.storage.layout.REGISTRY.items() if info["device"] == DeviceType.CPU
 ]
 GPU_LAYOUTS = [
     pytest.param(name, marks=pytest.mark.requires_gpu)
     for name, info in gt4py.storage.layout.REGISTRY.items()
-    if info["device"] == StorageDevice.GPU
+    if info["device"] == DeviceType.CUDA
 ]
 
 try:


### PR DESCRIPTION
## Description

Refactors from recent debugging sessions around transient arrays in the "unexpanded SDFG" (the one with the library nodes):

- Remove unused `**kwargs` from `OirSDFGBuilder`
- Forward debugging information about transient arrays to DaCe
- Use a (constant) variable for connector prefixes of data going in to/out of the library nodes
- Configure the lifetime of transient arrays directly in `OirSDFGBuilder`
- Configure storage type of transient arrays directly in `OirSDFGBuilder` (for GPU targets)
- Configure the `LibraryNode`'s device type directly in `OirSDFGBuilder` (for GPU targets)
- Enum type for `StorageDevice` in `LayoutInfo`

Sidenote on the allocation lifetime: In the orchestrated code path, we reset the allocation lifetime of transients to `SDFG` when we freeze the stencil with origin/domain

https://github.com/GridTools/gt4py/blob/ac253b6b10a8adf87313a48b62328debaf39f07f/src/gt4py/cartesian/backend/dace_backend.py#L270-L317

This might be relevant when tracking down orchestration performance. Seems odd at least.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  Covered by existing tests
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A