### PR TITLE
fix[next][dace]: Use SDFG hash in dace cache for orchestration tests

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -148,7 +148,7 @@ build_py310_image_aarch64:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     # Another problem, observed in test stage, is that gpu tests hang in combination with CUDA MPS,
     # when high test parallelism is used.
-    NUM_PROCESSES: 64
+    NUM_PROCESSES: 32
 
 # test_py311_x86_64:
 #   extends: [.test_helper_x86_64]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -148,7 +148,7 @@ build_py310_image_aarch64:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     # Another problem, observed in test stage, is that gpu tests hang in combination with CUDA MPS,
     # when high test parallelism is used.
-    NUM_PROCESSES: 16
+    NUM_PROCESSES: 64
 
 # test_py311_x86_64:
 #   extends: [.test_helper_x86_64]

--- a/tests/next_tests/definitions.py
+++ b/tests/next_tests/definitions.py
@@ -76,7 +76,6 @@ class OptionalProgramBackendId(_PythonObjectIdMixin, str, enum.Enum):
     DACE_CPU = "gt4py.next.program_processors.runners.dace.run_dace_cpu"
     DACE_GPU = "gt4py.next.program_processors.runners.dace.run_dace_gpu"
     DACE_CPU_NO_OPT = "gt4py.next.program_processors.runners.dace.run_dace_cpu_noopt"
-    DACE_GPU_NO_OPT = "gt4py.next.program_processors.runners.dace.run_dace_gpu_noopt"
 
 
 class ProgramFormatterId(_PythonObjectIdMixin, str, enum.Enum):
@@ -195,7 +194,6 @@ BACKEND_SKIP_TEST_MATRIX = {
     OptionalProgramBackendId.DACE_CPU: DACE_SKIP_TEST_LIST,
     OptionalProgramBackendId.DACE_GPU: DACE_SKIP_TEST_LIST,
     OptionalProgramBackendId.DACE_CPU_NO_OPT: DACE_SKIP_TEST_LIST,
-    OptionalProgramBackendId.DACE_GPU_NO_OPT: DACE_SKIP_TEST_LIST,
     ProgramBackendId.GTFN_CPU: GTFN_SKIP_TEST_LIST
     + [(USES_SCAN_NESTED, XFAIL, UNSUPPORTED_MESSAGE)],
     ProgramBackendId.GTFN_CPU_IMPERATIVE: GTFN_SKIP_TEST_LIST

--- a/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
+++ b/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
@@ -59,7 +59,7 @@ def test_sdfgConvertible_laplap(cartesian_case):  # noqa: F811
             tmp_field, out_field
         )
 
-    # use unique cache name based on process id to avoid clashes between parallel pytest workers
+    # use unique SDFG folder in dace cache to avoid clashes between parallel pytest workers
     with dace.config.set_temporary("cache", value="unique"):
         sdfg()
 
@@ -132,7 +132,7 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
         # DaCe strides: number of elements to jump
         return arg.strides[axis] // arg.itemsize
 
-    # use SDFG unique folder in dace cache to avoid clashes between parallel pytest workers
+    # use unique SDFG folder in dace cache to avoid clashes between parallel pytest workers
     with dace.config.set_temporary("cache", value="unique"):
         SDFG = sdfg.to_sdfg(connectivities=connectivities)
         cSDFG = SDFG.compile()

--- a/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
+++ b/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
@@ -124,9 +124,6 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
     connectivities = {"E2V": e2v}  # replace 'e2v' with 'e2v.__gt_type__()' when GTIR is AOT
     offset_provider = OffsetProvider_t.dtype._typeclass.as_ctypes()(E2V=e2v.data_ptr())
 
-    SDFG = sdfg.to_sdfg(connectivities=connectivities)
-    cSDFG = SDFG.compile()
-
     a = gtx.as_field([Vertex], xp.asarray([0.0, 1.0, 2.0]), allocator=allocator)
     out = gtx.zeros({Edge: 3}, allocator=allocator)
 
@@ -135,8 +132,11 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
         # DaCe strides: number of elements to jump
         return arg.strides[axis] // arg.itemsize
 
