### PR TITLE
feat[dace][next]: Updated GPU Transformation Scheme

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -573,23 +573,22 @@ def gt_remove_trivial_gpu_maps(
 ) -> dace.SDFG:
     """Removes trivial maps that were created by the GPU transformation.
 
-    The main problem is, that in DaCe a Tasklets, outside of a Map, can not write
-    into an _array_ that is on GPU. `sdfg.apply_gpu_transformations()` will wrap
-    such Tasklets in a Map. There `GT4PyMoveTaskletIntoMap` that runs beforer, but
-    only works if the tasklet is adjacent to a map.
+    The main problem is that a Tasklet outside of a Map cannot write into an
+    _array_ that is on GPU. `sdfg.apply_gpu_transformations()` will wrap such
+    Tasklets in a Map. The `GT4PyMoveTaskletIntoMap` pass, that runs before,
+    but only works if the tasklet is adjacent to a map.
 
-    It first tries to promote them such that they can be fused in other maps,
-    it will then also perform fusion on them, to reduce the number of kernel calls.
+    It first tries to promote them such that they can be fused in other non-trivial
+    maps, it will then also perform fusion on them, to reduce the number of kernel
+    calls.
 
     Args:
         sdfg: The SDFG that we process.
-        map_postprocess: Enable post processing of the maps that are created.
-            See the Note section below.
         validate: Perform validation at the end of the function.
         validate_all: Perform validation also on intermediate steps.
     """
 
