### PR TITLE
fix[next][dace]: Removed Workaround For DaCe Issue 1959

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
@@ -95,21 +95,6 @@ def gt_simplify(
         # NOTE: See comment in `gt_inline_nested_sdfg()` for more.
         sdfg.reset_cfg_list()
 
-        # To mitigate DaCe issue 1959, we run the chain removal transformation here.
-        # TODO(phimuell): Remove as soon as we have a true solution.
-        if "CopyChainRemover" not in skip:
-            copy_chain_remover_result = gtx_transformations.gt_remove_copy_chain(
-                sdfg=sdfg,
-                validate=validate,
-                validate_all=validate_all,
-            )
-            if copy_chain_remover_result is not None:
-                at_least_one_xtrans_run = True
-                result = result or {}
-                if "CopyChainRemover" not in result:
-                    result["CopyChainRemover"] = 0
-                result["CopyChainRemover"] += copy_chain_remover_result
-
         if "InlineSDFGs" not in skip:
             inline_res = gt_inline_nested_sdfg(
                 sdfg=sdfg,


### PR DESCRIPTION
This [issue](https://github.com/spcl/dace/issues/1959) leaded to some problem, especially in ICON4Py stencil `39_to_40`. However, through an [update](https://github.com/GridTools/gt4py/pull/1915) in GT4Py this leads to now to other problems (`ConstantPropagation` involving AcccessNodes) in `19_to_20`. The underlying issue in DaCe was solved in [PR#1980](https://github.com/spcl/dace/pull/1980) and this PR now deactivate the workaround.

Only merge if the DaCe dependency in GT4Py was updated to include that fix.
