### PR TITLE
refactor[cartesian]: shiny error messges from the gt_script frontend

### DIFF
--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -131,16 +131,16 @@ class GTError(Exception):
 
 
 class GTSyntaxError(GTError):
-    def __init__(self, message, *, frontend):
+    def __init__(self, message: str, *, frontend: str):
         super().__init__(message)
         self.frontend = frontend
 
 
 class GTSpecificationError(GTError):
-    def __init__(self, message):
+    def __init__(self, message: str):
         super().__init__(message)
 
 
 class GTSemanticError(GTError):
-    def __init__(self, message):
+    def __init__(self, message: str):
         super().__init__(message)

--- a/src/gt4py/cartesian/frontend/exceptions.py
+++ b/src/gt4py/cartesian/frontend/exceptions.py
@@ -6,13 +6,16 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Any
+
 from gt4py.cartesian import definitions as gt_definitions
+from gt4py.cartesian.frontend import nodes
 
 from . import gtscript_frontend
 
 
 class GTScriptSyntaxError(gt_definitions.GTSyntaxError):
-    def __init__(self, message: str | None, *, loc=None):
+    def __init__(self, message: str | None, *, loc: nodes.Location | None = None):
         if message is None:
             message = "Syntax error"
             if loc is not None:
@@ -22,7 +25,7 @@ class GTScriptSyntaxError(gt_definitions.GTSyntaxError):
 
 
 class GTScriptSymbolError(GTScriptSyntaxError):
-    def __init__(self, name, message=None, *, loc=None):
+    def __init__(self, name: str, message: str | None = None, *, loc: nodes.Location | None = None):
         if message is None:
             message = f"Unknown symbol '{name}'"
             if loc is not None:
@@ -32,7 +35,14 @@ class GTScriptSymbolError(GTScriptSyntaxError):
 
 
 class GTScriptDefinitionError(GTScriptSyntaxError):
-    def __init__(self, name, value, message=None, *, loc=None):
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        message: str | None = None,
+        *,
+        loc: nodes.Location | None = None,
+    ):
         if message is None:
             message = f"Invalid definition for '{name}' symbol"
             if loc is not None:
@@ -43,35 +53,41 @@ class GTScriptDefinitionError(GTScriptSyntaxError):
 
 
 class GTScriptValueError(GTScriptDefinitionError):
-    def __init__(self, name, value, message=None, *, loc=None):
+    def __init__(
+        self,
+        name: str,
+        value: Any,
+        message: str | None = None,
+        *,
+        loc: nodes.Location | None = None,
+    ):
         if message is None:
-            if loc is None:
-                message = "Invalid value for '{name}'".format(name=name)
-            else:
-                message = (
-                    "Invalid value for '{name}' in '{scope}' (line: {line}, col: {col})".format(
-                        name=name, scope=loc.scope, line=loc.line, col=loc.column
-                    )
-                )
+            message = f"Invalid value for '{name}'"
+            if loc is not None:
+                message = f"{message} in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(name, value, message, loc=loc)
 
 
 class GTScriptDataTypeError(GTScriptSyntaxError):
-    def __init__(self, name, data_type, message=None, *, loc=None):
+    def __init__(
+        self,
+        name: str,
+        data_type: Any,
+        message: str | None = None,
+        *,
+        loc: nodes.Location | None = None,
+    ):
         if message is None:
-            if loc is None:
-                message = "Invalid data type for '{name}' numeric symbol ".format(name=name)
-            else:
-                message = "Invalid data type for '{name}' numeric symbol in '{scope}' (line: {line}, col: {col})".format(
-                    name=name, scope=loc.scope, line=loc.line, col=loc.column
-                )
+            message = f"Invalid data type for '{name}' numeric symbol "
+            if loc is not None:
+                message = f"{message} in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(message, loc=loc)
         self.name = name
         self.data_type = data_type
 
 
 class GTScriptAssertionError(gt_definitions.GTSpecificationError):
-    def __init__(self, source, *, loc=None):
+    def __init__(self, source: list[str], *, loc: nodes.Location | None = None):
         if loc:
             message = f"Assertion failed at line {loc.line}, col {loc.column}:\n{source}"
         else:

