### PR TITLE
refactor[cartesian]: random cleanups (early returns, adding types, unused imports, ...)

### DIFF
--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -211,7 +211,6 @@ class CLIBackendMixin(Backend):
 
         This can now be automatically be turned into a folder hierarchy that makes sense
         and can be incorporated into an external build system.
-
         """
         raise NotImplementedError
 
@@ -229,8 +228,7 @@ class CLIBackendMixin(Backend):
         Raises
         ------
         RuntimeError
-            If the backend does not support the bindings language
-
+            If the backend does not support the bindings language.
         """
         languages = getattr(self, "languages", {"bindings": {}})
         name = getattr(self, "name", "")

--- a/src/gt4py/cartesian/caching.py
+++ b/src/gt4py/cartesian/caching.py
@@ -76,7 +76,6 @@ class CachingStrategy(abc.ABC):
         ----------
         extra_cache_info:
             Additional info to be written
-
         """
         raise NotImplementedError
 

--- a/src/gt4py/cartesian/cli.py
+++ b/src/gt4py/cartesian/cli.py
@@ -194,8 +194,7 @@ class GTScriptBuilder:
         class of the backend that should be used.
 
     silent :
-        silence all reporting to stdout if True
-
+        silence all reporting to stdout if True.
     """
 
     def __init__(

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -101,7 +101,7 @@ class UnrollVectorAssignments(IRNodeMapper):
     def apply(cls, root, **kwargs):
         return cls().visit(root, **kwargs)
 
-    def _is_vector_assignment(self, stmt: Node, fields_decls: Dict[str, FieldDecl]):
+    def _is_vector_assignment(self, stmt: Node, fields_decls: Dict[str, FieldDecl]) -> bool:
         if not isinstance(stmt, Assign):
             return False
 
@@ -182,7 +182,7 @@ class UnrollVectorExpressions(IRNodeMapper):
     def visit_FieldRef(self, node: FieldRef, *, fields_decls: Dict[str, FieldDecl], **kwargs):
         name = node.name
         if fields_decls[name].data_dims:
-            field_list = []
+            field_list: List[Union[FieldRef, List[FieldRef]]] = []
             # vector
             if len(fields_decls[name].data_dims) == 1:
                 dims = fields_decls[name].data_dims[0]
@@ -197,7 +197,7 @@ class UnrollVectorExpressions(IRNodeMapper):
             elif len(fields_decls[name].data_dims) == 2:
                 rows, cols = fields_decls[name].data_dims
                 for row in range(rows):
-                    row_list = []
+                    row_list: List[FieldRef] = []
                     for col in range(cols):
                         data_type = DataType.INT32
                         data_index = [
@@ -246,24 +246,28 @@ class UnrollVectorExpressions(IRNodeMapper):
                     acc = BinOpExpr(op=BinaryOperator.ADD, lhs=acc, rhs=mul, loc=node.loc)
 
                 result.append(acc)
-        else:
-            # vector and vector
-            if isinstance(lhs, list) and isinstance(rhs, list):
-                assert len(lhs) == len(rhs)
-                for lhs_el, rhs_el in zip(lhs, rhs):
-                    result.append(BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs_el, loc=node.loc))
-            # scalar and vector
-            elif isinstance(lhs, Expr) and isinstance(rhs, list):
-                for rhs_el in rhs:
-                    result.append(BinOpExpr(op=node.op, lhs=lhs, rhs=rhs_el, loc=node.loc))
-            elif isinstance(lhs, list) and isinstance(rhs, Expr):
-                for lhs_el in lhs:
-                    result.append(BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs, loc=node.loc))
-            # scalar and scalar fallback
-            else:
-                result = self.generic_visit(node, **kwargs)
+            return result
 
-        return result
+        # vector and vector
+        if isinstance(lhs, list) and isinstance(rhs, list):
+            assert len(lhs) == len(rhs)
+            for lhs_el, rhs_el in zip(lhs, rhs):
+                result.append(BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs_el, loc=node.loc))
+            return result
+
+        # scalar and vector
+        if isinstance(lhs, Expr) and isinstance(rhs, list):
+            for rhs_el in rhs:
+                result.append(BinOpExpr(op=node.op, lhs=lhs, rhs=rhs_el, loc=node.loc))
+            return result
+
+        if isinstance(lhs, list) and isinstance(rhs, Expr):
+            for lhs_el in lhs:
+                result.append(BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs, loc=node.loc))
+            return result
+
+        # scalar and scalar fallback
+        return self.generic_visit(node, **kwargs)
 
 
 class DefIRToGTIR(IRNodeVisitor):
