### PR TITLE
feat[dace][next]: Added `MultiStateGlobalSelfCopyElimination2`

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
@@ -29,6 +29,7 @@ from .move_dataflow_into_if_body import MoveDataflowIntoIfBody
 from .redundant_array_removers import (
     CopyChainRemover,
     MultiStateGlobalSelfCopyElimination,
+    MultiStateGlobalSelfCopyElimination2,
     SingleStateGlobalDirectSelfCopyElimination,
     SingleStateGlobalSelfCopyElimination,
     gt_multi_state_global_self_copy_elimination,
@@ -69,6 +70,7 @@ __all__ = [
     "MapIterationOrder",
     "MoveDataflowIntoIfBody",
     "MultiStateGlobalSelfCopyElimination",
+    "MultiStateGlobalSelfCopyElimination2",
     "SerialMapPromoter",
     "SerialMapPromoterGPU",
     "SingleStateGlobalDirectSelfCopyElimination",

--- a/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, TypeAlias, Union
 
 import dace
 from dace import (
@@ -23,6 +23,11 @@ from dace.transformation.passes import analysis as dace_analysis
 from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
 
 
+AccessLocation: TypeAlias = tuple[dace.SDFGState, dace_nodes.AccessNode]
+"""An AccessNode and the state it is located in.
+"""
+
+
 def gt_multi_state_global_self_copy_elimination(
     sdfg: dace.SDFG,
     validate: bool = False,
@@ -31,15 +36,24 @@ def gt_multi_state_global_self_copy_elimination(
 
     For the return value see `MultiStateGlobalSelfCopyElimination.apply_pass()`.
     """
-    pipeline = dace_ppl.Pipeline([gtx_transformations.MultiStateGlobalSelfCopyElimination()])
-    res = pipeline.apply_pass(sdfg, {})
+    transforms = [
+        gtx_transformations.MultiStateGlobalSelfCopyElimination(),
+        gtx_transformations.MultiStateGlobalSelfCopyElimination2(),
+    ]
+
+    pipeline = dace_ppl.Pipeline(transforms)
+    pip_res = pipeline.apply_pass(sdfg, {})
 
     if validate:
         sdfg.validate()
 
-    if "MultiStateGlobalSelfCopyElimination" not in res:
-        return None
-    return res["MultiStateGlobalSelfCopyElimination"][sdfg]
+    res: dict[dace.SDFG, set[str]] = {}
+    for trans in transforms:
+        tname = trans.__class__.__name__
+        if tname in pip_res:
+            for nsdfg, processed_data in pip_res[tname].items():
+                res.setdefault(nsdfg, set()).update(processed_data)
+    return res if res else None
 
 
 def gt_remove_copy_chain(
@@ -468,6 +482,293 @@ class MultiStateGlobalSelfCopyElimination(dace_transformation.Pass):
                 if dnode.data == dname:
                     return True
         return False
+
+
+@dace_properties.make_properties
+class MultiStateGlobalSelfCopyElimination2(dace_transformation.Pass):
+    """Removes self copying across different states.
+
+    This function is very similar to `MultiStateGlobalSelfCopyElimination2`, however,
+    it is a bit more restricted, as `MultiStateGlobalSelfCopyElimination` has a much
+    better way to handle some edge cases.
+    The main difference is that `MultiStateGlobalSelfCopyElimination2` uses an other
+    way to locate the redundant data. Instead of focusing on the on the globals this
+    transformation focuses on the transients.
+
+    Todo:
+        Merge with the `MultiStateGlobalSelfCopyElimination2`.
+    """
+
+    def modifies(self) -> dace_ppl.Modifies:
+        return dace_ppl.Modifies.Memlets | dace_ppl.Modifies.AccessNodes
+
+    def should_reapply(self, modified: dace_ppl.Modifies) -> bool:
+        return modified & (dace_ppl.Modifies.Memlets | dace_ppl.Modifies.AccessNodes)
+
+    def apply_pass(
+        self, sdfg: dace.SDFG, pipeline_results: dict[str, Any]
+    ) -> Optional[dict[dace.SDFG, set[str]]]:
+        """Applies the pass.
+
+        The function will return a `dict` that contains for every SDFG, the name
+        of the processed data descriptors. If a name refers to a global memory,
+        then it means that all write backs, i.e. `(T) -> (G)` patterns, have
+        been removed for that `G`. If the name refers to a data descriptor that no
+        longer exists, then it means that the write `(G) -> (T)` was also eliminated.
+        Currently there is no possibility to identify which transient name belonged
+        to a global name.
+        """
+        result: dict[dace.SDFG, set[str]] = dict()
+        for nsdfg in sdfg.all_sdfgs_recursive():
+            single_level_res: set[str] = self._process_sdfg(nsdfg, pipeline_results)
+            if single_level_res:
+                result[nsdfg] = single_level_res
+
+        return result if result else None
+
+    def _process_sdfg(
+        self,
+        sdfg: dace.SDFG,
+        pipeline_results: dict[str, Any],
+    ) -> set[str]:
+        """Processes the SDFG in a not recursive way, it returns the set of transients
+        that have been eliminated.
+        """
+        redundant_transients = self._find_redundant_transients(sdfg)
+        if len(redundant_transients) == 0:
+            return set()
+
+        for global_data, write_locations, read_locations in redundant_transients.values():
+            self._remove_transient_at_definition_point(global_data, write_locations)
+            self._remove_transient_at_using_location(
+                sdfg,
+                global_data,
+                read_locations,
+            )
+
+        return set(redundant_transients.keys())
+
+    def _remove_transient_at_using_location(
+        self,
+        sdfg: dace.SDFG,
+        global_data: str,
+        read_locations: list[AccessLocation],
+    ) -> None:
+        """Removes the write back from the transient into the global.
+
+        If the global node has become isolated it will be removed. In addition the
+        function will also remove the transient data from the SDFG.
+        """
+        for state, transient_ac in read_locations:
+            assert state.in_degree(transient_ac) == 0
+            assert state.out_degree(transient_ac) == 1
+
+            transient_neighbours = [oedge.dst for oedge in state.out_edges(transient_ac)]
+            state.remove_node(transient_ac)
+
+            for transient_neighbour in transient_neighbours:
+                if state.degree(transient_neighbour) == 0:
+                    state.remove_node(transient_neighbour)
+
+            if transient_ac.data in sdfg.arrays:
+                sdfg.remove_data(transient_ac.data)
+
+    def _remove_transient_at_definition_point(
+        self,
+        global_data: str,
+        write_locations: list[AccessLocation],
+    ) -> None:
+        """Clean up the transient at its definition point.
+
+        The function removes the write from the global into the transient. The
+        function will also remove any node that has become isolated.
+        However, the function will not remove the transient data from the registry.
+        """
+        for state, transient_ac in write_locations:
+            assert state.in_degree(transient_ac) == 1
+            assert state.out_degree(transient_ac) == 0
+
+            transient_neighbours = [iedge.src for iedge in state.in_edges(transient_ac)]
+            state.remove_node(transient_ac)
+
+            for transient_neighbour in transient_neighbours:
+                if state.degree(transient_neighbour) == 0:
+                    state.remove_node(transient_neighbour)
+
+    def _find_redundant_transients(
+        self,
+        sdfg: dace.SDFG,
+    ) -> dict[str, tuple[str, list[AccessLocation], list[AccessLocation]]]:
+        """Find all redundant transients that can be eliminated.
+
+        The function returns a `dict` mapping the name of the transient data to a tuple
+        of length 3. The first element is the name of the global data that defines
+        the transient. The second element are the locations where the transient is
+        defined, i.e. written to and in the third element are the locations where the
+        transient is used.
+        """
+
+        # Scan all transients and find their location.
+        possible_redundant_transients: dict[
+            str, tuple[list[AccessLocation], list[AccessLocation]]
+        ] = {}
+        for data_name, desc in sdfg.arrays.items():
+            if not desc.transient:
+                continue
+            write_read_locations = self._find_exclusive_read_and_write_locations_of(sdfg, data_name)
+            if write_read_locations is None:
+                continue
+            if len(write_read_locations[1]) != 0:
+                possible_redundant_transients[data_name] = write_read_locations
+
+        # Nothing was found.
+        if len(possible_redundant_transients) == 0:
+            return {}
+
+        # Determine the associated global data.
+        redundant_transients_and_associated_data: dict[
+            str, tuple[str, list[AccessLocation], list[AccessLocation]]
+        ] = {}
+        involved_global_data: set[str] = set()
+        for transient_data, (
+            write_locations,
+            read_locations,
+        ) in possible_redundant_transients.items():
+            associated_global_data = self._filter_candidate(
+                sdfg,
+                transient_data,
+                write_locations,
+                read_locations,
+            )
+            if associated_global_data is not None:
+                # This is for simplifying implementation.
+                assert associated_global_data not in involved_global_data
+                involved_global_data.add(associated_global_data)
+                redundant_transients_and_associated_data[transient_data] = (
+                    associated_global_data,
+                    write_locations,
+                    read_locations,
+                )
+
+        return redundant_transients_and_associated_data
+
+    def _filter_candidate(
+        self,
+        sdfg: dace.SDFG,
+        transient_data: str,
+        write_locations: list[AccessLocation],
+        read_locations: list[AccessLocation],
+    ) -> Union[None, str]:
+        """Test if the transient can be eliminated.
+
+        The function tests if transient data can be eliminated and be replaced by a
+        global data. If this is the case the function returns the name of the data
+        and if this is not possible `None`.
+        """
+
+        # Currently we require that there is exactly one location where the temporary
+        #  is defined and written back. This is a simplification, that should be
+        #  removed.
+        if len(write_locations) != 1 and len(read_locations) != 1:
+            return None
+
+        # We actually have to check if the global data is not modified between the
+        #  location where the transient is defined and where it is written back.
+        #  `MultiStateGlobalSelfCopyElimination` does this in a quite sophisticated
+        #  way. We do it cheap we require that the state in which the definition of
+        #  the transient happens is the immediate predecessor of where it is used.
+        #  We now also hope that the transient is not used somewhere else.
+        for defining_state, _ in write_locations:
+            # If we are in a nested CFR, we will go upward until we found some
+            #  outgoing edge.
+            successor_states = gtx_transformations.utils.find_successor_state(defining_state)
+            if not all(
+                write_back_state in successor_states for write_back_state, _ in read_locations
+            ):
+                return None
+
+        # We now must look at what defines the transient. For that we look at what
+        #  defines it. For that there must be global data that writes into it.
+        # TODO(phimuell): To better handle `concat_where` also allows that more
+        #   producers are allowed, also differently.
+        # TODO(phimuell): In `concat_where` we are using `dynamic` Memlets, they should
+        #   also be checked.
+        global_data: Union[None, str] = None
+        for state, transient_access_node in write_locations:
+            for iedge in state.in_edges(transient_access_node):
+                src_node = iedge.src
+                if not isinstance(src_node, dace_nodes.AccessNode):
+                    return None
+
+                if src_node.desc(sdfg).transient:
+                    # Non global data writes into the transient.
+                    # TODO(phimuell): Lift this.
+                    return None
+
+                # TODO(phimuell): Extend this such that there could be multiple
+                #   connection from the same global.
+                if global_data is None:
+                    global_data = src_node.data
+                else:
+                    return None
+
+        # No global data defines the transient.
+        if global_data is None:
+            return None
+
+        # We now check that the transient is used to write back to the global.
+        #  Currently we only allow that there is a single connection.
+        #  The main issue with allowing multiple connections is that we can no
+        #  longer be sure that everything is written. I encountered some dead
+        #  writes once.
+        assert global_data is not None
+        for state, transient_access_node in read_locations:
+            assert state.in_degree(transient_access_node) == 0
+            if state.out_degree(transient_access_node) != 1:
+                return None
+            if not all(
+                isinstance(oedge.dst, dace_nodes.AccessNode) and oedge.dst.data == global_data
+                for oedge in state.out_edges(transient_access_node)
+            ):
+                return None
+
+        return global_data
+
+    def _find_exclusive_read_and_write_locations_of(
+        self,
+        sdfg: dace.SDFG,
+        data_name: str,
+    ) -> Union[None, tuple[list[AccessLocation], list[AccessLocation]]]:
+        """The function finds all locations were `data_name` is written and read.
+
+        The function will scan the SDFG and returns all places where `data_name` is
+        written and where it is read from. If there is however, a location where the
+        data is read and written to in the same place then the function returns
+        `None`.
+
+        In essence this function returns the set of all possible matches the
+        transformation is looking for, but further processing has to be performed.
+        """
+        read_locations: list[AccessLocation] = []
+        write_locations: list[AccessLocation] = []
+
+        for state in sdfg.states():
+            for dnode in state.data_nodes():
+                if dnode.data != data_name:
+                    continue
+                out_deg = state.out_degree(dnode)
+                in_deg = state.in_degree(dnode)
+
+                # This is not the pattern we are looking for.
+                if out_deg > 0 and in_deg > 0:
+                    return None
+                elif out_deg > 0:
+                    read_locations.append((state, dnode))
+                else:
+                    assert in_deg > 0
+                    write_locations.append((state, dnode))
+
+        return (write_locations, read_locations)
 
 
 @dace_properties.make_properties

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_multi_state_global_self_copy_elimination.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_multi_state_global_self_copy_elimination.py
@@ -26,7 +26,8 @@ import dace
 def apply_distributed_self_copy_elimination(
     sdfg: dace.SDFG,
 ) -> Optional[dict[dace.SDFG, set[str]]]:
-    return gtx_transformations.gt_multi_state_global_self_copy_elimination(sdfg=sdfg, validate=True)
+    res = gtx_transformations.gt_multi_state_global_self_copy_elimination(sdfg=sdfg, validate=True)
+    return res if res is None else res[sdfg]
 
 
 def _make_not_apply_because_of_write_to_g_sdfg() -> dace.SDFG:


### PR DESCRIPTION
This PR adds the `MultiStateGlobalSelfCopyElimination2` transformation.
It is very similar to `MultiStateGlobalSelfCopyElimination`, however, it uses a different way to identify what to remove.
Instead scanning the global data and then identifying it searches for the transient data.
In fact the two transformation should be merged, however, currently there is no time in doing that, thus they will exist for the time being in parallel.