--- a/src/gt4py/cartesian/frontend/exceptions.py
+++ b/src/gt4py/cartesian/frontend/exceptions.py
@@ -12,7 +12,11 @@ from . import gtscript_frontend
 
 
 class GTScriptSyntaxError(gt_definitions.GTSyntaxError):
-    def __init__(self, message, *, loc=None):
+    def __init__(self, message: str | None, *, loc=None):
+        if message is None:
+            message = "Syntax error"
+            if loc is not None:
+                message = f"{message} in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(message, frontend=gtscript_frontend.GTScriptFrontend.name)
         self.loc = loc
 
@@ -20,14 +24,9 @@ class GTScriptSyntaxError(gt_definitions.GTSyntaxError):
 class GTScriptSymbolError(GTScriptSyntaxError):
     def __init__(self, name, message=None, *, loc=None):
         if message is None:
-            if loc is None:
-                message = "Unknown symbol '{name}' symbol".format(name=name)
-            else:
-                message = (
-                    "Unknown symbol '{name}' symbol in '{scope}' (line: {line}, col: {col})".format(
-                        name=name, scope=loc.scope, line=loc.line, col=loc.column
-                    )
-                )
+            message = f"Unknown symbol '{name}'"
+            if loc is not None:
+                message = f"{message} in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(message, loc=loc)
         self.name = name
 
@@ -35,12 +34,9 @@ class GTScriptSymbolError(GTScriptSyntaxError):
 class GTScriptDefinitionError(GTScriptSyntaxError):
     def __init__(self, name, value, message=None, *, loc=None):
         if message is None:
-            if loc is None:
-                message = "Invalid definition for '{name}' symbol".format(name=name)
-            else:
-                message = "Invalid definition for '{name}' symbol in '{scope}' (line: {line}, col: {col})".format(
-                    name=name, scope=loc.scope, line=loc.line, col=loc.column
-                )
+            message = f"Invalid definition for '{name}' symbol"
+            if loc is not None:
+                message = f"{message} in '{loc.scope}' (line: {loc.line}, col: {loc.column})"
         super().__init__(message, loc=loc)
         self.name = name
         self.value = value
@@ -50,7 +46,7 @@ class GTScriptValueError(GTScriptDefinitionError):
     def __init__(self, name, value, message=None, *, loc=None):
         if message is None:
             if loc is None:
