### PR TITLE
fix[next][dace]: Fix compile time symbol substitution

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
@@ -318,6 +318,7 @@ def gt_substitute_compiletime_symbols(
             sdfg=sdfg,
             validate=validate,
             validate_all=validate_all,
+            skip=["ConstantPropagation"],  # Avoid skipping "ScalarToSymbolPromotion"
         )
 
     # We will use the `replace` function of the top SDFG, however, lower levels


### PR DESCRIPTION
- In `gt_substitute_compiletime_symbols` when we call `gt_simplify` we have to make sure that `ScalarToSymbolPromotion` is executed before the `ConstantPropagation` pass
  - If we don't pass any option in `skip` then by default `ScalarToSymbolPromotion` and `ConstantPropagation` are skipped in `gt_simplify`
  - We can skip `ConstantPropagation` when we call `gt_simplify` since this is called right after