### PR TITLE
refactor[next][dace]: Introduce context dataclass in SDFG lowering

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
@@ -129,6 +129,14 @@ class DataflowBuilder(Protocol):
         return state.add_mapped_tasklet(unique_name, map_ranges, inputs, code, outputs, **kwargs)
 
 
+@dataclasses.dataclass(frozen=True)
+class SubgraphContext:
+    """Represents the subgraph context in which to lower a GTIR expression to dataflow."""
+
+    sdfg: dace.SDFG
+    state: dace.SDFGState
+
+
 class SDFGBuilder(DataflowBuilder, Protocol):
     """Visitor interface available to GTIR-primitive translators."""
 
@@ -155,11 +163,11 @@ class SDFGBuilder(DataflowBuilder, Protocol):
     def setup_nested_context(
         self,
         expr: gtir.Lambda,
-        sdfg: dace.SDFG,
-        parent: dace.SDFG,
+        sdfg_name: str,
+        parent_ctx: SubgraphContext,
         scope_symbols: dict[str, ts.DataType],
         symbolic_inputs: set[str],
-    ) -> SDFGBuilder:
+    ) -> tuple[SDFGBuilder, SubgraphContext]:
         """
         Create an nested SDFG context to lower a lambda expression, indipendent
         from the current context where the parent expression is being translated.
@@ -171,8 +179,8 @@ class SDFGBuilder(DataflowBuilder, Protocol):
 
         Args:
             expr: The lambda expression to be lowered as a nested SDFG.
-            sdfg: The nested SDFG where to lower the nested expression.
-            parent: The parent SDFG.
+            sdfg_name: The name of the nested SDFG where to lower the given expression.
+            parent_ctx: The parent SDFG context.
             scope_symbols: Mapping from symbol name to data type for the GTIR symbols
                 forwarded to the nested context.
             symbolic_inputs: Arguments that have to be passed to the nested SDFG
@@ -302,12 +310,17 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
     def setup_nested_context(
         self,
         expr: gtir.Lambda,
-        sdfg: dace.SDFG,
-        parent: dace.SDFG,
+        sdfg_name: str,
+        parent_ctx: SubgraphContext,
         scope_symbols: dict[str, ts.DataType],
         symbolic_inputs: set[str],
-    ) -> SDFGBuilder:
+    ) -> tuple[SDFGBuilder, SubgraphContext]:
+        sdfg = dace.SDFG(name=self.unique_nsdfg_name(parent_ctx.sdfg, sdfg_name))
+        sdfg.debuginfo = gtir_to_sdfg_utils.debug_info(expr, default=parent_ctx.sdfg.debuginfo)
+        state = sdfg.add_state(f"{sdfg_name}_entry")
+        nested_ctx = SubgraphContext(sdfg, state)
         nsdfg_builder = GTIRToSDFG(self.offset_provider_type, self.column_axis, scope_symbols)
+
         # We pass to the nested SDFG all GTIR-symbols in scope, which includes the
         # values mapped to the parameters of the lambda expression (`node.params`)
         # and the GTIR-symbols defined in the current context.
@@ -331,7 +344,9 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         # Scalar GTIR-symbols represented as dace symbols in parent SDFG are mapped
         # to dace symbols in the nested SDFG.
         parent_symbols = {
-            name for p in flatten_tuple_syms(params) if (name := str(p.id)) in parent.symbols
+            name
+            for p in flatten_tuple_syms(params)
+            if (name := str(p.id)) in parent_ctx.sdfg.symbols
         }
 
         # All GTIR-symbols accessed in domain expressions by the lambda need to be
@@ -354,7 +369,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             params,
             symbolic_params=(domain_symbols | parent_symbols | symbolic_inputs),
         )
-        return nsdfg_builder
+        return nsdfg_builder, nested_ctx
 
     def unique_nsdfg_name(self, sdfg: dace.SDFG, prefix: str) -> str:
         nsdfg_list = [
@@ -524,7 +539,11 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         raise NotImplementedError("Temporaries not supported yet by GTIR DaCe backend.")
 
     def _visit_expression(
-        self, node: gtir.Expr, sdfg: dace.SDFG, head_state: dace.SDFGState, use_temp: bool = True
+        self,
+        node: gtir.Expr,
+        sdfg: dace.SDFG,
+        head_state: dace.SDFGState,
+        use_temp: bool = True,
     ) -> list[gtir_to_sdfg_types.FieldopData]:
         """
         Specialized visit method for fieldview expressions.
@@ -535,7 +554,9 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         Returns:
             A list of array nodes containing the result fields.
         """
-        result = self.visit(node, sdfg=sdfg, head_state=head_state)
+
+        ctx = SubgraphContext(sdfg, head_state)
+        result = self.visit(node, ctx=ctx)
 
         # sanity check: each statement should preserve the property of single exit state (aka head state),
         # i.e. eventually only introduce internal branches, and keep the same head state
@@ -744,22 +765,21 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
     def visit_FunCall(
         self,
         node: gtir.FunCall,
-        sdfg: dace.SDFG,
-        head_state: dace.SDFGState,
+        ctx: SubgraphContext,
     ) -> gtir_to_sdfg_types.FieldopResult:
         # use specialized dataflow builder classes for each builtin function
         if cpm.is_call_to(node, "concat_where"):
-            return gtir_to_sdfg_concat_where.translate_concat_where(node, sdfg, head_state, self)
+            return gtir_to_sdfg_concat_where.translate_concat_where(node, ctx, self)
         elif cpm.is_call_to(node, "if_"):
-            return gtir_to_sdfg_primitives.translate_if(node, sdfg, head_state, self)
+            return gtir_to_sdfg_primitives.translate_if(node, ctx, self)
         elif cpm.is_call_to(node, "index"):
-            return gtir_to_sdfg_primitives.translate_index(node, sdfg, head_state, self)
+            return gtir_to_sdfg_primitives.translate_index(node, ctx, self)
         elif cpm.is_call_to(node, "make_tuple"):
-            return gtir_to_sdfg_primitives.translate_make_tuple(node, sdfg, head_state, self)
+            return gtir_to_sdfg_primitives.translate_make_tuple(node, ctx, self)
         elif cpm.is_call_to(node, "tuple_get"):
-            return gtir_to_sdfg_primitives.translate_tuple_get(node, sdfg, head_state, self)
+            return gtir_to_sdfg_primitives.translate_tuple_get(node, ctx, self)
         elif cpm.is_applied_as_fieldop(node):
-            return gtir_to_sdfg_primitives.translate_as_fieldop(node, sdfg, head_state, self)
+            return gtir_to_sdfg_primitives.translate_as_fieldop(node, ctx, self)
         elif isinstance(node.fun, gtir.Lambda):
             # Special handling of scalar arguments of a let-lambda that can be lowered
             # as symbolic expressions: when all the GTIR-symbols the scalar expression
@@ -780,37 +800,27 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                     ):
                         raise
                     continue
-                if all(str(s) in sdfg.symbols for s in symbolic_expr.free_symbols):
+                if all(str(s) in ctx.sdfg.symbols for s in symbolic_expr.free_symbols):
                     symbolic_args[str(p.id)] = symbolic_expr
             # All other lambda arguments are lowered to some dataflow that produces a data node.
             args = {
                 str(p.id): (
                     gtir_to_sdfg_types.SymbolicData(p.type, symbolic_args[param])  # type: ignore[arg-type]
                     if (param := str(p.id)) in symbolic_args
-                    else self.visit(
-                        arg,
-                        sdfg=sdfg,
-                        head_state=head_state,
-                    )
+                    else self.visit(arg, ctx=ctx)
                 )
                 for p, arg in zip(node.fun.params, node.args, strict=True)
             }
-            return self.visit(
-                node.fun,
-                sdfg=sdfg,
-                head_state=head_state,
-                args=args,
-            )
+            return self.visit(node.fun, ctx=ctx, args=args)
         elif isinstance(node.type, ts.ScalarType):
-            return gtir_to_sdfg_primitives.translate_scalar_expr(node, sdfg, head_state, self)
+            return gtir_to_sdfg_primitives.translate_scalar_expr(node, ctx, self)
         else:
             raise NotImplementedError(f"Unexpected 'FunCall' expression ({node}).")
 
     def visit_Lambda(
         self,
         node: gtir.Lambda,
-        sdfg: dace.SDFG,
-        head_state: dace.SDFGState,
+        ctx: SubgraphContext,
         args: Mapping[str, gtir_to_sdfg_types.FieldopResult | gtir_to_sdfg_types.SymbolicData],
     ) -> gtir_to_sdfg_types.FieldopResult:
         """
