### PR TITLE
fix[next][dace]: Revisit dace config and compile arguments

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -115,11 +115,7 @@ def gt_auto_optimize(
             not if we have too much internal space (register pressure).
     """
     device = dace.DeviceType.GPU if gpu else dace.DeviceType.CPU
-
-    with dace.config.temporary_config():
-        dace.Config.set("optimizer", "match_exception", value=True)
-        dace.Config.set("store_history", value=False)
-
+    with dace.config.set_temporary("optimizer", "match_exception", value=True):
         # Initial Cleanup
         if constant_symbols:
             gtx_transformations.gt_substitute_compiletime_symbols(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -72,21 +72,29 @@ class DaCeCompiler(
         sdfg.build_folder = cache.get_cache_folder(inp, self.cache_lifetime)
 
         with dace.config.temporary_config():
-            dace.config.Config.set("compiler", "build_type", value=self.cmake_build_type.value)
-            dace.config.Config.set("compiler", "use_cache", value=False)  # we use the gt4py cache
+            dace.config.Config.set("compiler.build_type", value=self.cmake_build_type.value)
+            dace.config.Config.set("compiler.use_cache", value=False)  # we use the gt4py cache
 
-            # dace dafault setting use fast-math in both cpu and gpu compilation, we disable it
-            dace.config.Config.set("compiler", "cpu", "args", value="-std=c++14 -fPIC -Wall -Wextra -O3 -march=native -Wno-unused-parameter -Wno-unused-label")
-            dace.config.Config.set("compiler", "cuda", "args", value="-Xcompiler -march=native -Xcompiler -Wno-unused-parameter")
-            dace.config.Config.set("compiler", "cuda", "hip_args", value="-std=c++17 -fPIC -O3 -Wno-unused-parameter")
+            # dace dafault setting use fast-math in both cpu and gpu compilation, don't use it here
+            dace.config.Config.set(
+                "compiler.cpu.args",
+                value="-std=c++14 -fPIC -Wall -Wextra -O3 -march=native -Wno-unused-parameter -Wno-unused-label",
+            )
+            dace.config.Config.set(
+                "compiler.cuda.args",
+                value="-Xcompiler -march=native -Xcompiler -Wno-unused-parameter",
+            )
+            dace.config.Config.set(
+                "compiler.cuda.hip_args", value="-std=c++17 -fPIC -O3 -Wno-unused-parameter"
+            )
 
             # In some stencils, mostly in `apply_diffusion_to_w` the cuda codegen messes
             #  up with the cuda streams, i.e. it allocates N streams but uses N+1.
             #  This is a workaround until this issue if fixed in DaCe.
-            dace.config.Config.set("compiler", "cuda", "max_concurrent_streams", value=1)
+            dace.config.Config.set("compiler.cuda.max_concurrent_streams", value=1)
 
             if self.device_type == core_defs.DeviceType.ROCM:
-                dace.config.Config.set("compiler", "cuda", "backend", value="hip")
+                dace.config.Config.set("compiler.cuda.backend", value="hip")
 
             sdfg_program = sdfg.compile(validate=False)
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -78,14 +78,15 @@ class DaCeCompiler(
             # dace dafault setting use fast-math in both cpu and gpu compilation, don't use it here
             dace.config.Config.set(
                 "compiler.cpu.args",
-                value="-std=c++14 -fPIC -Wall -Wextra -O3 -march=native -Wno-unused-parameter -Wno-unused-label",
+                value="-std=c++14 -fPIC -O3 -march=native -Wall -Wextra -Wno-unused-parameter -Wno-unused-label",
             )
             dace.config.Config.set(
                 "compiler.cuda.args",
-                value="-Xcompiler -march=native -Xcompiler -Wno-unused-parameter",
+                value="-Xcompiler -O3 -Xcompiler -march=native -Xcompiler -Wno-unused-parameter",
             )
             dace.config.Config.set(
-                "compiler.cuda.hip_args", value="-std=c++17 -fPIC -O3 -Wno-unused-parameter"
+                "compiler.cuda.hip_args",
+                value="-std=c++17 -fPIC -O3 -march=native -Wno-unused-parameter",
             )
 
             # In some stencils, mostly in `apply_diffusion_to_w` the cuda codegen messes

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -88,6 +88,11 @@ class DaCeTranslator(
         if not self.disable_itir_transforms:
             ir = itir_transforms.apply_fieldview_transforms(ir, offset_provider=offset_provider)
         offset_provider_type = common.offset_provider_to_type(offset_provider)
+
+        # do not store transformation history in SDFG
+        dace_config_store_history = dace.Config.get("store_history")
+        dace.Config.set("store_history", value=False)
+
         sdfg = gtir_sdfg.build_sdfg_from_gtir(
             ir,
             offset_provider_type,
@@ -118,6 +123,9 @@ class DaCeTranslator(
             # result is written to a GPU global variable (https://github.com/spcl/dace/issues/1773).
             gtx_transformations.gt_simplify(sdfg)
             gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
+
+        # restore old value in dace config
+        dace.Config.set("store_history", value=dace_config_store_history)
 
         return sdfg
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -90,42 +90,37 @@ class DaCeTranslator(
         offset_provider_type = common.offset_provider_to_type(offset_provider)
 
         # do not store transformation history in SDFG
-        dace_config_store_history = dace.Config.get("store_history")
-        dace.Config.set("store_history", value=False)
-
-        sdfg = gtir_sdfg.build_sdfg_from_gtir(
-            ir,
-            offset_provider_type,
-            column_axis,
-            disable_field_origin_on_program_arguments=self.disable_field_origin_on_program_arguments,
-        )
-
-        if auto_opt:
-            unit_strides_kind = (
-                common.DimensionKind.HORIZONTAL
-                if config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE
-                else None  # let `gt_auto_optimize` select `unit_strides_kind` based on `gpu` argument
+        with dace.config.set_temporary("store_history", value=False):
+            sdfg = gtir_sdfg.build_sdfg_from_gtir(
+                ir,
+                offset_provider_type,
+                column_axis,
+                disable_field_origin_on_program_arguments=self.disable_field_origin_on_program_arguments,
             )
-            constant_symbols = _find_constant_symbols(ir, sdfg, offset_provider_type)
-            gtx_transformations.gt_auto_optimize(
-                sdfg,
-                gpu=on_gpu,
-                gpu_block_size=(32, 8, 1),  # TODO: make block size configurable
-                unit_strides_kind=unit_strides_kind,
-                constant_symbols=constant_symbols,
-                assume_pointwise=True,
-                make_persistent=False,
-            )
-        elif on_gpu:
-            # We run simplify to bring the SDFG into a canonical form that the gpu transformations
-            # can handle. This is a workaround for an issue with scalar expressions that are
-            # promoted to symbolic expressions and computed on the host (CPU), but the intermediate
-            # result is written to a GPU global variable (https://github.com/spcl/dace/issues/1773).
-            gtx_transformations.gt_simplify(sdfg)
-            gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
 
-        # restore old value in dace config
-        dace.Config.set("store_history", value=dace_config_store_history)
+            if auto_opt:
+                unit_strides_kind = (
+                    common.DimensionKind.HORIZONTAL
+                    if config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE
+                    else None  # let `gt_auto_optimize` select `unit_strides_kind` based on `gpu` argument
+                )
+                constant_symbols = _find_constant_symbols(ir, sdfg, offset_provider_type)
+                gtx_transformations.gt_auto_optimize(
+                    sdfg,
+                    gpu=on_gpu,
+                    gpu_block_size=(32, 8, 1),  # TODO: make block size configurable
+                    unit_strides_kind=unit_strides_kind,
+                    constant_symbols=constant_symbols,
+                    assume_pointwise=True,
+                    make_persistent=False,
+                )
+            elif on_gpu:
+                # We run simplify to bring the SDFG into a canonical form that the gpu transformations
+                # can handle. This is a workaround for an issue with scalar expressions that are
+                # promoted to symbolic expressions and computed on the host (CPU), but the intermediate
+                # result is written to a GPU global variable (https://github.com/spcl/dace/issues/1773).
+                gtx_transformations.gt_simplify(sdfg)
+                gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
 
         return sdfg
 


### PR DESCRIPTION
The purpose of this PR is to review and update the dace configuration for SDFG lowering and compilation.

The following changes are made with respect to the default/previous configuration:
- disable storing of the transformation history in SDFG
- remove `use-fast-math` from compiler args