### PR TITLE
fix/build[dace][next]: Fixing Expanding of Empty Memlets

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -266,8 +266,10 @@ def _gt_expand_non_standard_memlets_sdfg(
     for state in sdfg.states():
         for e in state.edges():
             # We are only interested in edges that connects two access nodes of GPU memory.
+            #  However, we must exclude Memlets that are empty.
             if not (
-                isinstance(e.src, dace_nodes.AccessNode)
+                (not e.data.is_empty())
+                and isinstance(e.src, dace_nodes.AccessNode)
                 and isinstance(e.dst, dace_nodes.AccessNode)
                 and e.src.desc(sdfg).storage == dace_dtypes.StorageType.GPU_Global
                 and e.dst.desc(sdfg).storage == dace_dtypes.StorageType.GPU_Global

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/GridTools/dace?branch=gt4py-next-integration#268fc18b99b4e76bdd4f9e1bdc289086fe8c808b" }
+source = { git = "https://github.com/GridTools/dace?branch=gt4py-next-integration#4b49068dfbd1d839a562c1d4535c7ea340597c07" }
 resolution-markers = [
     "python_full_version >= '3.11'",
     "python_full_version < '3.11'",
@@ -1094,7 +1094,7 @@ dace = [
     { name = "dace", version = "1.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 dace-next = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?branch=gt4py-next-integration#268fc18b99b4e76bdd4f9e1bdc289086fe8c808b" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?branch=gt4py-next-integration#4b49068dfbd1d839a562c1d4535c7ea340597c07" } },
 ]
 formatting = [
     { name = "clang-format" },


### PR DESCRIPTION
Memlets that can not be expressed as a `cudaMemcpy*()` call are translated into Maps.
For that are Memlets are scanned, however, if there is an empty Memlet between two AccessNodes there is an error, because the subsets are not defined.
Thus we have to skip those Memlets.

Note that this is essentially the same as in [DaCe Pr#2006](https://github.com/spcl/dace/pull/2006) and therefore we also have to update the DaCe dependency.
