### PR TITLE
fix[next][dace]: assert on subset_to_adjust in CopyChainRemover

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
@@ -1030,10 +1030,9 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
                 if memlet_to_adjust.data == a1.data:
                     memlet_to_adjust.data = a2.data
 
-                if is_producer_edge:
-                    subset_to_adjust = memlet_to_adjust.get_dst_subset(edge_to_adjust, state)
-                else:
-                    subset_to_adjust = memlet_to_adjust.get_src_subset(edge_to_adjust, state)
+                subset_to_adjust = (
+                    memlet_to_adjust.dst_subset if is_producer_edge else memlet_to_adjust.src_subset
+                )
                 assert subset_to_adjust is not None
                 subset_to_adjust.offset(a2_offsets, negative=False)
 


### PR DESCRIPTION
The `subset_to_adjust` was `None` in icon4py CI, see for example:
https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/5125340235196978/2255149825504671/-/jobs/9378871351

This code change seems to retrieve it correctly.