### PR TITLE
fix[next]: offset_provider optional

### DIFF
--- a/examples/lap_cartesian_vs_next.ipynb
+++ b/examples/lap_cartesian_vs_next.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,23 +55,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<link href=\"https://fonts.googleapis.com/icon?family=Material+Icons\" rel=\"stylesheet\"><script src=\"https://spcl.github.io/dace/webclient2/dist/sdfv.js\"></script>\n",
-       "<link href=\"https://spcl.github.io/dace/webclient2/sdfv.css\" rel=\"stylesheet\">\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import gt4py.next as gtx\n",
     "\n",
@@ -107,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,26 +128,18 @@
     "# next_backend = gtx.gtfn_cpu\n",
     "# next_backend = gtx.gtfn_gpu\n",
     "\n",
-    "Ioff = gtx.FieldOffset(\"I\", source=I, target=(I,))\n",
-    "Joff = gtx.FieldOffset(\"J\", source=J, target=(J,))\n",
-    "\n",
     "\n",
     "@gtx.field_operator\n",
     "def lap_next(inp: Field[[I, J, K], dtype]) -> Field[[I, J, K], dtype]:\n",
-    "    return -4.0 * inp + inp(Ioff[-1]) + inp(Ioff[1]) + inp(Joff[-1]) + inp(Joff[1])\n",
+    "    return -4.0 * inp + inp(I - 1) + inp(I + 1) + inp(J - 1) + inp(J + 1)\n",
     "\n",
     "\n",
-    "@gtx.program(backend=next_backend)\n",
-    "def lap_next_program(inp: Field[[I, J, K], dtype], out: Field[[I, J, K], dtype]):\n",
-    "    lap_next(inp, out=out[1:-1, 1:-1, :])\n",
-    "\n",
-    "\n",
-    "lap_next_program(inp, out_next, offset_provider={\"Ioff\": I, \"Joff\": J})"
+    "lap_next(inp, out=out_next[1:-1, 1:-1, :])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +149,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "gt4py",
    "language": "python",
    "name": "python3"
   },
@@ -185,7 +163,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.18"
   }
  },
  "nbformat": 4,

--- a/src/gt4py/next/embedded/operators.py
+++ b/src/gt4py/next/embedded/operators.py
@@ -93,14 +93,16 @@ def field_operator_call(op: EmbeddedOperator[_R, _P], args: Any, kwargs: Any) ->
     if "out" in kwargs:
         # called from program or direct field_operator as program
         new_context_kwargs = {}
-        if not embedded_context.within_valid_context():
+        if embedded_context.within_valid_context():
+            # called from program
+            assert "offset_provider" not in kwargs
+        else:
             # field_operator as program
             if "offset_provider" not in kwargs:
                 raise errors.MissingArgumentError(None, "offset_provider", True)
-            offset_provider = kwargs.pop("offset_provider")
+            offset_provider = kwargs.pop("offset_provider", None)
 
             new_context_kwargs["offset_provider"] = offset_provider
-        # else called from program (we already have a context with `offset_provider`)
 
         out = kwargs.pop("out")
 

--- a/src/gt4py/next/embedded/operators.py
+++ b/src/gt4py/next/embedded/operators.py
@@ -93,16 +93,14 @@ def field_operator_call(op: EmbeddedOperator[_R, _P], args: Any, kwargs: Any) ->
     if "out" in kwargs:
         # called from program or direct field_operator as program
         new_context_kwargs = {}
-        if embedded_context.within_valid_context():
-            # called from program
-            assert "offset_provider" not in kwargs
-        else:
+        if not embedded_context.within_valid_context():
             # field_operator as program
             if "offset_provider" not in kwargs:
                 raise errors.MissingArgumentError(None, "offset_provider", True)
-            offset_provider = kwargs.pop("offset_provider", None)
+            offset_provider = kwargs.pop("offset_provider")
 
             new_context_kwargs["offset_provider"] = offset_provider
+        # else called from program (we already have a context with `offset_provider`)
 
         out = kwargs.pop("out")
 

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -54,6 +54,30 @@ from gt4py.next.type_system import type_info, type_specifications as ts, type_tr
 DEFAULT_BACKEND: next_backend.Backend | None = None
 
 
