### PR TITLE
fix[next]: change ordering of dims so vertical dims go at the end

### DIFF
--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -1161,9 +1161,9 @@ def promote_dims(*dims_list: Sequence[Dimension]) -> list[Dimension]:
         Traceback (most recent call last):
         ...
         ValueError: Dimensions 'K[vertical], J[horizontal]' are not ordered correctly, expected 'J[horizontal], K[vertical]'.
-        >>> promote_dims([I, K], [J, E2V]) == [I, J, K, E2V]
+        >>> promote_dims([I, K], [J, E2V]) == [I, J, E2V, K]
         True
-        >>> promote_dims([I, E2C], [K, E2V])
+        >>> promote_dims([I, E2C], [E2V, K])
         Traceback (most recent call last):
         ...
         ValueError: There are more than one dimension with DimensionKind 'LOCAL'.

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -69,7 +69,7 @@ class DimensionKind(StrEnum):
         return self.value
 
 
-_DIM_KIND_ORDER = {DimensionKind.HORIZONTAL: 1, DimensionKind.VERTICAL: 2, DimensionKind.LOCAL: 3}
+_DIM_KIND_ORDER = {DimensionKind.HORIZONTAL: 0, DimensionKind.LOCAL: 1, DimensionKind.VERTICAL: 2}
 
 
 def dimension_to_implicit_offset(dim: str) -> str:
@@ -1145,7 +1145,7 @@ def promote_dims(*dims_list: Sequence[Dimension]) -> list[Dimension]:
     Find an ordering of multiple lists of dimensions.
 
     The resulting list contains all unique dimensions from the input lists,
-    sorted first by dims_kind_order, i.e., `Dimension.kind` (`HORIZONTAL` < `VERTICAL` < `LOCAL`) and then
+    sorted first by dims_kind_order, i.e., `Dimension.kind` (`HORIZONTAL` < `LOCAL` < `VERTICAL`) and then
     lexicographically by `Dimension.value`.
 
     Examples:

--- a/tests/next_tests/unit_tests/ffront_tests/test_type_deduction.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_type_deduction.py
@@ -163,6 +163,20 @@ def test_premap_nbfield(premap_setup):
     )
 
 
+def test_premap_nbfield_with_vertical(premap_setup):
+    X, Y, Y2XDim, Y2X = premap_setup
+    K = Dimension("K", kind=DimensionKind.VERTICAL)
+
+    def premap_fo(bar: Field[[X, K], int64]) -> Field[[Y, Y2XDim, K], int64]:
+        return bar(Y2X)
+
+    parsed = FieldOperatorParser.apply_to_function(premap_fo)
+
+    assert parsed.body.stmts[0].value.type == ts.FieldType(
+        dims=[Y, Y2XDim, K], dtype=ts.ScalarType(kind=ts.ScalarKind.INT64)
+    )
+
+
 def test_premap_reduce(premap_setup):
     X, Y, Y2XDim, Y2X = premap_setup
 

--- a/tests/next_tests/unit_tests/test_common.py
+++ b/tests/next_tests/unit_tests/test_common.py
@@ -586,7 +586,7 @@ def dimension_promotion_cases() -> (
             None,
             "There are more than one dimension with DimensionKind 'LOCAL'.",
         ),
-        ([[JDim, V2E], [IDim, KDim]], [IDim, JDim, V2E, KDim, ], None),
+        ([[JDim, V2E], [IDim, KDim]], [IDim, JDim, V2E, KDim], None),
     ]
     return [
         ([[el for el in arg] for arg in args], [el for el in result] if result else result, msg)

--- a/tests/next_tests/unit_tests/test_common.py
+++ b/tests/next_tests/unit_tests/test_common.py
@@ -582,11 +582,11 @@ def dimension_promotion_cases() -> (
             "Dimensions 'KDim[vertical], JDim[horizontal]' are not ordered correctly, expected 'JDim[horizontal], KDim[vertical]'.",
         ),
         (
-            [[JDim, V2E], [IDim, KDim, E2C2V]],
+            [[JDim, V2E], [IDim, E2C2V, KDim]],
             None,
             "There are more than one dimension with DimensionKind 'LOCAL'.",
         ),
-        ([[JDim, V2E], [IDim, KDim]], [IDim, JDim, KDim, V2E], None),
+        ([[JDim, V2E], [IDim, KDim]], [IDim, JDim, V2E, KDim, ], None),
     ]
     return [
         ([[el for el in arg] for arg in args], [el for el in result] if result else result, msg)


### PR DESCRIPTION
This PR modifies the default ordering of dimensions in a domain defined in #1847 to follow the most common ordering used by users, where horizontal dimensions go first and the vertical dimension goes at the end. See #1847 for more details.