### PR TITLE
feat[next]: make compiledb project relocatable

### DIFF
--- a/src/gt4py/next/otf/compilation/build_systems/compiledb.py
+++ b/src/gt4py/next/otf/compilation/build_systems/compiledb.py
@@ -204,7 +204,7 @@ class CompiledbProject(
                     log_file_pointer.flush()
                     subprocess.check_call(
                         entry["command"],
-                        cwd=entry["directory"],
+                        cwd=self.root_path / entry["directory"],
                         shell=True,
                         stdout=log_file_pointer,
                         stderr=log_file_pointer,
@@ -321,7 +321,7 @@ def _cc_create_compiledb(
     assert compile_db
 
     for entry in compile_db:
-        entry["directory"] = entry["directory"].replace(str(path), "$SRC_PATH")
+        entry["directory"] = entry["directory"].replace(str(path), ".")
         entry["command"] = (
             entry["command"]
             .replace(f"CMakeFiles/{name}.dir", ".")
@@ -329,6 +329,8 @@ def _cc_create_compiledb(
             .replace(binding_src_name, "$BINDINGS_FILE")
             .replace(name, "$NAME")
             .replace("-I$SRC_PATH/build/_deps", f"-I{path}/build/_deps")
+            # make path relative to the build folder
+            .replace("$SRC_PATH/$BINDINGS_FILE", "../$BINDINGS_FILE")
         )
         entry["file"] = (
             entry["file"]

--- a/tests/next_tests/unit_tests/otf_tests/compilation_tests/build_systems_tests/test_compiledb.py
+++ b/tests/next_tests/unit_tests/otf_tests/compilation_tests/build_systems_tests/test_compiledb.py
@@ -9,6 +9,9 @@
 from gt4py.next import config
 from gt4py.next.otf.compilation import build_data, importer
 from gt4py.next.otf.compilation.build_systems import compiledb
+import shutil
+import tempfile
+import pathlib
 
 
 def test_default_compiledb_factory(compilable_source_example, clean_example_session_cache):
@@ -29,3 +32,45 @@ def test_default_compiledb_factory(compilable_source_example, clean_example_sess
     )
 
     assert (otf_builder.root_path / "build.sh").exists()
+
+
+def test_compiledb_project_is_relocatable(compilable_source_example, clean_example_session_cache):
+    builder = compiledb.CompiledbFactory()(
+        compilable_source_example, cache_lifetime=config.BuildCacheLifetime.SESSION
+    )
+
+    # make sure the example project has not been written yet
+    assert not build_data.contains_data(builder.root_path)
+
+    builder.build()
+
+    if True:
+        # with tempfile.TemporaryDirectory(dir=config.BUILD_CACHE_DIR) as tmpdir:
+
+        # copy the project to a new location
+        tmpdir = tempfile.mkdtemp(dir=config.BUILD_CACHE_DIR)
+        relocated_dir = pathlib.Path(tmpdir) / "relocated"
+        shutil.move(builder.root_path, relocated_dir)
+        # make sure the orignal project has been removed
+        assert not build_data.contains_data(builder.root_path)
+
+        data = build_data.read_data(relocated_dir)
+        assert data.status == build_data.BuildStatus.COMPILED
+        # unset it's build status
+        build_data.update_status(build_data.BuildStatus.CONFIGURED, relocated_dir)
+
+        # rebuild (not this test uses internal API)
+        empty_compiledb_project = compiledb.CompiledbProject(
+            relocated_dir,
+            source_files={},
+            program_name="",
+            compile_commands_cache="",
+            bindings_file_name="",
+        )
+        empty_compiledb_project._run_build()
+
+        new_data = build_data.read_data(relocated_dir)
+        assert new_data.status == build_data.BuildStatus.COMPILED
+        assert hasattr(
+            importer.import_from_path(relocated_dir / data.module), data.entry_point_name
+        )


### PR DESCRIPTION
The build command for a compiledb project contained a few absolute paths which prevented the project to be moved. Now the build cache can be relocated and the projects can be rebuilt.