### PR TITLE
feat[dace][next]: Modified How the GPU Block Size Is Set

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -373,20 +373,21 @@ def _gt_auto_configure_maps_and_strides(
     For a description of the arguments see the `gt_auto_optimize()` function.
     """
 
+    # We now set the iteration order of the Maps. For that we use `unit_strides_kind`
+    #  argument and if not supplied we guess depending if we are on the GPU or not.
     if unit_strides_kind is None:
         unit_strides_kind = (
             gtx_common.DimensionKind.HORIZONTAL if gpu else gtx_common.DimensionKind.VERTICAL
         )
-    if unit_strides_kind is not None:
-        # It is not possible to use the `unit_strides_dim` argument of the
-        #  function, because `LoopBlocking` will change the name of the parameter
-        #  but the dimension can still be identified by its "kind".
-        gtx_transformations.gt_set_iteration_order(
-            sdfg=sdfg,
-            unit_strides_kind=unit_strides_kind,
-            validate=validate,
-            validate_all=validate_all,
-        )
+    # It is not possible to use the `unit_strides_dim` argument of the
+    #  function, because `LoopBlocking`, if run, changed the name of the
+    #  parameter but the dimension can still be identified by its "kind".
+    gtx_transformations.gt_set_iteration_order(
+        sdfg=sdfg,
+        unit_strides_kind=unit_strides_kind,
+        validate=validate,
+        validate_all=validate_all,
+    )
 
     # NOTE: We have to set the strides of transients before the non-standard Memlets
     #   get expanded, i.e. turned into Maps because no `cudaMemcpy*()` call exists,

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -63,6 +63,8 @@ def gt_gpu_transformation(
     Notes:
         - In addition it might fuse Maps together that should not be fused. To prevent
             that you should set `try_removing_trivial_maps` to `False`.
+        - The function assumes that the iteration order has been set correctly before
+            it is called.
 
     Todo:
         - Currently only one block size for all maps is given, add more options.
@@ -343,6 +345,10 @@ def gt_set_gpu_blocksize(
         launch_bounds: The value for the launch bound that should be used.
         launch_factor: If no `launch_bounds` was given use the number of threads
             in a block multiplied by this number.
+
+    Note:
+        If a Map is found whose range is smaller than the specified block size for
+        that dimension then the block size for that map is reduced.
     """
     for dim in [1, 2, 3]:
         for arg, val in {
@@ -448,6 +454,12 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
     three dimensional). If no value is specified then the block size `(32, 1, 1)`
     will be used an no launch bound will be be emitted.
 
+    If a Map is found whose iteration size in a particular dimension is smaller than
+    the block size, the block size for that dimension is reduced to that value. For
+    example, the block size for 2D Maps is `(32, 8, 1)` and a Map that only performs
+    four iteration in the second dimension, will get a block size of `(32, 4, 1)`.
+    Note that this modification will not influence the launch bound value.
+
     Args:
         block_size_Xd: The size of a thread block on the GPU for `X` dimensional maps.
         launch_bounds_Xd: The value for the launch bound that should be used for `X`
@@ -459,6 +471,7 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
         - You should use the `gt_set_gpu_blocksize()` function.
         - "Over specification" is ignored, i.e. if `(32, 3, 1)` is passed as block
             size for 1 dimensional maps, then it is changed to `(32, 1, 1)`.
+        - In case the Map has more than 3 dimension, normal DaCe semantic is used.
     """
 
     _block_size_default: Final[tuple[int, int, int]] = (32, 1, 1)
@@ -569,16 +582,37 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
     ) -> None:
         """Modify the map as requested."""
         gpu_map: dace_nodes.Map = self.map_entry.map
-        if len(gpu_map.params) == 1:
-            block_size = self.block_size_1d
+        map_params: list[str] = gpu_map.params
+        map_size = gpu_map.range.size()
+        map_dim = len(map_params)
+
+        # Because of a particularity of the DaCe code generator, the iteration
+        #  variable that is associated to the `x` dimension of the block is the
+        #  last parameter, i.e. `map_params[-1]`. The one for `y` the second last.
+        if map_dim == 1:
+            block_size = list(self.block_size_1d)
             launch_bounds = self.launch_bounds_1d
-        elif len(gpu_map.params) == 2:
-            block_size = self.block_size_2d
+            inspect_dims = 1
+        elif map_dim == 2:
+            block_size = list(self.block_size_2d)
             launch_bounds = self.launch_bounds_2d
+            inspect_dims = 2
         else:
-            block_size = self.block_size_3d
+            block_size = list(self.block_size_3d)
             launch_bounds = self.launch_bounds_3d
-        gpu_map.gpu_block_size = block_size
+            # If there are more than three dimensions DaCe will condense them into
+            #  the `z` dimension of the block, so we have to ignore the `z` dimension,
+            #  when we modify the block sizes.
+            inspect_dims = 3 if map_dim == 3 else 2
+
+        # Cut down the block size.
+        # TODO(phimuell): Think if it is useful to also modify the launch bounds.
+        for i in range(inspect_dims):
+            map_dim_idx_to_inspect = map_dim - 1 - i
+            if (map_size[map_dim_idx_to_inspect] < block_size[i]) == True:  # noqa: E712 [true-false-comparison]  # SymPy Fancy comparison.
+                block_size[i] = map_size[map_dim_idx_to_inspect]
+
+        gpu_map.gpu_block_size = tuple(block_size)
         if launch_bounds is not None:  # Note: empty string has a meaning in DaCe
             gpu_map.gpu_launch_bounds = launch_bounds
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -582,33 +582,32 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
     ) -> None:
         """Modify the map as requested."""
         gpu_map: dace_nodes.Map = self.map_entry.map
-        map_params: list[str] = gpu_map.params
         map_size = gpu_map.range.size()
-        map_dim = len(map_params)
+        num_map_params = len(gpu_map.params)
 
         # Because of a particularity of the DaCe code generator, the iteration
         #  variable that is associated to the `x` dimension of the block is the
-        #  last parameter, i.e. `map_params[-1]`. The one for `y` the second last.
-        if map_dim == 1:
+        #  last parameter, i.e. `gpu_map.params[-1]`. The one for `y` the second last.
+        if num_map_params == 1:
             block_size = list(self.block_size_1d)
             launch_bounds = self.launch_bounds_1d
-            inspect_dims = 1
-        elif map_dim == 2:
+            dims_to_inspect = 1
+        elif num_map_params == 2:
             block_size = list(self.block_size_2d)
             launch_bounds = self.launch_bounds_2d
-            inspect_dims = 2
+            dims_to_inspect = 2
         else:
             block_size = list(self.block_size_3d)
             launch_bounds = self.launch_bounds_3d
             # If there are more than three dimensions DaCe will condense them into
             #  the `z` dimension of the block, so we have to ignore the `z` dimension,
             #  when we modify the block sizes.
-            inspect_dims = 3 if map_dim == 3 else 2
+            dims_to_inspect = 3 if num_map_params == 3 else 2
 
         # Cut down the block size.
         # TODO(phimuell): Think if it is useful to also modify the launch bounds.
-        for i in range(inspect_dims):
-            map_dim_idx_to_inspect = map_dim - 1 - i
+        for i in range(dims_to_inspect):
+            map_dim_idx_to_inspect = num_map_params - 1 - i
             if (map_size[map_dim_idx_to_inspect] < block_size[i]) == True:  # noqa: E712 [true-false-comparison]  # SymPy Fancy comparison.
                 block_size[i] = map_size[map_dim_idx_to_inspect]
 

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
@@ -158,7 +158,7 @@ def test_set_gpu_properties():
     state = sdfg.add_state(is_start_block=True)
 
     map_entries: dict[int, dace_nodes.MapEntry] = {}
-    for dim in [1, 2, 3]:
+    for dim in [1, 2, 3, 4]:
         shape = (10,) * dim
         sdfg.add_array(
             f"A_{dim}", shape=shape, dtype=dace.float64, storage=dace.StorageType.GPU_Global
@@ -181,22 +181,34 @@ def test_set_gpu_properties():
 
     gtx_dace_fieldview_gpu_utils.gt_set_gpu_blocksize(
         sdfg=sdfg,
-        block_size=(10, "11", 12),
+        block_size=(9, "11", 12),
         launch_factor_2d=2,
-        block_size_2d=(2, 2, 2),
+        block_size_2d=(2, "12", 2),
         launch_bounds_3d=200,
     )
 
-    map1, map2, map3 = (map_entries[d].map for d in [1, 2, 3])
+    map1, map2, map3, map4 = (map_entries[d].map for d in [1, 2, 3, 4])
 
+    # It takes the normal block size and does not regulate anything.
     assert len(map1.params) == 1
-    assert map1.gpu_block_size == [10, 1, 1]
+    assert map1.gpu_block_size == [9, 1, 1]
     assert map1.gpu_launch_bounds == "0"
 
+    # It takes the specialization for the 2d version, but it modifies the y dimension.
+    #  The value of the launch bounds are not affected from this modification, so they
+    #  are still based in `(2, 12, 1)` and then multiplied with 2.
     assert len(map2.params) == 2
-    assert map2.gpu_block_size == [2, 2, 1]
-    assert map2.gpu_launch_bounds == "8"
+    assert map2.gpu_block_size == [2, 10, 1]
+    assert map2.gpu_launch_bounds == "48"
 
+    # It takes normal block size but regulates the y and z dimension.
     assert len(map3.params) == 3
-    assert map3.gpu_block_size == [10, 11, 12]
+    assert map3.gpu_block_size == [9, 10, 10]
     assert map3.gpu_launch_bounds == "200"
+
+    # It takes the normal block size and regulates the y dimension, but because
+    #  there are more than three dim, it will not regulate the z block.
+    #  Even though `map4` is a 4D Map, the launch bound value for 3D map is used.
+    assert len(map4.params) == 4
+    assert map4.gpu_block_size == [9, 10, 12]
+    assert map4.gpu_launch_bounds == "200"


### PR DESCRIPTION
Before all GPU Maps had the same block size, although it was possible to select different ones depending on the number of dimensions of a Map, i.e. selecting `(128, 1, 1)` for Maps with just one parameter but `(32, 8, 1)` for Maps with 2 parameters.
This PR allows that the block size of Maps is adjusted downwards, if it is known at code generation time, that the number of iterations is smaller.

For an example assume that the block size is `(32, 8, 1)` and the Map, for which we want to set the block size, only performs 4 iterations in the `y` dimension, which is a common pattern with `concat_where` applied to the vertical dimension.
Before we would have set the block size of that map to `(32, 8, 1)`, which means that 50% of the threads would do nothing.
With this PR we will use a block size of `(32, 4, 1)`.




