### PR TITLE
refactor: stick to supported device types

### DIFF
--- a/src/gt4py/_core/definitions.py
+++ b/src/gt4py/_core/definitions.py
@@ -373,37 +373,25 @@ class DeviceType(enum.IntEnum):
 
     CPU = 1
     CUDA = 2
-    CPU_PINNED = 3
-    OPENCL = 4
-    VULKAN = 7
-    METAL = 8
-    VPI = 9
+    # CPU_PINNED = 3    # noqa: ERA001
+    # OPENCL = 4        # noqa: ERA001
+    # VULKAN = 7        # noqa: ERA001
+    # METAL = 8         # noqa: ERA001
+    # VPI = 9           # noqa: ERA001
     ROCM = 10
-    CUDA_MANAGED = 13
-    ONE_API = 14
+    # CUDA_MANAGED = 13 # noqa: ERA001
+    # ONE_API = 14      # noqa: ERA001
 
 
 CPUDeviceTyping: TypeAlias = Literal[DeviceType.CPU]
 CUDADeviceTyping: TypeAlias = Literal[DeviceType.CUDA]
-CPUPinnedDeviceTyping: TypeAlias = Literal[DeviceType.CPU_PINNED]
-OpenCLDeviceTyping: TypeAlias = Literal[DeviceType.OPENCL]
-VulkanDeviceTyping: TypeAlias = Literal[DeviceType.VULKAN]
-MetalDeviceTyping: TypeAlias = Literal[DeviceType.METAL]
-VPIDeviceTyping: TypeAlias = Literal[DeviceType.VPI]
 ROCMDeviceTyping: TypeAlias = Literal[DeviceType.ROCM]
-CUDAManagedDeviceTyping: TypeAlias = Literal[DeviceType.CUDA_MANAGED]
-OneApiDeviceTyping: TypeAlias = Literal[DeviceType.ONE_API]
 
 
 DeviceTypeT = TypeVar(
     "DeviceTypeT",
     CPUDeviceTyping,
     CUDADeviceTyping,
-    CPUPinnedDeviceTyping,
-    OpenCLDeviceTyping,
-    VulkanDeviceTyping,
-    MetalDeviceTyping,
-    VPIDeviceTyping,
     ROCMDeviceTyping,
 )
 

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -199,7 +199,7 @@ def asarray(
     elif not device:
         if hasattr(array, "__dlpack_device__"):
             kind, _ = array.__dlpack_device__()
-            if kind in [core_defs.DeviceType.CPU, core_defs.DeviceType.CPU_PINNED]:
+            if kind in [core_defs.DeviceType.CPU]:
                 xp = np
             elif kind in [
                 core_defs.DeviceType.CUDA,


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsystem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

Following the [YAGNI principle](https://github.com/GridTools/gt4py/blob/main/CODING_GUIDELINES.md#software-design), stick to the device types that are actually supported in the codebase. We can add support for other devices later.

@havogt as discussed the other day, let's have a discussion about whether or not we need all these device types defined. I know that @FlorianDeconinck would like to work towards over protection and throwing errors rather sooner than later for unsupported things (very much in general).

This is part of a clean-up series tracked in issue https://github.com/GridTools/gt4py/issues/1880.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
