### PR TITLE
Remove the occurences of the old license headers

### DIFF
--- a/src/gt4py/next/ffront/signature.py
+++ b/src/gt4py/next/ffront/signature.py
@@ -6,20 +6,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-# GT4Py - GridTools Framework
-#
-# Copyright (c) 2014-2023, ETH Zurich
-# All rights reserved.
-#
-# This file is part of the GT4Py project and the GridTools framework.
-# GT4Py is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or any later
-# version. See the LICENSE.txt file at the top-level directory of this
-# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 # TODO(ricoh): This overlaps with `canonicalize_arguments`, solutions:
 # - merge the two
 # - extract the signature gathering functionality from canonicalize_arguments

--- a/src/gt4py/next/otf/arguments.py
+++ b/src/gt4py/next/otf/arguments.py
@@ -6,20 +6,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-# GT4Py - GridTools Framework
-#
-# Copyright (c) 2014-2023, ETH Zurich
-# All rights reserved.
-#
-# This file is part of the GT4Py project and the GridTools framework.
-# GT4Py is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or any later
-# version. See the LICENSE.txt file at the top-level directory of this
-# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 from __future__ import annotations
 
 import dataclasses

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_if_stmt.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_if_stmt.py
@@ -14,7 +14,7 @@ import gt4py.next as gtx
 from gt4py.next.iterator.builtins import as_fieldop, cartesian_domain, deref, named_range
 from gt4py.next.iterator.runtime import fendef, fundef, if_stmt, offset, set_at
 
-from next_tests.unit_tests.conftest import run_processor
+from next_tests.unit_tests.conftest import program_processor_no_transforms, run_processor
 
 
 i = offset("i")

--- a/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_if_stmt.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/iterator_tests/test_if_stmt.py
@@ -6,29 +6,16 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-# GT4Py - GridTools Framework
-#
-# Copyright (c) 2014-2023, ETH Zurich
-# All rights reserved.
-#
-# This file is part of the GT4Py project and the GridTools framework.
-# GT4Py is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or any later
-# version. See the LICENSE.txt file at the top-level directory of this
-# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
 
 import numpy as np
 import pytest
 
 import gt4py.next as gtx
-from gt4py.next.iterator.builtins import cartesian_domain, deref, as_fieldop, named_range
-from gt4py.next.iterator.runtime import set_at, if_stmt, fendef, fundef, offset
-from gt4py.next.program_processors.runners import gtfn
+from gt4py.next.iterator.builtins import as_fieldop, cartesian_domain, deref, named_range
+from gt4py.next.iterator.runtime import fendef, fundef, if_stmt, offset, set_at
 
-from next_tests.unit_tests.conftest import program_processor_no_transforms, run_processor
+from next_tests.unit_tests.conftest import run_processor
+
 
 i = offset("i")
 


### PR DESCRIPTION
## Description

Upon cleanup, we found 3 files still with the old headers. This cleans that up.

