### PR TITLE
bug[next]: Respect bc in `InlineCenterDerefLiftVars`

### DIFF
--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_inline_center_deref_lift_vars.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_inline_center_deref_lift_vars.py
@@ -6,20 +6,33 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from gt4py.next.type_system import type_specifications as ts
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms import cse
 from gt4py.next.iterator.transforms.inline_center_deref_lift_vars import InlineCenterDerefLiftVars
 
+field_type = ts.FieldType(dims=[], dtype=ts.ScalarType(kind=ts.ScalarKind.FLOAT64))
 
-def wrap_in_program(expr: itir.Expr) -> itir.Program:
+
+def wrap_in_program(expr: itir.Expr, *, arg_dtypes=None) -> itir.Program:
+    if arg_dtypes is None:
+        arg_dtypes = [ts.ScalarKind.FLOAT64]
+    arg_types = [ts.FieldType(dims=[], dtype=ts.ScalarType(kind=dtype)) for dtype in arg_dtypes]
+    indices = [i for i in range(1, len(arg_dtypes) + 1)] if len(arg_dtypes) > 1 else [""]
     return itir.Program(
         id="f",
         function_definitions=[],
-        params=[im.sym("d"), im.sym("inp"), im.sym("out")],
+        params=[
+            *(im.sym(f"inp{i}", type_) for i, type_ in zip(indices, arg_types)),
+            im.sym("out", field_type),
+        ],
         declarations=[],
         body=[
             itir.SetAt(
-                expr=im.as_fieldop(im.lambda_("it")(expr))(im.ref("inp")),
+                expr=im.as_fieldop(im.lambda_(*(f"it{i}" for i in indices))(expr))(
+                    *(im.ref(f"inp{i}") for i in indices)
+                ),
                 domain=im.call("cartesian_domain")(),
                 target=im.ref("out"),
             )
@@ -34,7 +47,7 @@ def unwrap_from_program(program: itir.Program) -> itir.Expr:
 
 def test_simple():
     testee = im.let("var", im.lift("deref")("it"))(im.deref("var"))
-    expected = "(λ(_icdlv_1) → ·(↑(λ() → _icdlv_1))())(·it)"
+    expected = "(λ(_icdlv_1) → ·(↑(λ() → _icdlv_1()))())(λ() → ·it)"
 
     actual = unwrap_from_program(InlineCenterDerefLiftVars.apply(wrap_in_program(testee)))
     assert str(actual) == expected
@@ -42,7 +55,7 @@ def test_simple():
 
 def test_double_deref():
     testee = im.let("var", im.lift("deref")("it"))(im.plus(im.deref("var"), im.deref("var")))
-    expected = "(λ(_icdlv_1) → ·(↑(λ() → _icdlv_1))() + ·(↑(λ() → _icdlv_1))())(·it)"
+    expected = "(λ(_icdlv_1) → ·(↑(λ() → _icdlv_1()))() + ·(↑(λ() → _icdlv_1()))())(λ() → ·it)"
 
     actual = unwrap_from_program(InlineCenterDerefLiftVars.apply(wrap_in_program(testee)))
     assert str(actual) == expected
@@ -62,3 +75,18 @@ def test_deref_at_multiple_pos():
 
     actual = unwrap_from_program(InlineCenterDerefLiftVars.apply(wrap_in_program(testee)))
     assert testee == actual
+
+
+def test_bc():
+    # we also check that the common subexpression is able to extract the inlined value, such
+    # that it is only evaluated once
+    testee = im.let("var", im.lift("deref")("it2"))(
+        im.if_(im.deref("it1"), im.literal_from_value(0), im.plus(im.deref("var"), im.deref("var")))
+    )
+    expected = "(λ(_icdlv_1) → if ·it1 then 0 else (λ(_cs_1) → _cs_1 + _cs_1)(·(↑(λ() → _icdlv_1()))()))(λ() → ·it2)"
+
+    actual = InlineCenterDerefLiftVars.apply(
+        wrap_in_program(testee, arg_dtypes=[ts.ScalarKind.BOOL, ts.ScalarKind.FLOAT64])
+    )
+    simplified = unwrap_from_program(cse.CommonSubexpressionElimination.apply(actual))
+    assert str(simplified) == expected


### PR DESCRIPTION
Changes the `InlineCenterDerefLiftVars` such that it respect boundary condition by lazy evaluating the inlined values.

Consider the following case:
```
let(var, (↑deref)(it2))(if ·on_bc then 0 else ·var)
```
Then var should only be dereferenced in case `·on_bc` evalutes to False. Previously we just evaluated all values unconditionally:
```
let(_icdlv_1, ·it)(if ·on_bc then 0 else _icdlv_1)
```
Now we instead create a 0-ary lambda function for `_icdlv_1` and evaluate it when the value is needed.

```
let(var, (↑deref)(it2))(if ·on_bc then 0 else ·var)
```
Note that as a result we do evaluate the function multiple times. To avoid redundant recomputes usage of the common subexpression is therefor required.