### PR TITLE
refactor[cartesian]: Report mutable class defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -414,7 +414,6 @@ split-on-trailing-comma = false
 max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
-'src/gt4py/cartesian/*' = ['RUF012']
 'src/gt4py/eve/extended_typing.py' = ['F401', 'F405']
 'src/gt4py/next/__init__.py' = ['F401']
 

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -8,12 +8,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, disabled, register
 from gt4py.cartesian.backend.gtc_common import (
     BackendCodegen,
+    BaseGTBackend,
+    CUDAPyExtModuleGenerator,
+    GTBackendOptions,
     bindings_main_template,
     pybuffer_to_sid,
 )
@@ -27,8 +30,6 @@ from gt4py.cartesian.gtc.passes.oir_optimizations.caches import FillFlushToLocal
 from gt4py.cartesian.gtc.passes.oir_optimizations.pruning import NoFieldAccessPruning
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.eve import codegen
-
-from .gtc_common import BaseGTBackend, CUDAPyExtModuleGenerator
 
 
 if TYPE_CHECKING:
@@ -130,11 +131,11 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     """CUDA backend using gtc."""
 
     name = "cuda"
-    options = {
+    options: ClassVar[GTBackendOptions] = {
         **BaseGTBackend.GT_BACKEND_OPTS,
         "device_sync": {"versioning": True, "type": bool},
     }
-    languages = {"computation": "cuda", "bindings": ["python"]}
+    languages: ClassVar[dict] = {"computation": "cuda", "bindings": ["python"]}
     storage_info = gt_storage.layout.CUDALayout
     PYEXT_GENERATOR_CLASS = CudaExtGenerator
     MODULE_GENERATOR_CLASS = CUDAPyExtModuleGenerator

--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -12,7 +12,7 @@ import abc
 import os
 import textwrap
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Final, List, Optional, Tuple, Type, Union
 
 import gt4py.cartesian.gtc.utils
 import gt4py.cartesian.gtc.utils as gtc_utils
@@ -213,8 +213,11 @@ class BackendCodegen:
         pass
 
 
+GTBackendOptions = Dict[str, Dict[str, Any]]
+
+
 class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
-    GT_BACKEND_OPTS: Dict[str, Dict[str, Any]] = {
+    GT_BACKEND_OPTS: Final[GTBackendOptions] = {
         "add_profile_info": {"versioning": True, "type": bool},
         "clean": {"versioning": False, "type": bool},
         "debug_mode": {"versioning": True, "type": bool},

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -8,12 +8,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, register
 from gt4py.cartesian.backend.gtc_common import (
     BackendCodegen,
+    BaseGTBackend,
+    CUDAPyExtModuleGenerator,
+    GTBackendOptions,
     bindings_main_template,
     pybuffer_to_sid,
 )
@@ -25,8 +28,6 @@ from gt4py.cartesian.gtc.gtir_to_oir import GTIRToOIR
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.eve import codegen
-
-from .gtc_common import BaseGTBackend, CUDAPyExtModuleGenerator
 
 
 if TYPE_CHECKING:
@@ -152,7 +153,7 @@ class GTCpuIfirstBackend(GTBaseBackend):
 
     name = "gt:cpu_ifirst"
     GT_BACKEND_T = "cpu_ifirst"
-    languages = {"computation": "c++", "bindings": ["python"]}
+    languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
     storage_info = gt_storage.layout.CPUIFirstLayout
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
@@ -165,7 +166,7 @@ class GTCpuKfirstBackend(GTBaseBackend):
 
     name = "gt:cpu_kfirst"
     GT_BACKEND_T = "cpu_kfirst"
-    languages = {"computation": "c++", "bindings": ["python"]}
+    languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
     storage_info = gt_storage.layout.CPUKFirstLayout
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
@@ -179,8 +180,11 @@ class GTGpuBackend(GTBaseBackend):
     MODULE_GENERATOR_CLASS = CUDAPyExtModuleGenerator
     name = "gt:gpu"
     GT_BACKEND_T = "gpu"
-    languages = {"computation": "cuda", "bindings": ["python"]}
-    options = {**BaseGTBackend.GT_BACKEND_OPTS, "device_sync": {"versioning": True, "type": bool}}
+    languages: ClassVar[dict] = {"computation": "cuda", "bindings": ["python"]}
+    options: ClassVar[GTBackendOptions] = {
+        **BaseGTBackend.GT_BACKEND_OPTS,
+        "device_sync": {"versioning": True, "type": bool},
+    }
     storage_info = gt_storage.layout.CUDALayout
 
     def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:

--- a/src/gt4py/cartesian/backend/numpy_backend.py
+++ b/src/gt4py/cartesian/backend/numpy_backend.py
@@ -78,7 +78,7 @@ class NumpyBackend(BaseBackend, CLIBackendMixin):
         "ignore_np_errstate": {"versioning": True, "type": bool},
     }
     storage_info = gt_storage.layout.NaiveCPULayout
-    languages = {"computation": "python", "bindings": ["python"]}
+    languages: ClassVar[dict] = {"computation": "python", "bindings": ["python"]}
     MODULE_GENERATOR_CLASS = ModuleGenerator
 
     def generate_computation(self) -> Dict[str, Union[str, Dict]]:

--- a/src/gt4py/cartesian/cli.py
+++ b/src/gt4py/cartesian/cli.py
@@ -17,6 +17,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Final,
     Generator,
     KeysView,
     Optional,
@@ -105,7 +106,12 @@ class BackendOption(click.ParamType):
 
     name = "option"
 
-    converter_map = {bool: click.BOOL, int: click.INT, float: click.FLOAT, str: click.STRING}
+    converter_map: Final[dict] = {
+        bool: click.BOOL,
+        int: click.INT,
+        float: click.FLOAT,
+        str: click.STRING,
+    }
 
     def _convert_value(
         self,

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -10,7 +10,7 @@ import copy
 import functools
 import itertools
 import numbers
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Final, List, Optional, Tuple, Union, cast
 
 import numpy as np
 
@@ -267,18 +267,23 @@ class UnrollVectorExpressions(IRNodeMapper):
 
 
 class DefIRToGTIR(IRNodeVisitor):
-    GT4PY_ITERATIONORDER_TO_GTIR_LOOPORDER = {
+    GT4PY_ITERATIONORDER_TO_GTIR_LOOPORDER: Final[dict[IterationOrder, common.LoopOrder]] = {
         IterationOrder.BACKWARD: common.LoopOrder.BACKWARD,
         IterationOrder.PARALLEL: common.LoopOrder.PARALLEL,
         IterationOrder.FORWARD: common.LoopOrder.FORWARD,
     }
 
-    GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER = {
+    GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER: Final[dict[LevelMarker, common.LevelMarker]] = {
         LevelMarker.START: common.LevelMarker.START,
         LevelMarker.END: common.LevelMarker.END,
     }
 
-    GT4PY_OP_TO_GTIR_OP = {
+    GT4PY_OP_TO_GTIR_OP: Final[
+        dict[
+            BinaryOperator,
+            common.ArithmeticOperator | common.LogicalOperator | common.ComparisonOperator,
+        ]
+    ] = {
         # arithmetic
         BinaryOperator.ADD: common.ArithmeticOperator.ADD,
         BinaryOperator.SUB: common.ArithmeticOperator.SUB,
@@ -296,13 +301,13 @@ class DefIRToGTIR(IRNodeVisitor):
         BinaryOperator.GE: common.ComparisonOperator.GE,
     }
 
-    GT4PY_UNARYOP_TO_GTIR = {
+    GT4PY_UNARYOP_TO_GTIR: Final[dict[UnaryOperator, common.UnaryOperator]] = {
         UnaryOperator.POS: common.UnaryOperator.POS,
         UnaryOperator.NEG: common.UnaryOperator.NEG,
         UnaryOperator.NOT: common.UnaryOperator.NOT,
     }
 
-    GT4PY_NATIVE_FUNC_TO_GTIR = {
+    GT4PY_NATIVE_FUNC_TO_GTIR: Final[dict[NativeFunction, common.NativeFunction]] = {
         NativeFunction.ABS: common.NativeFunction.ABS,
         NativeFunction.MIN: common.NativeFunction.MIN,
         NativeFunction.MAX: common.NativeFunction.MAX,
@@ -333,7 +338,7 @@ class DefIRToGTIR(IRNodeVisitor):
         NativeFunction.TRUNC: common.NativeFunction.TRUNC,
     }
 
-    GT4PY_BUILTIN_TO_GTIR = {
+    GT4PY_BUILTIN_TO_GTIR: Final[dict[Builtin, common.BuiltInLiteral]] = {
         Builtin.TRUE: common.BuiltInLiteral.TRUE,
         Builtin.FALSE: common.BuiltInLiteral.FALSE,
     }

--- a/src/gt4py/cartesian/gtc/cuir/cuir_codegen.py
+++ b/src/gt4py/cartesian/gtc/cuir/cuir_codegen.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Collection, Dict, List, Set, Union
+from typing import Any, Collection, Dict, Final, List, Set, Union
 
 import numpy as np
 
@@ -109,7 +109,7 @@ class CUIRCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
 
     BinaryOp = as_fmt("({left} {op} {right})")
 
-    UNARY_OPERATOR_TO_CODE = {
+    UNARY_OPERATOR_TO_CODE: Final[dict[UnaryOperator, str]] = {
         UnaryOperator.NOT: "!",
         UnaryOperator.NEG: "-",
         UnaryOperator.POS: "+",
@@ -121,7 +121,10 @@ class CUIRCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
 
     Cast = as_fmt("static_cast<{dtype}>({expr})")
 
-    BUILTIN_LITERAL_TO_CODE = {BuiltInLiteral.TRUE: "true", BuiltInLiteral.FALSE: "false"}
+    BUILTIN_LITERAL_TO_CODE: Final[dict[BuiltInLiteral, str]] = {
+        BuiltInLiteral.TRUE: "true",
+        BuiltInLiteral.FALSE: "false",
+    }
 
     def visit_BuiltInLiteral(self, builtin: BuiltInLiteral, **kwargs: Any) -> str:
         try:
@@ -139,7 +142,7 @@ class CUIRCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
             dtype = self.visit(node.dtype, **kwargs)
             return f"static_cast<{dtype}>({value})"
 
-    NATIVE_FUNCTION_TO_CODE = {
+    NATIVE_FUNCTION_TO_CODE: Final[dict[NativeFunction, str]] = {
         NativeFunction.ABS: "std::abs",
         NativeFunction.MIN: "std::min",
         NativeFunction.MAX: "std::max",
@@ -181,7 +184,7 @@ class CUIRCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
 
     NativeFuncCall = as_mako("${func}(${','.join(args)})")
 
-    DATA_TYPE_TO_CODE = {
+    DATA_TYPE_TO_CODE: Final[dict[DataType, str]] = {
         DataType.BOOL: "bool",
         DataType.INT8: "std::int8_t",
         DataType.INT16: "std::int16_t",

--- a/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, ClassVar, Dict, List
 
 import dace
 import dace.data
@@ -20,8 +20,7 @@ import sympy
 from gt4py.cartesian.gtc.dace import daceir as dcir, prefix
 from gt4py.cartesian.gtc.dace.expansion.daceir_builder import DaCeIRBuilder
 from gt4py.cartesian.gtc.dace.expansion.sdfg_builder import StencilComputationSDFGBuilder
-
-from .utils import split_horizontal_executions_regions
+from gt4py.cartesian.gtc.dace.expansion.utils import split_horizontal_executions_regions
 
 
 if TYPE_CHECKING:
@@ -29,10 +28,7 @@ if TYPE_CHECKING:
 
 
 class StencilComputationExpansion(dace.library.ExpandTransformation):
-    environments: List
-
-    def __init__(self):
-        self.environments = []
+    environments: ClassVar[List] = []
 
     @staticmethod
     def _solve_for_domain(field_decls: Dict[str, dcir.FieldDecl], outer_subsets):

--- a/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/expansion.py
@@ -29,7 +29,10 @@ if TYPE_CHECKING:
 
 
 class StencilComputationExpansion(dace.library.ExpandTransformation):
-    environments: List = []
+    environments: List
+
+    def __init__(self):
+        self.environments = []
 
     @staticmethod
     def _solve_for_domain(field_decls: Dict[str, dcir.FieldDecl], outer_subsets):

--- a/src/gt4py/cartesian/gtc/dace/nodes.py
+++ b/src/gt4py/cartesian/gtc/dace/nodes.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import base64
 import pickle
 import typing
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, Final, List, Optional, Set, Union
 
 import dace.data
 import dace.dtypes
@@ -80,7 +80,7 @@ class PickledDictProperty(PickledProperty, dace.properties.DictProperty):
 
 @library.node
 class StencilComputation(library.LibraryNode):
-    implementations: Dict[str, dace.library.ExpandTransformation] = {
+    implementations: Final[Dict[str, dace.library.ExpandTransformation]] = {
         "default": StencilComputationExpansion
     }
     default_implementation = "default"

--- a/src/gt4py/cartesian/gtc/definitions.py
+++ b/src/gt4py/cartesian/gtc/definitions.py
@@ -10,6 +10,7 @@ import collections
 import enum
 import numbers
 import operator
+from typing import Final
 
 from gt4py.cartesian.gtc.utils import filter_mask, interpolate_mask
 
@@ -24,7 +25,7 @@ class CartesianSpace:
         def __str__(self) -> str:
             return self.name
 
-    names = [ax.name for ax in Axis]
+    names: Final[list[str]] = [ax.name for ax in Axis]
     ndim = len(names)
 
 

--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Collection, Dict, Optional, Union
+from typing import Any, Collection, Dict, Final, Optional, Union
 
 import numpy as np
 
@@ -184,7 +184,7 @@ class GTCppCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
 
     NativeFuncCall = as_mako("${func}(${','.join(args)})")
 
-    DATA_TYPE_TO_CODE = {
+    DATA_TYPE_TO_CODE: Final[dict[DataType, str]] = {
         DataType.BOOL: "bool",
         DataType.INT8: "std::int8_t",
         DataType.INT16: "std::int16_t",
@@ -202,7 +202,7 @@ class GTCppCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
                 f"Not implemented DataType '{dtype.name}' encountered."
             ) from error
 
-    UNARY_OPERATOR_TO_CODE = {
+    UNARY_OPERATOR_TO_CODE: Final[dict[UnaryOperator, str]] = {
         UnaryOperator.NOT: "!",
         UnaryOperator.NEG: "-",
         UnaryOperator.POS: "+",

--- a/src/gt4py/cartesian/gtc/passes/gtir_pipeline.py
+++ b/src/gt4py/cartesian/gtc/passes/gtir_pipeline.py
@@ -28,11 +28,12 @@ class GtirPipeline:
     May only call existing passes and may not contain any pass logic itself.
     """
 
-    _cache: Dict[Tuple[StencilID, Tuple[PASS_T, ...]], gtir.Stencil] = {}
+    _cache: Dict[Tuple[StencilID, Tuple[PASS_T, ...]], gtir.Stencil]
 
     def __init__(self, node: gtir.Stencil, stencil_id: StencilID):
         self.gtir = node
         self._stencil_id = stencil_id
+        self._cache = {}
 
     @property
     def stencil_id(self) -> StencilID:

--- a/src/gt4py/cartesian/gtc/passes/gtir_pipeline.py
+++ b/src/gt4py/cartesian/gtc/passes/gtir_pipeline.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Callable, Dict, Optional, Sequence, Tuple
+from typing import Callable, ClassVar, Dict, Optional, Sequence, Tuple
 
 from gt4py.cartesian.definitions import StencilID
 from gt4py.cartesian.gtc import gtir
@@ -28,12 +28,12 @@ class GtirPipeline:
     May only call existing passes and may not contain any pass logic itself.
     """
 
-    _cache: Dict[Tuple[StencilID, Tuple[PASS_T, ...]], gtir.Stencil]
+    # Cache pipelines across all instances
+    _cache: ClassVar[Dict[Tuple[StencilID, Tuple[PASS_T, ...]], gtir.Stencil]] = {}
 
     def __init__(self, node: gtir.Stencil, stencil_id: StencilID):
         self.gtir = node
         self._stencil_id = stencil_id
-        self._cache = {}
 
     @property
     def stencil_id(self) -> StencilID:

--- a/src/gt4py/cartesian/testing/suites.py
+++ b/src/gt4py/cartesian/testing/suites.py
@@ -11,6 +11,7 @@ import inspect
 import sys
 import types
 from itertools import count, product
+from typing import Final
 
 import hypothesis as hyp
 import hypothesis.strategies as hyp_st
@@ -58,7 +59,14 @@ class SuiteMeta(type):
     to test a stencil definition and implementations using Hypothesis and pytest.
     """
 
-    required_members = {"domain_range", "symbols", "definition", "validation", "backends", "dtypes"}
+    required_members: Final[set[str]] = {
+        "domain_range",
+        "symbols",
+        "definition",
+        "validation",
+        "backends",
+        "dtypes",
+    }
 
     def collect_symbols(cls_name, cls_dict):
         domain_range = cls_dict["domain_range"]


### PR DESCRIPTION
## Description

Mutable class default values share state across all instances of that class. This isn't an obvious behavior and might lead to unintended side effects. Ruff reports these now and forces developers to think twice when adding mutable defaults. [Ruff docs](https://docs.astral.sh/ruff/rules/mutable-class-default/)

Fixed all of the reported cases with explicit `ClassVar` or `Final` annotations, meaning there's nothing wrong with the current code. We just have to be aware and tool for our future selves.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/Index.md) folder.
  N/A