@@ -351,14 +355,16 @@ class DefIRToGTIR(IRNodeVisitor):
         field_params = {f.name: self.visit(f) for f in node.api_fields}
         scalar_params = {p.name: self.visit(p) for p in node.parameters}
         vertical_loops = [self.visit(c) for c in node.computations if c.body.stmts]
-        if node.externals is not None:
-            externals = {
+        externals = (
+            {}
+            if node.externals is None
+            else {
                 name: _make_literal(value)
                 for name, value in node.externals.items()
                 if isinstance(value, numbers.Number)
             }
-        else:
-            externals = {}
+        )
+
         return gtir.Stencil(
             name=node.name,
             api_signature=[
@@ -447,7 +453,7 @@ class DefIRToGTIR(IRNodeVisitor):
             loc=location_to_source_location(node.loc),
         )
 
-    def visit_BuiltinLiteral(self, node: BuiltinLiteral) -> gtir.Literal:  # type: ignore[return]
+    def visit_BuiltinLiteral(self, node: BuiltinLiteral) -> gtir.Literal:
         # currently deals only with boolean literals
         if node.value in self.GT4PY_BUILTIN_TO_GTIR.keys():
             return gtir.Literal(
@@ -488,15 +494,15 @@ class DefIRToGTIR(IRNodeVisitor):
                 ),
                 loc=location_to_source_location(node.loc),
             )
-        else:
-            return gtir.ScalarIfStmt(
-                cond=cond,
-                true_branch=gtir.BlockStmt(body=self.visit(node.main_body)),
-                false_branch=(
-                    gtir.BlockStmt(body=self.visit(node.else_body)) if node.else_body else None
-                ),
-                loc=location_to_source_location(node.loc),
-            )
+
+        return gtir.ScalarIfStmt(
+            cond=cond,
+            true_branch=gtir.BlockStmt(body=self.visit(node.main_body)),
+            false_branch=(
+                gtir.BlockStmt(body=self.visit(node.else_body)) if node.else_body else None
+            ),
+            loc=location_to_source_location(node.loc),
+        )
 
     def visit_HorizontalIf(self, node: HorizontalIf) -> gtir.FieldIfStmt:
         def make_bound_or_level(bound: AxisBound, level) -> Optional[common.AxisBound]:
@@ -504,11 +510,11 @@ class DefIRToGTIR(IRNodeVisitor):
                 level == LevelMarker.END and bound.offset >= 10000
             ):
                 return None
