### PR TITLE
refactor[cartesian|next] Move imports of implementation down one level

### DIFF
--- a/src/gt4py/__init__.py
+++ b/src/gt4py/__init__.py
@@ -6,11 +6,14 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Python library for generating high-performance implementations of stencil kernels for weather and climate modeling."""
+"""Python library for generating high-performance implementations of stencil kernels for weather and climate modeling.
 
-import sys as _sys
+The library carries to implementations available as submodule imports:
+    - `gt4py.cartesian` is a cartesian grid restricted,
+    - `gt4py.next` supports structured and unstructured grid.
+"""
 
-from . import cartesian, eve, storage
+from . import eve, storage
 from .__about__ import __author__, __copyright__, __license__, __version__, __version_info__
 
 
@@ -20,13 +23,6 @@ __all__ = [
     "__license__",
     "__version__",
     "__version_info__",
-    "cartesian",
     "eve",
     "storage",
 ]
-
-
-if _sys.version_info >= (3, 10):
-    from . import next  # noqa: A004 shadowing a Python builtin
-
-    __all__ += ["next"]

--- a/src/gt4py/__init__.py
+++ b/src/gt4py/__init__.py
@@ -8,7 +8,7 @@
 
 """Python library for generating high-performance implementations of stencil kernels for weather and climate modeling.
 
-The library carries to implementations available as submodule imports:
+The library carries two implementations available as submodule imports:
     - `gt4py.cartesian` is a cartesian grid restricted,
     - `gt4py.next` supports structured and unstructured grid.
 """


### PR DESCRIPTION
## Description

As it stands now we have `gt4py.cartesian` and `gt4py.next `default importing themselves into the top level __init__.py . Now it isn't an issue per se, but it's a double import of a lot of files that ultimately will rarely be used in concert.

This proposes to remove the "all" import and rely on users to actually call `gt4py.next` and `gt4py.cartesian` which I expect is the common case anyway.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
