### PR TITLE
fix[next][dace]: Add method to create custom dace backend

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace/__init__.py
@@ -10,6 +10,7 @@
 from gt4py.next.program_processors.runners.dace.gtir_sdfg import build_sdfg_from_gtir
 from gt4py.next.program_processors.runners.dace.sdfg_callable import get_sdfg_args
 from gt4py.next.program_processors.runners.dace.workflow.backend import (
+    make_dace_backend,
     run_dace_cpu,
     run_dace_cpu_cached,
     run_dace_cpu_noopt,
@@ -22,6 +23,7 @@ from gt4py.next.program_processors.runners.dace.workflow.backend import (
 __all__ = [
     "build_sdfg_from_gtir",
     "get_sdfg_args",
+    "make_dace_backend",
     "run_dace_cpu",
     "run_dace_cpu_cached",
     "run_dace_cpu_noopt",

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -17,7 +17,7 @@ import dace
 import factory
 
 from gt4py._core import definitions as core_defs
-from gt4py.next import config, metrics
+from gt4py.next import config
 from gt4py.next.otf import languages, stages, step_types, workflow
 
 from . import common as dace_common
@@ -117,17 +117,12 @@ class DaCeCompiler(
         self,
         inp: stages.CompilableSource[languages.SDFG, languages.LanguageSettings, languages.Python],
     ) -> CompiledDaceProgram:
-        sdfg = dace.SDFG.from_json(inp.program_source.source_code)
-
-        if config.COLLECT_METRICS_LEVEL >= metrics.PERFORMANCE:
-            # measure execution time of the top-level SDFG
-            sdfg.instrument = dace.dtypes.InstrumentationType.Timer
-
         with dace.config.temporary_config():
             dace_common.set_dace_config(
                 device_type=self.device_type,
                 cmake_build_type=self.cmake_build_type,
             )
+            sdfg = dace.SDFG.from_json(inp.program_source.source_code)
             sdfg_program = sdfg.compile(validate=False)
 
         assert inp.binding_source is not None

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -15,7 +15,7 @@ import dace
 import factory
 
 from gt4py._core import definitions as core_defs
-from gt4py.next import common, config
+from gt4py.next import common, config, metrics
 from gt4py.next.iterator import ir as itir, transforms as itir_transforms
 from gt4py.next.otf import arguments, languages, stages, step_types, workflow
 from gt4py.next.otf.binding import interface
@@ -184,9 +184,12 @@ class DaCeTranslator(
                 gtx_transformations.gt_simplify(sdfg)
                 gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
 
-        # Do not use async SDFG call when collecting metrics: we use SDFG instrumentatiom
-        #   and therefore the SDFG execution has to complete before we can retrieve the report.
-        if on_gpu and self.async_sdfg_call and not config.COLLECT_METRICS_LEVEL:
+        if config.COLLECT_METRICS_LEVEL != metrics.DISABLED:
+            # measure execution time of the top-level SDFG
+            sdfg.instrument = dace.dtypes.InstrumentationType.Timer
+        elif on_gpu and self.async_sdfg_call:
+            # Do not use async SDFG call when collecting metrics: we use SDFG instrumentatiom
+            #   and therefore the SDFG execution has to complete before we can retrieve the report.
             make_sdfg_async(sdfg)
 
         return sdfg
@@ -216,7 +219,7 @@ class DaCeTranslator(
         module: stages.ProgramSource[languages.SDFG, languages.LanguageSettings] = (
             stages.ProgramSource(
                 entry_point=interface.Function(program.id, program_parameters),
-                source_code=sdfg.to_json(),
+                source_code=sdfg.to_json(hash=True),
                 library_deps=tuple(),
                 language=languages.SDFG,
                 language_settings=languages.LanguageSettings(


### PR DESCRIPTION
This PR was developed while debugging why the dace cache was not working in the icon4py granule tests. It was found that the granule test was setting up the dace backend with custom settings in a wrong way, basically disabling the translation cache. Therefore, this PR introduces a function `make_dace_backend()` to create a dace backend with custom setting for SDFG lowering and auto-optimize. Besides, this PR also contains some cleanup in the area of SDFG serialization to JSON and compilation.