### PR TITLE
fix[next][dace]: Fix memlet subset in splitting tools

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_memlet.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_memlet.py
@@ -166,7 +166,9 @@ class SplitConsumerMemlet(dace_transformation.SingleStateTransformation):
     ) -> tuple[list[dace_sbs.Subset], list[dace_graph.MultiConnectorEdge]]:
         split_description = [
             desc.subset
-            for desc in gtx_transformations.spliting_tools.describe_incoming_edges(state, node)
+            for desc in gtx_transformations.spliting_tools.describe_incoming_edges(
+                sdfg, state, node
+            )
         ]
         edges_to_split = [
             oedge

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_memlet.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_memlet.py
@@ -166,9 +166,7 @@ class SplitConsumerMemlet(dace_transformation.SingleStateTransformation):
     ) -> tuple[list[dace_sbs.Subset], list[dace_graph.MultiConnectorEdge]]:
         split_description = [
             desc.subset
-            for desc in gtx_transformations.spliting_tools.describe_incoming_edges(
-                sdfg, state, node
-            )
+            for desc in gtx_transformations.spliting_tools.describe_incoming_edges(state, node)
         ]
         edges_to_split = [
             oedge

--- a/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
@@ -132,7 +132,6 @@ def describe_incoming_edges(
 def describe_outgoing_edges(
     state: dace.SDFGState,
     node: dace_nodes.Node,
-    state: Optional[dace.SDFGState] = None,
 ) -> list[EdgeConnectionSpec]:
     """Describes the out going edges of `node`."""
     return describe_edges(state, node, False)
@@ -141,7 +140,6 @@ def describe_outgoing_edges(
 def describe_all_edges(
     state: dace.SDFGState,
     node: dace_nodes.Node,
-    state: Optional[dace.SDFGState] = None,
 ) -> list[EdgeConnectionSpec]:
     """Describes the all edges of `node`."""
     return describe_edges(state, node, False) + describe_edges(state, node, True)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
@@ -75,10 +75,24 @@ class EdgeConnectionSpec:
 def describe_edge(
     edge: dace_graph.MultiConnectorEdge,
     incoming_edge: bool,
+    state: Optional[dace.SDFGState] = None,
 ) -> EdgeConnectionSpec:
-    """Create a description for a single edge."""
+    """Create a description for a single edge.
+
+    Args:
+        state: The state in which `node` is located, when the state is valid.
+            Set to `None` when the state is invalid, which can happen in the middle
+            of an SDFG transformation.
+        node: The node whose edges should be described.
+        incoming_edges: Describe the incoming (`True`) or out going (`False`) edges
+            of `node`.
+    """
     get_sbs = lambda e: e.data.dst_subset if incoming_edge else e.data.src_subset  # noqa: E731 [lambda-assignment]
     get_node = lambda e: e.dst if incoming_edge else e.src  # noqa: E731 [lambda-assignment]
+    if state is not None:
+        # To ensures that the `{src,dst}_subset` are properly set, run initialization.
+        #  See [issue 1708](https://github.com/spcl/dace/issues/1703)
+        edge.data.try_initialize(state.sdfg, state, edge)
     return EdgeConnectionSpec(
         node=get_node(edge),
         subset=get_sbs(edge),
@@ -87,7 +101,6 @@ def describe_edge(
 
 
 def describe_edges(
-    sdfg: dace.SDFG,
     state: dace.SDFGState,
     node: dace_nodes.Node,
     incoming_edges: bool,
@@ -105,38 +118,31 @@ def describe_edges(
             of `node`.
     """
     edges = state.in_edges(node) if incoming_edges else state.out_edges(node)
-    # To ensures that the `{src,dst}_subset` are properly set, run initialization.
-    #  See [issue 1708](https://github.com/spcl/dace/issues/1703)
-    for edge in edges:
-        edge.data.try_initialize(sdfg, state, edge)
-    return [describe_edge(e, incoming_edges) for e in edges]
+    return [describe_edge(e, incoming_edges, state) for e in edges]
 
 
 def describe_incoming_edges(
-    sdfg: dace.SDFG,
     state: dace.SDFGState,
     node: dace_nodes.Node,
 ) -> list[EdgeConnectionSpec]:
     """Describes the incoming edges of `node`."""
-    return describe_edges(sdfg, state, node, True)
+    return describe_edges(state, node, True)
 
 
 def describe_outgoing_edges(
-    sdfg: dace.SDFG,
     state: dace.SDFGState,
     node: dace_nodes.Node,
 ) -> list[EdgeConnectionSpec]:
     """Describes the out going edges of `node`."""
-    return describe_edges(sdfg, state, node, False)
+    return describe_edges(state, node, False)
 
 
 def describe_all_edges(
-    sdfg: dace.SDFG,
     state: dace.SDFGState,
     node: dace_nodes.Node,
 ) -> list[EdgeConnectionSpec]:
     """Describes the all edges of `node`."""
-    return describe_edges(sdfg, state, node, False) + describe_edges(sdfg, state, node, True)
+    return describe_edges(state, node, False) + describe_edges(state, node, True)
 
 
 def describes_incoming_edge(desc: EdgeConnectionSpec) -> bool:
@@ -256,8 +262,8 @@ def split_node(
     assert not gtx_transformations.utils.is_view(desc_to_split)
     assert isinstance(desc_to_split, dace_data.Array)
 
-    input_descriptions = describe_incoming_edges(sdfg, state, node_to_split)
-    output_descriptions = describe_outgoing_edges(sdfg, state, node_to_split)
+    input_descriptions = describe_incoming_edges(state, node_to_split)
+    output_descriptions = describe_outgoing_edges(state, node_to_split)
     edge_descriptions = input_descriptions + output_descriptions
 
     # Ensure that no edge is on multiple new fragments and that every edge

--- a/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
@@ -80,12 +80,11 @@ def describe_edge(
     """Create a description for a single edge.
 
     Args:
-        state: The state in which `node` is located, when the state is valid.
+        edge: The edge to describe.
+        incoming_edge: Describe whether it is an incoming (`True`) or outgoing (`False`) edge.
+        state: The state in which `edge` is located, when the state is valid.
             Set to `None` when the state is invalid, which can happen in the middle
             of an SDFG transformation.
-        node: The node whose edges should be described.
-        incoming_edges: Describe the incoming (`True`) or out going (`False`) edges
-            of `node`.
     """
     get_sbs = lambda e: e.data.dst_subset if incoming_edge else e.data.src_subset  # noqa: E731 [lambda-assignment]
     get_node = lambda e: e.dst if incoming_edge else e.src  # noqa: E731 [lambda-assignment]

--- a/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
@@ -74,10 +74,15 @@ class EdgeConnectionSpec:
 
 def describe_edge(
     edge: dace_graph.MultiConnectorEdge,
+    state: dace.SDFGState,
     incoming_edge: bool,
 ) -> EdgeConnectionSpec:
     """Create a description for a single edge."""
-    get_sbs = lambda e: e.data.dst_subset if incoming_edge else e.data.src_subset  # noqa: E731 [lambda-assignment]
+    get_sbs = (
+        lambda e: e.data.get_dst_subset(e, state)
+        if incoming_edge
+        else e.data.get_src_subset(e, state)
+    )  # noqa: E731 [lambda-assignment]
     get_node = lambda e: e.dst if incoming_edge else e.src  # noqa: E731 [lambda-assignment]
     return EdgeConnectionSpec(
         node=get_node(edge),
@@ -104,7 +109,7 @@ def describe_edges(
             of `node`.
     """
     edges = state.in_edges(node) if incoming_edges else state.out_edges(node)
-    return [describe_edge(e, incoming_edges) for e in edges]
+    return [describe_edge(e, state, incoming_edges) for e in edges]
 
 
 def describe_incoming_edges(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/spliting_tools.py
@@ -81,10 +81,11 @@ def describe_edge(
 
     Args:
         edge: The edge to describe.
-        incoming_edge: Describe whether it is an incoming (`True`) or outgoing (`False`) edge.
-        state: The state in which `edge` is located, when the state is valid.
-            Set to `None` when the state is invalid, which can happen in the middle
-            of an SDFG transformation.
+        incoming_edge: Describe whether it is an incoming (`True`) or outgoing (`False`)
+            edge, used to select the destination or source subset.
+        state: If it is passed, the memlet subset will be extracted using `get_{src, dst}_subset()`.
+            If `None`, the default, the `{src, dst}_subset` property will be used.
+            Only pass `state` if the state is not inconsistent.
     """
     get_sbs = lambda e: e.data.dst_subset if incoming_edge else e.data.src_subset  # noqa: E731 [lambda-assignment]
     get_node = lambda e: e.dst if incoming_edge else e.src  # noqa: E731 [lambda-assignment]
@@ -131,6 +132,7 @@ def describe_incoming_edges(
 def describe_outgoing_edges(
     state: dace.SDFGState,
     node: dace_nodes.Node,
+    state: Optional[dace.SDFGState] = None,
 ) -> list[EdgeConnectionSpec]:
     """Describes the out going edges of `node`."""
     return describe_edges(state, node, False)
@@ -139,6 +141,7 @@ def describe_outgoing_edges(
 def describe_all_edges(
     state: dace.SDFGState,
     node: dace_nodes.Node,
+    state: Optional[dace.SDFGState] = None,
 ) -> list[EdgeConnectionSpec]:
     """Describes the all edges of `node`."""
     return describe_edges(state, node, False) + describe_edges(state, node, True)


### PR DESCRIPTION
The memlet source and destination subsets were not properly set, because of a known limitation in the SDFG representation ( see [issue 1708](https://github.com/spcl/dace/issues/1703) in dace). As a workaround, this PR calls `try_initialize()` on the memlet before accessing its subset.