-                message = "Invalid value for '{name}' symbol ".format(name=name)
+                message = "Invalid value for '{name}'".format(name=name)
             else:
                 message = (
                     "Invalid value for '{name}' in '{scope}' (line: {line}, col: {col})".format(

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1512,7 +1512,9 @@ class IRMaker(ast.NodeVisitor):
 
     def visit_With(self, node: ast.With):
         loc = nodes.Location.from_ast_node(node, scope=self.stencil_name)
-        error_message = f"Invalid 'with' statement in '{loc.scope}' at line {loc.line} (column {loc.column})"
+        error_message = (
+            f"Invalid 'with' statement in '{loc.scope}' at line {loc.line} (column {loc.column})"
+        )
 
         if (
             len(node.items) == 1
@@ -1581,17 +1583,21 @@ class IRMaker(ast.NodeVisitor):
             #  the nested computation blocks must be specified in their order of execution. The order of execution is
             #  such that the lowest (highest) interval is processed first if the iteration order is forward (backward).
             if not self._are_blocks_sorted(compute_blocks):
-                raise GTScriptSyntaxError(f"{error_message}: Intervals must be specified in order of execution.")
-            
+                raise GTScriptSyntaxError(
+                    f"{error_message}: Intervals must be specified in order of execution."
+                )
+
             if not self._are_intervals_nonoverlapping(compute_blocks):
                 raise GTScriptSyntaxError(f"{error_message}: Overlapping intervals detected.")
 
             return compute_blocks
-        
+
         if self.parsing_context == ParsingContext.CONTROL_FLOW:
             return gtc_utils.listify(self._visit_computation_node(node))
-        
-        raise GTScriptSyntaxError(f"{error_message}: Mixing nested `with` blocks and statements is not allowed.")
+
+        raise GTScriptSyntaxError(
+            f"{error_message}: Mixing nested `with` blocks and statements is not allowed."
+        )
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> List[nodes.ComputationBlock]:
         self.stencil_name = node.name

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -53,34 +53,35 @@ class AssertionChecker(ast.NodeTransformer):
 
     def _process_assertion(self, expr_node: ast.Expr) -> None:
         condition_value = gt_utils.meta.ast_eval(expr_node, self.context, default=NOTHING)
-        if condition_value is not NOTHING:
-            if not condition_value:
-                source_lines = textwrap.dedent(self.source).split("\n")
-                loc = nodes.Location.from_ast_node(expr_node)
-                raise GTScriptAssertionError(source_lines[loc.line - 1], loc=loc)
-        else:
+        if condition_value is NOTHING:
             raise GTScriptSyntaxError(
                 "Evaluation of compile_assert condition failed at the preprocessing step."
             )
+
+        if not condition_value:
+            source_lines = textwrap.dedent(self.source).split("\n")
+            loc = nodes.Location.from_ast_node(expr_node)
+            raise GTScriptAssertionError(source_lines[loc.line - 1], loc=loc)
+
         return None
 
     def _process_call(self, node: ast.Call) -> Optional[ast.Call]:
         name = gt_meta.get_qualified_name_from_node(node.func)
         if name != "compile_assert":
             return node
-        else:
-            if len(node.args) != 1:
-                raise GTScriptSyntaxError(
-                    "Invalid assertion. Correct syntax: compile_assert(condition)"
-                )
-            return self._process_assertion(node.args[0])
+
+        if len(node.args) != 1:
+            raise GTScriptSyntaxError(
+                "Invalid assertion. Correct syntax: compile_assert(condition)"
+            )
+        return self._process_assertion(node.args[0])
 
     def visit_Expr(self, node: ast.Expr) -> Optional[ast.AST]:
         if isinstance(node.value, ast.Call):
             ret = self._process_call(node.value)
             return ast.Expr(value=ret) if ret else None
-        else:
-            return node
+
+        return node
 
 
 class AxisIntervalParser(gt_meta.ASTPass):
@@ -159,28 +160,28 @@ class AxisIntervalParser(gt_meta.ASTPass):
     ) -> nodes.AxisBound:
         if isinstance(value, nodes.AxisBound):
             return value
-        else:
-            if isinstance(value, int):
-                level = nodes.LevelMarker.END if value < 0 else nodes.LevelMarker.START
-                offset = value
-            elif isinstance(value, nodes.VarRef):
-                level = value
-                offset = 0
-            elif isinstance(value, gtscript.AxisIndex):
-                level = nodes.LevelMarker.START if value.index >= 0 else nodes.LevelMarker.END
-                offset = value.index + value.offset
-            elif value is None:
-                LARGE_NUM = 10000
-                seq_name = nodes.Domain.LatLonGrid().sequential_axis.name
-                level = endpt
-                if self.axis_name == seq_name:
-                    offset = 0
-                else:
-                    offset = -LARGE_NUM if level == nodes.LevelMarker.START else LARGE_NUM
-            else:
-                raise self.interval_error
 
-            return nodes.AxisBound(level=level, offset=offset, loc=self.loc)
+        if isinstance(value, int):
+            level = nodes.LevelMarker.END if value < 0 else nodes.LevelMarker.START
+            offset = value
+        elif isinstance(value, nodes.VarRef):
+            level = value
+            offset = 0
+        elif isinstance(value, gtscript.AxisIndex):
+            level = nodes.LevelMarker.START if value.index >= 0 else nodes.LevelMarker.END
+            offset = value.index + value.offset
+        elif value is None:
+            LARGE_NUM = 10000
+            seq_name = nodes.Domain.LatLonGrid().sequential_axis.name
+            level = endpt
+            if self.axis_name == seq_name:
+                offset = 0
+            else:
+                offset = -LARGE_NUM if level == nodes.LevelMarker.START else LARGE_NUM
+        else:
+            raise self.interval_error
+
+        return nodes.AxisBound(level=level, offset=offset, loc=self.loc)
 
     def visit_Name(self, node: ast.Name) -> nodes.VarRef:
         return nodes.VarRef(name=node.id, loc=nodes.Location.from_ast_node(node))
@@ -188,15 +189,15 @@ class AxisIntervalParser(gt_meta.ASTPass):
     def visit_Constant(self, node: ast.Constant) -> Union[int, gtscript.AxisIndex, None]:
         if isinstance(node.value, gtscript.AxisIndex):
             return node.value
-        elif isinstance(node.value, numbers.Number):
+        if isinstance(node.value, numbers.Number):
             return int(node.value)
-        elif node.value is None:
+        if node.value is None:
             return None
-        else:
-            raise GTScriptSyntaxError(
-                f"Unexpected type found {type(node.value)}. Expected one of: int, AxisIndex, string (var ref), or None.",
-                loc=self.loc,
-            )
+
+        raise GTScriptSyntaxError(
+            f"Unexpected type found {type(node.value)}. Expected one of: int, AxisIndex, string (var ref), or None.",
+            loc=self.loc,
+        )
 
     def visit_BinOp(self, node: ast.BinOp) -> Union[gtscript.AxisIndex, nodes.AxisBound, int]:
         left = self.visit(node.left)
@@ -226,30 +227,30 @@ class AxisIntervalParser(gt_meta.ASTPass):
             return gtscript.AxisIndex(
                 axis=left.axis, index=left.index, offset=bin_op(left.offset, right)
             )
-        elif isinstance(left, nodes.VarRef):
+        if isinstance(left, nodes.VarRef):
             if not isinstance(right, numbers.Number):
                 raise incompatible_types_error
             return nodes.AxisBound(level=left, offset=u_op(right), loc=self.loc)
-        elif isinstance(left, nodes.AxisBound):
+        if isinstance(left, nodes.AxisBound):
             if not isinstance(right, numbers.Number):
                 raise incompatible_types_error
             return nodes.AxisBound(
                 level=left.level, offset=bin_op(left.offset, right), loc=self.loc
             )
-        elif isinstance(left, numbers.Number) and isinstance(right, numbers.Number):
+        if isinstance(left, numbers.Number) and isinstance(right, numbers.Number):
             return bin_op(left, right)
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> nodes.AxisBound:
-        if isinstance(node.op, ast.USub):
-            op = lambda x: -x  # noqa: E731 [lambda-assignment]
-        else:
+        if not isinstance(node.op, ast.USub):
             raise self.interval_error
 
+        op = lambda x: -x  # noqa: E731 [lambda-assignment]
         value = self.visit(node.operand)
+
         if isinstance(value, numbers.Number):
             return op(value)
-        else:
-            raise self.interval_error
+
+        raise self.interval_error
 
     def visit_Subscript(self, node: ast.Subscript) -> nodes.AxisBound:
         if node.value.id != self.axis_name:
@@ -329,10 +330,8 @@ class ReturnReplacer(gt_utils.meta.ASTTransformPass):
                 lineno=node.lineno,
                 col_offset=node.col_offset,
             )
-        else:
-            raise GTScriptSyntaxError(
-                "Number of returns values does not match arguments on left side"
-            )
+
+        raise GTScriptSyntaxError("Number of returns values does not match arguments on left side")
 
 
 class CallInliner(ast.NodeTransformer):
@@ -410,8 +409,8 @@ class CallInliner(ast.NodeTransformer):
             # This node can be now removed since the trivial assignment has been already done
             # in the Call visitor
             return None
-        else:
-            return self.generic_visit(node)
+
+        return self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call, *, target_node=None):  # Cyclomatic complexity too high
         call_name = gt_meta.get_qualified_name_from_node(node.func)
