### PR TITLE
fix[next][dace]: Update cuda codegen for concat_where

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -278,6 +278,7 @@ def _gt_expand_non_standard_memlets_sdfg(
                 continue
             elif dims == 2:
                 if src_strides[0] != copy_shape[1] or dst_strides[0] != copy_shape[1]:
+                    # not a continuous read/write in dim 0: use 'CopyToMap' with 'ignore_strides'
                     ignore_strides = True
                 elif src_strides[-1] != 1 or dst_strides[-1] != 1:
                     try:
@@ -295,6 +296,7 @@ def _gt_expand_non_standard_memlets_sdfg(
                     functools.reduce(lambda x, y: x * y, copy_shape[i:], 1) for i in range(1, dims)
                 ]
                 if src_strides[: dims - 1] != copy_size or dst_strides[: dims - 1] != copy_shape:
+                    # not a continuous read/write in dim (0, ndims-1): use 'CopyToMap' with 'ignore_strides'
                     ignore_strides = True
                 elif not (src_strides[-1] != 1 or dst_strides[-1] != 1):
                     continue

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import copy
+import functools
 from typing import Any, Callable, Final, Optional, Sequence, Union
 
 import dace
@@ -290,9 +291,10 @@ def _gt_expand_non_standard_memlets_sdfg(
                 else:
                     continue
             elif dims > 2:
-                if any(src_strides[i] != copy_shape[i + 1] for i in range(dims - 1)) or any(
-                    dst_strides[i] != copy_shape[i + 1] for i in range(dims - 1)
-                ):
+                copy_size = [
+                    functools.reduce(lambda x, y: x * y, copy_shape[i:], 1) for i in range(1, dims)
+                ]
+                if src_strides[: dims - 1] != copy_size or dst_strides[: dims - 1] != copy_shape:
                     ignore_strides = True
                 elif not (src_strides[-1] != 1 or dst_strides[-1] != 1):
                     continue


### PR DESCRIPTION
We use `CopyToMap` in CUDA lowering for copies between arrays that do not necessarily have the same strides. This happens in case of `concat_where`, where we copy a source array into a subset of the destination array.

For this reason, the option `ignore_strides` must be set to `True` (`False` by default).