### PR TITLE
fix-CI: upgrade cmake in base image

### DIFF
--- a/ci/base.Dockerfile
+++ b/ci/base.Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     build-essential \
     tar \
     wget \
+    cmake \
     curl \
     ca-certificates \
     zlib1g-dev \


### PR DESCRIPTION
This addresses an issue observed in CI: `Compatibility with CMake < 3.5 has been removed from CMake.`

The `cmake` version in ubuntu base image did not satisfy the minimum requirement `>= 3.5`. By adding cmake to the list of packages to be installed, the latest package version `3.22.1` is installed, which satisfies the requirement.