### PR TITLE
feat[next]: Cache type synthesizer invocation

### DIFF
--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -408,7 +408,7 @@ hashable_by_id = hashable_by(id)
 def lru_cache(
     func: Optional[Callable[_P, _T]] = None,
     *,
-    key: Optional[Callable[_P, Any]] = None,
+    key: Optional[Callable[_P, int]] = None,
     maxsize: Optional[int] = 128,
     typed: bool = False,
 ) -> Union[Callable[_P, _T], Callable[[Callable[_P, _T]], Callable[_P, _T]]]:

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -414,10 +414,7 @@ def lru_cache(  # redefinition of unused function
 
     Be careful: `key(obj1) == key(obj2)` must imply `obj1 == obj2`.
 
-    >>> def key_fn(x):
-    ...     return id(x)
-
-    >>> @lru_cache(key=key_fn)
+    >>> @lru_cache(key=id)
     ... def func(x):
     ...     print("called")
     ...     return x

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -445,8 +445,8 @@ def lru_cache(
                     **{k: hashable_by(key, arg) for k, arg in kwargs.items()},
                 )
 
-            inner.cache_parameters = cached_func.cache_parameters
-            inner.cache_info = cached_func.cache_info
+            inner.cache_parameters = cached_func.cache_parameters  # type: ignore[attr-defined]  # mypy not aware of functools.lru_cache behavior
+            inner.cache_info = cached_func.cache_info  # type: ignore[attr-defined]  # mypy not aware of functools.lru_cache behavior
 
             return typing.cast(Callable[_P, _T], inner)
 

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -433,6 +433,7 @@ def lru_cache(
     def _decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:
         if key:
             assert not typed, "Cannot use both 'key' and 'typed'"
+
             @functools.lru_cache(maxsize=maxsize, typed=False)
             def cached_func(*args: HashableBy, **kwargs: HashableBy) -> _T:
                 return func(*(arg.value for arg in args), **{k: v.value for k, v in kwargs.items()})
@@ -443,6 +444,7 @@ def lru_cache(
                     *(hashable_by(key, arg) for arg in args),
                     **{k: hashable_by(key, arg) for k, arg in kwargs.items()},
                 )
+
             inner.cache_parameters = cached_func.cache_parameters
             inner.cache_info = cached_func.cache_info
 

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -402,7 +402,7 @@ def hashable_by(
 hashable_by_id = hashable_by(id)
 
 
-def lru_cache(  # redefinition of unused function
+def lru_cache(
     func: Optional[Callable[_P, _T]] = None,
     *,
     key: Callable[_P, Any],

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -450,7 +450,9 @@ def lru_cache(
 
             return typing.cast(Callable[_P, _T], inner)
 
-        return functools.lru_cache(maxsize=maxsize, typed=typed)(func)
+        return typing.cast(
+            Callable[_P, _T], functools.lru_cache(maxsize=maxsize, typed=typed)(func)
+        )
 
     return _decorator(func) if func is not None else _decorator
 

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -432,7 +432,8 @@ def lru_cache(
 
     def _decorator(func: Callable[_P, _T]) -> Callable[_P, _T]:
         if key:
-            assert not typed, "Cannot use both 'key' and 'typed'"
+            if typed:
+                raise ValueError("Cannot use both 'key' and 'typed'")
 
             @functools.lru_cache(maxsize=maxsize, typed=False)
             def cached_func(*args: HashableBy, **kwargs: HashableBy) -> _T:

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -444,6 +444,7 @@ def lru_cache(
                     **{k: hashable_by(key, arg) for k, arg in kwargs.items()},
                 )
             inner.cache_parameters = cached_func.cache_parameters
+            inner.cache_info = cached_func.cache_info
 
             return typing.cast(Callable[_P, _T], inner)
 

--- a/src/gt4py/next/iterator/type_system/inference.py
+++ b/src/gt4py/next/iterator/type_system/inference.py
@@ -108,8 +108,8 @@ class ObservableTypeSynthesizer(type_synthesizer.TypeSynthesizer):
 
     >>> from gt4py.next.iterator.ir_utils import ir_makers as im
     >>> square_func = im.lambda_("base")(im.call("power")("base", 2))
-    >>> square_func_type_synthesizer = type_synthesizer.TypeSynthesizer(
-    ...     type_synthesizer=lambda base: power(base, int_type)
+    >>> square_func_type_synthesizer = type_synthesizer.type_synthesizer(
+    ...     lambda base: power(base, int_type)
     ... )
     >>> square_func_type_synthesizer(float_type, offset_provider_type={})
     ScalarType(kind=<ScalarKind.FLOAT64: 11>, shape=None)
@@ -531,7 +531,7 @@ class ITIRTypeInference(eve.NodeTranslator):
     def visit_Lambda(
         self, node: itir.Lambda | itir.FunctionDefinition, *, ctx: dict[str, ts.TypeSpec]
     ) -> type_synthesizer.TypeSynthesizer:
-        @type_synthesizer.TypeSynthesizer
+        @type_synthesizer.type_synthesizer(cache=True)
         def fun(*args):
             return self.visit(
                 node.expr, ctx=ctx | {p.id: a for p, a in zip(node.params, args, strict=True)}

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -11,13 +11,21 @@ from __future__ import annotations
 import dataclasses
 import functools
 import inspect
+from typing import TypeVar, overload
 
+from gt4py.eve import utils as eve_utils
 from gt4py.eve.extended_typing import Callable, Iterable, Optional, Union
 from gt4py.next import common
 from gt4py.next.iterator import builtins
 from gt4py.next.iterator.type_system import type_specifications as it_ts
 from gt4py.next.type_system import type_info, type_specifications as ts
 from gt4py.next.utils import tree_map
+
+
+def _type_synth_arg_cache_key(type_or_synth: TypeOrTypeSynthesizer) -> int:
+    if isinstance(type_or_synth, TypeSynthesizer):
+        return id(type_or_synth)
+    return hash(eve_utils.content_hash(type_or_synth))
 
 
 @dataclasses.dataclass
@@ -39,11 +47,18 @@ class TypeSynthesizer:
     """
 
     type_synthesizer: Callable[..., TypeOrTypeSynthesizer]
+    cache: bool = False
 
     def __post_init__(self):
         if "offset_provider_type" not in inspect.signature(self.type_synthesizer).parameters:
             synthesizer = self.type_synthesizer
             self.type_synthesizer = lambda *args, offset_provider_type: synthesizer(*args)
+        if self.cache:
+            self.type_synthesizer = eve_utils.lru_cache(
+                self.type_synthesizer,
+                maxsize=1,
+                key=_type_synth_arg_cache_key,
+            )
 
     def __call__(
         self, *args: TypeOrTypeSynthesizer, offset_provider_type: common.OffsetProviderType
@@ -52,6 +67,22 @@ class TypeSynthesizer:
 
 
 TypeOrTypeSynthesizer = Union[ts.TypeSpec, TypeSynthesizer]
+F = TypeVar("F", bound=Callable[..., TypeOrTypeSynthesizer])
+
+
+@overload
+def type_synthesizer(fun: F) -> TypeSynthesizer: ...
+@overload
+def type_synthesizer(*, cache: bool = False) -> Callable[[F], TypeSynthesizer]: ...
+
+
+def type_synthesizer(
+    fun: Optional[F] = None, cache: bool = False
+) -> Union[TypeSynthesizer, Callable[[F], TypeSynthesizer]]:
+    if fun is None:
+        return functools.partial(TypeSynthesizer, cache=cache)
+    return TypeSynthesizer(fun, cache=cache)
+
 
 #: dictionary from name of a builtin to its type synthesizer
 builtin_type_synthesizers: dict[str, TypeSynthesizer] = {}
@@ -76,7 +107,7 @@ def _register_builtin_type_synthesizer(
     # store names in function object for better debuggability
     synthesizer.fun_names = fun_names or [synthesizer.__name__]  # type: ignore[attr-defined]
     for f in synthesizer.fun_names:  # type: ignore[attr-defined]
-        builtin_type_synthesizers[f] = TypeSynthesizer(type_synthesizer=synthesizer)
+        builtin_type_synthesizers[f] = type_synthesizer(synthesizer)
     return synthesizer
 
 
@@ -241,7 +272,7 @@ def neighbors(
 
 @_register_builtin_type_synthesizer
 def lift(stencil: TypeSynthesizer) -> TypeSynthesizer:
-    @TypeSynthesizer
+    @type_synthesizer
     def apply_lift(
         *its: it_ts.IteratorType, offset_provider_type: common.OffsetProviderType
     ) -> it_ts.IteratorType:
@@ -328,7 +359,7 @@ def as_fieldop(
     if domain is None:
         domain = it_ts.DomainType(dims="unknown")
 
-    @TypeSynthesizer
+    @type_synthesizer
     def applied_as_fieldop(*fields) -> ts.FieldType | ts.DeferredType:
         if any(
             isinstance(el, ts.DeferredType)
@@ -358,7 +389,7 @@ def scan(
 ) -> TypeSynthesizer:
     assert isinstance(direction, ts.ScalarType) and direction.kind == ts.ScalarKind.BOOL
 
-    @TypeSynthesizer
+    @type_synthesizer
     def apply_scan(
         *its: it_ts.IteratorType, offset_provider_type: common.OffsetProviderType
     ) -> ts.DataType:
@@ -371,7 +402,7 @@ def scan(
 
 @_register_builtin_type_synthesizer
 def map_(op: TypeSynthesizer) -> TypeSynthesizer:
-    @TypeSynthesizer
+    @type_synthesizer
     def applied_map(
         *args: ts.ListType, offset_provider_type: common.OffsetProviderType
     ) -> ts.ListType:
@@ -390,7 +421,7 @@ def map_(op: TypeSynthesizer) -> TypeSynthesizer:
 
 @_register_builtin_type_synthesizer
 def reduce(op: TypeSynthesizer, init: ts.TypeSpec) -> TypeSynthesizer:
-    @TypeSynthesizer
+    @type_synthesizer
     def applied_reduce(*args: ts.ListType, offset_provider_type: common.OffsetProviderType):
         assert all(isinstance(arg, ts.ListType) for arg in args)
         return op(
@@ -402,7 +433,7 @@ def reduce(op: TypeSynthesizer, init: ts.TypeSpec) -> TypeSynthesizer:
 
 @_register_builtin_type_synthesizer
 def shift(*offset_literals, offset_provider_type: common.OffsetProviderType) -> TypeSynthesizer:
-    @TypeSynthesizer
+    @type_synthesizer
     def apply_shift(
         it: it_ts.IteratorType | ts.DeferredType,
     ) -> it_ts.IteratorType | ts.DeferredType:

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -58,7 +58,7 @@ class TypeSynthesizer:
             self.type_synthesizer = eve_utils.lru_cache(
                 self.type_synthesizer,
                 # we only cache `itir.Lambda` right now which is only ever evaluated with
-                # the same argumemts. Hence, the cache only needs a size of one.
+                # the same arguments. Hence, the cache only needs a size of one.
                 maxsize=1,
                 key=_type_synth_arg_cache_key,
             )

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -25,6 +25,7 @@ from gt4py.next.utils import tree_map
 def _type_synth_arg_cache_key(type_or_synth: TypeOrTypeSynthesizer) -> int:
     if isinstance(type_or_synth, TypeSynthesizer):
         return id(type_or_synth)
+    # TODO(tehrengruber): use regular __hash__ again when ts.TypeSpec supports it.
     return hash(eve_utils.content_hash(type_or_synth))
 
 

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -57,8 +57,8 @@ class TypeSynthesizer:
         if self.cache:
             self.type_synthesizer = eve_utils.lru_cache(
                 self.type_synthesizer,
-                # we only cache `itir.Lambda` right now which is only every evaluated with
-                # the same argumemts. Hence the cache only needs a size of one.
+                # we only cache `itir.Lambda` right now which is only ever evaluated with
+                # the same argumemts. Hence, the cache only needs a size of one.
                 maxsize=1,
                 key=_type_synth_arg_cache_key,
             )

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -57,6 +57,8 @@ class TypeSynthesizer:
         if self.cache:
             self.type_synthesizer = eve_utils.lru_cache(
                 self.type_synthesizer,
+                # we only cache `itir.Lambda` right now which is only every evaluated with
+                # the same argumemts. Hence the cache only needs a size of one.
                 maxsize=1,
                 key=_type_synth_arg_cache_key,
             )

--- a/tests/eve_tests/unit_tests/test_utils.py
+++ b/tests/eve_tests/unit_tests/test_utils.py
@@ -391,3 +391,4 @@ def test_lru_cache_key_id_called_once():
     assert call_count == 1
 
     assert cached.cache_info().hits == 1
+    assert cached.cache_info().misses == 1

--- a/tests/eve_tests/unit_tests/test_utils.py
+++ b/tests/eve_tests/unit_tests/test_utils.py
@@ -369,3 +369,21 @@ def test_xenumerate():
     from gt4py.eve.utils import xenumerate
 
     assert list(xenumerate(string.ascii_letters[:3])) == [(0, "a"), (1, "b"), (2, "c")]
+
+
+def test_lru_cache_key_id_called_once():
+    from gt4py.eve.utils import lru_cache
+
+    call_count = 0
+
+    def func(x):
+        nonlocal call_count
+        call_count += 1
+        return x
+
+    cached = lru_cache(func, key=id)
+
+    obj = object()
+    assert cached(obj) is obj
+    assert cached(obj) is obj
+    assert call_count == 1

--- a/tests/eve_tests/unit_tests/test_utils.py
+++ b/tests/eve_tests/unit_tests/test_utils.py
@@ -383,6 +383,8 @@ def test_lru_cache_key_id_called_once():
 
     cached = lru_cache(func, key=id)
 
+    assert cached.__wrapped__ == func
+
     obj = object()
     assert cached(obj) is obj
     assert cached(obj) is obj

--- a/tests/eve_tests/unit_tests/test_utils.py
+++ b/tests/eve_tests/unit_tests/test_utils.py
@@ -389,3 +389,5 @@ def test_lru_cache_key_id_called_once():
     assert cached(obj) is obj
     assert cached(obj) is obj
     assert call_count == 1
+
+    assert cached.cache_info().hits == 1


### PR DESCRIPTION
The ITIR type inference is generally fast. In some narrow cases encountered in icon4py where a lambda function is called many times the runtime increases significantly since the return type is synthesized many types even though it never changes (and can never change as all lambda invocations need to have the same type by specification of the IR). This PR restores linear runtime in the length of the expression by caching the return type synthesis.

This was encountered in icon4py in [`prepare_ffsl_flux_area_patches_list`](https://github.com/C2SM/icon4py/blob/82dd7cf9af5aa8506e20cb8bbafb6880f1b55ca2/model/atmosphere/advection/src/icon4py/model/atmosphere/advection/stencils/prepare_ffsl_flux_area_patches_list.py#L600) after field operator fusion. The lambdas that are evaluated repeatedly are created by `InlineCenterDerefLiftVars`.