### PR TITLE
fix[next][dace]: Enable mapping a scalar expression to a symbol on a nested SDFG

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_scan_translator.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_scan_translator.py
@@ -316,7 +316,7 @@ def _lower_lambda_to_nested_sdfg(
     # This property is used by pattern matching in SDFG transformation framework
     # to skip those transformations that do not yet support control flow blocks.
     nsdfg.using_explicit_control_flow = True
-    lambda_translator = sdfg_builder.setup_nested_context(nsdfg, sdfg, lambda_symbols)
+    lambda_translator = sdfg_builder.setup_nested_context(lambda_node, nsdfg, sdfg, lambda_symbols)
 
     # use the vertical dimension in the domain as scan dimension
     scan_domain = [

--- a/src/gt4py/next/program_processors/runners/dace/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_sdfg.py
@@ -146,16 +146,17 @@ class SDFGBuilder(DataflowBuilder, Protocol):
         scope_symbols: dict[str, ts.DataType],
     ) -> SDFGBuilder:
         """
-        Create an SDFG context to translate a nested expression, indipendent
+        Create an nested SDFG context to lower a lambda expression, indipendent
         from the current context where the parent expression is being translated.
 
         This method will setup the global symbols, that correspond to the parameters
         of the expression to be lowered, as well as the set of symbolic arguments,
-        that is scalar values represented as dace symbols in the parent SDFG.
+        that is symbols used in domain expressions or scalar values represented
+        as dace symbols in the parent SDFG.
 
         Args:
-            node: The expression to be lowered as a nested SDFG.
-            sdfg: The SDFG where to lower the nested expression.
+            node: The lambda expression to be lowered as a nested SDFG.
+            sdfg: The nested SDFG where to lower the nested expression.
             parent: The parent SDFG.
             scope_symbols: Mapping from symbol name to data type for the GTIR symbols
                 forwarded to the nested context.
@@ -849,6 +850,9 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         nsdfg_symbols_mapping = {}
         for sym in nsdfg.free_symbols:
             if (sym_id := str(sym)) in lambda_arg_nodes:
+                # Map a scalar container to a symbol on the nested SDFG.
+                # This is done by adding a connector on the nested SDFG with the
+                # same name as the free symbol.
                 source_data_node = lambda_arg_nodes[sym_id].dc_node
                 source_data_desc = source_data_node.desc(sdfg)
                 assert isinstance(source_data_desc, dace.data.Scalar)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -1725,6 +1725,7 @@ def test_gtir_let_lambda_scalar_expression():
         declarations=[],
         body=[
             gtir.SetAt(
+                # we create an inner symbol that will be mapped to a scalar expression of the parent node
                 expr=im.let("size_inner", im.plus("size", 1))(
                     im.let("tmp", im.multiplies_("a", "b"))(
                         im.as_fieldop(
@@ -1747,6 +1748,9 @@ def test_gtir_let_lambda_scalar_expression():
     c = np.random.rand(N)
     d = np.empty_like(c)
 
+    # we use `skip_domain_inference=True` to avoid propagating the compute domain
+    # to the inner expression, so that the mapping of the scalar expression `size + 1`
+    # to the symbol `inner_size` is preserved, for which we want to test the lowering.
     sdfg = build_dace_sdfg(
         testee, offset_provider_type=CARTESIAN_OFFSETS, skip_domain_inference=True
     )


### PR DESCRIPTION
The lowering from GTIR to SDFG was missing a feature: the possibility to call a `Lambda` and map a scalar expression to a symbol used in an inner domain expression. This corresponds to the mapping of a scalar data container in the parent SDFG to a symbol on the nested SDFG, that is used inside a range by an inner map.

The lack of this feature represents a lowering issue in icon4py, for the new combined stencils.

This feature is blocked by dace issue https://github.com/spcl/dace/issues/2012