### PR TITLE
fix[next]: Restore type information in fuse_as_fieldop pass

### DIFF
--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -285,9 +285,9 @@ class FuseAsFieldOp(
         new_node = cls(uids=uids, enabled_transformations=enabled_transformations).visit(
             node, within_set_at_expr=within_set_at_expr
         )
-        # This pass does not fully preserve the type information yet. In particular for the
-        # generated lifts this is tricky and error prone. For simplicity we just reinfer everything
-        # here.
+        # The `FuseAsFieldOp` pass does not fully preserve the type information yet. In particular
+        # for the generated lifts this is tricky and error-prone. For simplicity, we just reinfer
+        # everything here ensuring later passes can use the information.
         new_node = type_inference.infer(
             new_node,
             offset_provider_type=offset_provider_type,

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -285,7 +285,9 @@ class FuseAsFieldOp(
         new_node = cls(uids=uids, enabled_transformations=enabled_transformations).visit(
             node, within_set_at_expr=within_set_at_expr
         )
-        
+        # This pass does not fully preserve the type information yet. In particular for the
+        # generated lifts this is tricky and error prone. For simplicity we just reinfer everything
+        # here.
         new_node = type_inference.infer(
             new_node,
             offset_provider_type=offset_provider_type,

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -282,9 +282,16 @@ class FuseAsFieldOp(
         if not uids:
             uids = eve_utils.UIDGenerator()
 
-        return cls(uids=uids, enabled_transformations=enabled_transformations).visit(
+        new_node = cls(uids=uids, enabled_transformations=enabled_transformations).visit(
             node, within_set_at_expr=within_set_at_expr
         )
+        
+        new_node = type_inference.infer(
+            new_node,
+            offset_provider_type=offset_provider_type,
+            allow_undeclared_symbols=allow_undeclared_symbols,
+        )
+        return new_node
 
     def transform_fuse_make_tuple(self, node: itir.Node, **kwargs):
         if not cpm.is_call_to(node, "make_tuple"):


### PR DESCRIPTION
The `FuseAsFieldOp` pass does not fully preserve the type information yet. In particular for the generated lifts this is tricky and error prone. For simplicity we just reinfer everything here ensuring later passes can use the information.