### PR TITLE
ci[cartesian]: Thread safe parallel stencil tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -91,7 +91,7 @@ def test_cartesian(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"])
 
     session.run(
-        *f"pytest --cache-clear -sv -n {num_processes}".split(),
+        *f"pytest --cache-clear -sv -n {num_processes} --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "cartesian_tests"),
         *session.posargs,

--- a/src/gt4py/cartesian/testing/suites.py
+++ b/src/gt4py/cartesian/testing/suites.py
@@ -608,7 +608,7 @@ class StencilTestSuite(metaclass=SuiteMeta):
         implementation = test["implementation"]
         assert (
             implementation is not None
-        ), "Stencil not yet generated. Did you attempt to run stencil tests in parallel?"
+        ), "Stencil implementation not found. This usually means code generation failed."
         assert isinstance(implementation, StencilObject)
 
         cls._run_test_implementation(parameters_dict, implementation)


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsystem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

To avoid repeating boiler plate code in testing, `StencilTestSuite` provides a convenient interace to test gtscript stencils.

Within that `StencilTestSuite` base class, generating the stencil is separated from running & validating the stencil code. Each deriving test class will end up with two tests: one for stencil generation and a second one to test the implementation by running the generated code with defined inputs and expected outputs.

The base class was written such that the implementation test would re-use the generated stencil code from the first test. This introduces an implicit test order dependency. To save time and avoid unnecessary test failure outputs, failing to generate the stencil code would automatically skip the implementation/validation test.

Running tests in parallel (with `xdist`) breaks the expected test execution order (in the default configuration). This leads to automatically skiped validation tests in case the stencil code wasn't generated yet. On the CI, we only run with 2 threads so only a couple tests were skipped usually. Locally, I was running with 16 threads and got ~30 skipped validation tests.

This PR proposes to address the issue by setting an `xdist_group` mark on the generation/implementation tests that belong togehter. In combination with `--dist loadgroup`, this will keep the expected order where necessary. Only tests with `xdist_group` markers are affected by `--dist loadgroup`. Tests without that marker will be distributed normally as if in `--dist load` mode (the default so far). By grouping with `cls_name` and backend, we keep maximal parallelization, grouping only the two tests that are depending on each other.

Further reading: see [`--dist` section](https://pytest-xdist.readthedocs.io/en/stable/distribution.html) in `pytest-xdist` documentation.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Existing tests are still green. No more skipped tests \o/ Works as expected locally
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A