@@ -426,7 +425,7 @@ class CallInliner(ast.NodeTransformer):
         if call_name in gtscript.IGNORE_WHEN_INLINING:
             # Not a function to inline, return as-is.
             return node
-        elif call_name not in self.context or not hasattr(self.context[call_name], "_gtscript_"):
+        if call_name not in self.context or not hasattr(self.context[call_name], "_gtscript_"):
             raise GTScriptSyntaxError("Unknown call", loc=nodes.Location.from_ast_node(node))
 
         # Recursively inline any possible nested subroutine call
@@ -1000,13 +999,13 @@ class IRMaker(ast.NodeVisitor):
         value = node.value
         if value is None:
             return nodes.BuiltinLiteral(value=nodes.Builtin.from_value(value))
-        elif isinstance(value, bool):
+        if isinstance(value, bool):
             return nodes.Cast(
                 data_type=nodes.DataType.BOOL,
                 expr=nodes.BuiltinLiteral(value=nodes.Builtin.from_value(value)),
                 loc=nodes.Location.from_ast_node(node),
             )
-        elif isinstance(value, numbers.Number):
+        if isinstance(value, numbers.Number):
             value_type = (
                 self.dtypes[type(value)]
                 if self.dtypes and type(value) in self.dtypes.keys()
@@ -1014,11 +1013,11 @@ class IRMaker(ast.NodeVisitor):
             )
             data_type = nodes.DataType.from_dtype(value_type)
             return nodes.ScalarLiteral(value=value, data_type=data_type)
