### PR TITLE
fix[next]: Frontend test for negative domain temporary

### DIFF
--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -208,7 +208,10 @@ def _arg_inline_predicate(node: itir.Expr, shifts: set[tuple[itir.OffsetLiteral,
     ) or cpm.is_call_to(node, "if_"):
         # always inline arg if it is an applied fieldop with only a single arg
         if is_applied_fieldop and len(node.args) == 1:
-            return True
+            # ... and not too much overcompute
+            # TODO(havogt): tune this value or improve heuristic
+            if len(shifts) < 6:
+                return True
         # argument is never used, will be removed when inlined
         if len(shifts) == 0:
             return True

--- a/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_laplacian.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_laplacian.py
@@ -47,6 +47,11 @@ def laplap(in_field: gtx.Field[[IDim, JDim], "float"]) -> gtx.Field[[IDim, JDim]
     return lap(lap(in_field))
 
 
+@gtx.field_operator
+def laplaplaplap(in_field: gtx.Field[[IDim, JDim], "float"]) -> gtx.Field[[IDim, JDim], "float"]:
+    return laplap(laplap(in_field))
+
+
 @gtx.program
 def lap_program(
     in_field: gtx.Field[[IDim, JDim], "float"], out_field: gtx.Field[[IDim, JDim], "float"]
@@ -67,6 +72,13 @@ def laplap_program(
     in_field: gtx.Field[[IDim, JDim], "float"], out_field: gtx.Field[[IDim, JDim], "float"]
 ):
     laplap(in_field, out=out_field[2:-2, 2:-2])
+
+
+@gtx.program
+def laplaplaplap_program_no_output_halo(
+    in_field: gtx.Field[[IDim, JDim], "float"], out_field: gtx.Field[[IDim, JDim], "float"]
+):
+    laplaplaplap(in_field, out=out_field)
 
 
 def square(inp):
@@ -129,4 +141,25 @@ def test_ffront_laplap(cartesian_case):
         out_field,
         inout=out_field[2:-2, 2:-2],
         ref=lap_ref(lap_ref(in_field.array_ns.asarray(in_field.ndarray))),
+    )
+
+
+def test_ffront_laplaplaplap_no_output_halo(cartesian_case):
+    halolines = 4
+    in_field = cases.allocate(
+        cartesian_case,
+        laplaplaplap_program_no_output_halo,
+        "in_field",
+        extend={IDim: (halolines, halolines), JDim: (halolines, halolines)},
+    )()
+    in_field = square(square(in_field))
+    out_field = cases.allocate(cartesian_case, laplaplaplap_program_no_output_halo, "out_field")()
+
+    cases.verify(
+        cartesian_case,
+        laplaplaplap_program_no_output_halo,
+        in_field,
+        out_field,
+        inout=out_field,
+        ref=lap_ref(lap_ref(lap_ref(lap_ref(in_field.asnumpy())))),
     )


### PR DESCRIPTION
Adds a regression test, driven from the frontend, for the gtfn negative-domain temporary allocation bug fixed in #2092.

Triggering the bug requires an intermediate temporary with a negative domain start. To force one inside a chain of single-argument `as_fieldop`s (a 4x-nested laplacian), `fuse_as_fieldop` now stops inlining a single-arg applied fieldop once it accumulates too much overcompute (`len(shifts) >= 6`). Without this the whole chain fully fuses into one stencil and trips the recursion limit during compilation.

The codegen fix originally in this PR was merged separately in #2092 and has been dropped; only the heuristic and the test remain.
