### PR TITLE
fix[next][dace]: fix for granule build with dace

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -73,7 +73,6 @@ class DaCeCompiler(
 
         with dace.config.temporary_config():
             dace.config.Config.set("compiler", "build_type", value=self.cmake_build_type.value)
-            dace.config.Config.set("compiler", "use_cache", value=False)  # we use the gt4py cache
             if self.device_type == core_defs.DeviceType.CPU:
                 compiler_args = dace.config.Config.get("compiler", "cpu", "args")
                 # disable finite-math-only in order to support isfinite/isinf/isnan builtins

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -73,6 +73,7 @@ class DaCeCompiler(
 
         with dace.config.temporary_config():
             dace.config.Config.set("compiler", "build_type", value=self.cmake_build_type.value)
+            dace.config.Config.set("compiler", "use_cache", value=False)  # we use the gt4py cache
             if self.device_type == core_defs.DeviceType.CPU:
                 compiler_args = dace.config.Config.get("compiler", "cpu", "args")
                 # disable finite-math-only in order to support isfinite/isinf/isnan builtins

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -73,7 +73,7 @@ class DaCeCompiler(
 
         with dace.config.temporary_config():
             dace.config.Config.set("compiler", "build_type", value=self.cmake_build_type.value)
-            dace.config.Config.set("compiler", "use_cache", value=False)  # we use the gt4py cache
+            dace.config.Config.set("cache", value="unique")  # enable multi-process build
             if self.device_type == core_defs.DeviceType.CPU:
                 compiler_args = dace.config.Config.get("compiler", "cpu", "args")
                 # disable finite-math-only in order to support isfinite/isinf/isnan builtins


### PR DESCRIPTION
Dace needs a build folder. the build directory has to be unique for MPI process, otherwise the following error will occur:
```
  File "/scratch/mch/epaone/repo/icon-exclaim/externals/gt4py/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py", line 85, in __call__
    sdfg_program = sdfg.compile(validate=False)
  File "/scratch/mch/epaone/repo/icon-exclaim/externals/icon4py/.venv/lib/python3.10/site-packages/dace/sdfg/sdfg.py", line 2396, in compile
    shared_library = compiler.configure_and_compile(program_folder, sdfg.name)
  File "/scratch/mch/epaone/repo/icon-exclaim/externals/icon4py/.venv/lib/python3.10/site-packages/dace/codegen/compiler.py", line 230, in configure_and_compile
    os.makedirs(build_folder)
  File "/user-environment/env/icon/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/scratch/mch/epaone/repo/icon-exclaim/build_gpu2py_verify/bin/gt4py_build_cache_dir/.gt4py_cache/copy_field_f4a44ff41bcb1adfe9df396546052671a775e75440b576ef75cfc9b7a5f6e82f/build'
    FINISH PE:     1 diffusion_py: Diffusion wrapper run failed.
```
