### PR TITLE
ci: set `CC` and `CXX` to force compiler used in `setuptools` / `distutils`

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  pull_request:
-    branches:
-    - main
+  # pull_request:
+  #   branches:
+  #   - main
   ## END
 
 jobs:
@@ -55,6 +55,7 @@ jobs:
       env:
         NUM_PROCESSES: auto
         UV_RESOLUTION: ${{ matrix.dependencies-strategy }}
+        # Force a specific compiler for setuptools/distutils (used in gt4py.cartesian)
         CXX: g++
         CC: gcc
       run: uv run nox -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  # pull_request:
-  #   branches:
-  #   - main
+  pull_request:
+    branches:
+    - main
   ## END
 
 jobs:
@@ -55,6 +55,7 @@ jobs:
       env:
         NUM_PROCESSES: auto
         UV_RESOLUTION: ${{ matrix.dependencies-strategy }}
+        CXX: g++
       run: uv run nox -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
 
     - name: Notify slack

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -56,6 +56,7 @@ jobs:
         NUM_PROCESSES: auto
         UV_RESOLUTION: ${{ matrix.dependencies-strategy }}
         CXX: g++
+        CC: gcc
       run: uv run nox -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
 
     - name: Notify slack

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -48,6 +48,10 @@ jobs:
         gcc --version
         clang --version
 
+    - name: print environment variables
+      shell: bash
+      run: env
+
     - name: Install uv and set the python version
       uses: astral-sh/setup-uv@v5
       with:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -53,5 +53,6 @@ jobs:
       env:
         NUM_PROCESSES: auto
         CXX: g++
+        CC: gcc
       shell: bash
       run: uv run nox -s 'test_cartesian-${{ matrix.python-version }}(${{ matrix.codegen-factor }}, cpu)'

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -35,10 +35,11 @@ jobs:
     strategy:
       matrix:
         codegen-factor: [internal, dace]
+        os: ["ubuntu-latest"]
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python-versions) }}
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python-versions) }}
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 
@@ -48,6 +48,11 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
         python-version: ${{ matrix.python-version }}
+
+    - name: Install C++ libraries
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      shell: bash
+      run: sudo apt install libboost-dev
 
     - name: Run CPU 'cartesian' tests with nox
       env:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -52,6 +52,7 @@ jobs:
     - name: Run CPU 'cartesian' tests with nox
       env:
         NUM_PROCESSES: auto
+        # Force a specific compiler for setuptools/distutils
         CXX: g++
         CC: gcc
       shell: bash

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -35,11 +35,10 @@ jobs:
     strategy:
       matrix:
         codegen-factor: [internal, dace]
-        os: ["ubuntu-latest"]
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python-versions) }}
       fail-fast: false
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -42,17 +42,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: get some versions
+      shell: bash
+      run: |
+        gcc --version
+        clang --version
+
     - name: Install uv and set the python version
       uses: astral-sh/setup-uv@v5
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
         python-version: ${{ matrix.python-version }}
-
-    - name: Install C++ libraries
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      shell: bash
-      run: sudo apt install libboost-dev
 
     - name: Run CPU 'cartesian' tests with nox
       env:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -37,6 +37,8 @@ jobs:
         codegen-factor: [internal, dace]
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python-versions) }}
       fail-fast: false
+    env:
+      CXX: g++
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/test-cartesian.yml
+++ b/.github/workflows/test-cartesian.yml
@@ -37,22 +37,10 @@ jobs:
         codegen-factor: [internal, dace]
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python-versions) }}
       fail-fast: false
-    env:
-      CXX: g++
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-
-    - name: get some versions
-      shell: bash
-      run: |
-        gcc --version
-        clang --version
-
-    - name: print environment variables
-      shell: bash
-      run: env
 
     - name: Install uv and set the python version
       uses: astral-sh/setup-uv@v5
@@ -64,5 +52,6 @@ jobs:
     - name: Run CPU 'cartesian' tests with nox
       env:
         NUM_PROCESSES: auto
+        CXX: g++
       shell: bash
       run: uv run nox -s 'test_cartesian-${{ matrix.python-version }}(${{ matrix.codegen-factor }}, cpu)'

--- a/tests/cartesian_tests/unit_tests/test_file.py
+++ b/tests/cartesian_tests/unit_tests/test_file.py
@@ -1,9 +1,0 @@
-# GT4Py - GridTools Framework
-#
-# Copyright (c) 2014-2024, ETH Zurich
-# All rights reserved.
-#
-# Please, refer to the LICENSE file in the root directory.
-# SPDX-License-Identifier: BSD-3-Clause
-
-# just added to trigger cartesian CI

--- a/tests/cartesian_tests/unit_tests/test_file.py
+++ b/tests/cartesian_tests/unit_tests/test_file.py
@@ -1,0 +1,9 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# just added to trigger cartesian CI


### PR DESCRIPTION
## Description

`gt4py.cartesian` uses `setuptools` / `distutils` to compiler sources. For some unknown reason, the default compiler changed in the GHA runners over the last weekend. Daily CI started to fail as a consequence. This PR forces the GNU compiler suite by setting `CC` and `CXX` environment variable to `gcc` and `g++` respectively.

While `setuptools` version 75 is happy with just `CXX`, the oldest supported `setuptools` version (70) also requires setting `CC` in order not to mix the (apparent new default) `clang` compiler with `g++` as `C` and `C++` compilers respectively. From reading

- https://github.com/pypa/setuptools/issues/1732
- https://github.com/pypa/distutils/pull/228 (scroll all the way down to get to comments as recent as 2024)

setting compilers is a bit fragile and subject to active discussions/development.

Tested by also running the "Daily CI" job temporarily on this PR.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests. N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. N/A
