### PR TITLE
test[cartesian]: conditional xfail instead of two tests 

### DIFF
--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -14,7 +14,6 @@ except (ImportError, RuntimeError):
     cp = None
 
 import datetime
-
 import numpy as np
 import pytest
 
@@ -22,7 +21,7 @@ from gt4py import cartesian as gt4pyc
 from gt4py.cartesian import utils as gt_utils
 
 
-def _backend_name_as_param(name):
+def _backend_name_as_param(name: str):
     marks = []
     if gt4pyc.backend.from_name(name).storage_info["device"] == "gpu":
         marks.append(pytest.mark.requires_gpu)
@@ -48,14 +47,9 @@ CPU_BACKENDS = _get_backends_with_storage_info("cpu")
 GPU_BACKENDS = _get_backends_with_storage_info("gpu")
 ALL_BACKENDS = CPU_BACKENDS + GPU_BACKENDS
 
-_PERFORMANCE_BACKEND_NAMES = [name for name in _ALL_BACKEND_NAMES if name not in ("numpy", "cuda")]
-PERFORMANCE_BACKENDS = [_backend_name_as_param(name) for name in _PERFORMANCE_BACKEND_NAMES]
-
-DACE_BACKENDS = [
-    _backend_name_as_param(name)
-    for name in filter(lambda name: name.startswith("dace:"), _ALL_BACKEND_NAMES)
+PERFORMANCE_BACKENDS = [
+    _backend_name_as_param(name) for name in _ALL_BACKEND_NAMES if name not in ("numpy", "cuda")
 ]
-NON_DACE_BACKENDS = [backend for backend in ALL_BACKENDS if backend not in DACE_BACKENDS]
 
 
 @pytest.fixture()

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -30,8 +30,6 @@ from gt4py.storage.cartesian import utils as storage_utils
 from cartesian_tests.definitions import (
     ALL_BACKENDS,
     CPU_BACKENDS,
-    DACE_BACKENDS,
-    NON_DACE_BACKENDS,
     get_array_library,
 )
 from cartesian_tests.integration_tests.multi_feature_tests.stencil_definitions import (
@@ -770,20 +768,21 @@ def test_function_inline_in_while(backend):
     assert (out_arr[:, :, :] == 388.0).all()
 
 
-@pytest.mark.parametrize("backend", NON_DACE_BACKENDS)
+def _xfail_dace_backends(param):
+    if param.values[0].startswith("dace:"):
+        marks = param.marks + [
+            pytest.mark.xfail(
+                raises=ValueError,
+                reason="Missing support in DaCe backends, see https://github.com/GridTools/gt4py/issues/1881.",
+            )
+        ]
+        # make a copy because otherwise we are operating in-place
+        return pytest.param(*param.values, marks=marks)
+    return param
+
+
+@pytest.mark.parametrize("backend", map(_xfail_dace_backends, ALL_BACKENDS))
 def test_cast_in_index(backend):
-    @gtscript.stencil(backend)
-    def cast_in_index(
-        in_field: Field[np.float64], i32: np.int32, i64: np.int64, out_field: Field[np.float64]
-    ):
-        """Simple copy stencil with forced cast in index calculation."""
-        with computation(PARALLEL), interval(...):
-            out_field = in_field[0, 0, i32 - i64]
-
-
-@pytest.mark.parametrize("backend", DACE_BACKENDS)
-@pytest.mark.xfail(raises=ValueError)
-def test_dace_no_cast_in_index(backend):
     @gtscript.stencil(backend)
     def cast_in_index(
         in_field: Field[np.float64], i32: np.int32, i64: np.int64, out_field: Field[np.float64]


### PR DESCRIPTION
<!--
Delete this comment and add a proper description of the changes contained in this PR. The text here will be used in the commit message since the approved PRs are always squash-merged. The preferred format is:

- PR Title: <type>[<scope>]: <one-line-summary>

    <type>:
        - build: Changes that affect the build system or external dependencies
        - ci: Changes to our CI configuration files and scripts
        - docs: Documentation only changes
        - feat: A new feature
        - fix: A bug fix
        - perf: A code change that improves performance
        - refactor: A code change that neither fixes a bug nor adds a feature
        - style: Changes that do not affect the meaning of the code
        - test: Adding missing tests or correcting existing tests

    <scope>: cartesian | eve | next | storage
    # ONLY if changes are limited to a specific subsystem

- PR Description:

    Description of the main changes with links to appropriate issues/documents/references/...
-->

## Description

Follow-up from PR https://github.com/GridTools/gt4py/pull/1882 to merge two test cases which only differed in the expected outcome. With this PR, we'll have one single test case with a conditional `xfail` as @havogt proposed in the GridTools slack channel.

Related issue: https://github.com/GridTools/gt4py/issues/1881

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
