### PR TITLE
fix[next]: Prevent extraction from lambdas in cse pass

### DIFF
--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -212,7 +212,7 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                     node.fun, state=new_state, is_let_form=True, **(kwargs | {"depth": depth + 1})
                 )
                 for arg in node.args:
-                    self.visit(arg, state=new_state, **{**kwargs, "depth": depth + 1})
+                    self.visit(arg, state=new_state, **(kwargs | {"depth": depth + 1})
             else:
                 super().visit(
                     node,

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -209,7 +209,7 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                     parent_state.subexprs, collected_child_node_ids, used_symbol_ids
                 )
                 self.visit(
-                    node.fun, state=new_state, is_let_form=True, **{**kwargs, "depth": depth + 1}
+                    node.fun, state=new_state, is_let_form=True, **(kwargs | {"depth": depth + 1})
                 )
                 for arg in node.args:
                     self.visit(arg, state=new_state, **{**kwargs, "depth": depth + 1})

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -174,7 +174,7 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                 # collect subexpressions for all arguments to the `if_`
                 arg_states = [self.State() for _ in node.args]
                 for arg, state in zip(node.args, arg_states):
-                    self.visit(arg, state=state, **(kwargs | {"depth": depth + 1})
+                    self.visit(arg, state=state, **(kwargs | {"depth": depth + 1}))
 
                 # remove all subexpressions that are not eligible for collection
                 #  (either they occur in the condition or in both branches)
@@ -191,12 +191,8 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                         merged_data = subexprs.setdefault(subexpr, self.SubexpressionData())
                         merged_data.subexprs.extend(data.subexprs)
                         merged_data.max_depth = max(merged_data.max_depth, data.max_depth)
-                collected_child_node_ids = functools.reduce(
-                    operator.or_, (state.collected_child_node_ids for state in arg_states)
-                )
-                used_symbol_ids = functools.reduce(
-                    operator.or_, (state.used_symbol_ids for state in arg_states)
-                )
+                collected_child_node_ids = set.union(*(state.collected_child_node_ids for state in arg_states))
+                used_symbol_ids = set.union(*(state.used_symbol_ids for state in arg_states))
                 # propagate collected subexpressions to parent
                 for subexpr, data in subexprs.items():
                     parent_data = parent_state.subexprs.setdefault(
@@ -212,7 +208,7 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                     node.fun, state=new_state, is_let_form=True, **(kwargs | {"depth": depth + 1})
                 )
                 for arg in node.args:
-                    self.visit(arg, state=new_state, **(kwargs | {"depth": depth + 1})
+                    self.visit(arg, state=new_state, **(kwargs | {"depth": depth + 1}))
             else:
                 super().visit(
                     node,

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -174,7 +174,7 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                 # collect subexpressions for all arguments to the `if_`
                 arg_states = [self.State() for _ in node.args]
                 for arg, state in zip(node.args, arg_states):
-                    self.visit(arg, state=state, **{**kwargs, "depth": depth + 1})
+                    self.visit(arg, state=state, **(kwargs | {"depth": depth + 1})
 
                 # remove all subexpressions that are not eligible for collection
                 #  (either they occur in the condition or in both branches)

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -154,9 +154,9 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
         can_collect_children = not isinstance(node, itir.Lambda) or is_let_form
 
         if (
-            not isinstance(node, SymbolTableTrait)
+            can_collect_children
+            and not isinstance(node, SymbolTableTrait)
             and not _is_collectable_expr(node)
-            and can_collect_children
         ):
             return super().visit(node, **kwargs)
 

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -149,8 +149,15 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
         depth = kwargs.pop("depth")
         return super().generic_visit(node, depth=depth + 1, **kwargs)
 
-    def visit(self, node: itir.Node, **kwargs) -> None:  # type: ignore[override] # supertype accepts any node, but we want to be more specific here.
-        if not isinstance(node, SymbolTableTrait) and not _is_collectable_expr(node):
+    def visit(self, node: itir.Node, is_let_form: bool = False, **kwargs) -> None:  # type: ignore[override] # supertype accepts any node, but we want to be more specific here.
+        # do not descent into un-applied lambda
+        can_collect_children = not isinstance(node, itir.Lambda) or is_let_form
+
+        if (
+            not isinstance(node, SymbolTableTrait)
+            and not _is_collectable_expr(node)
+            and can_collect_children
+        ):
             return super().visit(node, **kwargs)
 
         depth = kwargs["depth"]
@@ -158,48 +165,62 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
         collected_child_node_ids: set[int] = set()
         used_symbol_ids: set[int] = set()
 
-        # Special handling of `if_(condition, true_branch, false_branch)` like expressions that
-        # avoids extracting subexpressions unless they are used in either the condition or both
-        # branches.
-        if isinstance(node, itir.FunCall) and node.fun == itir.SymRef(id="if_"):
-            assert len(node.args) == 3
-            # collect subexpressions for all arguments to the `if_`
-            arg_states = [self.State() for _ in node.args]
-            for arg, state in zip(node.args, arg_states):
-                self.visit(arg, state=state, **{**kwargs, "depth": depth + 1})
+        if can_collect_children:
+            # Special handling of `if_(condition, true_branch, false_branch)` like expressions that
+            # avoids extracting subexpressions unless they are used in either the condition or both
+            # branches.
+            if cpm.is_call_to(node, "if_"):
+                assert len(node.args) == 3
+                # collect subexpressions for all arguments to the `if_`
+                arg_states = [self.State() for _ in node.args]
+                for arg, state in zip(node.args, arg_states):
+                    self.visit(arg, state=state, **{**kwargs, "depth": depth + 1})
 
-            # remove all subexpressions that are not eligible for collection
-            #  (either they occur in the condition or in both branches)
-            eligible_subexprs = arg_states[0].subexprs.keys() | (
-                arg_states[1].subexprs.keys() & arg_states[2].subexprs.keys()
-            )
-            for arg_state in arg_states:
-                arg_state.remove_subexprs(arg_state.subexprs.keys() - eligible_subexprs)
+                # remove all subexpressions that are not eligible for collection
+                #  (either they occur in the condition or in both branches)
+                eligible_subexprs = arg_states[0].subexprs.keys() | (
+                    arg_states[1].subexprs.keys() & arg_states[2].subexprs.keys()
+                )
+                for arg_state in arg_states:
+                    arg_state.remove_subexprs(arg_state.subexprs.keys() - eligible_subexprs)
 
-            # merge the states of the three arguments
-            subexprs: dict[itir.Node, CollectSubexpressions.SubexpressionData] = {}
-            for state in arg_states:
-                for subexpr, data in state.subexprs.items():
-                    merged_data = subexprs.setdefault(subexpr, self.SubexpressionData())
-                    merged_data.subexprs.extend(data.subexprs)
-                    merged_data.max_depth = max(merged_data.max_depth, data.max_depth)
-            collected_child_node_ids = functools.reduce(
-                operator.or_, (state.collected_child_node_ids for state in arg_states)
-            )
-            used_symbol_ids = functools.reduce(
-                operator.or_, (state.used_symbol_ids for state in arg_states)
-            )
-            # propagate collected subexpressions to parent
-            for subexpr, data in subexprs.items():
-                parent_data = parent_state.subexprs.setdefault(subexpr, self.SubexpressionData())
-                parent_data.subexprs.extend(data.subexprs)
-                parent_data.max_depth = max(merged_data.max_depth, data.max_depth)
-        else:
-            super().visit(
-                node,
-                state=self.State(parent_state.subexprs, collected_child_node_ids, used_symbol_ids),
-                **kwargs,
-            )
+                # merge the states of the three arguments
+                subexprs: dict[itir.Node, CollectSubexpressions.SubexpressionData] = {}
+                for state in arg_states:
+                    for subexpr, data in state.subexprs.items():
+                        merged_data = subexprs.setdefault(subexpr, self.SubexpressionData())
+                        merged_data.subexprs.extend(data.subexprs)
+                        merged_data.max_depth = max(merged_data.max_depth, data.max_depth)
+                collected_child_node_ids = functools.reduce(
+                    operator.or_, (state.collected_child_node_ids for state in arg_states)
+                )
+                used_symbol_ids = functools.reduce(
+                    operator.or_, (state.used_symbol_ids for state in arg_states)
+                )
+                # propagate collected subexpressions to parent
+                for subexpr, data in subexprs.items():
+                    parent_data = parent_state.subexprs.setdefault(
+                        subexpr, self.SubexpressionData()
+                    )
+                    parent_data.subexprs.extend(data.subexprs)
+                    parent_data.max_depth = max(merged_data.max_depth, data.max_depth)
+            elif cpm.is_let(node):
+                new_state = self.State(
+                    parent_state.subexprs, collected_child_node_ids, used_symbol_ids
+                )
+                self.visit(
+                    node.fun, state=new_state, is_let_form=True, **{**kwargs, "depth": depth + 1}
+                )
+                for arg in node.args:
+                    self.visit(arg, state=new_state, **{**kwargs, "depth": depth + 1})
+            else:
+                super().visit(
+                    node,
+                    state=self.State(
+                        parent_state.subexprs, collected_child_node_ids, used_symbol_ids
+                    ),
+                    **kwargs,
+                )
 
         if isinstance(node, SymbolTableTrait):
             # remove symbols used in child nodes if they are declared in the current node

--- a/src/gt4py/next/iterator/transforms/cse.py
+++ b/src/gt4py/next/iterator/transforms/cse.py
@@ -8,10 +8,9 @@
 
 from __future__ import annotations
 
+import collections
 import dataclasses
-import functools
 import math
-import operator
 from typing import Callable, Iterable, TypeVar, Union, cast
 
 import gt4py.next.iterator.ir_utils.ir_makers as im
@@ -185,13 +184,17 @@ class CollectSubexpressions(PreserveLocationVisitor, VisitorWithSymbolTableTrait
                     arg_state.remove_subexprs(arg_state.subexprs.keys() - eligible_subexprs)
 
                 # merge the states of the three arguments
-                subexprs: dict[itir.Node, CollectSubexpressions.SubexpressionData] = {}
+                subexprs: dict[itir.Node, CollectSubexpressions.SubexpressionData] = (
+                    collections.defaultdict(self.SubexpressionData)
+                )
                 for state in arg_states:
                     for subexpr, data in state.subexprs.items():
-                        merged_data = subexprs.setdefault(subexpr, self.SubexpressionData())
+                        merged_data = subexprs[subexpr]
                         merged_data.subexprs.extend(data.subexprs)
                         merged_data.max_depth = max(merged_data.max_depth, data.max_depth)
-                collected_child_node_ids = set.union(*(state.collected_child_node_ids for state in arg_states))
+                collected_child_node_ids = set.union(
+                    *(state.collected_child_node_ids for state in arg_states)
+                )
                 used_symbol_ids = set.union(*(state.used_symbol_ids for state in arg_states))
                 # propagate collected subexpressions to parent
                 for subexpr, data in subexprs.items():

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_cse.py
@@ -304,8 +304,6 @@ def test_scalar_extraction_inside_as_fieldop():
 def test_no_extraction_from_unapplied_lambda():
     testee = im.if_(
         "cond",
-        # the `+0`, and `+1` respectively, are only needed to avoid that f itself is collected
-        # which is not what we are interested in here
         im.let("f", im.lambda_()(im.deref("guarded_it")))(im.if_("cond2", im.call("f")(), 0)),
         im.deref("guarded_it"),
     )


### PR DESCRIPTION
The common subexpression elimination pass already has a mechanism to avoid extracting from `if_` calls, such that the evaluation of expressions can be guarded in order to to avoid out-of-bounds accesses or excessive pre-computation. The former protection can be circumvented by placing things inside a lambda outside of the protecting if:
```
if cond then
  let f = λ() → ·guarded_it in
    if cond2 then f() else 0
else
  ·guarded_it
```
This PR prevents that by not extracting from lambdas unless they are a let-form in which case it is clear that the function is unconditionally evaluated.