### PR TITLE
fix[dace][next]: Fixed name of pattern nodes

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -718,9 +718,9 @@ class TrivialGPUMapElimination(dace_transformation.SingleStateTransformation):
         if not self.do_not_fuse:
             gtx_transformations.MapFusionSerial.apply_to(
                 sdfg=sdfg,
-                map_exit_1=trivial_map_exit,
-                intermediate_access_node=access_node,
-                map_entry_2=second_map_entry,
+                first_map_exit=trivial_map_exit,
+                array=access_node,
+                second_map_entry=second_map_entry,
                 verify=True,
             )
 


### PR DESCRIPTION
In PR#1857 we updated the `MapFusion` because of that the names of the pattern nodes have been changed.
Apparently, in that PR not all occurrences of the old names have been replaced.
