### PR TITLE
CI: Limit GT4PY_BUILD_JOBS=2 as workaround for hanging of dace-gpu tests

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,6 +109,8 @@ build_py310_image_aarch64:
   stage: test
   image: $CSCS_REGISTRY_PATH/public/$ARCH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
   script:
+  - pwd
+  - ls -la
   - cd /gt4py.src
   - echo "CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}"
   - export GITHUB_PR="${CI_COMMIT_BRANCH#__CSCSCI__pr}"

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,8 +109,7 @@ build_py310_image_aarch64:
   stage: test
   image: $CSCS_REGISTRY_PATH/public/$ARCH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
   script:
-  - cp -r /gt4py.src .
-  - cd gt4py.src
+  - cd /gt4py.src
   - echo "CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}"
   - export GITHUB_PR="${CI_COMMIT_BRANCH#__CSCSCI__pr}"
   - echo "GITHUB_PR=${GITHUB_PR}"
@@ -152,8 +151,7 @@ build_py310_image_aarch64:
       VARIANT: ['cuda12', 'cpu']
   variables:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    # Another problem, observed in test stage, is that gpu tests hang in combination with CUDA MPS,
-    # when high test parallelism is used.
+    GT4PY_BUILD_JOBS: 8
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 
 # test_py311_x86_64:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,8 +109,6 @@ build_py310_image_aarch64:
   stage: test
   image: $CSCS_REGISTRY_PATH/public/$ARCH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
   script:
-  - export GT4PY_BUILD_CACHE_DIR=$PWD
-  - export GT4PY_BUILD_CACHE_LIFETIME=session
   - cd /gt4py.src
   - echo "CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}"
   - export GITHUB_PR="${CI_COMMIT_BRANCH#__CSCSCI__pr}"
@@ -155,7 +153,7 @@ build_py310_image_aarch64:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     # Another problem, observed in test stage, is that gpu tests hang in combination with CUDA MPS,
     # when high test parallelism is used.
-    PYTEST_XDIST_AUTO_NUM_WORKERS: 32
+    PYTEST_XDIST_AUTO_NUM_WORKERS: 16
 
 # test_py311_x86_64:
 #   extends: [.test_helper_x86_64]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,8 +109,8 @@ build_py310_image_aarch64:
   stage: test
   image: $CSCS_REGISTRY_PATH/public/$ARCH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
   script:
-  - pwd
-  - ls -la
+  - export GT4PY_BUILD_CACHE_DIR=$PWD
+  - export GT4PY_BUILD_CACHE_LIFETIME=session
   - cd /gt4py.src
   - echo "CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}"
   - export GITHUB_PR="${CI_COMMIT_BRANCH#__CSCSCI__pr}"

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -151,7 +151,7 @@ build_py310_image_aarch64:
       VARIANT: ['cuda12', 'cpu']
   variables:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    GT4PY_BUILD_JOBS: 8
+    GT4PY_BUILD_JOBS: 1
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 
 # test_py311_x86_64:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -33,7 +33,7 @@ stages:
   variables:
     DOCKERFILE: ci/base.Dockerfile
     # change to 'always' if you want to rebuild, even if target tag exists already (if-not-exists is the default, i.e. we could also skip the variable)
-    CSCS_REBUILD_POLICY: if-not-exists
+    CSCS_REBUILD_POLICY: always
     DOCKER_BUILD_ARGS: '["CUDA_VERSION=$CUDA_VERSION", "CUPY_PACKAGE=$CUPY_PACKAGE", "CUPY_VERSION=$CUPY_VERSION", "UBUNTU_VERSION=$UBUNTU_VERSION", "PYVERSION=$PYVERSION"]'
 .build_baseimage_x86_64:
   extends: [.container-builder-cscs-zen2, .build_baseimage]
@@ -118,7 +118,7 @@ build_py310_image_aarch64:
   - NOX_SESSION_ARGS="${VARIANT:+($VARIANT}${SUBVARIANT:+, $SUBVARIANT}${DETAIL:+, $DETAIL}${VARIANT:+)}"
   - nox -s "test_$SUBPACKAGE-${PYVERSION:0:4}$NOX_SESSION_ARGS"
   variables:
