### PR TITLE
fix[next][dace]: Fixed a bug in the map fusion's default parameter

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -343,6 +343,8 @@ def gt_auto_fuse_top_level_maps(
 
         fusion_transformation = gtx_transformations.MapFusion(
             only_toplevel_maps=True,
+            allow_parallel_map_fusion=True,
+            allow_serial_map_fusion=True,
             only_if_common_ancestor=False,
         )
         fusion_transformation._single_use_data = single_use_data

--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion.py
@@ -49,8 +49,10 @@ class MapFusion(dace_map_fusion.MapFusion):
 
     It is a wrapper that adds some functionality to the transformation that is not
     present in the DaCe version of this transformation.
-    There are two important differences when compared with DaCe's MapFusion:
+    There are three important differences when compared with DaCe's MapFusion:
     - In DaCe strict data flow is enabled by default, in GT4Py it is disabled by default.
+    - In DaCe `MapFusion` only performs the fusion of serial maps by default. In GT4Py
+        `MapFusion` will also perform parallel map fusion by default.
     - GT4Py accepts an additional argument `apply_fusion_callback`. This is a
         function that is called by the transformation, at the _beginning_ of
         `self.can_be_applied()`, i.e. before the transformation does any check if
@@ -65,7 +67,7 @@ class MapFusion(dace_map_fusion.MapFusion):
         strict_dataflow: Strict dataflow mode should be used, it is disabled by default.
         assume_always_shared: Assume that all intermediates are shared.
         allow_serial_map_fusion: Allow serial map fusion, by default `True`.
-        allow_parallel_fusion: Allow to merge parallel maps, by default `False`.
+        allow_parallel_fusion: Allow to merge parallel maps, by default `True`.
         only_if_common_ancestor: In parallel map fusion mode, only fuse if both maps
             have a common direct ancestor.
         apply_fusion_callback: The callback function that is used.
@@ -81,11 +83,18 @@ class MapFusion(dace_map_fusion.MapFusion):
     def __init__(
         self,
         strict_dataflow: bool = False,
+        allow_serial_map_fusion: bool = True,
+        allow_parallel_map_fusion: bool = True,
         apply_fusion_callback: Optional[FusionTestCallback] = None,
         **kwargs: Any,
     ) -> None:
         self._apply_fusion_callback = None
-        super().__init__(strict_dataflow=strict_dataflow, **kwargs)
+        super().__init__(
+            strict_dataflow=strict_dataflow,
+            allow_serial_map_fusion=allow_serial_map_fusion,
+            allow_parallel_map_fusion=allow_parallel_map_fusion,
+            **kwargs,
+        )
         if apply_fusion_callback is not None:
             self._apply_fusion_callback = apply_fusion_callback
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion_dace.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion_dace.py
@@ -293,11 +293,18 @@ class MapFusion(transformation.SingleStateTransformation):
         sdfg: dace.SDFG,
     ) -> bool:
         """Check if the matched Maps can be fused in parallel."""
-        assert self.expr_index == 1
 
         # NOTE: The after this point it is not legal to access the matched nodes
         first_map_entry: nodes.MapEntry = self.first_parallel_map_entry
         second_map_entry: nodes.MapEntry = self.second_parallel_map_entry
+
+        assert self.expr_index == 1
+        assert isinstance(first_map_entry, nodes.MapEntry)
+        assert isinstance(second_map_entry, nodes.MapEntry)
+
+        # We will now check if the two maps are parallel.
+        if not self.is_parallel(graph=graph, node1=first_map_entry, node2=second_map_entry):
+            return False
 
         # Check the structural properties of the Maps. The function will return
         #  the `dict` that describes how the parameters must be renamed (for caching)
@@ -333,12 +340,15 @@ class MapFusion(transformation.SingleStateTransformation):
         * Tests if there are read write dependencies.
         * Tests if the decomposition exists.
         """
-        assert self.expr_index == 0
-
         # NOTE: The after this point it is not legal to access the matched nodes
         first_map_entry: nodes.MapEntry = graph.entry_node(self.first_map_exit)
         first_map_exit: nodes.MapExit = self.first_map_exit
         second_map_entry: nodes.MapEntry = self.second_map_entry
+
+        assert self.expr_index == 0
+        assert isinstance(first_map_exit, nodes.MapExit)
+        assert isinstance(second_map_entry, nodes.MapEntry)
+        assert isinstance(self.array, nodes.AccessNode)
 
         # Check the structural properties of the Maps. The function will return
         #  the `dict` that describes how the parameters must be renamed (for caching)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_map_fusion.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_map_fusion.py
@@ -591,3 +591,18 @@ def test_parallel_2():
     assert nb_applies == 1
     assert util.count_nodes(state, dace_nodes.AccessNode) == 3
     assert util.count_nodes(state, dace_nodes.MapEntry) == 1
+
+
+def test_parallel_3():
+    """Test that the parallel map fusion does not apply for serial maps."""
+    sdfg = _make_serial_sdfg_1(20)
+    assert util.count_nodes(sdfg, dace_nodes.AccessNode) == 3
+    assert util.count_nodes(sdfg, dace_nodes.MapEntry) == 2
+
+    # Because the maps are fully serial, parallel map fusion should never apply.
+    nb_applies = sdfg.apply_transformations_repeated(
+        [gtx_transformations.MapFusionParallel(only_if_common_ancestor=False)]
+    )
+    assert nb_applies == 0
+    assert util.count_nodes(sdfg, dace_nodes.AccessNode) == 3
+    assert util.count_nodes(sdfg, dace_nodes.MapEntry) == 2


### PR DESCRIPTION
`MapFusion` was behaving as the one from DaCe, i.e. it only did serial fusion by default, now it allows both by default. There are still `MapFusionSerial` and `MapFusionParallel` with the respective settings. This commit also changes auto optimizer to explicitly request them.
