### PR TITLE
bug[next]: fix constant folding of expression with boolean literals

### DIFF
--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -523,38 +523,33 @@ def promote_scalars(val: CompositeOfScalarOrField):
         )
 
 
+_python_builtins: dict[str, Callable] = {
+    "bool": bool,
+    "str": str,
+    "plus": operator.add,
+    "minus": operator.sub,
+    "multiplies": operator.mul,
+    "divides": operator.truediv,
+    "mod": operator.mod,
+    "floordiv": operator.floordiv,
+    "eq": operator.eq,
+    "less": operator.lt,
+    "greater": operator.gt,
+    "greater_equal": operator.ge,
+    "less_equal": operator.le,
+    "not_eq": operator.ne,
+    "and_": operator.and_,
+    "or_": operator.or_,
+    "xor_": operator.xor,
+    "neg": operator.neg,
+}
 for math_builtin_name in builtins.ARITHMETIC_BUILTINS | builtins.TYPE_BUILTINS:
-    python_builtins: dict[str, Callable] = {
-        "int": int,
-        "float": float,
-        "bool": bool,
-        "str": str,
-        "plus": operator.add,
-        "minus": operator.sub,
-        "multiplies": operator.mul,
-        "divides": operator.truediv,
-        "mod": operator.mod,
-        "floordiv": operator.floordiv,
-        "eq": operator.eq,
-        "less": operator.lt,
-        "greater": operator.gt,
-        "greater_equal": operator.ge,
-        "less_equal": operator.le,
-        "not_eq": operator.ne,
-        "and_": operator.and_,
-        "or_": operator.or_,
-        "xor_": operator.xor,
-        "neg": operator.neg,
-    }
     decorator = getattr(builtins, math_builtin_name).register(EMBEDDED)
     impl: Callable
     if math_builtin_name in ["gamma", "not_"]:
         continue  # treated explicitly
-    elif math_builtin_name in python_builtins:
-        # TODO: Should potentially use numpy fixed size types to be consistent
-        #   with compiled backends. Currently using Python types to preserve
-        #   existing behaviour.
-        impl = python_builtins[math_builtin_name]
+    elif math_builtin_name in _python_builtins:
+        impl = _python_builtins[math_builtin_name]
     else:
         impl = getattr(np, math_builtin_name)
 

--- a/src/gt4py/next/iterator/transforms/constant_folding.py
+++ b/src/gt4py/next/iterator/transforms/constant_folding.py
@@ -15,12 +15,16 @@ import operator
 from typing import Optional
 
 from gt4py import eve
+from gt4py._core import definitions as core_defs
 from gt4py.next.iterator import builtins, embedded, ir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm, ir_makers as im
 from gt4py.next.iterator.transforms import fixed_point_transformation
+from gt4py.next.type_system import type_specifications as ts
 
 
-def _value_from_literal(literal: ir.Literal):
+def _value_from_literal(literal: ir.Literal) -> core_defs.Scalar:
+    if literal.type.kind == ts.ScalarKind.BOOL:
+        return literal.value == "True"
     return getattr(embedded, str(literal.type))(literal.value)
 
 
@@ -37,12 +41,12 @@ class UndoCanonicalizeMinus(eve.NodeTranslator):
             a, b = node.args
             if cpm.is_call_to(b, "neg"):
                 return im.minus(a, b.args[0])
-            if isinstance(b, ir.Literal) and _value_from_literal(b) < 0:
-                return im.minus(a, -_value_from_literal(b))
+            if isinstance(b, ir.Literal) and (val := _value_from_literal(b)) < 0:
+                return im.minus(a, -val)  # type: ignore[operator] # if val would represent an unsigend int, `-` is not supported, but error would be somewhere else
             if cpm.is_call_to(a, "neg"):
                 return im.minus(b, a.args[0])
-            if isinstance(a, ir.Literal) and _value_from_literal(a) < 0:
-                return im.minus(b, -_value_from_literal(a))
+            if isinstance(a, ir.Literal) and (val := _value_from_literal(a)) < 0:
+                return im.minus(b, -val)  # type: ignore[operator] # if val would represent an unsigend int, `-` is not supported, but error would be somewhere else
         return node
 
 
@@ -227,5 +231,6 @@ class ConstantFolding(
             if node.args[0].value == "True":
                 return node.args[1]
             else:
+                assert node.args[0].value == "False"
                 return node.args[2]
         return None

--- a/src/gt4py/next/iterator/transforms/constant_folding.py
+++ b/src/gt4py/next/iterator/transforms/constant_folding.py
@@ -24,6 +24,7 @@ from gt4py.next.type_system import type_specifications as ts
 
 def _value_from_literal(literal: ir.Literal) -> core_defs.Scalar:
     if literal.type.kind == ts.ScalarKind.BOOL:
+        assert literal.value in ["True", "False"]
         return literal.value == "True"
     return getattr(embedded, str(literal.type))(literal.value)
 


### PR DESCRIPTION
`_value_from_literal` for booleans did `bool("False")` which evaluates to `True`.