-        else:
-            raise GTScriptSyntaxError(
-                f"Unknown constant value found: {value}. Expected boolean or number.",
-                loc=nodes.Location.from_ast_node(node),
-            )
+
+        raise GTScriptSyntaxError(
+            f"Unknown constant value found: {value}. Expected boolean or number.",
+            loc=nodes.Location.from_ast_node(node),
+        )
 
     def visit_Tuple(self, node: ast.Tuple) -> tuple:
         value = tuple(self.visit(elem) for elem in node.elts)
@@ -1033,9 +1032,9 @@ class IRMaker(ast.NodeVisitor):
                 arg=self.visit(node.value),
                 loc=nodes.Location.from_ast_node(node),
             )
-        else:
-            qualified_name = gt_meta.get_qualified_name_from_node(node)
-            return self.visit(ast.Name(id=qualified_name, ctx=node.ctx))
+
+        qualified_name = gt_meta.get_qualified_name_from_node(node)
+        return self.visit(ast.Name(id=qualified_name, ctx=node.ctx))
 
     def visit_Name(self, node: ast.Name) -> nodes.Ref:
         symbol = node.id
@@ -1075,32 +1074,33 @@ class IRMaker(ast.NodeVisitor):
                 raise GTScriptSyntaxError(
                     message="Could not evaluate axis shift expression.", loc=index_node
                 ) from ex
+
             if not isinstance(value, (gtscript.ShiftedAxis, gtscript.Axis)):
                 raise GTScriptSyntaxError(
                     message=f"Axis shift expression evaluated to unrecognized type {type(value)}.",
                     loc=index_node,
                 )
-            else:
-                axis_index = all_spatial_axes.index(value.name)
-                if axis_index < 0:
-                    raise GTScriptSyntaxError(
-                        message=f"Unrecognized axis: {value.name}", loc=index_node
-                    )
-                elif axis_index < last_index:
-                    raise GTScriptSyntaxError(
-                        message=f"Axis {value.name} is specified out of order", loc=index_node
-                    )
-                elif axis_index == last_index:
-                    raise GTScriptSyntaxError(
-                        message=f"Duplicate axis found: {value.name}", loc=index_node
-                    )
-                last_index = axis_index
 
-                try:
-                    shift = value.shift
-                except AttributeError:
-                    shift = 0
-                index_dict[value.name] = shift
+            axis_index = all_spatial_axes.index(value.name)
+            if axis_index < 0:
+                raise GTScriptSyntaxError(
+                    message=f"Unrecognized axis: {value.name}", loc=index_node
+                )
+            if axis_index < last_index:
+                raise GTScriptSyntaxError(
+                    message=f"Axis {value.name} is specified out of order", loc=index_node
+                )
+            if axis_index == last_index:
+                raise GTScriptSyntaxError(
+                    message=f"Duplicate axis found: {value.name}", loc=index_node
+                )
+            last_index = axis_index
+
+            try:
+                shift = value.shift
+            except AttributeError:
+                shift = 0
+            index_dict[value.name] = shift
 
         return [index_dict.get(axis, 0) for axis in ("I", "J", "K") if axis in field_axes]
 
@@ -1130,17 +1130,16 @@ class IRMaker(ast.NodeVisitor):
             # This is the new-style syntax for representing spatial axis offsets, e.g. [I+1]
             return self._eval_new_spatial_index(index_nodes, field_axes)
 
