### PR TITLE
feat[next]: Faster inline lambda

### DIFF
--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -96,10 +96,13 @@ def past_to_gtir(inp: AOT_PRG) -> stages.CompilableProgram:
         i: arg.value for i, arg in enumerate(inp.args.args) if isinstance(arg, arguments.StaticArg)
     }
     static_args = {
-        itir_program.params[i].id: im.literal_from_tuple_value(value)
+        str(itir_program.params[i].id): im.literal_from_tuple_value(value)
         for i, value in static_args_index.items()
     }
-    body = remap_symbols.RemapSymbolRefs.apply(itir_program.body, symbol_map=static_args)
+    body = [
+        remap_symbols.RemapSymbolRefs.apply(stmt, symbol_map=static_args)
+        for stmt in itir_program.body
+    ]
     itir_program = itir.Program(
         id=itir_program.id,
         function_definitions=itir_program.function_definitions,

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -99,7 +99,7 @@ def past_to_gtir(inp: AOT_PRG) -> stages.CompilableProgram:
         itir_program.params[i].id: im.literal_from_tuple_value(value)
         for i, value in static_args_index.items()
     }
-    body = remap_symbols.RemapSymbolRefs().visit(itir_program.body, symbol_map=static_args)
+    body = remap_symbols.RemapSymbolRefs.apply(itir_program.body, symbol_map=static_args)
     itir_program = itir.Program(
         id=itir_program.id,
         function_definitions=itir_program.function_definitions,

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -102,7 +102,7 @@ def past_to_gtir(inp: AOT_PRG) -> stages.CompilableProgram:
     body = [
         remap_symbols.RemapSymbolRefs.apply(stmt, symbol_map=static_args)
         for stmt in itir_program.body
-    ]
+    ]  # type: ignore[arg-type]
     itir_program = itir.Program(
         id=itir_program.id,
         function_definitions=itir_program.function_definitions,

--- a/src/gt4py/next/iterator/transforms/remap_symbols.py
+++ b/src/gt4py/next/iterator/transforms/remap_symbols.py
@@ -10,20 +10,65 @@ from typing import Any, Dict, Optional, Set
 
 from gt4py.eve import NodeTranslator, PreserveLocationVisitor, SymbolTableTrait
 from gt4py.next.iterator import ir
+from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms import symbol_ref_utils
 from gt4py.next.iterator.type_system import inference as type_inference
+
+
+def unique_name(name, prohibited_symbols):
+    while name in prohibited_symbols:
+        name += "_"
+    return name
 
 
 class RemapSymbolRefs(PreserveLocationVisitor, NodeTranslator):
     # This pass preserves, but doesn't use the `type`, `recorded_shifts`, `domain` annex.
     PRESERVED_ANNEX_ATTRS = ("type", "recorded_shifts", "domain")
 
-    def visit_SymRef(self, node: ir.SymRef, *, symbol_map: Dict[str, ir.Node]):
+    @classmethod
+    def apply(cls, node: ir.Node, symbol_map: Dict[str, ir.Node]):
+        external_symbols = set().union(
+            *(symbol_ref_utils.collect_symbol_refs(expr) for expr in [node, *symbol_map.values()])
+        )
+        return cls().visit(node, symbol_map=symbol_map, reserved_params=external_symbols)
+
+    def visit_SymRef(
+        self, node: ir.SymRef, *, symbol_map: Dict[str, ir.Node], reserved_params: set[str]
+    ):
         return symbol_map.get(str(node.id), node)
 
-    def visit_Lambda(self, node: ir.Lambda, *, symbol_map: Dict[str, ir.Node]):
+    def visit_Lambda(
+        self, node: ir.Lambda, *, symbol_map: Dict[str, ir.Node], reserved_params: set[str]
+    ):
         params = {str(p.id) for p in node.params}
-        new_symbol_map = {k: v for k, v in symbol_map.items() if k not in params}
-        return ir.Lambda(params=node.params, expr=self.visit(node.expr, symbol_map=new_symbol_map))
+
+        clashes = params & reserved_params
+        if clashes:
+            reserved_params = {*reserved_params}
+            new_symbol_map: Dict[str, ir.Node] = {}
+            new_params: list[ir.Sym] = []
+            for param in node.params:
+                if param.id in clashes:
+                    new_param = im.sym(unique_name(param.id, reserved_params), param.type)
+                    assert new_param.id not in symbol_map
+                    new_symbol_map[param.id] = im.ref(new_param.id, param.type)
+                    reserved_params.add(new_param.id)
+                else:
+                    new_param = param
+                new_params.append(new_param)
+
+            new_symbol_map = symbol_map | new_symbol_map
+        else:
+            new_params = node.params  # keep params as is
+            new_symbol_map = symbol_map
+
+        filtered_symbol_map = {k: v for k, v in new_symbol_map.items() if k not in new_params}
+        return ir.Lambda(
+            params=new_params,
+            expr=self.visit(
+                node.expr, symbol_map=filtered_symbol_map, reserved_params=reserved_params
+            ),
+        )
 
     def generic_visit(self, node: ir.Node, **kwargs: Any):  # type: ignore[override]
         assert isinstance(node, SymbolTableTrait) == isinstance(

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_inline_lambdas.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_inline_lambdas.py
@@ -41,6 +41,19 @@ test_data = [
         im.multiplies_(im.plus(2, 1), im.plus("x", "x")),
     ),
     (
+        "name_shadowing_external",
+        im.call(im.lambda_("x")(im.lambda_("y")(im.plus("x", "y"))))(im.plus("x", "y")),
+        im.lambda_("y_")(im.plus(im.plus("x", "y"), "y_")),
+    ),
+    (
+        "renaming_collision",
+        # the `y` param of the lambda may not be renamed to `y_` as this name is already referenced
+        im.call(im.lambda_("x")(im.lambda_("y")(im.plus(im.plus("x", "y"), "y_"))))(
+            im.plus("x", "y")
+        ),
+        im.lambda_("y__")(im.plus(im.plus(im.plus("x", "y"), "y__"), "y_")),
+    ),
+    (
         # ensure opcount preserving option works whether `itir.SymRef` has a type or not
         "typed_ref",
         im.let("a", im.call("opaque")())(


### PR DESCRIPTION
So far just a spontaneous idea I tried. Tried this with the large muphys field operator where it was roughly 10% faster. Real benefit would only be there if we cache the `collect_symbol_refs` in the annex (which was not possible with the previous approach).