### PR TITLE
fix[next][dace]: Make default make_persistent=False

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -27,7 +27,7 @@ def gt_auto_optimize(
     ] = None,
     aggressive_fusion: bool = True,
     max_optimization_rounds_p2: int = 100,
-    make_persistent: bool = True,
+    make_persistent: bool = False,
     gpu_block_size: Optional[Sequence[int | str] | str] = None,
     blocking_dim: Optional[gtx_common.Dimension] = None,
     blocking_size: int = 10,


### PR DESCRIPTION
GT4Py programs use fields with symbolic shape and strides. This allows to invoke the same stencil multiple times with different argument fields, without needing to recompile it (no JIT). Therefore, the temporary fields used inside the program cannot be made persistent. That means that the lifescope of transient arrays is limited to the SDFG scope.