### PR TITLE
fix[next]: Improve dead-code-elimination to avoid domain inference failure 

### DIFF
--- a/src/gt4py/next/iterator/transforms/constant_folding.py
+++ b/src/gt4py/next/iterator/transforms/constant_folding.py
@@ -105,8 +105,12 @@ class ConstantFolding(
     enabled_transformations: Transformation = Transformation.all()  # noqa: RUF009 [function-call-in-dataclass-default-argument]
 
     @classmethod
-    def apply(cls, node: ir.Node) -> ir.Node:
-        node = cls().visit(node)
+    def apply(
+        cls, node: ir.Node, enabled_transformations: Optional[Transformation] = None
+    ) -> ir.Node:
+        enabled_transformations = enabled_transformations or cls.Transformation.all()
+
+        node = cls(enabled_transformations=enabled_transformations).visit(node)
         return UndoCanonicalizeMinus().visit(node)
 
     def transform_canonicalize_op_funcall_symref_literal(

--- a/src/gt4py/next/iterator/transforms/dead_code_elimination.py
+++ b/src/gt4py/next/iterator/transforms/dead_code_elimination.py
@@ -1,0 +1,48 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Optional
+
+from gt4py.eve import utils as eve_utils
+from gt4py.next import common
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.transforms.collapse_tuple import CollapseTuple
+from gt4py.next.iterator.transforms.constant_folding import ConstantFolding
+from gt4py.next.iterator.transforms.inline_lambdas import InlineLambdas
+
+
+def dead_code_elimination(
+    ir: itir.Program,
+    *,
+    collapse_tuple_uids: Optional[eve_utils.UIDGenerator] = None,
+    offset_provider_type: common.OffsetProviderType,
+) -> itir.Program:
+    # remove dead-code, e.g. `let var=True in if_(var, val1, val2) end`
+    # ensure all constant let init forms are inlined
+    # `let var=True in if_(var, val1, val2) end` -> `if_(True, val1, val2)`
+    ir = InlineLambdas.apply(ir, opcount_preserving=True)
+
+    # remove the unreachable if branches
+    # `if_(True, val1, val2)` -> `val1`
+    ir = ConstantFolding.apply(ir, enabled_transformations=ConstantFolding.Transformation.FOLD_IF)  # type: ignore[assignment]  # always an itir.Program
+
+    # note: `force_inline_lambda_args` increases the size of the tree and may not be required for
+    # dead-code-elimination, but is needed since the domain inference cannot handle "user"
+    # functions, e.g. `let f = λ(...) → ... in f(...)`
+    ir = InlineLambdas.apply(ir, opcount_preserving=True, force_inline_lambda_args=True)
+
+    # get rid of tuple elements that are never accessed
+    # `{a, b}[0]` -> `a`
+    ir = CollapseTuple.apply(
+        ir,
+        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
+        uids=collapse_tuple_uids,
+        offset_provider_type=offset_provider_type,
+    )  # type: ignore[assignment]  # always an itir.Program
+
+    return ir

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -12,6 +12,7 @@ from gt4py.eve import utils as eve_utils
 from gt4py.next import common
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.transforms import (
+    dead_code_elimination,
     fuse_as_fieldop,
     global_tmps,
     infer_domain,
@@ -74,16 +75,9 @@ def apply_common_transforms(
     #  test_can_deref. We didn't notice previously as FieldOpFusion did this implicitly everywhere.
     ir = inline_lifts.InlineLifts().visit(ir)
 
-    # note: this increases the size of the tree
-    # Inline. The domain inference can not handle "user" functions, e.g. `let f = λ(...) → ... in f(...)`
-    ir = InlineLambdas.apply(ir, opcount_preserving=True, force_inline_lambda_args=True)
-    # required in order to get rid of expressions without a domain (e.g. when a tuple element is never accessed)
-    ir = CollapseTuple.apply(
-        ir,
-        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
-        uids=collapse_tuple_uids,
-        offset_provider_type=offset_provider_type,
-    )  # type: ignore[assignment]  # always an itir.Program
+    ir = dead_code_elimination.dead_code_elimination(
+        ir, collapse_tuple_uids=collapse_tuple_uids, offset_provider_type=offset_provider_type
+    )  # domain inference does not support dead-code
     ir = inline_dynamic_shifts.InlineDynamicShifts.apply(
         ir
     )  # domain inference does not support dynamic offsets yet
@@ -98,7 +92,9 @@ def apply_common_transforms(
         inlined = ir
 
         inlined = InlineLambdas.apply(inlined, opcount_preserving=True)
-        inlined = ConstantFolding.apply(inlined)  # type: ignore[assignment]  # always an itir.Program
+        inlined = ConstantFolding.apply(
+            inlined, enabled_transformations=ConstantFolding.Transformation.FOLD_IF
+        )  # type: ignore[assignment]  # always an itir.Program
         # This pass is required to be in the loop such that when an `if_` call with tuple arguments
         # is constant-folded the surrounding tuple_get calls can be removed.
         inlined = CollapseTuple.apply(
@@ -181,14 +177,11 @@ def apply_common_transforms(
 def apply_fieldview_transforms(
     ir: itir.Program, *, offset_provider: common.OffsetProvider
 ) -> itir.Program:
+    offset_provider_type = common.offset_provider_to_type(offset_provider)
+
     ir = inline_fundefs.InlineFundefs().visit(ir)
     ir = inline_fundefs.prune_unreferenced_fundefs(ir)
-    ir = InlineLambdas.apply(ir, opcount_preserving=True, force_inline_lambda_args=True)
-    ir = CollapseTuple.apply(
-        ir,
-        enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
-        offset_provider_type=common.offset_provider_to_type(offset_provider),
-    )  # type: ignore[assignment] # type is still `itir.Program`
+    ir = dead_code_elimination.dead_code_elimination(ir, offset_provider_type=offset_provider_type)
     ir = inline_dynamic_shifts.InlineDynamicShifts.apply(
         ir
     )  # domain inference does not support dynamic offsets yet

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -92,9 +92,7 @@ def apply_common_transforms(
         inlined = ir
 
         inlined = InlineLambdas.apply(inlined, opcount_preserving=True)
-        inlined = ConstantFolding.apply(
-            inlined, enabled_transformations=ConstantFolding.Transformation.FOLD_IF
-        )  # type: ignore[assignment]  # always an itir.Program
+        inlined = ConstantFolding.apply(inlined)  # type: ignore[assignment]  # always an itir.Program
         # This pass is required to be in the loop such that when an `if_` call with tuple arguments
         # is constant-folded the surrounding tuple_get calls can be removed.
         inlined = CollapseTuple.apply(

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
@@ -38,10 +38,10 @@ def program_factory(expr: itir.Expr) -> itir.Program:
         ],
     )
 
-@pytest.mark.parametrize("input,expected",
-    [
-        (im.let("val", "inp1")(im.if_(True, "val", "inp2")) , im.ref("inp1"))
-    ],
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [(im.let("val", "inp1")(im.if_(True, "val", "inp2")), im.ref("inp1"))],
 )
 def test_let_constant_foldable_if(input, expected):
     input_program = program_factory(input)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
@@ -38,10 +38,13 @@ def program_factory(expr: itir.Expr) -> itir.Program:
         ],
     )
 
-
-def test_let_constant_foldable_if():
-    testee = program_factory(im.let("val", "inp1")(im.if_(True, "val", "inp2")))
-
-    expected = program_factory(im.ref("inp1"))
-    inlined = dead_code_elimination.dead_code_elimination(testee, offset_provider_type={})
+@pytest.mark.parametrize("input,expected",
+    [
+        (im.let("val", "inp1")(im.if_(True, "val", "inp2")) , im.ref("inp1"))
+    ],
+)
+def test_let_constant_foldable_if(input, expected):
+    input_program = program_factory(input)
+    expected_program = program_factory(expected)
+    inlined = dead_code_elimination.dead_code_elimination(input, offset_provider_type={})
     assert inlined == expected

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
@@ -1,0 +1,47 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from gt4py.next import common
+from gt4py.next.type_system import type_specifications as ts
+from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.transforms import dead_code_elimination
+
+TDim = common.Dimension(value="TDim")
+int_type = ts.ScalarType(kind=ts.ScalarKind.INT32)
+field_type = ts.FieldType(dims=[TDim], dtype=int_type)
+
+
+def program_factory(expr: itir.Expr) -> itir.Program:
+    return itir.Program(
+        id="testee",
+        function_definitions=[],
+        params=[
+            im.sym("inp1", field_type),
+            im.sym("inp2", field_type),
+            im.sym("out", field_type),
+        ],
+        declarations=[],
+        body=[
+            itir.SetAt(
+                expr=expr,
+                target=im.ref("out"),
+                domain=im.domain(common.GridType.CARTESIAN, {TDim: (0, 1)}),
+            )
+        ],
+    )
+
+
+def test_let_constant_foldable_if():
+    testee = program_factory(im.let("val", "inp1")(im.if_(True, "val", "inp2")))
+
+    expected = program_factory(im.ref("inp1"))
+    inlined = dead_code_elimination.dead_code_elimination(testee, offset_provider_type={})
+    assert inlined == expected

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_dead_code_elimination.py
@@ -45,6 +45,5 @@ def program_factory(expr: itir.Expr) -> itir.Program:
 )
 def test_let_constant_foldable_if(input, expected):
     input_program = program_factory(input)
-    expected_program = program_factory(expected)
-    inlined = dead_code_elimination.dead_code_elimination(input, offset_provider_type={})
-    assert inlined == expected
+    inlined = dead_code_elimination.dead_code_elimination(input_program, offset_provider_type={})
+    assert inlined == program_factory(expected)


### PR DESCRIPTION
#1968 Introduced the possibility to specify (non-field) arguments at compile time. The resulting IR in some cases contained expressions similar to:
```
let field = as_fieldop(...)
  if_ True then
    val1
  else
    field
end
```
If constant folding is executed on such an expression
```
let field = as_fieldop(...)
  val1
end
```
`field` will never be used and the domain inference fails. This PR introduces a new transformation `dead_code_elimination` based upon `InlineLambdas`, `ConstantFolding`, `CollapseTuple` that properly handles such cases.