-    # use unique cache name based on process id to avoid clashes between parallel pytest workers
-    with dace.config.set_temporary("cache", value="unique"):
+    # use SDFG hash for dace cache to avoid clashes between parallel pytest workers
+    with dace.config.set_temporary("cache", value="hash"):
+        SDFG = sdfg.to_sdfg(connectivities=connectivities)
+        cSDFG = SDFG.compile()
+
         cSDFG(
             a,
             out,
@@ -148,18 +148,16 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
             __connectivity_E2V_stride_1=get_stride_from_numpy_to_dace(e2v.ndarray, 1),
         )
 
-    e2v_np = e2v.asnumpy()
-    assert np.allclose(out.asnumpy(), a.asnumpy()[e2v_np[:, 0]])
+        e2v_np = e2v.asnumpy()
+        assert np.allclose(out.asnumpy(), a.asnumpy()[e2v_np[:, 0]])
 
-    e2v = gtx.as_connectivity(
-        [Edge, E2VDim],
-        codomain=Vertex,
-        data=xp.asarray([[1, 0], [2, 1], [0, 2]]),
-        allocator=allocator,
-    )
-    offset_provider = OffsetProvider_t.dtype._typeclass.as_ctypes()(E2V=e2v.data_ptr())
-    # use unique cache name based on process id to avoid clashes between parallel pytest workers
-    with dace.config.set_temporary("cache", value="unique"):
+        e2v = gtx.as_connectivity(
+            [Edge, E2VDim],
+            codomain=Vertex,
+            data=xp.asarray([[1, 0], [2, 1], [0, 2]]),
+            allocator=allocator,
+        )
+        offset_provider = OffsetProvider_t.dtype._typeclass.as_ctypes()(E2V=e2v.data_ptr())
         cSDFG(
             a,
             out,
@@ -171,8 +169,8 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
             __connectivity_E2V_stride_1=get_stride_from_numpy_to_dace(e2v.ndarray, 1),
         )
 
-    e2v_np = e2v.asnumpy()
-    assert np.allclose(out.asnumpy(), a.asnumpy()[e2v_np[:, 0]])
+        e2v_np = e2v.asnumpy()
+        assert np.allclose(out.asnumpy(), a.asnumpy()[e2v_np[:, 0]])
 
 
 def get_stride_from_numpy_to_dace(numpy_array: np.ndarray, axis: int) -> int:

--- a/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
+++ b/tests/next_tests/integration_tests/feature_tests/dace/test_orchestration.py
@@ -132,8 +132,8 @@ def test_sdfgConvertible_connectivities(unstructured_case):  # noqa: F811
         # DaCe strides: number of elements to jump
         return arg.strides[axis] // arg.itemsize
 
-    # use SDFG hash for dace cache to avoid clashes between parallel pytest workers
-    with dace.config.set_temporary("cache", value="hash"):
+    # use SDFG unique folder in dace cache to avoid clashes between parallel pytest workers
+    with dace.config.set_temporary("cache", value="unique"):
         SDFG = sdfg.to_sdfg(connectivities=connectivities)
         cSDFG = SDFG.compile()
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/ffront_test_utils.py
@@ -72,10 +72,6 @@ no_backend = NoBackend(
             next_tests.definitions.OptionalProgramBackendId.DACE_CPU_NO_OPT,
             marks=pytest.mark.requires_dace,
         ),
-        pytest.param(
-            next_tests.definitions.OptionalProgramBackendId.DACE_GPU_NO_OPT,
-            marks=(pytest.mark.requires_dace, pytest.mark.requires_gpu),
-        ),
     ],
     ids=lambda p: p.short_id(),
 )


### PR DESCRIPTION
This PR fixes the setting for dace cache in the dace orchestration tests. These tests use the `dace.program` annotation and therefore use dace as a frontend, and rely on the dace cache (not the gt4py cache) for the build of the top-level SDFG. The default setting of the dace cache is to create a folder with the SDFG name (not a good option since we have multiple variants of the same test by means of a fixture). The option `unique` was partially used, and that works, but it was missing on the first call to SDFG compile.

Additional changes to avoid the timeout of the CI pipeline:
- Skip tests with `DACE_GPU_NO_OPT` backend
- Increases the number of pytest workers from 16 to 32