### PR TITLE
fix[next]: Properly show compilation errors if compilation fails

### DIFF
--- a/src/gt4py/next/errors/__init__.py
+++ b/src/gt4py/next/errors/__init__.py
@@ -10,6 +10,7 @@
 
 from . import excepthook  # noqa: F401 [unused-import]
 from .exceptions import (
+    CompilationError,
     DSLError,
     InvalidParameterAnnotationError,
     MissingArgumentError,
@@ -21,6 +22,7 @@ from .exceptions import (
 
 
 __all__ = [
+    "CompilationError",
     "DSLError",
     "InvalidParameterAnnotationError",
     "MissingArgumentError",

--- a/src/gt4py/next/errors/exceptions.py
+++ b/src/gt4py/next/errors/exceptions.py
@@ -110,3 +110,8 @@ class InvalidParameterAnnotationError(TypeError_):
         )
         self.param_name = param_name
         self.annotated_type = type_
+
+
+class CompilationError(GT4PyError):
+    def __init__(self, compilation_error: str) -> None:
+        super().__init__(f"See attached compilation log.\n{compilation_error}")

--- a/src/gt4py/next/otf/binding/nanobind.py
+++ b/src/gt4py/next/otf/binding/nanobind.py
@@ -102,7 +102,7 @@ def _type_string(type_: ts.TypeSpec) -> str:
 class BindingCodeGenerator(TemplatedGenerator):
     BindingFile = as_jinja(
         """\
-        include "{{callee_header_file}}"
+        #include "{{callee_header_file}}"
 
         {% for header_file in header_files: %}\
         #include <{{header_file}}>

--- a/src/gt4py/next/otf/binding/nanobind.py
+++ b/src/gt4py/next/otf/binding/nanobind.py
@@ -102,7 +102,7 @@ def _type_string(type_: ts.TypeSpec) -> str:
 class BindingCodeGenerator(TemplatedGenerator):
     BindingFile = as_jinja(
         """\
-        #include "{{callee_header_file}}"
+        include "{{callee_header_file}}"
 
         {% for header_file in header_files: %}\
         #include <{{header_file}}>

--- a/src/gt4py/next/otf/compilation/build_systems/compiledb.py
+++ b/src/gt4py/next/otf/compilation/build_systems/compiledb.py
@@ -194,8 +194,8 @@ class CompiledbProject(
                     )
         except subprocess.CalledProcessError as e:
             with logfile.open(mode="r") as log_file_pointer:
-                msg = log_file_pointer.read()
-            raise errors.CompilationError(msg) from e
+                log = log_file_pointer.read()
+            raise errors.CompilationError(log) from e
 
         build_data.update_status(new_status=build_data.BuildStatus.COMPILED, path=self.root_path)
 

--- a/src/gt4py/next/otf/compilation/build_systems/compiledb.py
+++ b/src/gt4py/next/otf/compilation/build_systems/compiledb.py
@@ -18,7 +18,7 @@ from typing import Optional, TypeVar
 
 from flufl import lock
 
-from gt4py.next import config
+from gt4py.next import config, errors
 from gt4py.next.otf import languages, stages
 from gt4py.next.otf.binding import interface
 from gt4py.next.otf.compilation import build_data, cache, compiler
@@ -184,6 +184,7 @@ class CompiledbProject(
             with logfile.open(mode="w") as log_file_pointer:
                 for entry in compile_db:
                     log_file_pointer.write(entry["command"] + "\n")
+                    log_file_pointer.flush()
                     subprocess.check_call(
                         entry["command"],
                         cwd=entry["directory"],
@@ -193,8 +194,8 @@ class CompiledbProject(
                     )
         except subprocess.CalledProcessError as e:
             with logfile.open(mode="r") as log_file_pointer:
-                print(log_file_pointer.read())
-            raise e
+                msg = log_file_pointer.read()
+            raise errors.CompilationError(msg) from e
 
         build_data.update_status(new_status=build_data.BuildStatus.COMPILED, path=self.root_path)
 


### PR DESCRIPTION
Before this PR, the actual compilation error can only be found in the build directory (and only if build with persistent cache). Now, the error is attached to the exception.