### PR TITLE
bug[next]: GTFN reduce python overhead

### DIFF
--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -85,7 +85,7 @@ def extract_connectivity_args(
     # note: the order here needs to agree with the order of the generated bindings
     args: list[tuple[core_defs.NDArrayObject, tuple[int, ...]]] = []
     for conn in offset_provider.values():
-        if ndarray := getattr(conn, "ndarray", None) is not None:
+        if (ndarray := getattr(conn, "ndarray", None)) is not None:
             assert common.is_neighbor_table(conn)
             args.append((ndarray, tuple([0] * 2)))
     return args

--- a/tests/next_tests/unit_tests/conftest.py
+++ b/tests/next_tests/unit_tests/conftest.py
@@ -14,6 +14,7 @@ from typing import TypeAlias
 import pytest
 
 import gt4py.next as gtx
+from gt4py._core import definitions as core_defs
 from gt4py.next import backend, common
 from gt4py.next.embedded import nd_array_field
 from gt4py.next.iterator import runtime
@@ -102,11 +103,18 @@ class DummyConnectivity(common.Connectivity):
 def nd_array_implementation_params():
     for xp in nd_array_field._nd_array_implementations:
         if hasattr(nd_array_field, "cp") and xp == nd_array_field.cp:
-            yield pytest.param(xp, id=xp.__name__, marks=pytest.mark.requires_gpu)
+            yield pytest.param(
+                (xp, core_defs.CUPY_DEVICE_TYPE), id=xp.__name__, marks=pytest.mark.requires_gpu
+            )
         else:
-            yield pytest.param(xp, id=xp.__name__)
+            yield pytest.param((xp, core_defs.DeviceType.CPU), id=xp.__name__)
 
 
 @pytest.fixture(params=nd_array_implementation_params())
 def nd_array_implementation(request):
+    yield request.param[0]
+
+
+@pytest.fixture(params=nd_array_implementation_params())
+def nd_array_implementation_and_device_type(request):
     yield request.param

--- a/tests/next_tests/unit_tests/test_field_utils.py
+++ b/tests/next_tests/unit_tests/test_field_utils.py
@@ -1,0 +1,24 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from gt4py._core import definitions as core_defs
+from gt4py.next import common, constructors, field_utils
+
+
+@pytest.mark.parametrize(
+    "device_type", [core_defs.DeviceType.CPU, core_defs.DeviceType.CUDA, core_defs.DeviceType.ROCM]
+)
+def test_verify_device_field_type(nd_array_implementation_and_device_type, device_type):
+    nd_array_implementation, compatible_device_type = nd_array_implementation_and_device_type
+
+    testee = constructors.as_field([common.Dimension("X")], nd_array_implementation.asarray([42.0]))
+
+    is_correct_device = compatible_device_type == device_type
+    assert field_utils.verify_device_field_type(testee, device_type) == is_correct_device

--- a/tests/next_tests/unit_tests/test_field_utils.py
+++ b/tests/next_tests/unit_tests/test_field_utils.py
@@ -13,7 +13,12 @@ from gt4py.next import common, constructors, field_utils
 
 
 @pytest.mark.parametrize(
-    "device_type", [core_defs.DeviceType.CPU, core_defs.DeviceType.CUDA, core_defs.DeviceType.ROCM]
+    "device_type",
+    [
+        core_defs.DeviceType.CPU,
+        pytest.param(core_defs.DeviceType.CUDA, marks=pytest.mark.requires_gpu),
+        pytest.param(core_defs.DeviceType.ROCM, marks=pytest.mark.requires_gpu),
+    ],
 )
 def test_verify_device_field_type(nd_array_implementation_and_device_type, device_type):
     nd_array_implementation, compatible_device_type = nd_array_implementation_and_device_type


### PR DESCRIPTION
Reduces Python overhead in the GTFN call. Replaces the implicit copy of connectivities to device by a check that it's on device if needed.

Similar changes in DaCe will be in a next PR.