### PR TITLE
refactor: centralize `CUPY_DEVICE_TYPE` in `_core/definitions`

### DIFF
--- a/src/gt4py/_core/definitions.py
+++ b/src/gt4py/_core/definitions.py
@@ -51,6 +51,9 @@ if TYPE_CHECKING:
 
     JaxNDArray: TypeAlias = jnp.ndarray
 
+# The actual assignment happens after the definition of `DeviceType` enum.
+CUPY_DEVICE_TYPE: Literal[None, DeviceType.CUDA, DeviceType.ROCM]
+"""Type of the GPU accelerator device, if present."""
 
 # -- Scalar types supported by GT4Py --
 bool_ = np.bool_
@@ -399,7 +402,7 @@ DeviceTypeT = TypeVar(
 )
 
 
-CUPY_DEVICE: Final[Literal[None, DeviceType.CUDA, DeviceType.ROCM]] = (
+CUPY_DEVICE_TYPE = (
     None if not cp else (DeviceType.ROCM if cp.cuda.runtime.is_hip else DeviceType.CUDA)
 )
 

--- a/src/gt4py/_core/definitions.py
+++ b/src/gt4py/_core/definitions.py
@@ -39,9 +39,12 @@ from gt4py.eve.extended_typing import (
 )
 
 
-if TYPE_CHECKING:
+try:
     import cupy as cp
+except ImportError:
+    cp = None
 
+if TYPE_CHECKING:
     CuPyNDArray: TypeAlias = cp.ndarray
 
     import jax.numpy as jnp
@@ -393,6 +396,11 @@ DeviceTypeT = TypeVar(
     CPUDeviceTyping,
     CUDADeviceTyping,
     ROCMDeviceTyping,
+)
+
+
+CUPY_DEVICE: Final[Literal[None, DeviceType.CUDA, DeviceType.ROCM]] = (
+    None if not cp else (DeviceType.ROCM if cp.cuda.runtime.is_hip else DeviceType.CUDA)
 )
 
 

--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -18,26 +18,12 @@ from gt4py.eve.extended_typing import (
     Any,
     Callable,
     Final,
-    Literal,
     Optional,
     Protocol,
     Sequence,
     TypeAlias,
     TypeGuard,
     cast,
-)
-
-
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
-
-
-CUPY_DEVICE: Final[Literal[None, core_defs.DeviceType.CUDA, core_defs.DeviceType.ROCM]] = (
-    None
-    if not cp
-    else (core_defs.DeviceType.ROCM if cp.cuda.runtime.is_hip else core_defs.DeviceType.CUDA)
 )
 
 
@@ -246,11 +232,11 @@ class InvalidFieldBufferAllocator(FieldBufferAllocatorProtocol[core_defs.DeviceT
         raise self.exception
 
 
-if CUPY_DEVICE is not None:
+if core_defs.CUPY_DEVICE is not None:
     assert isinstance(core_allocators.cupy_array_utils, core_allocators.ArrayUtils)
     cupy_array_utils = core_allocators.cupy_array_utils
 
-    if CUPY_DEVICE is core_defs.DeviceType.CUDA:
+    if core_defs.CUPY_DEVICE is core_defs.DeviceType.CUDA:
 
         class CUDAFieldBufferAllocator(BaseFieldBufferAllocator[core_defs.CUDADeviceTyping]):
             def __init__(self) -> None:
@@ -288,7 +274,9 @@ else:
 
 StandardGPUFieldBufferAllocator: Final[type[FieldBufferAllocatorProtocol]] = cast(
     type[FieldBufferAllocatorProtocol],
-    type(device_allocators[CUPY_DEVICE]) if CUPY_DEVICE else InvalidGPUFieldBufferAllocator,
+    type(device_allocators[core_defs.CUPY_DEVICE])
+    if core_defs.CUPY_DEVICE
+    else InvalidGPUFieldBufferAllocator,
 )
 
 

--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -232,11 +232,11 @@ class InvalidFieldBufferAllocator(FieldBufferAllocatorProtocol[core_defs.DeviceT
         raise self.exception
 
 
-if core_defs.CUPY_DEVICE is not None:
+if core_defs.CUPY_DEVICE_TYPE is not None:
     assert isinstance(core_allocators.cupy_array_utils, core_allocators.ArrayUtils)
     cupy_array_utils = core_allocators.cupy_array_utils
 
-    if core_defs.CUPY_DEVICE is core_defs.DeviceType.CUDA:
+    if core_defs.CUPY_DEVICE_TYPE is core_defs.DeviceType.CUDA:
 
         class CUDAFieldBufferAllocator(BaseFieldBufferAllocator[core_defs.CUDADeviceTyping]):
             def __init__(self) -> None:
@@ -274,8 +274,8 @@ else:
 
 StandardGPUFieldBufferAllocator: Final[type[FieldBufferAllocatorProtocol]] = cast(
     type[FieldBufferAllocatorProtocol],
-    type(device_allocators[core_defs.CUPY_DEVICE])
-    if core_defs.CUPY_DEVICE
+    type(device_allocators[core_defs.CUPY_DEVICE_TYPE])
+    if core_defs.CUPY_DEVICE_TYPE
     else InvalidGPUFieldBufferAllocator,
 )
 

--- a/src/gt4py/next/allocators.py
+++ b/src/gt4py/next/allocators.py
@@ -180,7 +180,7 @@ if TYPE_CHECKING:
 def horizontal_first_layout_mapper(
     dims: Sequence[common.Dimension],
 ) -> core_allocators.BufferLayoutMap:
-    """Map dimensions to a buffer layout making horizonal dims change the slowest (i.e. larger strides)."""
+    """Map dimensions to a buffer layout making horizontal dims change the slowest (i.e. larger strides)."""
 
     def pos_of_kind(kind: common.DimensionKind) -> list[int]:
         return [i for i, dim in enumerate(dims) if dim.kind == kind]
@@ -278,7 +278,7 @@ if CUPY_DEVICE is not None:
 
 else:
 
-    class InvalidGPUFielBufferAllocator(InvalidFieldBufferAllocator[core_defs.CUDADeviceTyping]):
+    class InvalidGPUFieldBufferAllocator(InvalidFieldBufferAllocator[core_defs.CUDADeviceTyping]):
         def __init__(self) -> None:
             super().__init__(
                 device_type=core_defs.DeviceType.CUDA,
@@ -288,7 +288,7 @@ else:
 
 StandardGPUFieldBufferAllocator: Final[type[FieldBufferAllocatorProtocol]] = cast(
     type[FieldBufferAllocatorProtocol],
-    type(device_allocators[CUPY_DEVICE]) if CUPY_DEVICE else InvalidGPUFielBufferAllocator,
+    type(device_allocators[CUPY_DEVICE]) if CUPY_DEVICE else InvalidGPUFieldBufferAllocator,
 )
 
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -27,7 +27,7 @@ class DaCeBackendFactory(factory.Factory):
         name_postfix = ""
         gpu = factory.Trait(
             allocator=next_allocators.StandardGPUFieldBufferAllocator(),
-            device_type=next_allocators.CUPY_DEVICE or core_defs.DeviceType.CUDA,
+            device_type=core_defs.CUPY_DEVICE or core_defs.DeviceType.CUDA,
             name_device="gpu",
         )
         cached = factory.Trait(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -27,7 +27,7 @@ class DaCeBackendFactory(factory.Factory):
         name_postfix = ""
         gpu = factory.Trait(
             allocator=next_allocators.StandardGPUFieldBufferAllocator(),
-            device_type=core_defs.CUPY_DEVICE or core_defs.DeviceType.CUDA,
+            device_type=core_defs.CUPY_DEVICE_TYPE or core_defs.DeviceType.CUDA,
             name_device="gpu",
         )
         cached = factory.Trait(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -84,7 +84,7 @@ class DaCeTranslator(
             inp.args.offset_provider,  # TODO(havogt): should be offset_provider_type once the transformation don't require run-time info
             inp.args.column_axis,
             auto_opt=self.auto_optimize,
-            on_gpu=(self.device_type == core_defs.CUPY_DEVICE),
+            on_gpu=(self.device_type == core_defs.CUPY_DEVICE_TYPE),
         )
 
         param_types = tuple(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -15,7 +15,7 @@ import dace
 import factory
 
 from gt4py._core import definitions as core_defs
-from gt4py.next import allocators as gtx_allocators, common
+from gt4py.next import common
 from gt4py.next.iterator import ir as itir, transforms as itir_transforms
 from gt4py.next.otf import languages, stages, step_types, workflow
 from gt4py.next.otf.binding import interface
@@ -84,7 +84,7 @@ class DaCeTranslator(
             inp.args.offset_provider,  # TODO(havogt): should be offset_provider_type once the transformation don't require run-time info
             inp.args.column_axis,
             auto_opt=self.auto_optimize,
-            on_gpu=(self.device_type == gtx_allocators.CUPY_DEVICE),
+            on_gpu=(self.device_type == core_defs.CUPY_DEVICE),
         )
 
         param_types = tuple(

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -185,7 +185,7 @@ class GTFNBackendFactory(factory.Factory):
         name_postfix = ""
         gpu = factory.Trait(
             allocator=next_allocators.StandardGPUFieldBufferAllocator(),
-            device_type=next_allocators.CUPY_DEVICE or core_defs.DeviceType.CUDA,
+            device_type=core_defs.CUPY_DEVICE or core_defs.DeviceType.CUDA,
             name_device="gpu",
         )
         cached = factory.Trait(

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -185,7 +185,7 @@ class GTFNBackendFactory(factory.Factory):
         name_postfix = ""
         gpu = factory.Trait(
             allocator=next_allocators.StandardGPUFieldBufferAllocator(),
-            device_type=core_defs.CUPY_DEVICE or core_defs.DeviceType.CUDA,
+            device_type=core_defs.CUPY_DEVICE_TYPE or core_defs.DeviceType.CUDA,
             name_device="gpu",
         )
         cached = factory.Trait(

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -40,12 +40,12 @@ _GPUBufferAllocator: Optional[allocators.NDArrayBufferAllocator] = None
 if cp:
     assert isinstance(allocators.cupy_array_utils, allocators.ArrayUtils)
 
-    if core_defs.CUPY_DEVICE == core_defs.DeviceType.CUDA:
+    if core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
             device_type=core_defs.DeviceType.CUDA,
             array_utils=allocators.cupy_array_utils,
         )
-    elif core_defs.CUPY_DEVICE == core_defs.DeviceType.ROCM:
+    elif core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
             device_type=core_defs.DeviceType.ROCM,
             array_utils=allocators.cupy_array_utils,
@@ -279,7 +279,7 @@ def _allocate_gpu(
 
 allocate_gpu = _allocate_gpu
 
-if core_defs.CUPY_DEVICE == core_defs.DeviceType.ROCM:
+if core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
 
     class CUDAArrayInterfaceNDArray(cp.ndarray):
         def __new__(cls, input_array: "cp.ndarray") -> CUDAArrayInterfaceNDArray:

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -12,7 +12,7 @@ import collections.abc
 import functools
 import math
 import numbers
-from typing import Final, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import Literal, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -30,13 +30,6 @@ except ImportError:
     cp = None
 
 
-CUPY_DEVICE: Final[Literal[None, core_defs.DeviceType.CUDA, core_defs.DeviceType.ROCM]] = (
-    None
-    if not cp
-    else (core_defs.DeviceType.ROCM if cp.cuda.get_hipcc_path() else core_defs.DeviceType.CUDA)
-)
-
-
 FieldLike = Union["cp.ndarray", np.ndarray, ArrayInterface, CUDAArrayInterface]
 
 _CPUBufferAllocator = allocators.NDArrayBufferAllocator(
@@ -47,12 +40,12 @@ _GPUBufferAllocator: Optional[allocators.NDArrayBufferAllocator] = None
 if cp:
     assert isinstance(allocators.cupy_array_utils, allocators.ArrayUtils)
 
-    if CUPY_DEVICE == core_defs.DeviceType.CUDA:
+    if core_defs.CUPY_DEVICE == core_defs.DeviceType.CUDA:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
             device_type=core_defs.DeviceType.CUDA,
             array_utils=allocators.cupy_array_utils,
         )
-    elif CUPY_DEVICE == core_defs.DeviceType.ROCM:
+    elif core_defs.CUPY_DEVICE == core_defs.DeviceType.ROCM:
         _GPUBufferAllocator = allocators.NDArrayBufferAllocator(
             device_type=core_defs.DeviceType.ROCM,
             array_utils=allocators.cupy_array_utils,
@@ -286,7 +279,7 @@ def _allocate_gpu(
 
 allocate_gpu = _allocate_gpu
 
-if CUPY_DEVICE == core_defs.DeviceType.ROCM:
+if core_defs.CUPY_DEVICE == core_defs.DeviceType.ROCM:
 
     class CUDAArrayInterfaceNDArray(cp.ndarray):
         def __new__(cls, input_array: "cp.ndarray") -> CUDAArrayInterfaceNDArray:

--- a/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
+++ b/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
@@ -86,7 +86,7 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
 
     allocator, backend = unstructured_case.allocator, unstructured_case.backend
 
-    if gtx_allocators.is_field_allocator_for(allocator, gtx_allocators.CUPY_DEVICE):
+    if gtx_allocators.is_field_allocator_for(allocator, core_defs.CUPY_DEVICE):
         import cupy as xp
 
         dace_storage_type = dace.StorageType.GPU_Global

--- a/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
+++ b/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
@@ -86,7 +86,7 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
 
     allocator, backend = unstructured_case.allocator, unstructured_case.backend
 
-    if gtx_allocators.is_field_allocator_for(allocator, core_defs.CUPY_DEVICE):
+    if gtx_allocators.is_field_allocator_for(allocator, core_defs.CUPY_DEVICE_TYPE):
         import cupy as xp
 
         dace_storage_type = dace.StorageType.GPU_Global

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace.py
@@ -175,7 +175,7 @@ def test_dace_fastcall_with_connectivity(unstructured_case, monkeypatch):
         offset_provider = unstructured_case.offset_provider
     else:
         assert gtx.allocators.is_field_allocator_for(
-            unstructured_case.backend.allocator, gtx.allocators.CUPY_DEVICE
+            unstructured_case.backend.allocator, core_defs.CUPY_DEVICE
         )
 
         import cupy as cp

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace.py
@@ -11,7 +11,6 @@
 import ctypes
 import unittest
 import unittest.mock
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -21,12 +20,11 @@ import gt4py.next as gtx
 from gt4py.next.ffront.fbuiltins import where
 
 from next_tests.integration_tests import cases
-from next_tests.integration_tests.cases import E2V, cartesian_case, unstructured_case
+from next_tests.integration_tests.cases import E2V, cartesian_case, unstructured_case  # noqa: F401
 from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils import (
-    exec_alloc_descriptor,
-    mesh_descriptor,
+    exec_alloc_descriptor,  # noqa: F401
+    mesh_descriptor,  # noqa: F401
 )
-
 
 dace = pytest.importorskip("dace")
 
@@ -186,7 +184,7 @@ def test_dace_fastcall_with_connectivity(unstructured_case, monkeypatch):
         # to gpu memory at each program call (see `dace_backend._ensure_is_on_device`),
         # therefore fast_call cannot be used (unless cupy reuses the same cupy array
         # from the its memory pool, but this behavior is random and unpredictable).
-        # Here we copy the connectivity to gpu memory, and resuse the same cupy array
+        # Here we copy the connectivity to gpu memory, and reuse the same cupy array
         # on multiple program calls, in order to ensure that fast_call is used.
         offset_provider = {
             "E2V": gtx.as_connectivity(

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace.py
@@ -175,7 +175,7 @@ def test_dace_fastcall_with_connectivity(unstructured_case, monkeypatch):
         offset_provider = unstructured_case.offset_provider
     else:
         assert gtx.allocators.is_field_allocator_for(
-            unstructured_case.backend.allocator, core_defs.CUPY_DEVICE
+            unstructured_case.backend.allocator, core_defs.CUPY_DEVICE_TYPE
         )
 
         import cupy as cp


### PR DESCRIPTION
## Description

This PR centralizes the definition of `CUPY_DEVICE_TYPE` in `_core/definitions`. This effectively de-duplicates the definition of `CUPY_DEVICE` in gt4py next and cartesian. Fixes a couple of typos along the way.

Related issue: https://github.com/GridTools/gt4py/issues/1880

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Should be covered by existing tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