@@ -859,18 +869,11 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         }
 
         # lower let-statement lambda node as a nested SDFG
-        nsdfg = dace.SDFG(name=self.unique_nsdfg_name(sdfg, "lambda"))
-        nsdfg.debuginfo = gtir_to_sdfg_utils.debug_info(node, default=sdfg.debuginfo)
-        lambda_translator = self.setup_nested_context(
-            node, nsdfg, sdfg, lambda_symbols, symbolic_inputs=set(symbolic_args.keys())
+        lamnda_translator, lambda_ctx = self.setup_nested_context(
+            node, "lambda", ctx, lambda_symbols, symbolic_inputs=set(symbolic_args.keys())
         )
 
-        nstate = nsdfg.add_state("lambda")
-        lambda_result = lambda_translator.visit(
-            node.expr,
-            sdfg=nsdfg,
-            head_state=nstate,
-        )
+        lambda_result = lamnda_translator.visit(node.expr, ctx=lambda_ctx)
 
         # Process lambda inputs
         #
@@ -883,23 +886,23 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         }
 
         input_memlets = {}
-        for nsdfg_dataname, nsdfg_datadesc in nsdfg.arrays.items():
+        for nsdfg_dataname, nsdfg_datadesc in lambda_ctx.sdfg.arrays.items():
             if nsdfg_datadesc.transient:
                 continue
 
             if nsdfg_dataname in lambda_arg_nodes:
                 src_node = lambda_arg_nodes[nsdfg_dataname].dc_node
                 dataname = src_node.data
-                datadesc = src_node.desc(sdfg)
+                datadesc = src_node.desc(ctx.sdfg)
             else:
                 dataname = nsdfg_dataname
-                datadesc = sdfg.arrays[nsdfg_dataname]
+                datadesc = ctx.sdfg.arrays[nsdfg_dataname]
 
             # ensure that connectivity tables are non-transient arrays in parent SDFG
             if dataname in connectivity_arrays:
                 datadesc.transient = False
 
-            input_memlets[nsdfg_dataname] = sdfg.make_array_memlet(dataname)
+            input_memlets[nsdfg_dataname] = ctx.sdfg.make_array_memlet(dataname)
 
         # Process lambda outputs
         #
@@ -925,12 +928,12 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         lambda_outputs = {
             output_data.dc_node.data
             for output_data in lambda_output_data
-            if output_data.dc_node.desc(nsdfg).transient
+            if output_data.dc_node.desc(lambda_ctx.sdfg).transient
         }
 
         # Map free symbols to parent SDFG
         nsdfg_symbols_mapping = {}
