### PR TITLE
fix[dace]: Updating MapFusion

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion_serial.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion_serial.py
@@ -1045,7 +1045,7 @@ class MapFusionSerial(mfh.MapFusionHelper):
             squeezed_dims: List[int] = []  # These are the dimensions we removed.
             new_inter_shape: List[int] = []  # This is the final shape of the new intermediate.
             for dim, (proposed_dim_size, full_dim_size) in enumerate(
-                zip(new_inter_shape_raw, inter_shape)
+                zip(new_inter_shape_raw, inter_shape, strict=True)
             ):
                 if full_dim_size == 1:  # Must be kept!
                     new_inter_shape.append(proposed_dim_size)


### PR DESCRIPTION
The [MapFusion PR](https://github.com/spcl/dace/pull/1629) in DaCe is still under review.
However, the MapFusion in that PR has evolved, i.e. some bugs were fixed and now GT4Py is also these bugs.
This PR essentially back ports some of the fixes to GT4Py.

Note that this is a temporary solution and as soon as the MapFusion PR has been merged (and parallel map fusion has been introduced) the GT4Py version will go away.



