### PR TITLE
refactor/test[dace][next]: Better Testing Infrastructure.

### DIFF
--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/conftest.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/conftest.py
@@ -26,4 +26,11 @@ def common_dace_config() -> Generator[None, None, None]:
     with dace.config.temporary_config():
         dace.Config.set("optimizer", "match_exception", value=True)
         dace.Config.set("compiler", "allow_view_arguments", value=True)
+
+        # If the cache is used, then only the name is considered. Thus in tests
+        #  that compile the SDFG multiple times, for example to check if the result
+        #  is the same after the transformation, will only compile the SDFG once.
+        #  Thus potential errors by the transformation are hidden.
+        dace.Config.set("compiler.use_cache", value=False)
+
         yield

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_copy_chain_remover.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_copy_chain_remover.py
@@ -408,15 +408,13 @@ def test_multi_stage_reduction():
     res = copy.deepcopy(ref)
 
     # Generate the reference solution.
-    csdfg_ref = util.compile_and_run_sdfg(sdfg, **ref)
-    del csdfg_ref
+    util.compile_and_run_sdfg(sdfg, **ref)
 
     # Apply the transformation.
     nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     # Run the processed SDFG
-    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
-    del csdfg_res
+    util.compile_and_run_sdfg(sdfg, **res)
 
     # Perform all the checks.
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
@@ -442,8 +440,7 @@ def test_not_fully_copied():
     org = copy.deepcopy(ref)
 
     # Compile and run the original SDFG
-    csdfg_ref = util.compile_and_run_sdfg(sdfg, **ref)
-    del csdfg_ref
+    util.compile_and_run_sdfg(sdfg, **ref)
 
     # Apply the transformation.
     #  It will only remove `d` all the others are retained, because they are not read
@@ -459,9 +456,7 @@ def test_not_fully_copied():
     assert "d" not in acnodes
 
     # Now run the test and compare the results, see above for the ranges.
-    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
-    del csdfg_res
-
+    util.compile_and_run_sdfg(sdfg, **res)
     assert np.all(ref["a"] == res["a"])
     assert np.all(org["a"] == res["a"])
     assert np.all(res["e"][0:8] == ref["e"][0:8])
@@ -498,8 +493,7 @@ def test_a1_additional_output():
     }
     res = copy.deepcopy(ref)
 
-    csdfg_ref = util.compile_and_run_sdfg(sdfg, **ref)
-    del csdfg_ref
+    util.compile_and_run_sdfg(sdfg, **ref)
 
     # Apply the transformation.
     #  The transformation removes `a1` and `a2`.
@@ -516,8 +510,7 @@ def test_a1_additional_output():
     # Now run the SDFG, which is essentially to check if the subsets were handled
     #  correctly. This is especially important for `o1` which is composed of both
     #  `i1` and `i2`.
-    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
-    del csdfg_res
+    util.compile_and_run_sdfg(sdfg, **res)
 
     assert all(np.allclose(ref[name], res[name]) for name in ref.keys())
 
@@ -573,6 +566,5 @@ def test_linear_chain_with_nested_sdfg():
     assert inner_sdfg.arrays["o0"].strides == sdfg.arrays["e"].strides
 
     # Now run the transformed SDFG to see if the same output is generated.
-    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
-    del csdfg_res
+    util.compile_and_run_sdfg(sdfg, **res)
     assert all(np.allclose(ref[name], res[name]) for name in ref.keys())

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_copy_chain_remover.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_copy_chain_remover.py
@@ -408,15 +408,15 @@ def test_multi_stage_reduction():
     res = copy.deepcopy(ref)
 
     # Generate the reference solution.
-    csdfg_ref = sdfg.compile()
-    csdfg_ref(**ref)
+    csdfg_ref = util.compile_and_run_sdfg(sdfg, **ref)
+    del csdfg_ref
 
     # Apply the transformation.
     nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     # Run the processed SDFG
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
+    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
+    del csdfg_res
 
     # Perform all the checks.
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
@@ -442,8 +442,8 @@ def test_not_fully_copied():
     org = copy.deepcopy(ref)
 
     # Compile and run the original SDFG
-    csdfg_ref = sdfg.compile()
-    csdfg_ref(**ref)
+    csdfg_ref = util.compile_and_run_sdfg(sdfg, **ref)
+    del csdfg_ref
 
     # Apply the transformation.
     #  It will only remove `d` all the others are retained, because they are not read
@@ -459,8 +459,8 @@ def test_not_fully_copied():
     assert "d" not in acnodes
 
     # Now run the test and compare the results, see above for the ranges.
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
+    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
+    del csdfg_res
 
     assert np.all(ref["a"] == res["a"])
     assert np.all(org["a"] == res["a"])
@@ -498,8 +498,8 @@ def test_a1_additional_output():
     }
     res = copy.deepcopy(ref)
 
-    csdfg_ref = sdfg.compile()
-    csdfg_ref(**ref)
+    csdfg_ref = util.compile_and_run_sdfg(sdfg, **ref)
+    del csdfg_ref
 
     # Apply the transformation.
     #  The transformation removes `a1` and `a2`.
