### PR TITLE
fix[next][dace]: remove temporary arrays with runtime shape on the output of a mapped nested SDFG

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -234,12 +234,8 @@ class DataflowOutputEdge:
     ) -> None:
         # retrieve the node which writes the result
         last_node = self.state.in_edges(self.result.dc_node)[0].src
-        if isinstance(last_node, dace.nodes.Tasklet):
+        if isinstance(last_node, (dace.nodes.Tasklet, dace.nodes.NestedSDFG)):
             # the last transient node can be deleted
-            # Note that it could also be applied when `last_node` is a NestedSDFG,
-            # but an exception would be when the inner write to global data is a
-            # WCR memlet, because that prevents fusion of the outer map. This case
-            # happens for the reduce with skip values, which uses a map with WCR.
             last_node_connector = self.state.in_edges(self.result.dc_node)[0].src_conn
             self.state.remove_node(self.result.dc_node)
         else:

--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -237,10 +237,10 @@ class DataflowOutputEdge:
         # check the kind of node which writes the result
         if isinstance(write_edge.src, dace.nodes.Tasklet):
             # The temporary data written by a tasklet can be safely deleted
-            assert write_size.is_constant
+            assert write_size.is_constant()
             remove_last_node = True
         elif isinstance(write_edge.src, dace.nodes.NestedSDFG):
-            if write_size.is_constant:
+            if write_size.is_constant():
                 # Temporary data with compile-time size is allocated on the stack
                 # and therefore is safe to keep. We decide to keep it as a workaround
                 # for a dace issue with memlet propagation in combination with


### PR DESCRIPTION
This PR provides a better fix than the one delivered earlier in https://github.com/GridTools/gt4py/pull/1828. It adds a check to detect whether the temporary output data has compile-time or runtime size. In case of runtime size, the transient array on the output connector of a mapped nested SDFG is removed. This is needed in order to avoid dynamic memory allocation inside the cuda kernel that represents a parallel map scope.