### PR TITLE
fix[dace][next]: Order of Map Fusion in `auto_optimizer()`

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion.py
@@ -194,6 +194,22 @@ class MapFusionSerial(MapFusion):
         for edge in graph.edges():
             edge.data.try_initialize(sdfg, graph, edge)
 
+        # If the call back is given then proceed with it.
+        if self._apply_fusion_callback is not None:
+            first_map_entry: dace_nodes.MapEntry = graph.entry_node(self.first_map_exit)
+            second_map_entry: dace_nodes.MapEntry = self.second_map_entry
+
+            # Apply the call back.
+            if not self._apply_fusion_callback(
+                self,
+                first_map_entry,
+                second_map_entry,
+                graph,
+                sdfg,
+                expr_index,
+            ):
+                return False
+
         return super().can_serial_map_fusion_be_applied(
             graph=graph,
             sdfg=sdfg,
@@ -251,6 +267,22 @@ class MapFusionParallel(MapFusion):
 
         for edge in graph.edges():
             edge.data.try_initialize(sdfg, graph, edge)
+
+        # If the call back is given then proceed with it.
+        if self._apply_fusion_callback is not None:
+            first_map_entry = self.first_parallel_map_entry
+            second_map_entry = self.second_parallel_map_entry
+
+            # Apply the call back.
+            if not self._apply_fusion_callback(
+                self,
+                first_map_entry,
+                second_map_entry,
+                graph,
+                sdfg,
+                expr_index,
+            ):
+                return False
 
         return super().can_parallel_map_fusion_be_applied(
             graph=graph,

--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion.py
@@ -151,9 +151,22 @@ class MapFusion(dace_map_fusion.MapFusion):
 class MapFusionSerial(MapFusion):
     """Wrapper around `MapFusion` that only supports serial map fusion.
 
+    It overrides the `expressions()` class method. This means that the pattern
+    matching system will not look for the parallel Maps that will be rejected
+    anyway.
+
     Note:
-        This class exists only for the transition period.
+        This class is needed to handle some stencils that have a lot of Maps, where
+        serial Map fusion has to be run first to bring down the number of Maps.
+        This splitting, having separate classes for parallel and serial Map fusion
+        is where DaCe will go anyway.
     """
+
+    @classmethod
+    def expressions(cls) -> Any:
+        return [
+            dace.sdfg.utils.node_path_graph(cls.first_map_exit, cls.array, cls.second_map_entry)
+        ]
 
     def __init__(
         self,
@@ -167,14 +180,51 @@ class MapFusionSerial(MapFusion):
             **kwargs,
         )
 
+    def can_be_applied(
+        self,
+        graph: Union[dace.SDFGState, dace.SDFG],
+        expr_index: int,
+        sdfg: dace.SDFG,
+        permissive: bool = False,
+    ) -> bool:
+        assert expr_index == 0
+        assert self.allow_parallel_map_fusion is False
+        assert self.allow_serial_map_fusion
+
+        for edge in graph.edges():
+            edge.data.try_initialize(sdfg, graph, edge)
+
+        return super().can_serial_map_fusion_be_applied(
+            graph=graph,
+            sdfg=sdfg,
+        )
+
+    def apply(
+        self,
+        graph: Union[dace.SDFGState, dace.SDFG],
+        sdfg: dace.SDFG,
+    ) -> None:
+        assert self.expr_index == 0
+        assert self.allow_parallel_map_fusion is False
+        assert self.allow_serial_map_fusion
+
+        return super().apply_serial_map_fusion(
+            graph=graph,
+            sdfg=sdfg,
+        )
+
 
 @dace_properties.make_properties
 class MapFusionParallel(MapFusion):
-    """Wrapper around `MapFusion` that only supports parallel map fusion.
+    """Wrapper around `MapFusion` that only supports parallel map fusion."""
 
-    Note:
-        This class exists only for the transition period.
-    """
+    @classmethod
+    def expressions(cls) -> Any:
+        map_fusion_parallel_match = dace.sdfg.graph.OrderedMultiDiConnectorGraph()
+        map_fusion_parallel_match.add_nodes_from(
+            [cls.first_parallel_map_entry, cls.second_parallel_map_entry]
+        )
+        return [map_fusion_parallel_match]
 
     def __init__(
         self,
@@ -186,4 +236,37 @@ class MapFusionParallel(MapFusion):
             allow_serial_map_fusion=False,
             allow_parallel_map_fusion=True,
             **kwargs,
+        )
+
+    def can_be_applied(
+        self,
+        graph: Union[dace.SDFGState, dace.SDFG],
+        expr_index: int,
+        sdfg: dace.SDFG,
+        permissive: bool = False,
+    ) -> bool:
+        assert expr_index == 0
+        assert self.allow_parallel_map_fusion
+        assert self.allow_serial_map_fusion is False
+
+        for edge in graph.edges():
+            edge.data.try_initialize(sdfg, graph, edge)
+
+        return super().can_parallel_map_fusion_be_applied(
+            graph=graph,
+            sdfg=sdfg,
+        )
+
+    def apply(
+        self,
+        graph: Union[dace.SDFGState, dace.SDFG],
+        sdfg: dace.SDFG,
+    ) -> None:
+        assert self.expr_index == 0
+        assert self.allow_parallel_map_fusion
+        assert self.allow_serial_map_fusion is False
+
+        return super().apply_parallel_map_fusion(
+            graph=graph,
+            sdfg=sdfg,
         )

--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion_dace.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_fusion_dace.py
@@ -222,7 +222,7 @@ class MapFusion(transformation.SingleStateTransformation):
 
     def can_be_applied(
         self,
-        graph: Union[SDFGState, SDFG],
+        graph: Union[dace.SDFGState, SDFG],
         expr_index: int,
         sdfg: dace.SDFG,
         permissive: bool = False,
@@ -310,7 +310,7 @@ class MapFusion(transformation.SingleStateTransformation):
 
     def can_parallel_map_fusion_be_applied(
         self,
-        graph: Union[SDFGState, SDFG],
+        graph: Union[dace.SDFGState, SDFG],
         sdfg: dace.SDFG,
     ) -> bool:
         """Check if the matched Maps can be fused in parallel."""
@@ -319,7 +319,6 @@ class MapFusion(transformation.SingleStateTransformation):
         first_map_entry: nodes.MapEntry = self.first_parallel_map_entry
         second_map_entry: nodes.MapEntry = self.second_parallel_map_entry
 
-        assert self.expr_index == 1
         assert isinstance(first_map_entry, nodes.MapEntry)
         assert isinstance(second_map_entry, nodes.MapEntry)
 
@@ -358,7 +357,7 @@ class MapFusion(transformation.SingleStateTransformation):
 
     def can_serial_map_fusion_be_applied(
         self,
-        graph: Union[SDFGState, SDFG],
+        graph: Union[dace.SDFGState, SDFG],
         sdfg: dace.SDFG,
     ) -> bool:
         """Tests if the matched Maps can be merged serially.
@@ -373,7 +372,6 @@ class MapFusion(transformation.SingleStateTransformation):
         first_map_exit: nodes.MapExit = self.first_map_exit
         second_map_entry: nodes.MapEntry = self.second_map_entry
 
-        assert self.expr_index == 0
         assert isinstance(first_map_exit, nodes.MapExit)
         assert isinstance(second_map_entry, nodes.MapEntry)
         assert isinstance(self.array, nodes.AccessNode)
@@ -445,9 +443,13 @@ class MapFusion(transformation.SingleStateTransformation):
 
         # NOTE: The after this point it is not legal to access the matched nodes
         first_map_entry: nodes.MapEntry = self.first_parallel_map_entry
-        first_map_exit: nodes.MapExit = graph.exit_node(first_map_entry)
         second_map_entry: nodes.MapEntry = self.second_parallel_map_entry
+        assert isinstance(first_map_entry, nodes.MapEntry)
+        assert isinstance(second_map_entry, nodes.MapEntry)
+
+        first_map_exit: nodes.MapExit = graph.exit_node(first_map_entry)
         second_map_exit: nodes.MapExit = graph.exit_node(second_map_entry)
+
         # We have to get the scope_dict before we start mutating the graph.
         scope_dict: Dict = graph.scope_dict().copy()
 
@@ -492,13 +494,17 @@ class MapFusion(transformation.SingleStateTransformation):
         :param graph: The SDFG state we are operating on.
         :param sdfg: The SDFG we are operating on.
         """
-        assert self.expr_index == 0
 
         # NOTE: The after this point it is not legal to access the matched nodes
         first_map_exit: nodes.MapExit = self.first_map_exit
         second_map_entry: nodes.MapEntry = self.second_map_entry
+        assert isinstance(first_map_exit, nodes.MapExit)
+        assert isinstance(second_map_entry, nodes.MapEntry)
+        assert isinstance(self.array, nodes.AccessNode)
+
         second_map_exit: nodes.MapExit = graph.exit_node(self.second_map_entry)
         first_map_entry: nodes.MapEntry = graph.entry_node(self.first_map_exit)
+
         # We have to get the scope_dict before we start mutating the graph.
         scope_dict: Dict = graph.scope_dict().copy()
 
@@ -576,8 +582,8 @@ class MapFusion(transformation.SingleStateTransformation):
 
     def partition_first_outputs(
         self,
-        state: SDFGState,
-        sdfg: SDFG,
+        state: dace.SDFGState,
+        sdfg: dace.SDFG,
         first_map_exit: nodes.MapExit,
         second_map_entry: nodes.MapEntry,
         param_repl: Dict[str, str],
@@ -836,8 +842,8 @@ class MapFusion(transformation.SingleStateTransformation):
         self,
         from_node: Union[nodes.MapExit, nodes.MapEntry],
         to_node: Union[nodes.MapExit, nodes.MapEntry],
-        state: SDFGState,
-        sdfg: SDFG,
+        state: dace.SDFGState,
+        sdfg: dace.SDFG,
         scope_dict: Dict,
     ) -> None:
         """Move the connectors and edges from `from_node` to `to_nodes` node.
@@ -951,7 +957,7 @@ class MapFusion(transformation.SingleStateTransformation):
         self,
         edge_to_move: graph.MultiConnectorEdge[dace.Memlet],
         to_node: Union[nodes.MapExit, nodes.MapEntry],
-        state: SDFGState,
+        state: dace.SDFGState,
         scope_dict: Dict,
     ) -> Tuple[str, bool]:
         """Determine the new connector name that should be used.
@@ -996,7 +1002,7 @@ class MapFusion(transformation.SingleStateTransformation):
     def handle_intermediate_set(
         self,
         intermediate_outputs: Set[graph.MultiConnectorEdge[dace.Memlet]],
-        state: SDFGState,
+        state: dace.SDFGState,
         sdfg: SDFG,
         first_map_exit: nodes.MapExit,
         second_map_entry: nodes.MapEntry,
@@ -1449,7 +1455,7 @@ class MapFusion(transformation.SingleStateTransformation):
 
     def is_parallel(
         self,
-        graph: SDFGState,
+        graph: dace.SDFGState,
         node1: nodes.Node,
         node2: nodes.Node,
     ) -> bool:
@@ -1476,7 +1482,7 @@ class MapFusion(transformation.SingleStateTransformation):
         self,
         first_map_entry: nodes.MapEntry,
         second_map_entry: nodes.MapEntry,
-        state: SDFGState,
+        state: dace.SDFGState,
         sdfg: SDFG,
     ) -> bool:
         """This function tests if there are dependency inside the Maps.
@@ -1538,7 +1544,7 @@ class MapFusion(transformation.SingleStateTransformation):
         first_map_entry: nodes.MapEntry,
         second_map_entry: nodes.MapEntry,
         param_repl: Dict[str, str],
-        state: SDFGState,
+        state: dace.SDFGState,
         sdfg: SDFG,
     ) -> bool:
         """Test if there is a read write dependency between the two maps to be fused.
@@ -1989,7 +1995,7 @@ class MapFusion(transformation.SingleStateTransformation):
         first_map: nodes.Map,
         second_map: nodes.Map,
         second_map_entry: nodes.MapEntry,
-        state: SDFGState,
+        state: dace.SDFGState,
     ) -> None:
         """Replaces the map parameters of the second map with names from the first.
 
@@ -2126,7 +2132,7 @@ class MapFusion(transformation.SingleStateTransformation):
         self,
         node: nodes.AccessNode,
         scope_node: Union[nodes.MapExit, nodes.MapEntry],
-        state: SDFGState,
+        state: dace.SDFGState,
         sdfg: SDFG,
         param_repl: Optional[Dict[str, str]],
     ) -> List[subsets.Subset]:
@@ -2184,7 +2190,7 @@ class MapFusion(transformation.SingleStateTransformation):
     def track_view(
         self,
         view: nodes.AccessNode,
-        state: SDFGState,
+        state: dace.SDFGState,
         sdfg: SDFG,
     ) -> nodes.AccessNode:
         """Find the original data of a View.


### PR DESCRIPTION
The match for parallel Map fusion is very general as it matches any two maps in the SDFG. To reduce the search space this PR changes auto optimizer in such a way that first serial map fusion is performed on its own. After that has ended, serial and parallel Map fusion are performed as before.

The PR also updates the `MapFusion{Serial, Parallel}` wrappers. They now override the `expression()` method, thus serial Map fusion will now no longer implicitly match parallel Maps, which should speed up things.

The implementation is pretty hacky.
However, DaCe will move inside this direction anyway, so they are just a temporary fix.