-            else:
-                return common.AxisBound(
-                    level=self.GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER[bound.level],
-                    offset=bound.offset,
-                )
+
+            return common.AxisBound(
+                level=self.GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER[bound.level],
+                offset=bound.offset,
+            )
 
         axes = {
             axis.lower(): common.HorizontalInterval(
@@ -529,7 +535,7 @@ class DefIRToGTIR(IRNodeVisitor):
             loc=location_to_source_location(node.loc),
         )
 
-    def visit_VarRef(self, node: VarRef, **kwargs):
+    def visit_VarRef(self, node: VarRef, **kwargs) -> gtir.ScalarAccess:
         return gtir.ScalarAccess(name=node.name, loc=location_to_source_location(node.loc))
 
     def visit_AxisInterval(self, node: AxisInterval) -> Tuple[gtir.AxisBound, gtir.AxisBound]:
@@ -567,7 +573,7 @@ class DefIRToGTIR(IRNodeVisitor):
         k_val = offset.get("K", 0)
         if isinstance(k_val, numbers.Integral):
             return common.CartesianOffset(i=offset.get("I", 0), j=offset.get("J", 0), k=k_val)
-        elif isinstance(k_val, Expr):
+        if isinstance(k_val, Expr):
             return gtir.VariableKOffset(k=self.visit(k_val, **kwargs))
-        else:
-            raise TypeError("Unrecognized vertical offset type")
+
+        raise TypeError("Unrecognized vertical offset type")

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -355,15 +355,11 @@ class DefIRToGTIR(IRNodeVisitor):
         field_params = {f.name: self.visit(f) for f in node.api_fields}
         scalar_params = {p.name: self.visit(p) for p in node.parameters}
         vertical_loops = [self.visit(c) for c in node.computations if c.body.stmts]
-        externals = (
-            {}
-            if node.externals is None
-            else {
-                name: _make_literal(value)
-                for name, value in node.externals.items()
-                if isinstance(value, numbers.Number)
-            }
-        )
+        externals = {
+            name: _make_literal(value)
+            for name, value in (node.externals or {}).items()
+            if isinstance(value, numbers.Number)
+        }
 
         return gtir.Stencil(
             name=node.name,

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -89,7 +89,6 @@ class AxisIntervalParser(gt_meta.ASTPass):
 
     Corner cases: `ast.Ellipsis` refers to the entire interval, and
     if an `ast.Subscript` is passed, this parses its slice attribute.
-
     """
 
     @classmethod

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -236,15 +236,13 @@ class Builtin(enum.Enum):
     TRUE = 1
 
     @classmethod
-    def from_value(cls, value):
+    def from_value(cls, value: bool | None):
         if value is None:
-            result = cls.NONE
-        elif value is True:
-            result = cls.TRUE
-        elif value is False:
-            result = cls.FALSE
-
-        return result
+            return cls.NONE
+        if value is True:
+            return cls.TRUE
+        if value is False:
+            return cls.FALSE
 
     def __str__(self) -> str:
         return self.name
@@ -655,9 +653,9 @@ class IterationOrder(enum.Enum):
     def symbol(self):
         if self == self.BACKWARD:
             return "<-"
-        elif self == self.PARALLEL:
+        if self == self.PARALLEL:
             return "||"
-        elif self == self.FORWARD:
+        if self == self.FORWARD:
             return "->"
 
     def __str__(self) -> str:
@@ -684,19 +682,17 @@ class AxisInterval(Node):
     loc = attribute(of=Location, optional=True)
 
     @classmethod
-    def full_interval(cls, order=IterationOrder.PARALLEL):
+    def full_interval(cls, order=IterationOrder.PARALLEL) -> AxisInterval:
         if order != IterationOrder.BACKWARD:
-            interval = cls(
+            return cls(
                 start=AxisBound(level=LevelMarker.START, offset=0),
                 end=AxisBound(level=LevelMarker.END, offset=0),
             )
-        else:
-            interval = cls(
-                start=AxisBound(level=LevelMarker.END, offset=-1),
-                end=AxisBound(level=LevelMarker.START, offset=-1),
-            )
 
-        return interval
+        return cls(
+            start=AxisBound(level=LevelMarker.END, offset=-1),
+            end=AxisBound(level=LevelMarker.START, offset=-1),
+        )
 
     @property
     def is_single_index(self) -> bool:

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -236,7 +236,7 @@ class Builtin(enum.Enum):
     TRUE = 1
 
     @classmethod
-    def from_value(cls, value: bool | None):
+    def from_value(cls, value: bool | None) -> Builtin:
         if value is None:
             return cls.NONE
         if value is True:

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -714,7 +714,6 @@ class HorizontalInterval(eve.Node):
 
     This is separate from `gtir.Interval` because the endpoints may
     be outside the compute domain.
-
     """
 
     start: Optional[AxisBound]

--- a/src/gt4py/cartesian/gtc/dace/expansion/tasklet_codegen.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/tasklet_codegen.py
@@ -10,8 +10,6 @@ import copy
 from typing import Any, ChainMap, List, Optional, Union
 
 import dace
-import dace.data
-import dace.library
 import dace.subsets
 
 import gt4py.cartesian.gtc.common as common

--- a/src/gt4py/cartesian/gtc/numpy/npir.py
+++ b/src/gt4py/cartesian/gtc/numpy/npir.py
@@ -40,7 +40,6 @@ class ScalarDecl(Decl):
     """Scalar per grid point.
 
     Used for API scalar parameters. Local scalars never have data_dims.
-
     """
 
     pass
@@ -50,7 +49,6 @@ class LocalScalarDecl(Decl):
     """Scalar per grid point.
 
     Used for API scalar parameters. Local scalars never have data_dims.
-
     """
 
     pass
@@ -72,7 +70,6 @@ class TemporaryDecl(Decl):
     ----------
     offset: Origin of the temporary field.
     padding: Buffer added to compute domain as field size.
-
     """
 
     data_dims: Tuple[int, ...] = eve.field(default_factory=tuple)

--- a/src/gt4py/cartesian/gtc/passes/horizontal_masks.py
+++ b/src/gt4py/cartesian/gtc/passes/horizontal_masks.py
@@ -105,7 +105,6 @@ def compute_relative_mask(
 
     This is used in the numpy backend to compute HorizontalMask bounds relative to
     the start/end bounds of the horizontal axes.
-
     """
     i_interval = _compute_relative_interval(extent[0], mask.i)
     j_interval = _compute_relative_interval(extent[1], mask.j)

--- a/src/gt4py/cartesian/gtc/passes/oir_optimizations/caches.py
+++ b/src/gt4py/cartesian/gtc/passes/oir_optimizations/caches.py
@@ -312,7 +312,6 @@ class FillFlushToLocalKCaches(eve.NodeTranslator, eve.VisitorWithSymbolTableTrai
 
         Returns:
             A dict, mapping field names to min and max read offsets relative to loop order (i.e., positive means in the direction of the loop order).
-
         """
 
         def directional_k_offset(offset: Tuple[int, int, int]) -> int:

--- a/src/gt4py/cartesian/gtc/passes/oir_optimizations/temporaries.py
+++ b/src/gt4py/cartesian/gtc/passes/oir_optimizations/temporaries.py
@@ -90,7 +90,6 @@ class LocalTemporariesToScalars(TemporariesToScalarsBase):
 
     Note that temporaries used in horizontal regions in a single horizontal execution
     may not be scalarized.
-
     """
 
     def visit_Stencil(self, node: oir.Stencil, **kwargs: Any) -> oir.Stencil:
@@ -121,7 +120,6 @@ class WriteBeforeReadTemporariesToScalars(TemporariesToScalarsBase):
 
     Note that temporaries used in horizontal regions in a single horizontal execution
     may not be scalarized.
-
     """
 
     def visit_Stencil(self, node: oir.Stencil, **kwargs: Any) -> oir.Stencil:

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -231,7 +231,6 @@ def stencil(
     Examples
     --------
         TODO
-
     """
 
     from gt4py.cartesian import loader as gt_loader

--- a/src/gt4py/cartesian/stencil_builder.py
+++ b/src/gt4py/cartesian/stencil_builder.py
@@ -46,7 +46,6 @@ class StencilBuilder:
     -----
     Backends can use the :py:meth:`with_backend_data` method the :py:meth:`backend_data` property
     to set and retrieve backend specific information for use in later steps.
-
     """
 
     def __init__(
@@ -136,7 +135,6 @@ class StencilBuilder:
 
         kwargs:
             passed through to the options instance
-
         """
         self._build_data = {}
         # mypy attribkwclass bug
@@ -162,8 +160,6 @@ class StencilBuilder:
         Notes
         -----
         Resets all cached build data.
-
-
         """
         self._build_data = {}
         backend = gt4pyc.backend.from_name(backend_name)

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -182,7 +182,6 @@ class StencilObject(abc.ABC):
         performance statistics. These include the stencil calls count, the
         cumulative time spent in all stencil calls, and the actual time spent
         in carrying out the computations.
-
     """
 
     # Those attributes are added to the class at loading time:

--- a/src/gt4py/cartesian/utils/base.py
+++ b/src/gt4py/cartesian/utils/base.py
@@ -77,7 +77,6 @@ def compose(*functions_or_iterable):
     """Return a function that chains the input functions.
 
     Derived from: https://mathieularose.com/function-composition-in-python/
-
     """
     if len(functions_or_iterable) == 1 and isinstance(
         functions_or_iterable[0], collections.abc.Iterable
@@ -237,7 +236,6 @@ def make_module_from_file(qualified_name, file_path, *, public_import=False):
     References:
       https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
       https://stackoverflow.com/a/43602645
-
     """
 
     def load():

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_npir_codegen.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_npir_codegen.py
@@ -326,7 +326,6 @@ def test_variable_read_outside_bounds(tmp_path) -> None:
 
     This tests whether that is appropriately clipped to support that case by constructing
     `a = b[0, 0, index]` where the read is outside bounds.
-
     """
     computation = ComputationFactory(
         vertical_passes__0__body__0__body__0=VectorAssignFactory(

--- a/tests/cartesian_tests/unit_tests/test_gtscript_imports.py
+++ b/tests/cartesian_tests/unit_tests/test_gtscript_imports.py
@@ -132,7 +132,7 @@ def make_two_files(tmp_path, extension, reset_importsys):
 @pytest.fixture
 def make_package(tmp_path, extension, reset_importsys):
     """
-    Provide a gactory for a gtscript file and package.
+    Provide a factory for a gtscript file and package.
 
     test-function unique prefix required.
 
@@ -147,7 +147,6 @@ def make_package(tmp_path, extension, reset_importsys):
         |  +- <prefix>_sub2/
         |  |  |- __init__.py
         |  |  +- <prefix>_sub_sub.<ext>
-
     """
 
     def run(prefix):


### PR DESCRIPTION
## Description

Some Friday afternoon cleanups including

- no `else:` after `return` in `if` condition
- adding types
- removing unused imports (not sure why `pre-commit` wasn't complaining about them)
- removing extra empty line at end of doc strings.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests. N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. N/A
