### PR TITLE
fix[next][dace]: use logical and/or/xor operators, not bitwise

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_python_codegen.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_python_codegen.py
@@ -66,11 +66,11 @@ MATH_BUILTINS_MAPPING = {
     "less_equal": "({} <= {})",
     "greater": "({} > {})",
     "greater_equal": "({} >= {})",
-    "and_": "({} & {})",
-    "or_": "({} | {})",
-    "xor_": "({} ^ {})",
+    "and_": "({} and {})",
+    "or_": "({} or {})",
+    "xor_": "({} != {})",
     "mod": "({} % {})",
-    "not_": "(not {})",  # ~ is not bitwise in numpy
+    "not_": "(not {})",
 }
 
 


### PR DESCRIPTION
The current mapping from GTIR logical operators to python code was inconsistent. The mapping was using bitwise operators instead of logical ones. This still resulted in functionally correct code because the boolean type has an integer representation in python language. This PR introduces the correct mapping, and leaves the dace toolchain and target compiler the possibility to generate optimized code.