### PR TITLE
fix[next][dace]: Updated `SerialMapPromoter`

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -268,19 +268,16 @@ def _gt_auto_process_top_level_maps(
 
         # Now do some cleanup task, that may enable further fusion opportunities.
         #  Note for performance reasons simplify is deferred.
-        cleanup_stages = [
-            gtx_transformations.SplitAccessNode(
-                single_use_data=single_use_data,
-            ),
-            gtx_transformations.GT4PyMapBufferElimination(
-                assume_pointwise=assume_pointwise,
-            ),
-        ]
-
-        # Perform the clean up.
         gtx_transformations.gt_reduce_distributed_buffering(sdfg)
         sdfg.apply_transformations_repeated(
-            cleanup_stages,
+            [
+                gtx_transformations.SplitAccessNode(
+                    single_use_data=single_use_data,
+                ),
+                gtx_transformations.GT4PyMapBufferElimination(
+                    assume_pointwise=assume_pointwise,
+                ),
+            ],
             validate=validate,
             validate_all=validate_all,
         )

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -252,6 +252,18 @@ def _gt_auto_process_top_level_maps(
             validate_all=validate_all,
         )
 
+        # We have to call it here, such that some other transformations, most
+        #  importantly the split transformations run.
+        # TODO(phimuell): Add a criteria to decide if we should promote or not.
+        sdfg.apply_transformations_repeated(
+            gtx_transformations.SerialMapPromoter(
+                only_toplevel_maps=True,
+                promote_vertical=True,
+                promote_horizontal=False,
+                promote_local=False,
+            ),
+        )
+
         # Now do some cleanup task, that may enable further fusion opportunities.
         #  Note for performance reasons simplify is deferred.
         cleanup_stages = [
@@ -260,13 +272,6 @@ def _gt_auto_process_top_level_maps(
             ),
             gtx_transformations.GT4PyMapBufferElimination(
                 assume_pointwise=assume_pointwise,
-            ),
-            # TODO(phimuell): Add a criteria to decide if we should promote or not.
-            gtx_transformations.SerialMapPromoter(
-                only_toplevel_maps=True,
-                promote_vertical=True,
-                promote_horizontal=False,
-                promote_local=False,
             ),
         ]
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -262,6 +262,8 @@ def _gt_auto_process_top_level_maps(
                 promote_horizontal=False,
                 promote_local=False,
             ),
+            validate=validate,
+            validate_all=validate_all,
         )
 
         # Now do some cleanup task, that may enable further fusion opportunities.

--- a/src/gt4py/next/program_processors/runners/dace/transformations/map_promoter.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/map_promoter.py
@@ -172,9 +172,9 @@ class SerialMapPromoter(dace_transformation.SingleStateTransformation):
 
         if self.only_inner_maps or self.only_toplevel_maps:
             scope_dict: Mapping[dace_nodes.Node, Union[dace_nodes.Node, None]] = graph.scope_dict()
-            if self.only_inner_maps and (scope_dict[first_map_exit] is None):
+            if self.only_inner_maps and (scope_dict[second_map_entry] is None):
                 return False
-            if self.only_toplevel_maps and (scope_dict[first_map_exit] is not None):
+            if self.only_toplevel_maps and (scope_dict[second_map_entry] is not None):
                 return False
 
         # Test if the map ranges and parameter are compatible with each other

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_serial_map_promoter.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_serial_map_promoter.py
@@ -75,14 +75,17 @@ def test_serial_map_promotion():
     assert len(map_entry_2d.map.range) == 2
 
     # Now apply the promotion
-    sdfg.apply_transformations(
+    count = sdfg.apply_transformations(
         gtx_transformations.SerialMapPromoter(
             promote_all=True,
+            # Do not fuse to inspect that the promotion worked.
+            fuse_after_promotion=False,
         ),
         validate=True,
         validate_all=True,
     )
 
+    assert count == 1
     assert util.count_nodes(sdfg, dace_nodes.MapEntry) == 2
     assert len(map_entry_1d.map.params) == 2
     assert len(map_entry_1d.map.range) == 2

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_serial_map_promoter.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_serial_map_promoter.py
@@ -16,12 +16,15 @@ from gt4py.next.program_processors.runners.dace import (
     transformations as gtx_transformations,
 )
 
+import copy
+
 
 from . import util
 
 
-def test_serial_map_promotion():
-    """Tests the serial Map promotion transformation."""
+def _make_serial_map_promotion_sdfg() -> (
+    tuple[dace.SDFG, dace.SDFGState, dace_nodes.MapEntry, dace_nodes.MapEntry]
+):
     N = 10
     shape_1d = (N,)
     shape_2d = (N, N)
@@ -68,6 +71,12 @@ def test_serial_map_promotion():
         external_edges=True,
     )
 
+    return sdfg, state, map_entry_1d, map_entry_2d
+
+
+def test_serial_map_promotion_only_promote():
+    sdfg, state, map_entry_1d, map_entry_2d = _make_serial_map_promotion_sdfg()
+
     assert util.count_nodes(sdfg, dace_nodes.MapEntry) == 2
     assert len(map_entry_1d.map.params) == 1
     assert len(map_entry_1d.map.range) == 1
@@ -96,3 +105,37 @@ def test_serial_map_promotion():
         rng_1d == rng_2d
         for rng_1d, rng_2d in zip(map_entry_1d.map.range.ranges, map_entry_2d.map.range.ranges)
     )
+
+
+def test_serial_map_promotion_promote_and_merge():
+    sdfg, state, map_entry_1d, map_entry_2d = _make_serial_map_promotion_sdfg()
+
+    assert util.count_nodes(sdfg, dace_nodes.MapEntry) == 2
+    assert len(map_entry_1d.map.params) == 1
+    assert len(map_entry_1d.map.range) == 1
+    assert len(map_entry_2d.map.params) == 2
+    assert len(map_entry_2d.map.range) == 2
+
+    original_2d_params = list(map_entry_2d.map.params)
+    original_2d_range = copy.deepcopy(map_entry_2d.map.range)
+
+    # Now apply the promotion
+    count = sdfg.apply_transformations(
+        gtx_transformations.SerialMapPromoter(
+            promote_all=True,
+            fuse_after_promotion=True,
+        ),
+        validate=True,
+        validate_all=True,
+    )
+
+    assert count == 1
+    mes = util.count_nodes(sdfg, dace_nodes.MapEntry, True)
+
+    assert len(mes) == 1
+    me = mes[0]
+
+    assert len(me.map.params) == 2
+    assert me.map.params == original_2d_params
+    assert len(me.map.range) == 2
+    assert me.map.range == original_2d_range


### PR DESCRIPTION
This PR modifies the `SerialMapPromoter` in such a way that it performs the fusing of the two Maps immediately after the promotion.
This is needed because technically such an SDFG is invalid as memory locations are now written multiple time (it was not critical, because they always write the same value).
By performing the fuse inside the `apply()` function, no invalid SDFG is visible to the outside.

Furthermore, this PR removes the `BasePromoter` that was not used anywhere else.
As an additional restriction it is now only possible to promote the first Map, and no longer the second Map, however, this feature was probably unneeded anyway (in GPU transformations it might be needed).