### PR TITLE
refactor[cartesian]: Remove __INLINED deprecation warning

### DIFF
--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -19,7 +19,6 @@ from gt4py.cartesian import gtscript
 from gt4py.cartesian.frontend import gtscript_frontend as gt_frontend, nodes
 from gt4py.cartesian.frontend.exceptions import GTScriptSyntaxError
 from gt4py.cartesian.gtscript import (
-    __INLINED,
     FORWARD,
     IJ,
     IJK,
@@ -1699,25 +1698,6 @@ class TestNativeFunctions:
                 in_field = asin(in_field) + 1 if 1 < in_field else sin(in_field)
 
         parse_definition(func, name=inspect.stack()[0][3], module=self.__class__.__name__)
-
-
-class TestWarnInlined:
-    def test_inlined_emits_warning(self):
-        def func(field: gtscript.Field[np.float64]):
-            from gt4py.cartesian.__externals__ import SET_TO_ONE
-
-            with computation(PARALLEL), interval(...):
-                field = 0
-                if __INLINED(SET_TO_ONE):
-                    field = 1
-
-        with pytest.warns(DeprecationWarning, match="__INLINED deprecated"):
-            parse_definition(
-                func,
-                name=inspect.stack()[0][3],
-                module=self.__class__.__name__,
-                externals={"SET_TO_ONE": True},
-            )
 
 
 @gtscript.function


### PR DESCRIPTION
## Description

While we all agree that `__INLINED` is not a nice name, there's currently no alternative (and there won't be one anytime soon). Deprecating a feature without an alternative and without a concrete plan to remove it, is pointless and just clutters the log files.

We thus decided the remove the deprecation warning for now. Once there's an alternative, we can put it back and push people to use the alternative instead.

Related issue: https://github.com/GridTools/gt4py/issues/2031

## Requirements

- [ ] All fixes and/or new features come with corresponding tests: N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder: N/A