### PR TITLE
bug[cartesian]: fix setuptools for CUDA compilation

### DIFF
--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -11,7 +11,7 @@ import copy
 import io
 import os
 import shutil
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, cast, overload
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
 
 import pybind11
 import setuptools
@@ -185,7 +185,8 @@ def setuptools_setup(*, build_ext_class: type[build_ext] | None, **kwargs) -> No
     old_setup_stop_after = setuptools.distutils.core._setup_stop_after
     setuptools.distutils.core._setup_stop_after = "commandline"
     dist = setuptools.setup(**kwargs)
-    dist.cmdclass.update({"build_ext": build_ext_class})
+    if build_ext_class is not None:
+        dist.cmdclass.update({"build_ext": build_ext_class})
     setuptools.distutils.core._setup_stop_after = old_setup_stop_after
     setuptools.distutils.core.run_commands(dist)
 
@@ -268,8 +269,7 @@ def build_pybind_ext(
     )
 
     if verbose:
-        script_args = cast(List[str], setuptools_args["script_args"])
-        script_args.append("-v")
+        setuptools_args["script_args"].append("-v")
         setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)
     else:
         setuptools_args["script_args"].append("-q")

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -172,6 +172,24 @@ def get_gt_pyext_build_opts(
     return build_opts
 
 
+def setuptools_setup(*, build_ext_class: type[build_ext] | None, **kwargs) -> None:
+    """
+    Calls setuptools.setup() with 'cmdclass' set to 'build_ext_class'.
+
+    This is a workaround because any config file that sets an element of
+    'cmdclass' will override (instead of extend) the 'cmdclass' dict passed
+    as argument to 'setuptools.setup()'.
+
+    Note: This is NOT thread-safe.
+    """
+    old_setup_stop_after = setuptools.distutils.core._setup_stop_after
+    setuptools.distutils.core._setup_stop_after = "commandline"
+    dist = setuptools.setup(**kwargs)
+    dist.cmdclass.update({"build_ext": build_ext_class})
+    setuptools.distutils.core._setup_stop_after = old_setup_stop_after
+    setuptools.distutils.core.run_commands(dist)
+
+
 # The following tells mypy to accept unpacking kwargs
 @overload
 def build_pybind_ext(
@@ -248,18 +266,16 @@ def build_pybind_ext(
             "--force",
         ],
     )
-    if build_ext_class is not None:
-        setuptools_args["cmdclass"] = {"build_ext": build_ext_class}
 
     if verbose:
         script_args = cast(List[str], setuptools_args["script_args"])
         script_args.append("-v")
-        setuptools.setup(**setuptools_args)
+        setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)
     else:
         setuptools_args["script_args"].append("-q")
         io_out, io_err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(io_out), contextlib.redirect_stderr(io_err):
-            setuptools.setup(**setuptools_args)
+            setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)
 
     # Copy extension in target path
     module_name = py_extension._full_name

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_cuir_compilation.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_cuir_compilation.py
@@ -34,11 +34,11 @@ def build_gridtools_test(tmp_path: Path, code: str):
         "--build-lib=" + str(tmp_src.parent),
         "--force",
     ]
-    setuptools.setup(
+    pyext_builder.setuptools_setup(
         name="test",
         ext_modules=[ext_module],
         script_args=args,
-        cmdclass={"build_ext": pyext_builder.CUDABuildExtension},
+        build_ext_class=pyext_builder.CUDABuildExtension,
     )
 
 

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_gtcpp_compilation.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_gtcpp_compilation.py
@@ -50,7 +50,9 @@ def build_gridtools_test(tmp_path: Path, code: str):
         "--build-lib=" + str(tmp_src.parent),
         "--force",
     ]
-    pyext_builder.setuptools_setup(name="test", ext_modules=[ext_module], script_args=args)
+    pyext_builder.setuptools_setup(
+        name="test", ext_modules=[ext_module], script_args=args, build_ext_class=None
+    )
 
 
 def make_compilation_input_and_expected():

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_gtcpp_compilation.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_gtcpp_compilation.py
@@ -13,6 +13,7 @@ import pytest
 import setuptools
 
 from gt4py.cartesian import config  # TODO required for getting boost path
+from gt4py.cartesian.backend import pyext_builder
 from gt4py.cartesian.gtc.gtcpp.gtcpp import GTApplyMethod, Intent, Program
 from gt4py.cartesian.gtc.gtcpp.gtcpp_codegen import GTCppCodegen
 from gt4py.cartesian.gtc.gtcpp.oir_to_gtcpp import _extract_accessors
@@ -49,7 +50,7 @@ def build_gridtools_test(tmp_path: Path, code: str):
         "--build-lib=" + str(tmp_src.parent),
         "--force",
     ]
-    setuptools.setup(name="test", ext_modules=[ext_module], script_args=args)
+    pyext_builder.setuptools_setup(name="test", ext_modules=[ext_module], script_args=args)
 
 
 def make_compilation_input_and_expected():


### PR DESCRIPTION
In migration to versioningit (#1832 ), a `setuptools.cmdclass` is set
```python
[tool.setuptools.cmdclass]
# This is required for the `onbuild` versioningit hook
build_py = "versioningit.cmdclass.build_py"
sdist = "versioningit.cmdclass.sdist"
```
This overrides the `cmdclass` for CUDA that is passed to the `pyext_builder` (instead of extending it).

Now, we set extend the `cmdclass` after the `Distribution` is created by using internal hooks to first create the Distribution and then execute it.

The code is not thread-safe!

---------

Co-authored-by: Enrique González Paredes <enriqueg@cscs.ch>