### PR TITLE
fix[next]: use gridtools::nanobind::dynamic_stride for  compatibility

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  pull_request:
-    branches:
-    - main
+  # pull_request:
+  #   branches:
+  #   - main
   ## END
 
 jobs:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  # pull_request:
-  #   branches:
-  #   - main
+  pull_request:
+    branches:
+    - main
   ## END
 
 jobs:

--- a/src/gt4py/next/otf/binding/nanobind.py
+++ b/src/gt4py/next/otf/binding/nanobind.py
@@ -149,7 +149,10 @@ class BindingCodeGenerator(TemplatedGenerator):
         dims = [self.visit(dim) for dim in sid.dimensions]
         origin = f"{sid.source_buffer}.second"
         stride_spec = [
-            dim.static_stride if dim.static_stride is not None else -1 for dim in sid.dimensions
+            "gridtools::nanobind::dynamic_size"
+            if dim.static_stride is None
+            else str(dim.static_stride)
+            for dim in sid.dimensions
         ]
         stride_spec_string = (
             f"gridtools::nanobind::stride_spec<{', '.join(str(s) for s in stride_spec)}>{{}}"


### PR DESCRIPTION
In #1943 we introduced stride 1 in a way that is not backwards compatible with nanobind < 2.0. Instead of `-1` we should use the `gridtools::nanobind::dyamic_size` to indicate runtime strides.