### PR TITLE
fix[next][dace]: limit cuda streams to 1

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -78,7 +78,7 @@ class DaCeCompiler(
             #  up with the cuda streams, i.e. it allocates N streams but uses N+1.
             #  This is a workaround until this issue if fixed in DaCe.
             dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=1)
-            
+
             if self.device_type == core_defs.DeviceType.CPU:
                 compiler_args = dace.config.Config.get("compiler", "cpu", "args")
                 # disable finite-math-only in order to support isfinite/isinf/isnan builtins

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -74,6 +74,11 @@ class DaCeCompiler(
         with dace.config.temporary_config():
             dace.config.Config.set("compiler", "build_type", value=self.cmake_build_type.value)
             dace.config.Config.set("compiler", "use_cache", value=False)  # we use the gt4py cache
+            # In some stencils, mostly in `apply_diffusion_to_w` the cuda codegen messes
+            #  up with the cuda streams, i.e. it allocates N streams but uses N+1.
+            #  This is a workaround until this issue if fixed in DaCe.
+            dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=1)
+            
             if self.device_type == core_defs.DeviceType.CPU:
                 compiler_args = dace.config.Config.get("compiler", "cpu", "args")
                 # disable finite-math-only in order to support isfinite/isinf/isnan builtins


### PR DESCRIPTION
Because of an issue in DaCe cuda codegen, we have to limit to a single cuda stream. The issue is that DaCe codegen allocates `N` cuda streams, but then it tries to use `N+1`.