-        else:
-            # This is either the old-style syntax using all spatial axes (e.g. [1, 0, 0]), or a data index.
-            index = []
-            for index_node in index_nodes:
-                try:
-                    offset = ast.literal_eval(index_node)
-                    index.append(offset)
-                except Exception:
-                    index.append(self.visit(index_node))
+        # This is either the old-style syntax using all spatial axes (e.g. [1, 0, 0]), or a data index.
+        index = []
+        for index_node in index_nodes:
+            try:
+                offset = ast.literal_eval(index_node)
+                index.append(offset)
+            except Exception:
+                index.append(self.visit(index_node))
 
-            return index
+        return index
 
     def visit_Subscript(self, node: ast.Subscript):
         assert isinstance(node.ctx, (ast.Load, ast.Store))
@@ -1207,11 +1206,9 @@ class IRMaker(ast.NodeVisitor):
         op = self.visit(node.op)
         arg = self.visit(node.operand)
         if isinstance(arg, numbers.Number):
-            result = eval("{op}{arg}".format(op=op.python_symbol, arg=arg))
-        else:
-            result = nodes.UnaryOpExpr(op=op, arg=arg, loc=nodes.Location.from_ast_node(node))
+            return eval("{op}{arg}".format(op=op.python_symbol, arg=arg))
 
-        return result
+        return nodes.UnaryOpExpr(op=op, arg=arg, loc=nodes.Location.from_ast_node(node))
 
     def visit_UAdd(self, node: ast.UAdd) -> nodes.UnaryOperator:
         return nodes.UnaryOperator.POS
@@ -1695,46 +1692,46 @@ class GTScriptParser(ast.NodeVisitor):
                     value=definition,
                     message="'*args' tuple parameter is not supported in GTScript definitions",
                 )
-            elif param.kind == inspect.Parameter.VAR_KEYWORD:
+            if param.kind == inspect.Parameter.VAR_KEYWORD:
                 raise GTScriptDefinitionError(
                     name=qualified_name,
                     value=definition,
                     message="'**kwargs' dict parameter is not supported in GTScript definitions",
                 )
-            else:
-                is_keyword = param.kind == inspect.Parameter.KEYWORD_ONLY
 
-                default = nodes.Empty
-                if param.default != inspect.Parameter.empty:
-                    if not isinstance(param.default, GTScriptParser.CONST_VALUE_TYPES):
-                        raise GTScriptValueError(
-                            name=param.name,
-                            value=param.default,
-                            message=f"Invalid default value for argument '{param.name}': {param.default}",
-                        )
-                    default = param.default
+            is_keyword = param.kind == inspect.Parameter.KEYWORD_ONLY
 
-                if isinstance(param.annotation, (str, gtscript._FieldDescriptor)):
-                    dtype_annotation = param.annotation
-                elif (
-                    isinstance(param.annotation, type)
-                    and param.annotation in gtscript._VALID_DATA_TYPES
-                ):
-                    dtype_annotation = np.dtype(param.annotation)
-                elif param.annotation is inspect.Signature.empty:
-                    dtype_annotation = None
-                else:
+            default = nodes.Empty
+            if param.default != inspect.Parameter.empty:
+                if not isinstance(param.default, GTScriptParser.CONST_VALUE_TYPES):
                     raise GTScriptValueError(
                         name=param.name,
-                        value=param.annotation,
-                        message=f"Invalid annotated dtype value for argument '{param.name}': {param.annotation}",
+                        value=param.default,
+                        message=f"Invalid default value for argument '{param.name}': {param.default}",
                     )
+                default = param.default
 