@@ -516,8 +516,9 @@ def test_a1_additional_output():
     # Now run the SDFG, which is essentially to check if the subsets were handled
     #  correctly. This is especially important for `o1` which is composed of both
     #  `i1` and `i2`.
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
+    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
+    del csdfg_res
+
     assert all(np.allclose(ref[name], res[name]) for name in ref.keys())
 
 
@@ -572,6 +573,6 @@ def test_linear_chain_with_nested_sdfg():
     assert inner_sdfg.arrays["o0"].strides == sdfg.arrays["e"].strides
 
     # Now run the transformed SDFG to see if the same output is generated.
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
+    csdfg_res = util.compile_and_run_sdfg(sdfg, **res)
+    del csdfg_res
     assert all(np.allclose(ref[name], res[name]) for name in ref.keys())

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_map_fusion.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_map_fusion.py
@@ -735,8 +735,7 @@ def test_multi_producer_sdfg():
     }
     res = copy.deepcopy(ref)
 
-    csdfg_ref = sdfg.compile()
-    csdfg_ref(**ref)
+    util.compile_and_run_sdfg(sdfg, **ref)
 
     nb_applies = sdfg.apply_transformations_repeated(
         gtx_transformations.MapFusion(), validate=True, validate_all=True
@@ -754,8 +753,7 @@ def test_multi_producer_sdfg():
     )
     assert util.count_nodes(state, dace_nodes.MapEntry) == 3
 
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
+    util.compile_and_run_sdfg(sdfg, **res)
     assert all(np.allclose(ref[name], res[name]) for name in ref)
 
 
@@ -773,8 +771,7 @@ def test_relocation_connectors():
     }
     res = copy.deepcopy(ref)
 
