### PR TITLE
bug[next]: Clip domain at zero to avoid oob access

### DIFF
--- a/src/gt4py/next/iterator/ir_utils/domain_utils.py
+++ b/src/gt4py/next/iterator/ir_utils/domain_utils.py
@@ -46,7 +46,10 @@ class SymbolicRange:
     stop: itir.Expr
 
     def translate(self, distance: int) -> SymbolicRange:
-        return SymbolicRange(im.plus(self.start, distance), im.plus(self.stop, distance))
+        start = im.plus(self.start, distance)
+        # TODO(tehrengruber): temporary solution to avoid oob-access without concat_where
+        start = im.call("maximum")(0, start)
+        return SymbolicRange(start, im.plus(self.stop, distance))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Fixes oob accesses in icon4py and pmap-go due to boundary stencils that use where instead of the not-yet-merged concat_where.