### PR TITLE
fix[next][dace]: set gpu block size to avoid dace warnings

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -105,7 +105,7 @@ class DaCeTranslator(
             gtx_transformations.gt_auto_optimize(
                 sdfg,
                 gpu=on_gpu,
-                gpu_block_size=None,  # TODO: set optimal block size
+                gpu_block_size=(32, 8, 1),  # TODO: make block size configurable
                 unit_strides_kind=unit_strides_kind,
                 constant_symbols=constant_symbols,
                 assume_pointwise=True,


### PR DESCRIPTION
The CI log is polluted with dace warnings about missing gpu block size. With this PR we set a default gpu block size, which seems good from preliminary benchmark results. However, the log-term solution is to make it configurable through the gt4py toolchain, so that the block size can be optimized for each program.