-    # First we try to promote and fuse them other maps.
+    # First we try to promote and fuse them with other non-trivial maps.
     sdfg.apply_transformations_once_everywhere(
         TrivialGPUMapElimination(
             do_not_fuse=False,

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -290,9 +290,18 @@ def _gt_expand_non_standard_memlets_sdfg(
             ]
 
             # Turn unsupported copy to a map
+            # NOTE: Compared with DaCe we call the `CopyToMap` transformation with
+            #   `ignore_strides=True`. This is a bug in DaCe, without it we would
+            #   get a code generator error of some unsupported 2D copies.
+            #   See https://github.com/spcl/dace/issues/1953 for more.
             try:
                 dace_transformation.dataflow.CopyToMap.apply_to(
-                    sdfg, save=False, annotate=False, a=a, b=b
+                    sdfg,
+                    save=False,
+                    annotate=False,
+                    a=a,
+                    b=b,
+                    options={"ignore_strides": True},
                 )
             except ValueError:  # If transformation doesn't match, continue normally
                 continue

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -290,18 +290,9 @@ def _gt_expand_non_standard_memlets_sdfg(
             ]
 
             # Turn unsupported copy to a map
-            # NOTE: Compared with DaCe we call the `CopyToMap` transformation with
-            #   `ignore_strides=True`. This is a bug in DaCe, without it we would
-            #   get a code generator error of some unsupported 2D copies.
-            #   See https://github.com/spcl/dace/issues/1953 for more.
             try:
                 dace_transformation.dataflow.CopyToMap.apply_to(
-                    sdfg,
-                    save=False,
-                    annotate=False,
-                    a=a,
-                    b=b,
-                    options={"ignore_strides": True},
+                    sdfg, save=False, annotate=False, a=a, b=b
                 )
             except ValueError:  # If transformation doesn't match, continue normally
                 continue

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -92,15 +92,10 @@ def gt_gpu_transformation(
     gtx_transformations.gt_simplify(sdfg)
 
     if try_removing_trivial_maps:
-        # In DaCe a Tasklet, outside of a Map, can not write into an _array_ that is on
-        #  GPU. `sdfg.apply_gpu_transformations()` will wrap such Tasklets in a Map. So
-        #  we might end up with lots of these trivial Maps, each requiring a separate
-        #  kernel launch. To prevent this we will combine these trivial maps, if
-        #  possible, with their downstream maps.
-        sdfg.apply_transformations_once_everywhere(
-            TrivialGPUMapElimination(),
-            validate=False,
-            validate_all=False,
+        gt_remove_trivial_gpu_maps(
+            sdfg=sdfg,
+            validate=validate,
+            validate_all=validate_all,
         )
         gtx_transformations.gt_simplify(sdfg, validate=validate, validate_all=validate_all)
 
@@ -569,6 +564,81 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
         gpu_map.gpu_block_size = block_size
         if launch_bounds is not None:  # Note: empty string has a meaning in DaCe
             gpu_map.gpu_launch_bounds = launch_bounds
+
+
+def gt_remove_trivial_gpu_maps(
+    sdfg: dace.SDFG,
+    validate: bool = True,
+    validate_all: bool = False,
+) -> dace.SDFG:
+    """Removes trivial maps that were created by the GPU transformation.
+
+    The main problem is, that in DaCe a Tasklets, outside of a Map, can not write
+    into an _array_ that is on GPU. `sdfg.apply_gpu_transformations()` will wrap
+    such Tasklets in a Map. There `GT4PyMoveTaskletIntoMap` that runs beforer, but
+    only works if the tasklet is adjacent to a map.
+
+    It first tries to promote them such that they can be fused in other maps,
+    it will then also perform fusion on them, to reduce the number of kernel calls.
+
+    Args:
+        sdfg: The SDFG that we process.
+        map_postprocess: Enable post processing of the maps that are created.
+            See the Note section below.
+        validate: Perform validation at the end of the function.
+        validate_all: Perform validation also on intermediate steps.
+    """
+
+    # First we try to promote and fuse them other maps.
+    sdfg.apply_transformations_once_everywhere(
+        TrivialGPUMapElimination(
+            do_not_fuse=False,
+            only_gpu_maps=True,
+        ),
+        validate=False,
+        validate_all=False,
+    )
+    gtx_transformations.gt_simplify(sdfg, validate=validate, validate_all=validate_all)
+
+    # Now we try to fuse them together, however, we restrict the fusion to trivial
+    #  GPU map.
+    def restrict_to_trivial_gpu_maps(
+        self: gtx_transformations.MapFusion,
+        map_entry_1: dace_nodes.MapEntry,
+        map_entry_2: dace_nodes.MapEntry,
+        graph: Union[dace.SDFGState, dace.SDFG],
+        sdfg: dace.SDFG,
+        permissive: bool,
+    ) -> bool:
+        for map_entry in [map_entry_1, map_entry_2]:
+            _map = map_entry.map
+            if len(_map.params) != 1:
+                return False
+            if _map.range[0][0] != _map.range[0][1]:
+                return False
+            if _map.schedule not in [
+                dace.dtypes.ScheduleType.GPU_Device,
+                dace.dtypes.ScheduleType.GPU_Default,
+            ]:
+                return False
+        return True
+
+    sdfg.apply_transformations_repeated(
+        [
+            gtx_transformations.MapFusionSerial(
+                only_toplevel_maps=True,
+                apply_fusion_callback=restrict_to_trivial_gpu_maps,
+            ),
+            gtx_transformations.MapFusionParallel(
+                only_toplevel_maps=True,
+                apply_fusion_callback=restrict_to_trivial_gpu_maps,
+            ),
+        ],
+        validate=validate,
+        validate_all=validate_all,
+    )
+
+    return sdfg
 
 
 @dace_properties.make_properties


### PR DESCRIPTION
This PR slightly changes how the GPU transformation works.
It mainly changes how trivial Maps are eliminated.
First, there is now a dedicated function, `gt_remove_trivial_gpu_maps()` for this.
Furthermore, before it was only using the `TrivialGPUMapElimination` transformation, which tries to promote and fuse the trivial maps, but only with downstream maps.
Now there is a second stage that tries to fuse the trivial maps together.
This is mostly to reduce the number of kernel calls that we are doing.
