### PR TITLE
bug[next]: fix tuple output in direct field operator call with domain argument

### DIFF
--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -32,8 +32,8 @@ from gt4py.next import (
     config,
     embedded as next_embedded,
     errors,
-    utils,
     metrics,
+    utils,
 )
 from gt4py.next.embedded import operators as embedded_operators
 from gt4py.next.ffront import (

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -722,7 +722,7 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
             out = kwargs.pop("out")
             if "domain" in kwargs:
                 domain = common.domain(kwargs.pop("domain"))
-                out = utils.tree_map(lambda out_1: out_1[domain])(out)
+                out = utils.tree_map(lambda f: f[domain])(out)
 
             args, kwargs = type_info.canonicalize_arguments(
                 self.foast_stage.foast_node.type, args, kwargs

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -31,6 +31,7 @@ from gt4py.next import (
     config,
     embedded as next_embedded,
     errors,
+    utils,
 )
 from gt4py.next.embedded import operators as embedded_operators
 from gt4py.next.ffront import (
@@ -704,7 +705,7 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
             out = kwargs.pop("out")
             if "domain" in kwargs:
                 domain = common.domain(kwargs.pop("domain"))
-                out = out[domain]
+                out = utils.tree_map(lambda out_1: out_1[domain])(out)
 
             args, kwargs = type_info.canonicalize_arguments(
                 self.foast_stage.foast_node.type, args, kwargs

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -301,8 +301,8 @@ def test_call_bound_program_with_already_bound_arg(cartesian_case, bound_args_te
 @pytest.mark.uses_origin
 def test_direct_fo_call_with_domain_arg(cartesian_case):
     @field_operator
-    def testee(inp: IField) -> IField:
-        return inp
+    def testee(inp: IField) -> tuple[IField, IField]:
+        return (inp, inp)
 
     size = cartesian_case.default_sizes[IDim]
     inp = cases.allocate(cartesian_case, testee, "inp").unique()()

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -301,6 +301,24 @@ def test_call_bound_program_with_already_bound_arg(cartesian_case, bound_args_te
 @pytest.mark.uses_origin
 def test_direct_fo_call_with_domain_arg(cartesian_case):
     @field_operator
+    def testee(inp: IField) -> IField:
+        return inp
+
+    size = cartesian_case.default_sizes[IDim]
+    inp = cases.allocate(cartesian_case, testee, "inp").unique()()
+    out = cases.allocate(
+        cartesian_case, testee, cases.RETURN, strategy=cases.ConstInitializer(42)
+    )()
+    ref = inp.array_ns.zeros(size)
+    ref[0] = ref[-1] = 42
+    ref[1:-1] = inp.ndarray[1:-1]
+
+    cases.verify(cartesian_case, testee, inp, out=out, domain={IDim: (1, size - 1)}, ref=ref)
+
+
+@pytest.mark.uses_origin
+def test_direct_fo_call_with_domain_arg_tuple_return(cartesian_case):
+    @field_operator
     def testee(inp: IField) -> tuple[IField, IField]:
         return (inp, inp)
 
@@ -313,4 +331,4 @@ def test_direct_fo_call_with_domain_arg(cartesian_case):
     ref[0] = ref[-1] = 42
     ref[1:-1] = inp.ndarray[1:-1]
 
-    cases.verify(cartesian_case, testee, inp, out=out, domain={IDim: (1, size - 1)}, ref=ref)
+    cases.verify(cartesian_case, testee, inp, out=out, domain={IDim: (1, size - 1)}, ref=(ref, ref))

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_gt4py_builtins.py
@@ -324,10 +324,15 @@ def test_conditional_nested_tuple(cartesian_case):
         a,
         b,
         out=cases.allocate(cartesian_case, conditional_nested_tuple, cases.RETURN)(),
-        ref=np.where(
-            mask.asnumpy(),
-            ((a.asnumpy(), b.asnumpy()), (b.asnumpy(), a.asnumpy())),
-            ((np.full(size, 5.0), np.full(size, 7.0)), (np.full(size, 7.0), np.full(size, 5.0))),
+        ref=tuple(
+            np.where(
+                mask.asnumpy(),
+                ((a.asnumpy(), b.asnumpy()), (b.asnumpy(), a.asnumpy())),
+                (
+                    (np.full(size, 5.0), np.full(size, 7.0)),
+                    (np.full(size, 7.0), np.full(size, 5.0)),
+                ),
+            )
         ),
     )
 


### PR DESCRIPTION
`out` can be a single or multiple, these different scenarios are now handled by the lambda function