### PR TITLE
refactor[cartesian, storage]: break dependency cycle; replace `GT4PY_USE_HIP`

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -19,6 +19,7 @@ import dace.data
 from dace.sdfg.utils import inline_sdfgs
 
 from gt4py import storage as gt_storage
+from gt4py._core import definitions as core_defs
 from gt4py.cartesian import config as gt_config
 from gt4py.cartesian.backend.base import CLIBackendMixin, register
 from gt4py.cartesian.backend.gtc_common import (
@@ -523,7 +524,7 @@ auto ${name}(const std::array<gt::uint_t, 3>& domain) {
         with dace.config.temporary_config():
             # To prevent conflict with 3rd party usage of DaCe config always make sure that any
             #  changes be under the temporary_config manager
-            if gt_config.GT4PY_USE_HIP:
+            if core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
                 dace.config.Config.set("compiler", "cuda", "backend", value="hip")
             dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=-1)
             dace.config.Config.set(

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -18,6 +18,7 @@ import setuptools
 from setuptools import distutils
 from setuptools.command.build_ext import build_ext
 
+from gt4py._core import definitions as core_defs
 from gt4py.cartesian import config as gt_config
 
 
@@ -51,6 +52,7 @@ def get_gt_pyext_build_opts(
 ) -> Dict[str, Union[str, List[str], Dict[str, Any]]]:
     include_dirs = [gt_config.build_settings["boost_include_path"]]
     extra_compile_args_from_config = gt_config.build_settings["extra_compile_args"]
+    is_rocm_gpu = core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM
 
     if uses_cuda:
         compute_capability = get_cuda_compute_capability()
@@ -67,8 +69,6 @@ def get_gt_pyext_build_opts(
         cuda_arch = ""
 
     gt_include_path = gt_config.build_settings["gt_include_path"]
-
-    import os
 
     extra_compile_args = dict(
         cxx=[
@@ -93,7 +93,7 @@ def get_gt_pyext_build_opts(
         "-DBOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE",
         *extra_compile_args_from_config["cuda"],
     ]
-    if gt_config.GT4PY_USE_HIP:
+    if is_rocm_gpu:
         extra_compile_args["cuda"] += [
             "-isystem{}".format(gt_include_path),
             "-isystem{}".format(gt_config.build_settings["boost_include_path"]),
@@ -125,7 +125,7 @@ def get_gt_pyext_build_opts(
         extra_compile_args["cxx"].append(
             "-isystem{}".format(os.path.join(dace_path, "runtime/include"))
         )
-        if gt_config.GT4PY_USE_HIP:
+        if is_rocm_gpu:
             extra_compile_args["cuda"].append(
                 "-isystem{}".format(os.path.join(dace_path, "runtime/include"))
             )
@@ -158,7 +158,7 @@ def get_gt_pyext_build_opts(
         if uses_cuda:
             cuda_flags = []
             for cpp_flag in cpp_flags:
-                if gt_config.GT4PY_USE_HIP:
+                if is_rocm_gpu:
                     cuda_flags.extend([cpp_flag])
                 else:
                     cuda_flags.extend(["--compiler-options", cpp_flag])
@@ -309,7 +309,7 @@ def build_pybind_cuda_ext(
     library_dirs = library_dirs or []
     library_dirs = [*library_dirs, gt_config.build_settings["cuda_library_path"]]
     libraries = libraries or []
-    if gt_config.GT4PY_USE_HIP:
+    if core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
         libraries = [*libraries, "hiprtc"]
     else:
         libraries = [*libraries, "cudart"]
@@ -363,7 +363,7 @@ class CUDABuildExtension(build_ext, object):
             cflags = copy.deepcopy(extra_postargs)
             try:
                 if os.path.splitext(src)[-1] == ".cu":
-                    if gt_config.GT4PY_USE_HIP:
+                    if core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
                         cuda_exec = os.path.join(gt_config.build_settings["cuda_bin_path"], "hipcc")
                     else:
                         cuda_exec = os.path.join(gt_config.build_settings["cuda_bin_path"], "nvcc")

--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List, Optional
 
 import gridtools_cpp
 
+from gt4py._core import definitions as core_defs
+
 
 GT4PY_INSTALLATION_PATH: str = os.path.dirname(os.path.abspath(__file__))
 
@@ -25,18 +27,6 @@ CUDA_ROOT: str = os.environ.get(
 )
 
 CUDA_HOST_CXX: Optional[str] = os.environ.get("CUDA_HOST_CXX", None)
-
-if "GT4PY_USE_HIP" in os.environ:
-    GT4PY_USE_HIP: bool = bool(int(os.environ["GT4PY_USE_HIP"]))
-else:
-    # Autodetect cupy with ROCm/HIP support
-    try:
-        import cupy as _cp
-
-        GT4PY_USE_HIP = _cp.cuda.get_hipcc_path() is not None
-        del _cp
-    except Exception:
-        GT4PY_USE_HIP = False
 
 GT_INCLUDE_PATH: str = os.path.abspath(gridtools_cpp.get_include_dir())
 
@@ -66,7 +56,7 @@ build_settings: Dict[str, Any] = {
     "parallel_jobs": multiprocessing.cpu_count(),
     "cpp_template_depth": os.environ.get("GT_CPP_TEMPLATE_DEPTH", GT_CPP_TEMPLATE_DEPTH),
 }
-if GT4PY_USE_HIP:
+if core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
     build_settings["cuda_library_path"] = os.path.join(CUDA_ROOT, "lib")
 else:
     build_settings["cuda_library_path"] = os.path.join(CUDA_ROOT, "lib64")

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -19,7 +19,6 @@ import numpy.typing as npt
 from numpy.typing import DTypeLike
 
 from gt4py._core import definitions as core_defs
-from gt4py.cartesian import config as gt_config
 from gt4py.eve.extended_typing import ArrayInterface, CUDAArrayInterface
 from gt4py.storage import allocators
 
@@ -259,9 +258,10 @@ def _allocate_gpu(
 ) -> Tuple["cp.ndarray", "cp.ndarray"]:
     assert cp is not None
     assert _GPUBufferAllocator is not None, "GPU allocation library or device not found"
+    if core_defs.CUPY_DEVICE_TYPE is None:
+        raise ValueError("CUPY_DEVICE_TYPE detection failed.")
     device = core_defs.Device(  # type: ignore[type-var]
-        (core_defs.DeviceType.ROCM if gt_config.GT4PY_USE_HIP else core_defs.DeviceType.CUDA),
-        0,
+        core_defs.CUPY_DEVICE_TYPE, 0
     )
     buffer = _GPUBufferAllocator.allocate(
         shape,

--- a/tach.toml
+++ b/tach.toml
@@ -16,6 +16,7 @@ depends_on = [
 [[modules]]
 path = "gt4py.cartesian"
 depends_on = [
+    { path = "gt4py._core" },
     { path = "gt4py.eve" },
     { path = "gt4py.storage" },
 ]
@@ -36,6 +37,5 @@ depends_on = [
 path = "gt4py.storage"
 depends_on = [
     { path = "gt4py._core" },
-    { path = "gt4py.cartesian" },  # for backward-compatibility the cartesian allocators are in `gt4py.storage`
     { path = "gt4py.eve" },
 ]


### PR DESCRIPTION
## Description

This PR breaks the dependency cycle between `gt4py.cartesian` and `gt4py.storage`. The last puzzle piece was the distinction between AMD and NVIDIA GPUs. This was controlled by `GT4PY_USE_HIP`. With this PR we re-use `CUPY_DEVICE_TYPE` (for `_core/definitions`) for this purpose.

`GT4PY_USE_HIP` could be set by an environment variable or be auto-detected. Auto-detection for `GT4PY_USE_HIP` and `CUPY_DEVICE_TYPE` is the same. And according to @stubbiali, the environment variable was never[^1] needed because auto-detection worked well. We thus don't expect issues removing the environment variable.

Related issue: https://github.com/GridTools/gt4py/issues/1880

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Assumed to covered by existing tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A

[^1]: https://github.com/GridTools/gt4py/pull/1867#issuecomment-2662742715