+def _implicit_offset_providers_from_types(types: list[ts.TypeSpec]) -> common.OffsetProvider:
+    """
+    Add all implicit offset providers.
+    Each dimension implicitly defines an offset provider such that we can allow syntax like::
+        field(TDim + 1)
+    This function adds these implicit offset providers.
+    """
+    # TODO(tehrengruber): We add all dimensions here regardless of whether they are cartesian
+    #  or unstructured. While it is conceptually fine, but somewhat meaningless,
+    #  to do something `Cell+1` the GTFN backend for example doesn't support these. We should
+    #  find a way to avoid adding these dimensions, but since we don't have the grid type here
+    #  and since the dimensions don't this information either, we just add all dimensions here
+    #  and filter them out in the backends that don't support this.
+    implicit_offset_provider = {}
+    for type_ in types:
+        if isinstance(type_, ts.FieldType):
+            for dim in type_.dims:
+                if dim.kind in (common.DimensionKind.HORIZONTAL, common.DimensionKind.VERTICAL):
+                    implicit_offset_provider.update(
+                        {common.dimension_to_implicit_offset(dim.value): dim}
+                    )
+    return implicit_offset_provider
+
+
 # TODO(tehrengruber): Decide if and how programs can call other programs. As a
 #  result Program could become a GTCallable.
 @dataclasses.dataclass(frozen=True)
@@ -236,32 +260,10 @@ class Program:
         return self._frontend_transforms.past_to_itir(no_args_past).data
 
     @functools.cached_property
-    def _implicit_offset_provider(self) -> dict[str, common.Dimension]:
-        """
-        Add all implicit offset providers.
-
-        Each dimension implicitly defines an offset provider such that we can allow syntax like::
-
-            field(TDim + 1)
-
-        This function adds these implicit offset providers.
-        """
-        # TODO(tehrengruber): We add all dimensions here regardless of whether they are cartesian
-        #  or unstructured. While it is conceptually fine, but somewhat meaningless,
-        #  to do something `Cell+1` the GTFN backend for example doesn't support these. We should
-        #  find a way to avoid adding these dimensions, but since we don't have the grid type here
-        #  and since the dimensions don't this information either, we just add all dimensions here
-        #  and filter them out in the backends that don't support this.
-        implicit_offset_provider = {}
-        params = self.past_stage.past_node.params
-        for param in params:
-            if isinstance(param.type, ts.FieldType):
-                for dim in param.type.dims:
-                    if dim.kind in (common.DimensionKind.HORIZONTAL, common.DimensionKind.VERTICAL):
-                        implicit_offset_provider.update(
-                            {common.dimension_to_implicit_offset(dim.value): dim}
-                        )
-        return implicit_offset_provider
+    def _implicit_offset_provider(self) -> common.OffsetProvider:
+        return _implicit_offset_providers_from_types(
+            [param.type for param in self.past_stage.past_node.params]
+        )
 
     @functools.cached_property
     def _compiled_programs(self) -> compiled_program.CompiledProgramsPool:
@@ -704,6 +706,12 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
     def __gt_closure_vars__(self) -> dict[str, Any]:
         return self.foast_stage.closure_vars
 
+    @functools.cached_property
+    def _implicit_offset_provider(self) -> common.OffsetProvider:
+        return _implicit_offset_providers_from_types(
+            [param.type for param in self.foast_stage.foast_node.definition.params]
+        )
+
     def as_program(self, compiletime_args: arguments.CompileTimeArgs) -> Program:
         foast_with_types = (
             toolchain.CompilableProgram(
@@ -725,12 +733,15 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
         )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if "offset_provider" not in kwargs:
+            kwargs["offset_provider"] = {}
+        kwargs["offset_provider"] = {
+            **self._implicit_offset_provider,
+            **kwargs["offset_provider"],
+        }
+
         if not next_embedded.context.within_valid_context() and self.backend is not None:
             # non embedded execution
-            if "offset_provider" not in kwargs:
-                raise errors.MissingArgumentError(None, "offset_provider", True)
-            offset_provider = kwargs.pop("offset_provider")
-
             if "out" not in kwargs:
                 raise errors.MissingArgumentError(None, "out", True)
             out = kwargs.pop("out")
@@ -745,7 +756,6 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
                 self.definition_stage,
                 *args,
                 out=out,
-                offset_provider=offset_provider,
                 **kwargs,
             )
         else:

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -770,6 +770,7 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
             )
         else:
             if not next_embedded.context.within_valid_context():
