### PR TITLE
fix[next]: Fix broadcast of field read on domain with more dimensions

### DIFF
--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -303,7 +303,10 @@ def create_global_tmps(
     """
     offset_provider_type = common.offset_provider_to_type(offset_provider)
     program = infer_domain.infer_program(
-        program, offset_provider=offset_provider, symbolic_domain_sizes=symbolic_domain_sizes
+        program,
+        offset_provider=offset_provider,
+        symbolic_domain_sizes=symbolic_domain_sizes,
+        keep_existing_domains=True,
     )
     program = type_inference.infer(program, offset_provider_type=offset_provider_type)
 

--- a/src/gt4py/next/iterator/transforms/prune_broadcast.py
+++ b/src/gt4py/next/iterator/transforms/prune_broadcast.py
@@ -14,6 +14,8 @@ from gt4py.next.iterator.ir_utils import (
     domain_utils,
     ir_makers as im,
 )
+from gt4py.next.iterator.type_system import inference
+from gt4py.next.type_system import type_specifications as ts
 
 
 @dataclasses.dataclass
@@ -27,9 +29,32 @@ class PruneBroadcast(PreserveLocationVisitor, NodeTranslator):
     def visit_FunCall(self, node: itir.FunCall) -> itir.FunCall:
         node = self.generic_visit(node)
 
+        # TODO(tehrengruber): write test to document why domain restriction is needed.
+        # For this case the domain inference writes a (Vertex, K) domain to val, but the type
+        # inference infers a Vertex only field, which leads to incompatible types after the
+        # broadcast is rewritten.
+        # let val = broadcast(1, (Vertex,))
+        #   as_fieldop(deref, unstructured_domain(Vertex, K))
+        # end
+        # Even with the fix below the temporary extraction fails, after the broadcast is rewritten
+        # if it overwrites the smaller domain we created here. Therefore the domain must not be
+        # overwritten. Document this in the domain inference.
         if cpm.is_call_to(node, "broadcast"):
             expr = self.visit(node.args[0])
-            node = im.as_fieldop("deref", domain_utils.SymbolicDomain.as_expr(node.annex.domain))(
+            dims_expr = node.args[1]
+            # reinference is fine even if node has not been inferred previously as long as we have
+            # axis literals only, but no refs to axis literals
+            inference.reinfer(dims_expr)
+            assert isinstance(dims_expr.type, ts.TupleType) and all(
+                isinstance(el, ts.DimensionType) for el in dims_expr.type.types
+            )
+            dims = [dt.dim for dt in dims_expr.type.types]
+            domain: domain_utils.SymbolicDomain = node.annex.domain
+            restricted_domain = domain_utils.SymbolicDomain(
+                grid_type=domain.grid_type,
+                ranges={d: r for d, r in domain.ranges.items() if d in dims},
+            )
+            node = im.as_fieldop("deref", domain_utils.SymbolicDomain.as_expr(restricted_domain))(
                 expr
             )
         return node


### PR DESCRIPTION
For this case the domain inference writes a (Vertex, K) domain to val, but the inference infers a Vertex only field, which leads to incompatible types after broadcast is rewritten.
```let val = broadcast(1, (Vertex,))
as_fieldop(deref, unstructured_domain(Vertex, K))
end
```
Even with the fix in `PruneBroadcast` the temporary extraction fails, after the broadcast is rewritten,
if it overwrites the smaller domain we created. Therefore the domain must not be overwritten. Document this in the domain inference.

The changes here are mostly (completly?) not needed after https://github.com/GridTools/gt4py/pull/1853. Let's revisit afterwards. In the meantime we use this in the PMAP staging branch.