### PR TITLE
refactor[cartesian]: fix mypy issues for pyext_builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,10 +213,6 @@ module = 'gt4py.cartesian.*'
 
 [[tool.mypy.overrides]]
 ignore_errors = true
-module = 'gt4py.cartesian.backend.pyext_builder'
-
-[[tool.mypy.overrides]]
-ignore_errors = true
 module = 'gt4py.cartesian.frontend.nodes'
 
 [[tool.mypy.overrides]]

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -11,7 +11,7 @@ import copy
 import io
 import os
 import shutil
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, TypedDict, Union
 
 import pybind11
 import setuptools
@@ -20,6 +20,12 @@ from setuptools.command.build_ext import build_ext
 
 from gt4py._core import definitions as core_defs
 from gt4py.cartesian import config as gt_config
+
+
+class SetuptoolsArgs(TypedDict):
+    name: str
+    ext_modules: list[setuptools.Extension]
+    script_args: list[str]
 
 
 def get_dace_module_path() -> Optional[str]:
@@ -225,7 +231,7 @@ def build_pybind_ext(
         extra_link_args=extra_link_args,
     )
 
-    setuptools_args = dict(
+    setuptools_args = SetuptoolsArgs(
         name=name,
         ext_modules=[py_extension],
         script_args=[
@@ -237,10 +243,10 @@ def build_pybind_ext(
     )
 
     if verbose:
-        setuptools_args["script_args"].append("-v")  # type: ignore
+        setuptools_args["script_args"].append("-v")
         setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)
     else:
-        setuptools_args["script_args"].append("-q")  # type: ignore
+        setuptools_args["script_args"].append("-q")
         io_out, io_err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(io_out), contextlib.redirect_stderr(io_err):
             setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -11,7 +11,7 @@ import copy
 import io
 import os
 import shutil
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import pybind11
 import setuptools
@@ -184,31 +184,6 @@ def setuptools_setup(*, build_ext_class: type[build_ext] | None, **kwargs) -> No
     setuptools.distutils.core.run_commands(dist)
 
 
-# The following tells mypy to accept unpacking kwargs
-@overload
-def build_pybind_ext(
-    name: str, sources: list, build_path: str, target_path: str, **kwargs: str
-) -> Tuple[str, str]: ...
-
-
-@overload
-def build_pybind_ext(
-    name: str,
-    sources: list,
-    build_path: str,
-    target_path: str,
-    *,
-    include_dirs: Optional[List[str]] = None,
-    library_dirs: Optional[List[str]] = None,
-    libraries: Optional[List[str]] = None,
-    extra_compile_args: Optional[Union[List[str], Dict[str, List[str]]]] = None,
-    extra_link_args: Optional[List[str]] = None,
-    build_ext_class: Optional[Type] = None,
-    verbose: bool = False,
-    clean: bool = False,
-) -> Tuple[str, str]: ...
-
-
 def build_pybind_ext(
     name: str,
     sources: list,
@@ -262,10 +237,10 @@ def build_pybind_ext(
     )
 
     if verbose:
-        setuptools_args["script_args"].append("-v")
+        setuptools_args["script_args"].append("-v")  # type: ignore
         setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)
     else:
-        setuptools_args["script_args"].append("-q")
+        setuptools_args["script_args"].append("-q")  # type: ignore
         io_out, io_err = io.StringIO(), io.StringIO()
         with contextlib.redirect_stdout(io_out), contextlib.redirect_stderr(io_err):
             setuptools_setup(**setuptools_args, build_ext_class=build_ext_class)
@@ -288,14 +263,6 @@ def build_pybind_ext(
         distutils.sysconfig._config_vars[key] = value
 
     return module_name, dest_path
-
-
-# The following tells mypy to accept unpacking kwargs
-@overload
-def build_pybind_cuda_ext(
-    name: str, sources: list, build_path: str, target_path: str, **kwargs: str
-) -> Tuple[str, str]:
-    pass
 
 
 def build_pybind_cuda_ext(


### PR DESCRIPTION
## Description

`mypy` was configured to ignore all errors in `pyext_builder`. This was a temporary workaround (I guess from when `mypy` was first added). It was easy enough to "fix" what `mypy` was complaining about:

1. The overload that would "tells mypy to accept unpacking kwargs" wasn't really working. It also seems like the code isn't used, so I'm getting rid of it.
2. `mypy` can't know that `setuptools_args["script_args"]` is a list because `setuptools_args` is a dictionary that does also contain values that aren't lists. This is fine, we know, so we can just ignore the error with a line override.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  All good as long as the CI is still green.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A