-                api_signature.append(
-                    nodes.ArgumentInfo(name=param.name, is_keyword=is_keyword, default=default)
+            if isinstance(param.annotation, (str, gtscript._FieldDescriptor)):
+                dtype_annotation = param.annotation
+            elif (
+                isinstance(param.annotation, type)
+                and param.annotation in gtscript._VALID_DATA_TYPES
+            ):
+                dtype_annotation = np.dtype(param.annotation)
+            elif param.annotation is inspect.Signature.empty:
+                dtype_annotation = None
+            else:
+                raise GTScriptValueError(
+                    name=param.name,
+                    value=param.annotation,
+                    message=f"Invalid annotated dtype value for argument '{param.name}': {param.annotation}",
                 )
 
-                api_annotations.append(dtype_annotation)
+            api_signature.append(
+                nodes.ArgumentInfo(name=param.name, is_keyword=is_keyword, default=default)
+            )
+
+            api_annotations.append(dtype_annotation)
 
         nonlocal_symbols, imported_symbols = GTScriptParser.collect_external_symbols(definition)
         ast_func_def = gt_meta.get_ast(definition, feature_version=PYTHON_AST_VERSION).body[0]

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -721,6 +721,7 @@ class IRMaker(ast.NodeVisitor):
         )
 
         self.backend_name = backend_name
+        self.stencil_name: str | None = None
         self.fields = fields
         self.parameters = parameters
         self.local_symbols = local_symbols
@@ -1510,10 +1511,8 @@ class IRMaker(ast.NodeVisitor):
         return self.visit_Assign(assignment)
 
     def visit_With(self, node: ast.With):
-        loc = nodes.Location.from_ast_node(node)
-        syntax_error = GTScriptSyntaxError(
-            f"Invalid 'with' statement at line {loc.line} (column {loc.column})", loc=loc
-        )
+        loc = nodes.Location.from_ast_node(node, scope=self.stencil_name)
+        error_message = f"Invalid 'with' statement in '{loc.scope}' at line {loc.line} (column {loc.column})"
 
         if (
             len(node.items) == 1
@@ -1521,7 +1520,8 @@ class IRMaker(ast.NodeVisitor):
             and node.items[0].context_expr.func.id == "horizontal"
         ):
             if any(isinstance(child_node, ast.With) for child_node in node.body):
-                raise GTScriptSyntaxError("Cannot nest `with` node inside horizontal region")
+                details = "Cannot nest `with` node inside a horizontal region."
+                raise GTScriptSyntaxError(f"{error_message}: {details}")
 
             self.parsing_horizontal_region = True
             intervals_dicts = self._visit_with_horizontal(node.items[0], loc)
@@ -1537,10 +1537,8 @@ class IRMaker(ast.NodeVisitor):
             names = _find_accesses_with_offsets(body_block)
             written_then_offset = names.intersection(self.written_vars)
             if written_then_offset:
-                raise GTScriptSyntaxError(
-                    "The following variables are"
-                    f"written before being referenced with an offset in a horizontal region: {', '.join(written_then_offset)}"
-                )
+                details = f"The following variables are written before being referenced with an offset in a horizontal region: {', '.join(written_then_offset)}"
+                raise GTScriptSyntaxError(f"{error_message} {details}")
             stmts.extend(
                 [
                     nodes.HorizontalIf(intervals=intervals_dict, body=body_block)
@@ -1548,57 +1546,55 @@ class IRMaker(ast.NodeVisitor):
                 ]
             )
             return stmts