-    csdfg_ref = sdfg.compile()
-    csdfg_ref(**ref)
+    util.compile_and_run_sdfg(sdfg, **ref)
 
     nb_applies = sdfg.apply_transformations_repeated(
         gtx_transformations.MapFusion(), validate=True, validate_all=True
@@ -807,7 +804,5 @@ def test_relocation_connectors():
     assert state.out_degree(inner_me) == 2
     assert len(inner_me.out_connectors) == 2
 
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
-
+    util.compile_and_run_sdfg(sdfg, **res)
     assert all(np.allclose(ref[name], res[name]) for name in res)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_move_dataflow_into_if_body.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_move_dataflow_into_if_body.py
@@ -11,7 +11,6 @@ import pytest
 import copy
 
 from typing import Optional
-import gc
 
 
 dace = pytest.importorskip("dace")
@@ -100,9 +99,7 @@ def _perform_test(
     res = copy.deepcopy(ref)
 
     if explected_applies != 0:
-        csdfg_ref = sdfg.compile()
-        csdfg_ref(**ref)
-        del csdfg_ref  # See note below.
+        util.compile_and_run_sdfg(sdfg, **ref)
 
     nb_apply = sdfg.apply_transformations_repeated(
         gtx_transformations.MoveDataflowIntoIfBody(),
@@ -114,14 +111,8 @@ def _perform_test(
     if explected_applies == 0:
         return
 
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
-
+    util.compile_and_run_sdfg(sdfg, **res)
     assert all(np.allclose(ref[name], res[name]) for name in ref.keys())
-
-    # NOTE: This ensures that the SDFG gets properly unloaded.
-    del csdfg_res
-    gc.collect()
 
 
 def test_if_mover_independent_branches():

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_move_tasklet_into_map.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_move_tasklet_into_map.py
@@ -75,8 +75,7 @@ def test_move_tasklet_inside_trivial_memlet_tree():
     B = np.array(np.random.rand(10, 10), dtype=np.float64, copy=True)
     ref = A + 1.2
 
-    csdfg = sdfg.compile()
-    csdfg(A=A, B=B)
+    util.compile_and_run_sdfg(sdfg, A=A, B=B)
     assert np.allclose(B, ref)
 
 
@@ -99,8 +98,7 @@ def test_move_tasklet_inside_non_trivial_memlet_tree():
     B = np.array(np.random.rand(10, 10), dtype=np.float64, copy=True)
     ref = A + 1.2
 
-    csdfg = sdfg.compile()
-    csdfg(A=A, B=B)
+    util.compile_and_run_sdfg(sdfg, A=A, B=B)
     assert np.allclose(B, ref)
 
 
@@ -132,8 +130,7 @@ def test_move_tasklet_inside_two_inner_connector():
     B = np.array(np.random.rand(10, 10), dtype=np.float64, copy=True)
     ref = A + 2 * (32.2)
 
-    csdfg = sdfg.compile()
-    csdfg(A=A, B=B)
+    util.compile_and_run_sdfg(sdfg, A=A, B=B)
     assert np.allclose(B, ref)
 
 
@@ -156,7 +153,6 @@ def test_move_tasklet_inside_outer_scalar_used_outside():
     ref_C = 22.6
     ref_B = A + ref_C
 
-    csdfg = sdfg.compile()
-    csdfg(A=A, B=B, C=C)
+    util.compile_and_run_sdfg(sdfg, A=A, B=B, C=C)
     assert np.allclose(B, ref_B)
     assert np.allclose(C, ref_C)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_single_state_global_self_copy_elimination.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_single_state_global_self_copy_elimination.py
@@ -260,8 +260,7 @@ def test_direct_global_self_copy_used():
     }
     res = {k: np.copy(v, order="K") for k, v in ref.items()}
 
-    csdfg_ref = sdfg.compile()
-    csdfg_ref(**ref)
+    util.compile_and_run_sdfg(sdfg, **ref)
 
     count = sdfg.apply_transformations_repeated(
         gtx_transformations.SingleStateGlobalDirectSelfCopyElimination,
@@ -274,9 +273,7 @@ def test_direct_global_self_copy_used():
     assert len(ac_nodes_after) == 4
     assert len(set(ac.data for ac in ac_nodes_after)) == 4
 
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
-
+    util.compile_and_run_sdfg(sdfg, **res)
     assert all(np.all(ref[k] == res[k]) for k in ref.keys())
 
 

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
@@ -42,8 +42,7 @@ def _perform_test(
         )
 
     if explected_applies != 0:
-        csdfg_ref = sdfg.compile()
-        csdfg_ref(**ref)
+        util.compile_and_run_sdfg(sdfg, **ref)
 
     nb_apply = gtx_transformations.gt_split_access_nodes(
         sdfg=sdfg,
@@ -55,9 +54,7 @@ def _perform_test(
     if explected_applies == 0:
         return
 
-    csdfg_res = sdfg.compile()
-    csdfg_res(**res)
-
+    util.compile_and_run_sdfg(sdfg, **res)
     assert all(np.allclose(ref[name], res[name]) for name in ref.keys())
 
     if removed_transients is not None:

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/util.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/util.py
@@ -76,12 +76,14 @@ def compile_and_run_sdfg(
     regenerated and recompiled properly. It will also suppress warnings about
     shared objects that are loaded multiple times.
     """
-    sdfg_clone = copy.deepcopy(sdfg)
 
-    sdfg_clone.name = unique_name(sdfg_clone.name)
-    sdfg_clone._recompile = True
-    sdfg_clone._regenerate_code = True  # Does this anything?
-    csdfg = sdfg_clone.compile()
-    csdfg(*args, **kwargs)
+    with dace.config.set_temporary("compiler.use_cache", value=False):
+        sdfg_clone = copy.deepcopy(sdfg)
+
+        sdfg_clone.name = unique_name(sdfg_clone.name)
+        sdfg_clone._recompile = True
+        sdfg_clone._regenerate_code = True  # TODO(phimuell): Find out if it has an effect.
+        csdfg = sdfg_clone.compile()
+        csdfg(*args, **kwargs)
 
     return csdfg

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/util.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/util.py
@@ -7,9 +7,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import uuid
-from typing import Literal, Union, overload
+from typing import Literal, Union, overload, Any
 
 import dace
+import copy
 from dace.sdfg import nodes as dace_nodes
 
 
@@ -57,4 +58,30 @@ def count_nodes(
 
 def unique_name(name: str) -> str:
     """Adds a unique string to `name`."""
-    return f"{name}_{str(uuid.uuid1()).replace('-', '_')}"
+    maximal_length = 200
+    unique_sufix = str(uuid.uuid1()).replace("-", "_")
+    if len(name) > (maximal_length - len(unique_sufix)):
+        name = name[: (maximal_length - len(unique_sufix) - 1)]
+    return f"{name}_{unique_sufix}"
+
+
+def compile_and_run_sdfg(
+    sdfg: dace.SDFG,
+    *args: Any,
+    **kwargs: Any,
+) -> dace.codegen.CompiledSDFG:
+    """This function guarantees that the SDFG is compiled and run.
+
+    This function will modify the name of the SDFG to ensure that the code is
+    regenerated and recompiled properly. It will also suppress warnings about
+    shared objects that are loaded multiple times.
+    """
+    sdfg_clone = copy.deepcopy(sdfg)
+
+    sdfg_clone.name = unique_name(sdfg_clone.name)
+    sdfg_clone._recompile = True
+    sdfg_clone._regenerate_code = True  # Does this anything?
+    csdfg = sdfg_clone.compile()
+    csdfg(*args, **kwargs)
+
+    return csdfg


### PR DESCRIPTION
This PR updates the set of configuration variables that are always set (by an autouse fixture).
It now also sets `use_cache` to `False`, the main issue is that some tests compile the SDFG multiple times.
It also adds a function that simplifies compilation.
It will give the SDFG a unique name which will avoid the warning that an SDFG was already loaded a and a different name was selected (this will mostly clean the log).

This PR should be merged after [PR#2050](https://github.com/GridTools/gt4py/pull/2050).


