### PR TITLE
fix[next]: get scalar value from 0d array in `_hyperslice` 

### DIFF
--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -761,7 +761,8 @@ def _hyperslice(
     nnz: tuple[core_defs.NDArrayObject, ...] = xp.nonzero(select_mask)
 
     slices = tuple(
-        slice(xp.min(dim_nnz_indices), xp.max(dim_nnz_indices) + 1) for dim_nnz_indices in nnz
+        slice(xp.min(dim_nnz_indices).item(), xp.max(dim_nnz_indices).item() + 1)
+        for dim_nnz_indices in nnz
     )
     hcube = select_mask[tuple(slices)]
     if skip_value is not None:


### PR DESCRIPTION
This PR fixes an issue when running embedded on CUPY arrays using the connectivity tables on CUPY arrays: when using the slice later on it fails because it contains 0d arrays and not scalars. 