### PR TITLE
build[dace][next]: Changed DaCe Source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,7 +434,7 @@ url = 'https://test.pypi.org/simple/'
 
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
-dace = {git = "https://github.com/spcl/dace", branch = "main", extra = "dace-next"}
+dace = {git = "https://github.com/philip-paul-mueller/dace", branch = "gt4py-next-integration", extra = "dace-next"}
 
 # -- versioningit --
 [tool.versioningit]

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/spcl/dace?branch=main#9c67b4c6fe02a3248fcc25c6686715988e9db015" }
+source = { git = "https://github.com/philip-paul-mueller/dace?branch=gt4py-next-integration#e537d2841cd70d7b055129a8e63304913c453e81" }
 resolution-markers = [
     "python_full_version >= '3.11'",
     "python_full_version < '3.11'",
@@ -1081,7 +1081,7 @@ dace = [
     { name = "dace", version = "1.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 dace-next = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/spcl/dace?branch=main#9c67b4c6fe02a3248fcc25c6686715988e9db015" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/philip-paul-mueller/dace?branch=gt4py-next-integration#e537d2841cd70d7b055129a8e63304913c453e81" } },
 ]
 formatting = [
     { name = "clang-format" },
@@ -1204,7 +1204,7 @@ requires-dist = [
     { name = "cupy-rocm-5-0", marker = "extra == 'rocm5-0'", specifier = ">=13.3.0" },
     { name = "cytoolz", specifier = ">=0.12.1" },
     { name = "dace", marker = "extra == 'dace'", specifier = ">=1.0.2,<1.1.0" },
-    { name = "dace", marker = "extra == 'dace-next'", git = "https://github.com/spcl/dace?branch=main" },
+    { name = "dace", marker = "extra == 'dace-next'", git = "https://github.com/philip-paul-mueller/dace?branch=gt4py-next-integration" },
     { name = "deepdiff", specifier = ">=5.6.0" },
     { name = "devtools", specifier = ">=0.6" },
     { name = "diskcache", specifier = ">=5.6.3" },


### PR DESCRIPTION
Instead of pulling directly from the official DaCe repo, we now (for the time being) pull from [this PR](https://github.com/philip-paul-mueller/dace/pull/4).
This became necessary as we have a lot of open PR in DaCe and need some custom fixes (that can in their current form not be merged into DaCe).

The only downside is that the repo belongs to me (@philip-paul-mueller), but this is more or less the best solution.