-    CRAY_CUDA_MPS: 1
+    CSCS_CUDA_MPS: 1
     SLURM_JOB_NUM_NODES: 1
     SLURM_TIMELIMIT: 20
     PYENV_VERSION: $PYVERSION

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -153,7 +153,7 @@ build_py310_image_aarch64:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     # Another problem, observed in test stage, is that gpu tests hang in combination with CUDA MPS,
     # when high test parallelism is used.
-    PYTEST_XDIST_AUTO_NUM_WORKERS: 16
+    PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 
 # test_py311_x86_64:
 #   extends: [.test_helper_x86_64]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,7 +109,8 @@ build_py310_image_aarch64:
   stage: test
   image: $CSCS_REGISTRY_PATH/public/$ARCH/gt4py/gt4py-ci:$CI_COMMIT_SHA-$PYVERSION
   script:
-  - cd /gt4py.src
+  - cp -r /gt4py.src .
+  - cd gt4py.src
   - echo "CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}"
   - export GITHUB_PR="${CI_COMMIT_BRANCH#__CSCSCI__pr}"
   - echo "GITHUB_PR=${GITHUB_PR}"

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -33,7 +33,7 @@ stages:
   variables:
     DOCKERFILE: ci/base.Dockerfile
     # change to 'always' if you want to rebuild, even if target tag exists already (if-not-exists is the default, i.e. we could also skip the variable)
-    CSCS_REBUILD_POLICY: always
+    CSCS_REBUILD_POLICY: if-not-exists
     DOCKER_BUILD_ARGS: '["CUDA_VERSION=$CUDA_VERSION", "CUPY_PACKAGE=$CUPY_PACKAGE", "CUPY_VERSION=$CUPY_VERSION", "UBUNTU_VERSION=$UBUNTU_VERSION", "PYVERSION=$PYVERSION"]'
 .build_baseimage_x86_64:
   extends: [.container-builder-cscs-zen2, .build_baseimage]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -150,8 +150,9 @@ build_py310_image_aarch64:
     - SUBPACKAGE: [storage]
       VARIANT: ['cuda12', 'cpu']
   variables:
+    # TODO: Fix issue with compile parallelism that causes tests to hang
+    GT4PY_BUILD_JOBS: 4
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    GT4PY_BUILD_JOBS: 2
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 
 # test_py311_x86_64:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -151,7 +151,7 @@ build_py310_image_aarch64:
       VARIANT: ['cuda12', 'cpu']
   variables:
     # TODO: Fix issue with compile parallelism that causes tests to hang
-    GT4PY_BUILD_JOBS: 4
+    GT4PY_BUILD_JOBS: 2
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -151,7 +151,7 @@ build_py310_image_aarch64:
       VARIANT: ['cuda12', 'cpu']
   variables:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-    GT4PY_BUILD_JOBS: 1
+    GT4PY_BUILD_JOBS: 2
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 
 # test_py311_x86_64:

--- a/noxfile.py
+++ b/noxfile.py
@@ -235,7 +235,7 @@ def test_next(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"] + mesh_markers)
 
     session.run(
-        *"pytest --cache-clear -sv -n auto".split(),
+        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "next_tests"),
         *session.posargs,

--- a/noxfile.py
+++ b/noxfile.py
@@ -235,7 +235,7 @@ def test_next(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"] + mesh_markers)
 
     session.run(
-        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --cache-clear -sv -n auto".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "next_tests"),
         *session.posargs,


### PR DESCRIPTION
The tests of the dace-gpu CI pipeline are hanging after the latest maintenance of Santis vCluster. The origin of the problem is not known yet, but it was observed that limiting the build parallelism of tests with static args (`GT4PY_BUILD_JOBS=2`) makes the tests pass. Probably this setting only triggers a different schedule of the tests that hides the issue. We merge this PR as a workaround to unblock the CI.