+                # field_operator as program
                 kwargs["offset_provider"] = {
                     **kwargs.pop("offset_provider", {}),
                     **self._implicit_offset_provider,

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -733,12 +733,7 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
         )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        if "offset_provider" not in kwargs:
-            kwargs["offset_provider"] = {}
-        kwargs["offset_provider"] = {
-            **self._implicit_offset_provider,
-            **kwargs["offset_provider"],
-        }
+        offset_provider = {**kwargs.pop("offset_provider", {}), **self._implicit_offset_provider}
 
         if not next_embedded.context.within_valid_context() and self.backend is not None:
             # non embedded execution
@@ -756,9 +751,11 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
                 self.definition_stage,
                 *args,
                 out=out,
+                offset_provider=offset_provider,
                 **kwargs,
             )
         else:
+            kwargs["offset_provider"] = offset_provider
             attributes = (
                 self.definition_stage.attributes
                 if self.definition_stage

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -755,7 +755,8 @@ class FieldOperator(GTCallable, Generic[OperatorNodeT]):
                 **kwargs,
             )
         else:
-            kwargs["offset_provider"] = offset_provider
+            if not next_embedded.context.within_valid_context():
+                kwargs["offset_provider"] = offset_provider
             attributes = (
                 self.definition_stage.attributes
                 if self.definition_stage

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -13,7 +13,7 @@ import typing
 import numpy as np
 import pytest
 
-from gt4py.next import errors, common, constructors
+from gt4py.next import errors
 from gt4py.next.ffront.decorator import field_operator, program, scan_operator
 from gt4py.next.ffront.fbuiltins import broadcast, int32
 
@@ -53,9 +53,7 @@ def test_call_field_operator_from_python(cartesian_case, arg_spec: tuple[tuple[s
     pos_args = [args[name] for name in arg_names]
     kw_args = {name: args[name] for name in kwarg_names}
 
-    testee.with_backend(cartesian_case.backend)(
-        *pos_args, **kw_args, out=out, offset_provider=cartesian_case.offset_provider
-    )
+    testee.with_backend(cartesian_case.backend)(*pos_args, **kw_args, out=out)
 
     expected = args["a"] * 2 * args["b"] - args["c"]
 
@@ -79,9 +77,7 @@ def test_call_program_from_python(cartesian_case, arg_spec):
     pos_args = [args[name] for name in arg_names]
     kw_args = {name: args[name] for name in kwarg_names}
 
-    testee.with_backend(cartesian_case.backend)(
-        *pos_args, **kw_args, offset_provider=cartesian_case.offset_provider
-    )
+    testee.with_backend(cartesian_case.backend)(*pos_args, **kw_args)
 
     expected = args["a"] + 2 * args["b"]
 

--- a/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_embedded_regression.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_embedded_regression.py
@@ -84,9 +84,6 @@ def test_missing_arg_field_operator(cartesian_case):
     with pytest.raises(errors.MissingArgumentError, match="'out'"):
         _ = copy(a, offset_provider={})
 
-    with pytest.raises(errors.MissingArgumentError, match="'offset_provider'"):
-        _ = copy(a, out=a)
-
 
 def test_missing_arg_scan_operator(cartesian_case):
     """Test that calling a scan_operator without required args raises an error."""
@@ -99,9 +96,6 @@ def test_missing_arg_scan_operator(cartesian_case):
 
     with pytest.raises(errors.MissingArgumentError, match="'out'"):
         _ = sum(a, offset_provider={})
-
-    with pytest.raises(errors.MissingArgumentError, match="'offset_provider'"):
-        _ = sum(a, out=a)
 
 
 def test_missing_arg_program(cartesian_case):
@@ -121,11 +115,3 @@ def test_missing_arg_program(cartesian_case):
             copy(a)
 
         _ = copy_program(a, offset_provider={})
-
-    with pytest.raises(TypeError, match="'offset_provider'"):
-
-        @gtx.program(backend=cartesian_case.backend)
-        def copy_program(a: IField, b: IField) -> IField:
-            copy(a, out=b)
-
-        _ = copy_program(a)


### PR DESCRIPTION
Makes the offset_provider optional in cases where previously we required `offset_provider={}`.

Additional: add the implicit offsetprovider in field_operator as programs call.