### PR TITLE
feature[next]: field operator fusion argument deduplication

### DIFF
--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -37,10 +37,10 @@ from gt4py.next.type_system import type_info, type_specifications as ts
 
 
 def _merge_arguments(
-    args1: dict[str, itir.Expr], arg2: dict[str, itir.Expr]
+    args1: dict[str, itir.Expr], args2: dict[str, itir.Expr]
 ) -> dict[str, itir.Expr]:
     new_args = {**args1}
-    for stencil_param, stencil_arg in arg2.items():
+    for stencil_param, stencil_arg in args2.items():
         assert stencil_param not in new_args
         new_args[stencil_param] = stencil_arg
     return new_args

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import collections
 import dataclasses
 import enum
 import functools
@@ -40,10 +41,8 @@ def _merge_arguments(
 ) -> dict[str, itir.Expr]:
     new_args = {**args1}
     for stencil_param, stencil_arg in arg2.items():
-        if stencil_param not in new_args:
-            new_args[stencil_param] = stencil_arg
-        else:
-            assert new_args[stencil_param] == stencil_arg
+        assert stencil_param not in new_args
+        new_args[stencil_param] = stencil_arg
     return new_args
 
 
@@ -69,15 +68,7 @@ def _inline_as_fieldop_arg(
     stencil_body: itir.Expr = stencil.expr
 
     for inner_param, inner_arg in zip(stencil.params, inner_args, strict=True):
-        if isinstance(inner_arg, itir.SymRef):
-            if inner_arg.id in extracted_args:
-                assert extracted_args[inner_arg.id] == inner_arg
-                alias = stencil_params[list(extracted_args.keys()).index(inner_arg.id)]
-                stencil_body = im.let(inner_param, im.ref(alias.id))(stencil_body)
-            else:
-                stencil_params.append(inner_param)
-            extracted_args[inner_arg.id] = inner_arg
-        elif isinstance(inner_arg, itir.Literal):
+        if isinstance(inner_arg, itir.Literal):
             # note: only literals, not all scalar expressions are required as it doesn't make sense
             # for them to be computed per grid point.
             stencil_body = im.let(inner_param, im.promote_to_const_iterator(inner_arg))(
@@ -93,6 +84,41 @@ def _inline_as_fieldop_arg(
     return im.lift(im.lambda_(*stencil_params)(stencil_body))(
         *extracted_args.keys()
     ), extracted_args
+
+
+def _deduplicate_args(
+    args: dict[str, itir.Expr], stencil_body: itir.Expr
+) -> tuple[dict[str, itir.Expr], itir.Expr]:
+    new_args_inverted: dict[itir.Expr, list[str]] = collections.defaultdict(list)
+    for name, arg in args.items():
+        new_args_inverted[arg].append(name)
+
+    new_args: dict[str, itir.Expr] = {}
+    new_stencil_body = stencil_body
+    for arg, names in new_args_inverted.items():
+        # put internal names at the end
+        names = sorted(names, key=lambda s: (s.startswith("_"), s))
+        new_args[names[0]] = arg
+        if len(names) > 1:
+            new_stencil_body = im.let(*((name, names[0]) for name in names[1:]))(new_stencil_body)
+
+    return new_args, new_stencil_body
+
+
+def _prettify_args(
+    args: dict[str, itir.Expr], stencil_body: itir.Expr
+) -> tuple[dict[str, itir.Expr], itir.Expr]:
+    new_args: dict[str, itir.Expr] = {}
+    remap_table: dict[str, str] = {}
+    for name, arg in args.items():
+        if isinstance(arg, itir.SymRef):
+            assert arg.id not in new_args  # ensured by deduplication
+            new_args[arg.id] = arg
+            remap_table[name] = arg.id
+        else:
+            new_args[name] = arg
+
+    return new_args, im.let(*remap_table.items())(stencil_body)
 
 
 def fuse_as_fieldop(
@@ -135,15 +161,10 @@ def fuse_as_fieldop(
                 assert isinstance(arg.type, ts.TypeSpec)
                 dtype = type_info.apply_to_primitive_constituents(type_info.extract_dtype, arg.type)
                 assert not isinstance(dtype, ts.ListType)
-            new_param: str
-            if isinstance(
-                arg, itir.SymRef
-            ):  # use name from outer scope (optional, just to get a nice IR)
-                new_param = arg.id
-                new_stencil_body = im.let(stencil_param.id, arg.id)(new_stencil_body)
-            else:
-                new_param = stencil_param.id
-            new_args = _merge_arguments(new_args, {new_param: arg})
+            new_args = _merge_arguments(new_args, {stencil_param.id: arg})
+
+    new_args, new_stencil_body = _deduplicate_args(new_args, new_stencil_body)
+    new_args, new_stencil_body = _prettify_args(new_args, new_stencil_body)
 
     stencil = im.lambda_(*new_args.keys())(new_stencil_body)
     new_stencil = restore_scan(stencil)

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -95,10 +95,10 @@ def _deduplicate_as_fieldop_args(
     new_stencil_body = stencil_body
     for arg, names in new_args_inverted.items():
         # put internal names at the end
-        names = sorted(names, key=lambda s: (s.startswith("_"), s))
-        new_args[names[0]] = arg
-        if len(names) > 1:
-            new_stencil_body = im.let(*((name, names[0]) for name in names[1:]))(new_stencil_body)
+        new_name, *aliases = sorted(names, key=lambda s: (s.startswith("_"), s))
+        new_args[new_name] = arg
+        if aliases:
+            new_stencil_body = im.let(*((alias, new_name) for alias in aliases))(new_stencil_body)
 
     return new_args, new_stencil_body
 

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -84,7 +84,7 @@ def _inline_as_fieldop_arg(
     ), extracted_args
 
 
-def _deduplicate_args(
+def _deduplicate_as_fieldop_args(
     args: dict[str, itir.Expr], stencil_body: itir.Expr
 ) -> tuple[dict[str, itir.Expr], itir.Expr]:
     new_args_inverted: dict[itir.Expr, list[str]] = collections.defaultdict(list)
@@ -103,7 +103,7 @@ def _deduplicate_args(
     return new_args, new_stencil_body
 
 
-def _prettify_args(
+def _prettify_as_fieldop_args(
     args: dict[str, itir.Expr], stencil_body: itir.Expr
 ) -> tuple[dict[str, itir.Expr], itir.Expr]:
     new_args: dict[str, itir.Expr] = {}
@@ -161,8 +161,8 @@ def fuse_as_fieldop(
                 assert not isinstance(dtype, ts.ListType)
             new_args = _merge_arguments(new_args, {stencil_param.id: arg})
 
-    new_args, new_stencil_body = _deduplicate_args(new_args, new_stencil_body)
-    new_args, new_stencil_body = _prettify_args(new_args, new_stencil_body)
+    new_args, new_stencil_body = _deduplicate_as_fieldop_args(new_args, new_stencil_body)
+    new_args, new_stencil_body = _prettify_as_fieldop_args(new_args, new_stencil_body)
 
     stencil = im.lambda_(*new_args.keys())(new_stencil_body)
     new_stencil = restore_scan(stencil)

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -75,8 +75,6 @@ def _inline_as_fieldop_arg(
                 stencil_body
             )
         else:
-            # a scalar expression, a previously not inlined `as_fieldop` call or an opaque
-            # expression e.g. containing a tuple
             stencil_params.append(inner_param)
             new_outer_stencil_param = uids.sequential_id(prefix="__iasfop")
             extracted_args[new_outer_stencil_param] = inner_arg


### PR DESCRIPTION
When a field operator is fused into another field operator some arguments may occur multiple times like `inp` in this example
```
as_fieldop(plus_stencil)(as_fieldop("deref")(inp), inp)
```
In order to create a readable IR and to allow common subexpression elimination inside the stencil these arguments should be deduplicated such that the resulting field operators reads
```
as_fieldop(λ(it) → ·it + ·it)(inp)
```
instead of 
```
as_fieldop(λ(it1, it2) → ·it1 + ·it2)(inp, inp)
```
While this has already been the case when the argument is a `itir.SymRef` the mechanism was complex and error prune. This PR simplifies the mechanism and also allows non `itir.SymRef` expressions to be deduplicated, e.g. something like `index(IDim)`. This greatly improves the readability of large field operator with many `concat_where` expressions after fusion.