### PR TITLE
feat[next]: Allow setting compile-time stride to 1 for horizontal dimension

### DIFF
--- a/src/gt4py/next/config.py
+++ b/src/gt4py/next/config.py
@@ -81,3 +81,8 @@ BUILD_CACHE_LIFETIME: BuildCacheLifetime = BuildCacheLifetime[
 CMAKE_BUILD_TYPE: CMakeBuildType = CMakeBuildType[
     os.environ.get("GT4PY_CMAKE_BUILD_TYPE", "debug" if DEBUG else "release").upper()
 ]
+
+#: Experimental, use at your own risk: assume horizontal dimension has stride 1
+UNSTRUCTURED_HORIZONTAL_STRIDE_1: bool = env_flag_to_bool(
+    "GT4PY_UNSTRUCTURED_HORIZONTAL_STRIDE_1", default=False
+)

--- a/src/gt4py/next/config.py
+++ b/src/gt4py/next/config.py
@@ -83,6 +83,6 @@ CMAKE_BUILD_TYPE: CMakeBuildType = CMakeBuildType[
 ]
 
 #: Experimental, use at your own risk: assume horizontal dimension has stride 1
-UNSTRUCTURED_HORIZONTAL_STRIDE_1: bool = env_flag_to_bool(
-    "GT4PY_UNSTRUCTURED_HORIZONTAL_STRIDE_1", default=False
+UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE: bool = env_flag_to_bool(
+    "GT4PY_UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE", default=False
 )

--- a/src/gt4py/next/otf/binding/nanobind.py
+++ b/src/gt4py/next/otf/binding/nanobind.py
@@ -27,17 +27,15 @@ class Expr(eve.Node):
     pass
 
 
-class DimensionType(Expr):
+class DimensionSpec(Expr):
     name: str
     static_stride: Optional[int]
 
 
 class BufferSID(Expr):
     source_buffer: str
-    dimensions: Sequence[DimensionType]
+    dimensions: Sequence[DimensionSpec]
     scalar_type: ts.ScalarType
-    # TODO(havogt): implement `strides_kind: int` once we have the "frozen stencil" mechanism
-    # TODO(havogt): we can fix the dimension with `unit_stride_dim: int` once we have the "frozen stencil" mechanism
 
 
 class Tuple(Expr):
@@ -164,7 +162,7 @@ class BindingCodeGenerator(TemplatedGenerator):
 
     Tuple = as_jinja("""gridtools::tuple({{','.join(elems)}})""")
 
-    DimensionType = as_jinja("""generated::{{name}}_t""")
+    DimensionSpec = as_jinja("""generated::{{name}}_t""")
 
 
 def _tuple_get(index: int, var: str) -> str:
@@ -176,11 +174,11 @@ def make_argument(name: str, type_: ts.TypeSpec) -> str | BufferSID | Tuple:
         return BufferSID(
             source_buffer=name,
             dimensions=[
-                DimensionType(
+                DimensionSpec(
                     name=dim.value,
                     static_stride=1
                     if (
-                        config.UNSTRUCTURED_HORIZONTAL_STRIDE_1
+                        config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE
                         and dim.kind == common.DimensionKind.HORIZONTAL
                     )
                     else None,

--- a/src/gt4py/next/otf/binding/nanobind.py
+++ b/src/gt4py/next/otf/binding/nanobind.py
@@ -10,10 +10,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, TypeVar, Union
+from typing import Any, Optional, Sequence, TypeVar, Union
 
 import gt4py.eve as eve
 from gt4py.eve.codegen import JinjaTemplate as as_jinja, TemplatedGenerator
+from gt4py.next import common, config
 from gt4py.next.otf import cpp_utils, languages, stages, workflow
 from gt4py.next.otf.binding import cpp_interface, interface
 from gt4py.next.type_system import type_specifications as ts
@@ -28,6 +29,7 @@ class Expr(eve.Node):
 
 class DimensionType(Expr):
     name: str
+    static_stride: Optional[int]
 
 
 class BufferSID(Expr):
@@ -148,8 +150,14 @@ class BindingCodeGenerator(TemplatedGenerator):
         pybuffer = f"{sid.source_buffer}.first"
         dims = [self.visit(dim) for dim in sid.dimensions]
         origin = f"{sid.source_buffer}.second"
+        stride_spec = [
+            dim.static_stride if dim.static_stride is not None else -1 for dim in sid.dimensions
+        ]
+        stride_spec_string = (
+            f"gridtools::nanobind::stride_spec<{', '.join(str(s) for s in stride_spec)}>{{}}"
+        )
 
-        as_sid = f"gridtools::nanobind::as_sid({pybuffer})"
+        as_sid = f"gridtools::nanobind::as_sid({pybuffer}, {stride_spec_string})"
         shifted = f"gridtools::sid::shift_sid_origin({as_sid}, {origin})"
         renamed = f"gridtools::sid::rename_numbered_dimensions<{', '.join(dims)}>({shifted})"
         return renamed
@@ -167,7 +175,18 @@ def make_argument(name: str, type_: ts.TypeSpec) -> str | BufferSID | Tuple:
     if isinstance(type_, ts.FieldType):
         return BufferSID(
             source_buffer=name,
-            dimensions=[DimensionType(name=dim.value) for dim in type_.dims],
+            dimensions=[
+                DimensionType(
+                    name=dim.value,
+                    static_stride=1
+                    if (
+                        config.UNSTRUCTURED_HORIZONTAL_STRIDE_1
+                        and dim.kind == common.DimensionKind.HORIZONTAL
+                    )
+                    else None,
+                )
+                for dim in type_.dims
+            ],
             scalar_type=type_.dtype,
         )
     elif isinstance(type_, ts.TupleType):

--- a/src/gt4py/next/program_processors/codegens/gtfn/gtfn_module.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/gtfn_module.py
@@ -310,8 +310,7 @@ class GTFNTranslationStep(
 
     def _not_implemented_for_device_type(self) -> NotImplementedError:
         return NotImplementedError(
-            f"{self.__class__.__name__} is not implemented for "
-            f"device type {self.device_type.name}"
+            f"{self.__class__.__name__} is not implemented for device type {self.device_type.name}"
         )
 
 


### PR DESCRIPTION
Enable to propagate stride 1 information.

For now, it can only be enable for *all* fields and only for the horizontal dimension. The 2 lines enabling this are a quick hacky implementation, the proper implementation would allow to pass this as meta data per field argument.