-        for sym in nsdfg.free_symbols:
+        for sym in lambda_ctx.sdfg.free_symbols:
             if (sym_id := str(sym)) in lambda_arg_nodes:
                 assert isinstance(lambda_arg_nodes[sym_id].gt_type, ts.ScalarType)
                 raise NotImplementedError(
@@ -941,24 +944,24 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             else:
                 nsdfg_symbols_mapping[sym_id] = sym
         for param, arg in data_args.items():
-            nsdfg_symbols_mapping |= gtir_to_sdfg_utils.get_arg_symbol_mapping(param, arg, sdfg)
+            nsdfg_symbols_mapping |= gtir_to_sdfg_utils.get_arg_symbol_mapping(param, arg, ctx.sdfg)
 
-        nsdfg_node = head_state.add_nested_sdfg(
-            nsdfg,
-            parent=sdfg,
+        nsdfg_node = ctx.state.add_nested_sdfg(
+            lambda_ctx.sdfg,
+            parent=ctx.sdfg,
             inputs=set(input_memlets.keys()),
             outputs=lambda_outputs,
             symbol_mapping=nsdfg_symbols_mapping,
-            debuginfo=gtir_to_sdfg_utils.debug_info(node, default=sdfg.debuginfo),
+            debuginfo=gtir_to_sdfg_utils.debug_info(node, default=ctx.sdfg.debuginfo),
         )
 
         for connector, memlet in input_memlets.items():
             if connector in lambda_arg_nodes:
                 src_node = lambda_arg_nodes[connector].dc_node
             else:
-                src_node = head_state.add_access(memlet.data)
+                src_node = ctx.state.add_access(memlet.data)
 
-            head_state.add_edge(src_node, None, nsdfg_node, connector, memlet)
+            ctx.state.add_edge(src_node, None, nsdfg_node, connector, memlet)
 
         def construct_output_for_nested_sdfg(
             inner_data: gtir_to_sdfg_types.FieldopData,
@@ -975,7 +978,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             The same happens to symbols available in the lambda context but not explicitly passed as lambda
             arguments, that are simply returned by the lambda: it can be directly accessed in the parent SDFG.
             """
-            inner_desc = inner_data.dc_node.desc(nsdfg)
+            inner_desc = inner_data.dc_node.desc(lambda_ctx.sdfg)
             inner_dataname = inner_data.dc_node.data
             if inner_desc.transient:
                 # Transient data nodes only exist within the nested SDFG. In order to return some result data,
@@ -983,14 +986,14 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                 # that is externally allocated, as required by the SDFG IR. An output edge will write the result
                 # from the nested-SDFG to a new intermediate data container allocated in the parent SDFG.
                 outer_data = inner_data.map_to_parent_sdfg(
-                    self, nsdfg, sdfg, head_state, nsdfg_symbols_mapping
+                    self, lambda_ctx.sdfg, ctx.sdfg, ctx.state, nsdfg_symbols_mapping
                 )
-                head_state.add_edge(
+                ctx.state.add_edge(
                     nsdfg_node,
                     inner_dataname,
                     outer_data.dc_node,
                     None,
-                    sdfg.make_array_memlet(outer_data.dc_node.data),
+                    ctx.sdfg.make_array_memlet(outer_data.dc_node.data),
                 )
             elif inner_dataname in lambda_arg_nodes:
                 # This if branch and the next one handle the non-transient result nodes.
@@ -1000,15 +1003,15 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                 outer_data = lambda_arg_nodes[inner_dataname]
             else:
                 # This must be a symbol captured from the lambda parent scope.
-                outer_node = head_state.add_access(inner_dataname)
+                outer_node = ctx.state.add_access(inner_dataname)
                 outer_data = gtir_to_sdfg_types.FieldopData(
                     outer_node, inner_data.gt_type, inner_data.origin
                 )
             # Isolated access node will make validation fail.
             # Isolated access nodes can be found in the join-state of an if-expression
             # or in lambda expressions that just construct tuples from input arguments.
-            if nstate.degree(inner_data.dc_node) == 0:
-                nstate.remove_node(inner_data.dc_node)
+            if lambda_ctx.state.degree(inner_data.dc_node) == 0:
+                lambda_ctx.state.remove_node(inner_data.dc_node)
             return outer_data
 
         return gtx_utils.tree_map(construct_output_for_nested_sdfg)(lambda_result)
@@ -1016,18 +1019,16 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
     def visit_Literal(
         self,
         node: gtir.Literal,
-        sdfg: dace.SDFG,
-        head_state: dace.SDFGState,
+        ctx: SubgraphContext,
     ) -> gtir_to_sdfg_types.FieldopResult:
-        return gtir_to_sdfg_primitives.translate_literal(node, sdfg, head_state, self)
+        return gtir_to_sdfg_primitives.translate_literal(node, ctx, self)
 
     def visit_SymRef(
         self,
         node: gtir.SymRef,
-        sdfg: dace.SDFG,
-        head_state: dace.SDFGState,
+        ctx: SubgraphContext,
     ) -> gtir_to_sdfg_types.FieldopResult:
-        return gtir_to_sdfg_primitives.translate_symbol_ref(node, sdfg, head_state, self)
+        return gtir_to_sdfg_primitives.translate_symbol_ref(node, ctx, self)
 
 
 def _remove_field_origin_symbols(ir: gtir.Program, sdfg: dace.SDFG) -> None:

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_concat_where.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_concat_where.py
@@ -30,8 +30,7 @@ from gt4py.next.type_system import type_specifications as ts
 
 
 def _make_concat_field_slice(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     field: gtir_to_sdfg_types.FieldopData,
     field_desc: dace.data.Array,
     concat_dim: gtx_common.Dimension,
@@ -54,9 +53,9 @@ def _make_concat_field_slice(
         [*field.origin[:concat_dim_index], concat_dim_origin, *field.origin[concat_dim_index:]]
     )
     shape = tuple([*field_desc.shape[:concat_dim_index], 1, *field_desc.shape[concat_dim_index:]])
-    extended_field_data, extended_field_desc = sdfg.add_temp_transient(shape, field_desc.dtype)
-    extended_field_node = state.add_access(extended_field_data)
-    state.add_nedge(
+    extended_field_data, extended_field_desc = ctx.sdfg.add_temp_transient(shape, field_desc.dtype)
+    extended_field_node = ctx.state.add_access(extended_field_data)
+    ctx.state.add_nedge(
         field.dc_node,
         extended_field_node,
         dace.Memlet(
@@ -72,8 +71,7 @@ def _make_concat_field_slice(
 
 
 def _make_concat_scalar_broadcast(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     inp: gtir_to_sdfg_types.FieldopData,
     inp_desc: dace.data.Array,
     domain: gtir_domain.FieldopDomain,
@@ -91,18 +89,18 @@ def _make_concat_scalar_broadcast(
     out_dims, out_origin, out_shape = gtir_domain.get_field_layout(domain)
     out_type = ts.FieldType(dims=out_dims, dtype=inp.gt_type.dtype)
 
-    out_name, out_desc = sdfg.add_temp_transient(out_shape, inp_desc.dtype)
-    out_node = state.add_access(out_name)
+    out_name, out_desc = ctx.sdfg.add_temp_transient(out_shape, inp_desc.dtype)
+    out_node = ctx.state.add_access(out_name)
 
     map_variables = [gtir_to_sdfg_utils.get_map_variable(dim) for dim in out_dims]
     inp_index = (
         "0"
-        if isinstance(inp.dc_node.desc(sdfg), dace.data.Scalar)
+        if isinstance(inp.dc_node.desc(ctx.sdfg), dace.data.Scalar)
         else (
             f"({map_variables[concat_dim_index]} + {out_origin[concat_dim_index] - inp.origin[0]})"
         )
     )
-    state.add_mapped_tasklet(
+    ctx.state.add_mapped_tasklet(
         "broadcast",
         map_ranges=dict(zip(map_variables, dace_subsets.Range.from_array(out_desc), strict=True)),
         code="__out = __inp",
@@ -118,8 +116,7 @@ def _make_concat_scalar_broadcast(
 
 
 def _translate_concat_where_impl(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
     mask_domain: gtir_domain.FieldopDomain,
     node_domain: gtir.Expr,
@@ -142,9 +139,8 @@ def _translate_concat_where_impl(
     of the concat_where expression, passed as second and third argument, respectively.
 
     Args:
-        sdfg: The SDFG where the primitive subgraph should be instantiated
-        state: The SDFG state where the result of the primitive function should be made available
-        sdfg_builder: The object responsible for visiting child nodes of the primitive node.
+        ctx: The SDFG context where the primitive subgraph should be instantiated.
+        sdfg_builder: The object responsible for SubgraphContexting child nodes of the primitive node.
         mask_domain: Domain (only for concat dimension) of the true branch, infinite
             on lower or upper boundary.
         node_domain: Domain (all dimensions) of output field.
@@ -156,7 +152,7 @@ def _translate_concat_where_impl(
     Returns:
         The field resulted from concatanating the input fields on the lower and upper domain.
     """
-    tb_data_desc, fb_data_desc = (inp.dc_node.desc(sdfg) for inp in [tb_field, fb_field])
+    tb_data_desc, fb_data_desc = (inp.dc_node.desc(ctx.sdfg) for inp in [tb_field, fb_field])
     assert tb_data_desc.dtype == fb_data_desc.dtype
 
     tb_domain, fb_domain = (
@@ -247,8 +243,7 @@ def _translate_concat_where_impl(
             ]
         )
         lower, lower_desc = _make_concat_field_slice(
-            sdfg=sdfg,
-            state=state,
+            ctx=ctx,
             field=lower,
             field_desc=lower_desc,
             concat_dim=concat_domain.dim,
@@ -275,8 +270,7 @@ def _translate_concat_where_impl(
             ]
         )
         upper, upper_desc = _make_concat_field_slice(
-            sdfg=sdfg,
-            state=state,
+            ctx=ctx,
             field=upper,
             field_desc=upper_desc,
             concat_dim=concat_domain.dim,
@@ -314,8 +308,7 @@ def _translate_concat_where_impl(
             *output_domain[concat_dim_index + 1 :],
         ]
         lower, lower_desc = _make_concat_scalar_broadcast(
-            sdfg=sdfg,
-            state=state,
+            ctx=ctx,
             inp=lower,
             inp_desc=lower_desc,
             domain=lower_domain,
@@ -332,8 +325,7 @@ def _translate_concat_where_impl(
             *output_domain[concat_dim_index + 1 :],
         ]
         upper, upper_desc = _make_concat_scalar_broadcast(
-            sdfg=sdfg,
-            state=state,
+            ctx=ctx,
             inp=upper,
             inp_desc=upper_desc,
             domain=upper_domain,
@@ -373,8 +365,8 @@ def _translate_concat_where_impl(
     )
     upper_range_size = upper_range_1 - upper_range_0
 
-    output, output_desc = sdfg_builder.add_temp_array(sdfg, output_shape, lower_desc.dtype)
-    output_node = state.add_access(output)
+    output, output_desc = sdfg_builder.add_temp_array(ctx.sdfg, output_shape, lower_desc.dtype)
+    output_node = ctx.state.add_access(output)
 
     lower_subset = []
     lower_output_subset = []
@@ -428,7 +420,7 @@ def _translate_concat_where_impl(
             upper_output_subset.append((0, size - 1, 1))
 
     # use dynamic memlets because the subset range could be empty, but this is known only at runtime
-    state.add_nedge(
+    ctx.state.add_nedge(
         lower.dc_node,
         output_node,
         dace.Memlet(
@@ -438,7 +430,7 @@ def _translate_concat_where_impl(
             dynamic=True,
         ),
     )
-    state.add_nedge(
+    ctx.state.add_nedge(
         upper.dc_node,
         output_node,
         dace.Memlet(
@@ -454,8 +446,7 @@ def _translate_concat_where_impl(
 
 def translate_concat_where(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """
@@ -476,12 +467,11 @@ def translate_concat_where(
         raise NotImplementedError("Expected `concat_where` along single axis.")
 
     # we visit the field arguments for the true and false branch
-    tb, fb = (sdfg_builder.visit(node.args[i], sdfg=sdfg, head_state=state) for i in [1, 2])
+    tb, fb = (sdfg_builder.visit(node.args[i], ctx=ctx) for i in [1, 2])
 
     return (
         _translate_concat_where_impl(
-            sdfg,
-            state,
+            ctx,
             sdfg_builder,
             mask_domain,
             node.annex.domain,
@@ -498,11 +488,9 @@ def translate_concat_where(
             _tb_field,
             _fb_field,
             _sdfg_builder=sdfg_builder,
-            _sdfg=sdfg,
-            _state=state,
+            _ctx=ctx,
             _mask_domain=mask_domain: _translate_concat_where_impl(
-                _sdfg,
-                _state,
+                _ctx,
                 _sdfg_builder,
                 _mask_domain,
                 _node_domain,

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_primitives.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_primitives.py
@@ -42,8 +42,7 @@ class PrimitiveTranslator(Protocol):
     def __call__(
         self,
         node: gtir.Node,
-        sdfg: dace.SDFG,
-        state: dace.SDFGState,
+        ctx: gtir_to_sdfg.SubgraphContext,
         sdfg_builder: gtir_to_sdfg.SDFGBuilder,
     ) -> gtir_to_sdfg_types.FieldopResult:
         """Creates the dataflow subgraph representing a GTIR primitive function.
@@ -52,9 +51,8 @@ class PrimitiveTranslator(Protocol):
         for a specific GTIR primitive function.
 
         Args:
-            node: The GTIR node describing the primitive to be lowered
-            sdfg: The SDFG where the primitive subgraph should be instantiated
-            state: The SDFG state where the result of the primitive function should be made available
+            node: The GTIR node describing the primitive to be lowered.
+            ctx: The SDFG context in which to lower the primitive subgraph.
             sdfg_builder: The object responsible for visiting child nodes of the primitive node.
 
         Returns:
@@ -67,8 +65,7 @@ class PrimitiveTranslator(Protocol):
 
 def _parse_fieldop_arg(
     node: gtir.Expr,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
     domain: gtir_domain.FieldopDomain,
 ) -> (
@@ -78,19 +75,18 @@ def _parse_fieldop_arg(
 ):
     """Helper method to visit an expression passed as argument to a field operator."""
 
-    arg = sdfg_builder.visit(node, sdfg=sdfg, head_state=state)
+    arg = sdfg_builder.visit(node, ctx=ctx)
 
     if isinstance(arg, gtir_to_sdfg_types.FieldopData):
-        return arg.get_local_view(domain, sdfg)
+        return arg.get_local_view(domain, ctx.sdfg)
     else:
         # handle tuples of fields
         return gtx_utils.tree_map(lambda targ: targ.get_local_view(domain))(arg)
 
 
 def _create_field_operator_impl(
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
     domain: gtir_domain.FieldopDomain,
     output_edge: gtir_dataflow.DataflowOutputEdge,
     output_type: ts.FieldType,
@@ -103,9 +99,8 @@ def _create_field_operator_impl(
     This method is called by `_create_field_operator()`.
 
     Args:
+        ctx: The SDFG context in which to lower the field operator.
         sdfg_builder: The object used to build the map scope in the provided SDFG.
-        sdfg: The SDFG that represents the scope of the field data.
-        state: The SDFG state where to create an access node to the field data.
         domain: The domain of the field operator that computes the field.
         output_edge: The dataflow write edge representing the output data.
         output_type: The GT4Py field type descriptor.
@@ -115,7 +110,7 @@ def _create_field_operator_impl(
         The field data descriptor, which includes the field access node in the
         given `state` and the field domain offset.
     """
-    dataflow_output_desc = output_edge.result.dc_node.desc(sdfg)
+    dataflow_output_desc = output_edge.result.dc_node.desc(ctx.sdfg)
 
     # the memory layout of the output field follows the field operator compute domain
     field_dims, field_origin, field_shape = gtir_domain.get_field_layout(domain)
@@ -149,11 +144,13 @@ def _create_field_operator_impl(
 
     # allocate local temporary storage
     if len(field_shape) == 0:  # zero-dimensional field
-        field_name, _ = sdfg_builder.add_temp_scalar(sdfg, dataflow_output_desc.dtype)
+        field_name, _ = sdfg_builder.add_temp_scalar(ctx.sdfg, dataflow_output_desc.dtype)
         field_subset = dace_subsets.Range.from_string("0")
     else:
-        field_name, _ = sdfg_builder.add_temp_array(sdfg, field_shape, dataflow_output_desc.dtype)
-    field_node = state.add_access(field_name)
+        field_name, _ = sdfg_builder.add_temp_array(
+            ctx.sdfg, field_shape, dataflow_output_desc.dtype
+        )
+    field_node = ctx.state.add_access(field_name)
 
     # and here the edge writing the dataflow result data through the map exit node
     output_edge.connect(map_exit, field_node, field_subset)
@@ -164,8 +161,7 @@ def _create_field_operator_impl(
 
 
 def _create_field_operator(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     domain: gtir_domain.FieldopDomain,
     node_type: ts.FieldType | ts.TupleType,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
@@ -180,8 +176,7 @@ def _create_field_operator(
     fields: for each field, this method will call `_create_field_operator_impl()`.
 
     Args:
-        sdfg: The SDFG that represents the scope of the field data.
-        state: The SDFG state where to create an access node to the field data.
+        ctx: The SDFG context in which to lower the field operator.
         domain: The domain of the field operator that computes the field.
         node_type: The GT4Py type of the IR node that produces this field.
         sdfg_builder: The object used to build the map scope in the provided SDFG.
@@ -206,7 +201,7 @@ def _create_field_operator(
             ): f"{domain_range.start}:{domain_range.stop}"
             for domain_range in domain
         }
-    map_entry, map_exit = sdfg_builder.add_map("fieldop", state, map_range)
+    map_entry, map_exit = sdfg_builder.add_map("fieldop", ctx.state, map_range)
 
     # here we setup the edges passing through the map entry node
     for edge in input_edges:
@@ -218,22 +213,21 @@ def _create_field_operator(
         )
         output_edge = output_tree[0]
         return _create_field_operator_impl(
-            sdfg_builder, sdfg, state, domain, output_edge, node_type, map_exit
+            ctx, sdfg_builder, domain, output_edge, node_type, map_exit
         )
     else:
         # handle tuples of fields
         output_symbol_tree = gtir_to_sdfg_utils.make_symbol_tree("x", node_type)
         return gtx_utils.tree_map(
             lambda output_edge, output_sym: _create_field_operator_impl(
-                sdfg_builder, sdfg, state, domain, output_edge, output_sym.type, map_exit
+                ctx, sdfg_builder, domain, output_edge, output_sym.type, map_exit
             )
         )(output_tree, output_symbol_tree)
 
 
 def translate_as_fieldop(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """
@@ -258,7 +252,7 @@ def translate_as_fieldop(
     fieldop_expr, domain_expr = fun_node.args
 
     if cpm.is_call_to(fieldop_expr, "scan"):
-        return translate_scan(node, sdfg, state, sdfg_builder)
+        return translate_scan(node, ctx, sdfg_builder)
 
     if cpm.is_ref_to(fieldop_expr, "deref"):
         # Special usage of 'deref' as argument to fieldop expression, to pass a scalar
@@ -280,21 +274,18 @@ def translate_as_fieldop(
     domain = gtir_domain.extract_domain(domain_expr)
 
     # visit the list of arguments to be passed to the lambda expression
-    fieldop_args = [_parse_fieldop_arg(arg, sdfg, state, sdfg_builder, domain) for arg in node.args]
+    fieldop_args = [_parse_fieldop_arg(arg, ctx, sdfg_builder, domain) for arg in node.args]
 
     # represent the field operator as a mapped tasklet graph, which will range over the field domain
     input_edges, output_edges = gtir_dataflow.translate_lambda_to_dataflow(
-        sdfg, state, sdfg_builder, stencil_expr, fieldop_args
+        ctx.sdfg, ctx.state, sdfg_builder, stencil_expr, fieldop_args
     )
 
-    return _create_field_operator(
-        sdfg, state, domain, node.type, sdfg_builder, input_edges, output_edges
-    )
+    return _create_field_operator(ctx, domain, node.type, sdfg_builder, input_edges, output_edges)
 
 
 def _construct_if_branch_output(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
     domain: gtir.Expr,
     sym: gtir.Sym,
@@ -311,8 +302,8 @@ def _construct_if_branch_output(
     if isinstance(sym.type, ts.ScalarType):
         assert sym.type == out_type
         dtype = gtx_dace_utils.as_dace_type(sym.type)
-        out, _ = sdfg_builder.add_temp_scalar(sdfg, dtype)
-        out_node = state.add_access(out)
+        out, _ = sdfg_builder.add_temp_scalar(ctx.sdfg, dtype)
+        out_node = ctx.state.add_access(out)
         return gtir_to_sdfg_types.FieldopData(out_node, sym.type, origin=())
 
     assert isinstance(out_type, ts.FieldType)
@@ -333,15 +324,14 @@ def _construct_if_branch_output(
         assert isinstance(offset_provider_type, gtx_common.NeighborConnectivityType)
         shape = [*shape, offset_provider_type.max_neighbors]
 
-    out, _ = sdfg_builder.add_temp_array(sdfg, shape, dtype)
-    out_node = state.add_access(out)
+    out, _ = sdfg_builder.add_temp_array(ctx.sdfg, shape, dtype)
+    out_node = ctx.state.add_access(out)
 
     return gtir_to_sdfg_types.FieldopData(out_node, out_type, tuple(origin))
 
 
 def _write_if_branch_output(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     src: gtir_to_sdfg_types.FieldopData,
     dst: gtir_to_sdfg_types.FieldopData,
 ) -> None:
@@ -354,11 +344,11 @@ def _write_if_branch_output(
         raise ValueError(
             f"Source and destination type mismatch, '{dst.gt_type}' vs '{src.gt_type}'."
         )
-    dst_node = state.add_access(dst.dc_node.data)
-    dst_shape = dst_node.desc(sdfg).shape
+    dst_node = ctx.state.add_access(dst.dc_node.data)
+    dst_shape = dst_node.desc(ctx.sdfg).shape
 
     if isinstance(src.gt_type, ts.ScalarType):
-        state.add_nedge(
+        ctx.state.add_nedge(
             src.dc_node,
             dst_node,
             dace.Memlet(data=src.dc_node.data, subset="0"),
@@ -380,21 +370,20 @@ def _write_if_branch_output(
             for src_start, dst_start, size in zip(src_origin, dst_origin, dst_shape, strict=True)
         )
 
-        state.add_nedge(
+        ctx.state.add_nedge(
             src.dc_node,
             dst_node,
             dace.Memlet(
                 data=src.dc_node.data,
                 subset=data_subset,
-                other_subset=dace_subsets.Range.from_array(dst_node.desc(sdfg)),
+                other_subset=dace_subsets.Range.from_array(dst_node.desc(ctx.sdfg)),
             ),
         )
 
 
 def translate_if(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """Generates the dataflow subgraph for the `if_` builtin function."""
@@ -420,29 +409,23 @@ def translate_if(
     #           ==> |   head   | <==
     #               ------------
     #
-    cond_state = sdfg.add_state_before(state, state.label + "_cond")
-    sdfg.remove_edge(sdfg.out_edges(cond_state)[0])
+    cond_state = ctx.sdfg.add_state_before(ctx.state, ctx.state.label + "_cond")
+    ctx.sdfg.remove_edge(ctx.sdfg.out_edges(cond_state)[0])
 
     # expect true branch as second argument
-    true_state = sdfg.add_state(state.label + "_true_branch")
-    sdfg.add_edge(cond_state, true_state, dace.InterstateEdge(condition=if_stmt))
-    sdfg.add_edge(true_state, state, dace.InterstateEdge())
+    true_state = ctx.sdfg.add_state(ctx.state.label + "_true_branch")
+    tbranch_ctx = gtir_to_sdfg.SubgraphContext(ctx.sdfg, true_state)
+    ctx.sdfg.add_edge(cond_state, true_state, dace.InterstateEdge(condition=if_stmt))
+    ctx.sdfg.add_edge(true_state, ctx.state, dace.InterstateEdge())
 
     # and false branch as third argument
-    false_state = sdfg.add_state(state.label + "_false_branch")
-    sdfg.add_edge(cond_state, false_state, dace.InterstateEdge(condition=f"not({if_stmt})"))
-    sdfg.add_edge(false_state, state, dace.InterstateEdge())
+    false_state = ctx.sdfg.add_state(ctx.state.label + "_false_branch")
+    fbranch_ctx = gtir_to_sdfg.SubgraphContext(ctx.sdfg, false_state)
+    ctx.sdfg.add_edge(cond_state, false_state, dace.InterstateEdge(condition=f"not({if_stmt})"))
+    ctx.sdfg.add_edge(false_state, ctx.state, dace.InterstateEdge())
 
-    true_br_result = sdfg_builder.visit(
-        true_expr,
-        sdfg=sdfg,
-        head_state=true_state,
-    )
-    false_br_result = sdfg_builder.visit(
-        false_expr,
-        sdfg=sdfg,
-        head_state=false_state,
-    )
+    true_br_result = sdfg_builder.visit(true_expr, ctx=tbranch_ctx)
+    false_br_result = sdfg_builder.visit(false_expr, ctx=fbranch_ctx)
 
     if isinstance(node.type, ts.TupleType):
         symbol_tree = gtir_to_sdfg_utils.make_symbol_tree("x", node.type)
@@ -457,11 +440,9 @@ def translate_if(
             domain,
             true_br,
             false_br,
-            sdfg=sdfg,
-            state=state,
+            _ctx=ctx,
             sdfg_builder=sdfg_builder: _construct_if_branch_output(
-                sdfg,
-                state,
+                _ctx,
                 sdfg_builder,
                 domain,
                 sym,
@@ -475,31 +456,29 @@ def translate_if(
             false_br_result,
         )
         gtx_utils.tree_map(
-            lambda src, dst, state=true_state: _write_if_branch_output(sdfg, state, src, dst)
+            lambda src, dst, _ctx=tbranch_ctx: _write_if_branch_output(_ctx, src, dst)
         )(true_br_result, node_output)
         gtx_utils.tree_map(
-            lambda src, dst, state=false_state: _write_if_branch_output(sdfg, state, src, dst)
+            lambda src, dst, _ctx=fbranch_ctx: _write_if_branch_output(_ctx, src, dst)
         )(false_br_result, node_output)
     else:
         node_output = _construct_if_branch_output(
-            sdfg,
-            state,
+            ctx,
             sdfg_builder,
             node.annex.domain,
             im.sym("x", node.type),
             true_br_result,
             false_br_result,
         )
-        _write_if_branch_output(sdfg, true_state, true_br_result, node_output)
-        _write_if_branch_output(sdfg, false_state, false_br_result, node_output)
+        _write_if_branch_output(tbranch_ctx, true_br_result, node_output)
+        _write_if_branch_output(fbranch_ctx, false_br_result, node_output)
 
     return node_output
 
 
 def translate_index(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """
@@ -515,20 +494,20 @@ def translate_index(
     assert len(domain) == 1
     dim_index = gtir_to_sdfg_utils.get_map_variable(domain[0].dim)
 
-    index_data, _ = sdfg_builder.add_temp_scalar(sdfg, gtir_to_sdfg_types.INDEX_DTYPE)
-    index_node = state.add_access(index_data)
+    index_data, _ = sdfg_builder.add_temp_scalar(ctx.sdfg, gtir_to_sdfg_types.INDEX_DTYPE)
+    index_node = ctx.state.add_access(index_data)
     index_value = gtir_dataflow.ValueExpr(
         dc_node=index_node,
         gt_dtype=gtx_dace_utils.as_itir_type(gtir_to_sdfg_types.INDEX_DTYPE),
     )
     index_write_tasklet = sdfg_builder.add_tasklet(
         "index",
-        state,
+        ctx.state,
         inputs={},
         outputs={"__val"},
         code=f"__val = {dim_index}",
     )
-    state.add_edge(
+    ctx.state.add_edge(
         index_write_tasklet,
         "__val",
         index_node,
@@ -537,12 +516,10 @@ def translate_index(
     )
 
     input_edges = [
-        gtir_dataflow.EmptyInputEdge(state, index_write_tasklet),
+        gtir_dataflow.EmptyInputEdge(ctx.state, index_write_tasklet),
     ]
-    output_edge = gtir_dataflow.DataflowOutputEdge(state, index_value)
-    return _create_field_operator(
-        sdfg, state, domain, node.type, sdfg_builder, input_edges, (output_edge,)
-    )
+    output_edge = gtir_dataflow.DataflowOutputEdge(ctx.state, index_value)
+    return _create_field_operator(ctx, domain, node.type, sdfg_builder, input_edges, (output_edge,))
 
 
 def _get_data_nodes(
@@ -609,40 +586,30 @@ def _get_symbolic_value(
 
 def translate_literal(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """Generates the dataflow subgraph for a `ir.Literal` node."""
     assert isinstance(node, gtir.Literal)
 
     data_type = node.type
-    data_node = _get_symbolic_value(sdfg, state, sdfg_builder, node.value, data_type)
+    data_node = _get_symbolic_value(ctx.sdfg, ctx.state, sdfg_builder, node.value, data_type)
 
     return gtir_to_sdfg_types.FieldopData(data_node, data_type, origin=())
 
 
 def translate_make_tuple(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     assert cpm.is_call_to(node, "make_tuple")
-    return tuple(
-        sdfg_builder.visit(
-            arg,
-            sdfg=sdfg,
-            head_state=state,
-        )
-        for arg in node.args
-    )
+    return tuple(sdfg_builder.visit(arg, ctx=ctx) for arg in node.args)
 
 
 def translate_tuple_get(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     assert cpm.is_call_to(node, "tuple_get")
@@ -653,26 +620,21 @@ def translate_tuple_get(
     assert ti.is_integral(node.args[0].type)
     index = int(node.args[0].value)
 
-    data_nodes = sdfg_builder.visit(
-        node.args[1],
-        sdfg=sdfg,
-        head_state=state,
-    )
+    data_nodes = sdfg_builder.visit(node.args[1], ctx=ctx)
     if isinstance(data_nodes, gtir_to_sdfg_types.FieldopData):
         raise ValueError(f"Invalid tuple expression {node}")
     unused_arg_nodes: Iterable[gtir_to_sdfg_types.FieldopData] = gtx_utils.flatten_nested_tuple(
         tuple(arg for i, arg in enumerate(data_nodes) if i != index)
     )
-    state.remove_nodes_from(
-        [arg.dc_node for arg in unused_arg_nodes if state.degree(arg.dc_node) == 0]
+    ctx.state.remove_nodes_from(
+        [arg.dc_node for arg in unused_arg_nodes if ctx.state.degree(arg.dc_node) == 0]
     )
     return data_nodes[index]
 
 
 def translate_scalar_expr(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     assert isinstance(node, gtir.FunCall)
@@ -696,11 +658,7 @@ def translate_scalar_expr(
         if visit_expr:
             # we visit the argument expression and obtain the access node to
             # a scalar data container, which will be connected to the tasklet
-            arg = sdfg_builder.visit(
-                arg_expr,
-                sdfg=sdfg,
-                head_state=state,
-            )
+            arg = sdfg_builder.visit(arg_expr, ctx=ctx)
             if not (
                 isinstance(arg, gtir_to_sdfg_types.FieldopData)
                 and isinstance(node.type, ts.ScalarType)
@@ -719,14 +677,14 @@ def translate_scalar_expr(
     python_code = gtir_python_codegen.get_source(scalar_node)
     tasklet_node = sdfg_builder.add_tasklet(
         name="scalar_expr",
-        state=state,
+        state=ctx.state,
         inputs=set(connectors),
         outputs={"__out"},
         code=f"__out = {python_code}",
     )
     # create edges for the input data connectors
     for arg_node, conn in zip(args, connectors, strict=True):
-        state.add_edge(
+        ctx.state.add_edge(
             arg_node,
             None,
             tasklet_node,
@@ -734,9 +692,9 @@ def translate_scalar_expr(
             dace.Memlet(data=arg_node.data, subset="0"),
         )
     # finally, create temporary for the result value
-    temp_name, _ = sdfg_builder.add_temp_scalar(sdfg, gtx_dace_utils.as_dace_type(node.type))
-    temp_node = state.add_access(temp_name)
-    state.add_edge(
+    temp_name, _ = sdfg_builder.add_temp_scalar(ctx.sdfg, gtx_dace_utils.as_dace_type(node.type))
+    temp_node = ctx.state.add_access(temp_name)
+    ctx.state.add_edge(
         tasklet_node,
         "__out",
         temp_node,
@@ -749,8 +707,7 @@ def translate_scalar_expr(
 
 def translate_symbol_ref(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """Generates the dataflow subgraph for a `ir.SymRef` node."""
@@ -763,7 +720,7 @@ def translate_symbol_ref(
     # Create new access node in current state. It is possible that multiple
     # access nodes are created in one state for the same data container.
     # We rely on the dace simplify pass to remove duplicated access nodes.
-    return _get_data_nodes(sdfg, state, sdfg_builder, symbol_name, gt_symbol_type)
+    return _get_data_nodes(ctx.sdfg, ctx.state, sdfg_builder, symbol_name, gt_symbol_type)
 
 
 if TYPE_CHECKING:

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
@@ -44,8 +44,7 @@ from gt4py.next.type_system import type_info as ti, type_specifications as ts
 
 def _parse_scan_fieldop_arg(
     node: gtir.Expr,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
     domain: gtir_domain.FieldopDomain,
 ) -> gtir_dataflow.MemletExpr | tuple[gtir_dataflow.MemletExpr | tuple[Any, ...], ...]:
@@ -61,16 +60,16 @@ def _parse_scan_fieldop_arg(
     def _parse_fieldop_arg_impl(
         arg: gtir_to_sdfg_types.FieldopData,
     ) -> gtir_dataflow.MemletExpr:
-        arg_expr = arg.get_local_view(domain, sdfg)
+        arg_expr = arg.get_local_view(domain, ctx.sdfg)
         if isinstance(arg_expr, gtir_dataflow.MemletExpr):
             return arg_expr
         # In scan field operator, the arguments to the vertical stencil are passed by value.
         # Therefore, the full field shape is passed as `MemletExpr` rather than `IteratorExpr`.
         return gtir_dataflow.MemletExpr(
-            arg_expr.field, arg_expr.gt_dtype, arg_expr.get_memlet_subset(sdfg)
+            arg_expr.field, arg_expr.gt_dtype, arg_expr.get_memlet_subset(ctx.sdfg)
         )
 
-    arg = sdfg_builder.visit(node, sdfg=sdfg, head_state=state)
+    arg = sdfg_builder.visit(node, ctx=ctx)
 
     if isinstance(arg, gtir_to_sdfg_types.FieldopData):
         return _parse_fieldop_arg_impl(arg)
@@ -80,9 +79,8 @@ def _parse_scan_fieldop_arg(
 
 
 def _create_scan_field_operator_impl(
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
     domain: gtir_domain.FieldopDomain,
     output_edge: gtir_dataflow.DataflowOutputEdge,
     output_type: ts.FieldType,
@@ -103,7 +101,7 @@ def _create_scan_field_operator_impl(
     Refer to `gtir_to_sdfg_primitives._create_field_operator_impl()` for
     the description of function arguments and return values.
     """
-    dataflow_output_desc = output_edge.result.dc_node.desc(sdfg)
+    dataflow_output_desc = output_edge.result.dc_node.desc(ctx.sdfg)
     assert isinstance(dataflow_output_desc, dace.data.Array)
 
     # the memory layout of the output field follows the field operator compute domain
@@ -151,7 +149,7 @@ def _create_scan_field_operator_impl(
 
     # allocate local temporary storage
     field_name, field_desc = sdfg_builder.add_temp_array(
-        sdfg, field_shape, dataflow_output_desc.dtype
+        ctx.sdfg, field_shape, dataflow_output_desc.dtype
     )
     # the inner and outer strides have to match
     scan_output_stride = field_desc.strides[scan_dim_index]
@@ -162,7 +160,7 @@ def _create_scan_field_operator_impl(
     dataflow_output_desc.set_shape(dataflow_output_desc.shape, new_inner_strides)
 
     # and here the edge writing the dataflow result data through the map exit node
-    field_node = state.add_access(field_name)
+    field_node = ctx.state.add_access(field_name)
     output_edge.connect(map_exit, field_node, field_subset)
 
     return gtir_to_sdfg_types.FieldopData(
@@ -171,8 +169,7 @@ def _create_scan_field_operator_impl(
 
 
 def _create_scan_field_operator(
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     domain: gtir_domain.FieldopDomain,
     node_type: ts.FieldType | ts.TupleType,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
@@ -208,7 +205,7 @@ def _create_scan_field_operator(
         # create map range corresponding to the field operator domain
         map_entry, map_exit = sdfg_builder.add_map(
             "fieldop",
-            state,
+            ctx.state,
             ndrange={
                 gtir_to_sdfg_utils.get_map_variable(
                     domain_range.dim
@@ -225,7 +222,7 @@ def _create_scan_field_operator(
     if isinstance(node_type, ts.FieldType):
         assert isinstance(output_tree, gtir_dataflow.DataflowOutputEdge)
         return _create_scan_field_operator_impl(
-            sdfg_builder, sdfg, state, domain, output_tree, node_type, map_exit
+            ctx, sdfg_builder, domain, output_tree, node_type, map_exit
         )
     else:
         # handle tuples of fields
@@ -235,9 +232,8 @@ def _create_scan_field_operator(
         return gtx_utils.tree_map(
             lambda output_edge, output_sym: (
                 _create_scan_field_operator_impl(
+                    ctx,
                     sdfg_builder,
-                    sdfg,
-                    state,
                     domain,
                     output_edge,
                     output_sym.type,
@@ -264,14 +260,14 @@ def _scan_output_name(input_name: str) -> str:
 
 def _lower_lambda_to_nested_sdfg(
     lambda_node: gtir.Lambda,
-    sdfg: dace.SDFG,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
     domain: gtir_domain.FieldopDomain,
     init_data: gtir_to_sdfg_types.FieldopResult,
     lambda_symbols: dict[str, ts.DataType],
     scan_forward: bool,
     scan_carry_symbol: gtir.Sym,
-) -> tuple[dace.SDFG, gtir_to_sdfg_types.FieldopResult]:
+) -> tuple[gtir_to_sdfg.SubgraphContext, gtir_to_sdfg_types.FieldopResult]:
     """
     Helper method to lower the lambda node representing the scan stencil dataflow
     inside a separate SDFG.
@@ -288,7 +284,7 @@ def _lower_lambda_to_nested_sdfg(
 
     Args:
         lambda_node: The lambda representing the stencil expression on the horizontal level.
-        sdfg: The SDFG where the scan field operator is translated.
+        ctx: The SDFG context where the scan field operator is translated.
         sdfg_builder: The SDFG builder object to access the field operator context.
         domain: The field operator domain, with all horizontal and vertical dimensions.
         init_data: The data produced in the field operator context that is used
@@ -301,7 +297,7 @@ def _lower_lambda_to_nested_sdfg(
 
     Returns:
         A tuple of two elements:
-          - An SDFG containing the `LoopRegion` computation along the vertical
+          - The subgraph context containing the `LoopRegion` along the vertical
             dimension, to be instantied as a nested SDFG in the field operator context.
           - The inner fields, that is 1d arrays with vertical shape containing
             the output of the stencil computation. These fields will have to be
@@ -309,13 +305,6 @@ def _lower_lambda_to_nested_sdfg(
             that inner and outer arrays use the same strides.
     """
 
-    # the lambda expression, i.e. body of the scan, will be created inside a nested SDFG.
-    nsdfg = dace.SDFG(sdfg_builder.unique_nsdfg_name(sdfg, "scan"))
-    nsdfg.debuginfo = gtir_to_sdfg_utils.debug_info(lambda_node, default=sdfg.debuginfo)
-    # We set `using_explicit_control_flow=True` because the vertical scan is lowered to a `LoopRegion`.
-    # This property is used by pattern matching in SDFG transformation framework
-    # to skip those transformations that do not yet support control flow blocks.
-    nsdfg.using_explicit_control_flow = True
     # We pass an empty set as symbolic arguments, which implies that all scalar
     # inputs of the scan nested SDFG will be represented as scalar data containers.
     # The reason why we do not check for dace symbolic expressions and do not map
@@ -326,9 +315,15 @@ def _lower_lambda_to_nested_sdfg(
             lambda node: cpm.is_call_to(node, ("cartesian_domain", "unstructured_domain"))
         )
     )
-    lambda_translator = sdfg_builder.setup_nested_context(
-        lambda_node, nsdfg, sdfg, lambda_symbols, symbolic_inputs=set()
+    # the lambda expression, i.e. body of the scan, will be created inside a nested SDFG.
+    lambda_translator, lambda_ctx = sdfg_builder.setup_nested_context(
+        lambda_node, "scan", ctx, lambda_symbols, symbolic_inputs=set()
     )
+
+    # We set `using_explicit_control_flow=True` because the vertical scan is lowered to a `LoopRegion`.
+    # This property is used by pattern matching in SDFG transformation framework
+    # to skip those transformations that do not yet support control flow blocks.
+    lambda_ctx.sdfg.using_explicit_control_flow = True
 
     # use the vertical dimension in the domain as scan dimension
     scan_domain = next(
@@ -360,7 +355,7 @@ def _lower_lambda_to_nested_sdfg(
 
     # Create the body of the initialization state
     # This dataflow will write the initial value of the scan carry variable.
-    init_state = nsdfg.add_state("scan_init", is_start_block=True)
+    init_state = lambda_ctx.state
     scan_carry_input = (
         gtir_to_sdfg_utils.make_symbol_tree(scan_carry_symbol.id, scan_carry_symbol.type)
         if isinstance(scan_carry_symbol.type, ts.TupleType)
@@ -369,15 +364,15 @@ def _lower_lambda_to_nested_sdfg(
 
     def init_scan_carry(sym: gtir.Sym) -> None:
         scan_carry_dataname = str(sym.id)
-        scan_carry_desc = nsdfg.data(scan_carry_dataname)
+        scan_carry_desc = lambda_ctx.sdfg.data(scan_carry_dataname)
         input_scan_carry_dataname = _scan_input_name(scan_carry_dataname)
         input_scan_carry_desc = scan_carry_desc.clone()
-        nsdfg.add_datadesc(input_scan_carry_dataname, input_scan_carry_desc)
+        lambda_ctx.sdfg.add_datadesc(input_scan_carry_dataname, input_scan_carry_desc)
         scan_carry_desc.transient = True
         init_state.add_nedge(
             init_state.add_access(input_scan_carry_dataname),
             init_state.add_access(scan_carry_dataname),
-            nsdfg.make_array_memlet(input_scan_carry_dataname),
+            lambda_ctx.sdfg.make_array_memlet(input_scan_carry_dataname),
         )
 
     if isinstance(scan_carry_input, tuple):
@@ -404,25 +399,26 @@ def _lower_lambda_to_nested_sdfg(
             update_expr=f"{scan_loop_var} = {scan_loop_var} - 1",
             inverted=False,
         )
-    nsdfg.add_node(scan_loop)
-    nsdfg.add_edge(init_state, scan_loop, dace.InterstateEdge())
+    lambda_ctx.sdfg.add_node(scan_loop)
+    lambda_ctx.sdfg.add_edge(init_state, scan_loop, dace.InterstateEdge())
 
     # Inside the loop region, create a 'compute' and an 'update' state.
     # The body of the 'compute' state implements the stencil expression for one vertical level.
     # The 'update' state writes the value computed by the stencil into the scan carry variable,
     # in order to make it available to the next vertical level.
     compute_state = scan_loop.add_state("scan_compute")
+    compute_ctx = gtir_to_sdfg.SubgraphContext(lambda_ctx.sdfg, compute_state)
     update_state = scan_loop.add_state_after(compute_state, "scan_update")
 
     # inside the 'compute' state, visit the list of arguments to be passed to the stencil
     stencil_args = [
-        _parse_scan_fieldop_arg(im.ref(p.id), nsdfg, compute_state, lambda_translator, domain)
+        _parse_scan_fieldop_arg(im.ref(p.id), compute_ctx, lambda_translator, domain)
         for p in lambda_node.params
     ]
     # stil inside the 'compute' state, generate the dataflow representing the stencil
     # to be applied on the horizontal domain
     lambda_input_edges, lambda_result = gtir_dataflow.translate_lambda_to_dataflow(
-        nsdfg, compute_state, lambda_translator, lambda_node, stencil_args
+        compute_ctx.sdfg, compute_ctx.state, lambda_translator, lambda_node, stencil_args
     )
     # connect the dataflow input directly to the source data nodes, without passing through a map node;
     # the reason is that the map for horizontal domain is outside the scan loop region
@@ -451,12 +447,12 @@ def _lower_lambda_to_nested_sdfg(
                 f"{output_column_index}, 0:{scan_output_shape[1]}"
             )
         scan_result_data = scan_result.dc_node.data
-        scan_result_desc = scan_result.dc_node.desc(nsdfg)
+        scan_result_desc = scan_result.dc_node.desc(lambda_ctx.sdfg)
 
         # `sym` represents the global output data, that is the nested-SDFG output connector
         scan_carry_data = str(scan_carry_sym.id)
         output = _scan_output_name(scan_carry_data)
-        nsdfg.add_array(output, scan_output_shape, scan_result_desc.dtype)
+        lambda_ctx.sdfg.add_array(output, scan_output_shape, scan_result_desc.dtype)
         output_node = compute_state.add_access(output)
 
         # in the 'compute' state, we write the current vertical level data to the output field
@@ -491,23 +487,23 @@ def _lower_lambda_to_nested_sdfg(
     # in case tuples are passed as argument, isolated access nodes might be left in the state,
     # because not all tuple fields are necessarily accessed inside the lambda scope
     for data_node in compute_state.data_nodes():
-        data_desc = data_node.desc(nsdfg)
         if compute_state.degree(data_node) == 0:
             # By construction there should never be isolated transient nodes.
             # Therefore, the assert below implements a sanity check, that allows
             # the exceptional case (encountered in one GT4Py test) where the carry
             # variable is not used, so not a scan indeed because no data dependency.
-            assert (not data_desc.transient) or data_node.data.startswith(scan_carry_symbol.id)
+            assert (not data_node.desc(lambda_ctx.sdfg).transient) or data_node.data.startswith(
+                scan_carry_symbol.id
+            )
             compute_state.remove_node(data_node)
 
-    return nsdfg, lambda_output
+    return lambda_ctx, lambda_output
 
 
 def _connect_nested_sdfg_output_to_temporaries(
-    sdfg: dace.SDFG,
-    nsdfg: dace.SDFG,
+    inner_ctx: gtir_to_sdfg.SubgraphContext,
+    outer_ctx: gtir_to_sdfg.SubgraphContext,
     nsdfg_node: dace.nodes.NestedSDFG,
-    outer_state: dace.SDFGState,
     inner_data: gtir_to_sdfg_types.FieldopData,
 ) -> gtir_dataflow.DataflowOutputEdge:
     """
@@ -515,10 +511,9 @@ def _connect_nested_sdfg_output_to_temporaries(
     to temporary arrays in the parent SDFG, denoted as outer context.
 
     Args:
-        sdfg: The SDFG representing the outer context, where the field operator is translated.
-        nsdfg: The SDFG where the scan `LoopRegion` is translated.
+        inner_ctx: The inner SDFG context, where the scan `LoopRegion` is translated.
+        outer_ctx: The outer SDFG context, where the field operator is translated.
         nsdfg_node: The nested SDFG node in the outer context.
-        outer_state: The state in outer context where the field operator is translated.
         inner_data: The data produced by the scan `LoopRegion` in the inner context.
 
     Returns:
@@ -526,10 +521,10 @@ def _connect_nested_sdfg_output_to_temporaries(
     """
     assert isinstance(inner_data.gt_type, ts.FieldType)
     inner_dataname = inner_data.dc_node.data
-    inner_desc = nsdfg.data(inner_dataname)
-    outer_dataname, outer_desc = sdfg.add_temp_transient_like(inner_desc)
-    outer_node = outer_state.add_access(outer_dataname)
-    outer_state.add_edge(
+    inner_desc = inner_ctx.sdfg.data(inner_dataname)
+    outer_dataname, outer_desc = outer_ctx.sdfg.add_temp_transient_like(inner_desc)
+    outer_node = outer_ctx.state.add_access(outer_dataname)
+    outer_ctx.state.add_edge(
         nsdfg_node,
         inner_dataname,
         outer_node,
@@ -537,13 +532,12 @@ def _connect_nested_sdfg_output_to_temporaries(
         dace.Memlet.from_array(outer_dataname, outer_desc),
     )
     output_expr = gtir_dataflow.ValueExpr(outer_node, inner_data.gt_type.dtype)
-    return gtir_dataflow.DataflowOutputEdge(outer_state, output_expr)
+    return gtir_dataflow.DataflowOutputEdge(outer_ctx.state, output_expr)
 
 
 def translate_scan(
     node: gtir.Node,
-    sdfg: dace.SDFG,
-    state: dace.SDFGState,
+    ctx: gtir_to_sdfg.SubgraphContext,
     sdfg_builder: gtir_to_sdfg.SDFGBuilder,
 ) -> gtir_to_sdfg_types.FieldopResult:
     """
@@ -585,7 +579,7 @@ def translate_scan(
     # params[2]: the expression that computes the value for scan initialization
     init_expr = scan_expr.args[2]
     # visit the initialization value of the scan expression
-    init_data = sdfg_builder.visit(init_expr, sdfg=sdfg, head_state=state)
+    init_data = sdfg_builder.visit(init_expr, ctx=ctx)
     # extract type definition of the scan carry
     scan_carry_type = (
         init_data.gt_type
@@ -604,9 +598,9 @@ def translate_scan(
     }
 
     # lower the scan stencil expression in a separate SDFG context
-    nsdfg, lambda_output = _lower_lambda_to_nested_sdfg(
+    lambda_ctx, lambda_output = _lower_lambda_to_nested_sdfg(
         stencil_expr,
-        sdfg,
+        ctx,
         sdfg_builder,
         domain,
         init_data,
@@ -618,7 +612,7 @@ def translate_scan(
     # visit the arguments to be passed to the lambda expression
     # this must be executed before visiting the lambda expression, in order to populate
     # the data descriptor with the correct field domain offsets for field arguments
-    lambda_args = [sdfg_builder.visit(arg, sdfg=sdfg, head_state=state) for arg in node.args]
+    lambda_args = [sdfg_builder.visit(arg, ctx=ctx) for arg in node.args]
     lambda_args_mapping = [
         (im.sym(_scan_input_name(scan_carry), scan_carry_type), init_data),
     ] + [
@@ -644,15 +638,15 @@ def translate_scan(
         lambda_flat_outs = {_scan_output_name(scan_carry): scan_carry_type}
 
     # build the mapping of symbols from nested SDFG to field operator context
-    nsdfg_symbols_mapping = {str(sym): sym for sym in nsdfg.free_symbols}
+    nsdfg_symbols_mapping = {str(sym): sym for sym in lambda_ctx.sdfg.free_symbols}
     for psym, arg in lambda_args_mapping:
-        nsdfg_symbols_mapping |= gtir_to_sdfg_utils.get_arg_symbol_mapping(psym.id, arg, sdfg)
+        nsdfg_symbols_mapping |= gtir_to_sdfg_utils.get_arg_symbol_mapping(psym.id, arg, ctx.sdfg)
 
     # the scan nested SDFG is ready: it is instantiated in the field operator context
     # where the map scope over the horizontal domain lives
-    nsdfg_node = state.add_nested_sdfg(
-        nsdfg,
-        sdfg,
+    nsdfg_node = ctx.state.add_nested_sdfg(
+        lambda_ctx.sdfg,
+        ctx.sdfg,
         inputs=set(lambda_arg_nodes.keys()),
         outputs=set(lambda_flat_outs.keys()),
         symbol_mapping=nsdfg_symbols_mapping,
@@ -660,10 +654,10 @@ def translate_scan(
 
     lambda_input_edges = []
     for input_connector, outer_arg in lambda_arg_nodes.items():
-        arg_desc = outer_arg.dc_node.desc(sdfg)
+        arg_desc = outer_arg.dc_node.desc(ctx.sdfg)
         input_subset = dace_subsets.Range.from_array(arg_desc)
         input_edge = gtir_dataflow.MemletInputEdge(
-            state, outer_arg.dc_node, input_subset, nsdfg_node, input_connector
+            ctx.state, outer_arg.dc_node, input_subset, nsdfg_node, input_connector
         )
         lambda_input_edges.append(input_edge)
 
@@ -671,11 +665,11 @@ def translate_scan(
     # results of a column slice for each point in the horizontal domain
     lambda_output_tree = gtx_utils.tree_map(
         lambda lambda_output_data: _connect_nested_sdfg_output_to_temporaries(
-            sdfg, nsdfg, nsdfg_node, state, lambda_output_data
+            lambda_ctx, ctx, nsdfg_node, lambda_output_data
         )
     )(lambda_output)
 
     # we call a helper method to create a map scope that will compute the entire field
     return _create_scan_field_operator(
-        sdfg, state, domain, node.type, sdfg_builder, lambda_input_edges, lambda_output_tree
+        ctx, domain, node.type, sdfg_builder, lambda_input_edges, lambda_output_tree
     )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -30,27 +30,27 @@ def set_dace_config(
     #   is translating from `CompilableProgram` (ITIR.Program + CompileTimeArgs)
     #   to `ProgramSource`, so this step is storing in cache only the result
     #   of the SDFG transformations, not the compiled program binary.
-    dace.config.Config.set("cache", value="hash")  # use the SDFG hash as cache key
-    dace.config.Config.set("default_build_folder", value=str(config.BUILD_CACHE_DIR / "dace_cache"))
-    dace.config.Config.set("compiler.use_cache", value=True)
+    dace.Config.set("cache", value="hash")  # use the SDFG hash as cache key
+    dace.Config.set("default_build_folder", value=str(config.BUILD_CACHE_DIR / "dace_cache"))
+    dace.Config.set("compiler.use_cache", value=True)
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by
     #  `gt4py.next.program_processors.runners.dace.transfromations.gpu_utils.gt_gpu_transform_non_standard_memlet()`.
     dace.Config.set("compiler.cuda.allow_implicit_memlet_to_map", value=False)
 
     if cmake_build_type is not None:
-        dace.config.Config.set("compiler.build_type", value=cmake_build_type.value)
+        dace.Config.set("compiler.build_type", value=cmake_build_type.value)
 
     # dace dafault setting use fast-math in both cpu and gpu compilation, don't use it here
-    dace.config.Config.set(
+    dace.Config.set(
         "compiler.cpu.args",
         value="-std=c++14 -fPIC -O3 -march=native -Wall -Wextra -Wno-unused-parameter -Wno-unused-label",
     )
-    dace.config.Config.set(
+    dace.Config.set(
         "compiler.cuda.args",
         value="-Xcompiler -O3 -Xcompiler -march=native -Xcompiler -Wno-unused-parameter",
     )
-    dace.config.Config.set(
+    dace.Config.set(
         "compiler.cuda.hip_args",
         value="-std=c++17 -fPIC -O3 -march=native -Wno-unused-parameter",
     )
@@ -61,10 +61,10 @@ def set_dace_config(
     # However, when using asynchronous SDFG call (see `backend.make_dace_backend()`),
     #  we currently rely on this setting to ensure sequential execution of all kernels
     #  and memory operations on the default cuda stream.
-    dace.config.Config.set("compiler.cuda.max_concurrent_streams", value=1)
+    dace.Config.set("compiler.cuda.max_concurrent_streams", value=1)
 
     if device_type == core_defs.DeviceType.ROCM:
-        dace.config.Config.set("compiler.cuda.backend", value="hip")
+        dace.Config.set("compiler.cuda.backend", value="hip")
 
     # Instrumentation of SDFG timers
-    dace.config.Config.set("instrumentation", "report_each_invocation", value=True)
+    dace.Config.set("instrumentation", "report_each_invocation", value=True)


### PR DESCRIPTION
This PR is a code refactoring that introduces a `SubgraphContext` class to pass context information through the lowering of GTIR (it replaces sdfg and state).