### PR TITLE
fix[next][dace]: fix orchestration for cached translation stage

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/program.py
+++ b/src/gt4py/next/program_processors/runners/dace/program.py
@@ -89,7 +89,7 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
             compile_workflow.translation
             if not hasattr(compile_workflow.translation, "step")
             else compile_workflow.translation.step
-        )  # Same applies to the translation stage.
+        )  # Same for the translation stage, which could be a `CachedStep` depending on backend configuration.
         # TODO(ricoh): switch 'disable_itir_transforms=True' because we ran them separately previously
         # and so we can ensure the SDFG does not know any runtime info it shouldn't know. Remove with
         # the other parts of the workaround when possible.

--- a/src/gt4py/next/program_processors/runners/dace/program.py
+++ b/src/gt4py/next/program_processors/runners/dace/program.py
@@ -85,11 +85,16 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
             if not hasattr(self.backend.executor, "step")
             else self.backend.executor.step,
         )  # We know which backend we are using, but we don't know if the compile workflow is cached.
+        compile_workflow_translation = (
+            compile_workflow.translation
+            if not hasattr(compile_workflow.translation, "step")
+            else compile_workflow.translation.step
+        )  # Same applies to the translation stage.
         # TODO(ricoh): switch 'disable_itir_transforms=True' because we ran them separately previously
         # and so we can ensure the SDFG does not know any runtime info it shouldn't know. Remove with
         # the other parts of the workaround when possible.
         sdfg = dace.SDFG.from_json(
-            compile_workflow.translation.replace(
+            compile_workflow_translation.replace(
                 disable_itir_transforms=True, disable_field_origin_on_program_arguments=True
             )(gtir_stage).source_code
         )


### PR DESCRIPTION
This PR solves a runtime issue encountered in dace orchestration tests in icon4py, which use the cached backend. The issue follows the change in #1941 that makes the translation stage a `CachedStep` object in the cached backend.