-        else:
-            # If we find nested `with` blocks flatten them, i.e. transform
-            #  with computation(PARALLEL):
-            #   with interval(...):
-            #     ...
-            # into
-            #  with computation(PARALLEL), interval(...):
-            #    ...
-            # otherwise just parse the node
-            if self.parsing_context == ParsingContext.CONTROL_FLOW and all(
-                isinstance(child_node, ast.With)
-                and child_node.items[0].context_expr.func.id == "interval"
-                for child_node in node.body
+
+        # If we find nested `with` blocks flatten them, i.e. transform
+        #  with computation(PARALLEL):
+        #   with interval(...):
+        #     ...
+        # into
+        #  with computation(PARALLEL), interval(...):
+        #    ...
+        # otherwise just parse the node
+        if self.parsing_context == ParsingContext.CONTROL_FLOW and all(
+            isinstance(child_node, ast.With)
+            and child_node.items[0].context_expr.func.id == "interval"
+            for child_node in node.body
+        ):
+            # Ensure top level `with` specifies the iteration order
+            if not any(
+                with_item.context_expr.func.id == "computation"
+                for with_item in node.items
+                if isinstance(with_item.context_expr, ast.Call)
             ):
-                # Ensure top level `with` specifies the iteration order
-                if not any(
-                    with_item.context_expr.func.id == "computation"
-                    for with_item in node.items
-                    if isinstance(with_item.context_expr, ast.Call)
-                ):
-                    raise syntax_error
+                raise GTScriptSyntaxError(f"{error_message}.")
 
-                # Parse nested `with` blocks
-                compute_blocks = []
-                for with_node in node.body:
-                    with_node = copy.deepcopy(with_node)  # Copy to avoid altering original ast
-                    # Splice `withItems` of current/primary with statement into nested with
-                    with_node.items.extend(node.items)
+            # Parse nested `with` blocks
+            compute_blocks = []
+            for with_node in node.body:
+                with_node = copy.deepcopy(with_node)  # Copy to avoid altering original ast
+                # Splice `withItems` of current/primary with statement into nested with
+                with_node.items.extend(node.items)
 
-                    compute_blocks.append(self._visit_computation_node(with_node))
+                compute_blocks.append(self._visit_computation_node(with_node))
 
-                # Validate block specification order
-                #  the nested computation blocks must be specified in their order of execution. The order of execution is
-                #  such that the lowest (highest) interval is processed first if the iteration order is forward (backward).
-                if not self._are_blocks_sorted(compute_blocks):
-                    raise GTScriptSyntaxError(
-                        f"Invalid 'with' statement at line {loc.line} (column {loc.column}). Intervals must be specified in order of execution."
-                    )
-                if not self._are_intervals_nonoverlapping(compute_blocks):
-                    raise GTScriptSyntaxError(
-                        f"Overlapping intervals detected at line {loc.line} (column {loc.column})"
-                    )
+            # Validate block specification order
+            #  the nested computation blocks must be specified in their order of execution. The order of execution is
+            #  such that the lowest (highest) interval is processed first if the iteration order is forward (backward).
+            if not self._are_blocks_sorted(compute_blocks):
+                raise GTScriptSyntaxError(f"{error_message}: Intervals must be specified in order of execution.")
+            
+            if not self._are_intervals_nonoverlapping(compute_blocks):
+                raise GTScriptSyntaxError(f"{error_message}: Overlapping intervals detected.")
 
-                return compute_blocks
-            elif self.parsing_context == ParsingContext.CONTROL_FLOW:
-                return gtc_utils.listify(self._visit_computation_node(node))
-            else:
-                # Mixing nested `with` blocks with stmts not allowed
-                raise syntax_error
+            return compute_blocks
+        
+        if self.parsing_context == ParsingContext.CONTROL_FLOW:
+            return gtc_utils.listify(self._visit_computation_node(node))
+        
+        raise GTScriptSyntaxError(f"{error_message}: Mixing nested `with` blocks and statements is not allowed.")
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> List[nodes.ComputationBlock]:
+        self.stencil_name = node.name
         blocks = []
         for stmt in filter(lambda s: not isinstance(s, ast.AnnAssign), node.body):
             blocks.extend(self.visit(stmt))

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -168,9 +168,10 @@ class Location(Node):
     scope = attribute(of=str, default="<source>")
 
     @classmethod
-    def from_ast_node(cls, ast_node, scope="<source>"):
+    def from_ast_node(cls, ast_node, scope: str | None = None):
         lineno = getattr(ast_node, "lineno", 0)
         col_offset = getattr(ast_node, "col_offset", 0)
+        scope = "<source>" if scope is None else scope
         return cls(line=lineno, column=col_offset + 1, scope=scope)
 
 

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -823,7 +823,7 @@ class TestRegions:
 
         with pytest.raises(
             gt_frontend.GTScriptSyntaxError,
-            match="Cannot nest `with` node inside horizontal region",
+            match="Cannot nest `with` node inside a horizontal region.$",
         ):
             parse_definition(stencil, name=inspect.stack()[0][3], module=self.__class__.__name__)
 


### PR DESCRIPTION
## Description

Code readability and quality of life refactors around error messages coming from the gtscript frontend.

- Custom `GTError*` classes: added type hints
- Fontend exceptions: cleanup in default messages
- gtscript frontend
  - no `else` needed after `return` or `raise` in `if` statements.
  - leveraging early return to avoid unnecessary indentation levels
  - passing stencil name as `scope` in `nodes.Location` as part of error messages

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
