### PR TITLE
test[cartesian]: Fix some warnings in tests

### DIFF
--- a/tests/cartesian_tests/integration_tests/feature_tests/test_call_interface.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_call_interface.py
@@ -361,7 +361,7 @@ class TestAxesMismatch:
     def test_storage(self, sample_stencil):
         with pytest.raises(
             Exception,
-            match="Storage for '.*' has dimensions '.*' but the API signature expects '\[I, J\]'",
+            match="Storage for '.*' has dimensions '.*' but the API signature expects '\\[I, J\\]'",
         ):
             sample_stencil(
                 field_out=DimensionsWrapper(
@@ -392,7 +392,7 @@ class TestDataDimensions:
 
     def test_mismatch(self, sample_stencil):
         with pytest.raises(
-            ValueError, match="Field '.*' expects data dimensions \(2,\) but got \(3,\)"
+            ValueError, match="Field '.*' expects data dimensions \\(2,\\) but got \\(3,\\)"
         ):
             sample_stencil(
                 field_out=gt_storage.empty(

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -1550,7 +1550,7 @@ class TestAssignmentSyntax:
 
         with pytest.raises(
             gt_frontend.GTScriptSyntaxError,
-            match="writing to an GlobalTable \('A' global indexation\) is forbidden",
+            match="writing to an GlobalTable \\('A' global indexation\\) is forbidden",
         ):
             parse_definition(at_write, name=inspect.stack()[0][3], module=self.__class__.__name__)
 

--- a/tests/cartesian_tests/unit_tests/test_gtc/dace/test_daceir.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/dace/test_daceir.py
@@ -81,13 +81,11 @@ def test_DomainInterval_intersection() -> None:
         dcir.DomainInterval.intersection(dcir.Axis.I, I_2_10, I_2_5) == I_2_5
     ), "second contained in first"
     assert (
-        dcir.DomainInterval.intersection(dcir.Axis.I, I_8_15, I_full) == I_8_15,
-        "full interval overlaps with start level",
-    )
+        dcir.DomainInterval.intersection(dcir.Axis.I, I_8_15, I_full) == I_8_15
+    ), "full interval overlaps with start level"
     assert (
-        dcir.DomainInterval.intersection(dcir.Axis.I, I_end_m3, I_full) == I_end_m3,
-        "full interval overlaps with end level",
-    )
+        dcir.DomainInterval.intersection(dcir.Axis.I, I_end_m3, I_full) == I_end_m3
+    ), "full interval overlaps with end level"
 
     with pytest.raises(ValueError, match=r"^No intersection found for intervals *"):
         dcir.DomainInterval.intersection(dcir.Axis.I, I_0_4, I_8_15)


### PR DESCRIPTION
## Description

[Recent changes](https://github.com/GridTools/gt4py/pull/2032) brings the warnings down to a manageable level. Fixed a couple warnings that are now more apparent. While regex escapes aren't too bad, the brackets in daceir tests could have hidden issues.

Related issue: https://github.com/GEOS-ESM/SMT-Nebulae/issues/89

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
