### PR TITLE
refactor[cartesian]: more type hints

### DIFF
--- a/src/gt4py/cartesian/__init__.py
+++ b/src/gt4py/cartesian/__init__.py
@@ -11,6 +11,7 @@
 import typing
 
 from . import (
+    backend,
     caching,
     cli,
     config,
@@ -28,6 +29,7 @@ from .stencil_object import StencilObject
 
 __all__ = [
     "StencilObject",
+    "backend",
     "caching",
     "cli",
     "config",

--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -48,9 +48,9 @@ if TYPE_CHECKING:
 REGISTRY = gt_utils.Registry()
 
 
-def from_name(name: str) -> Optional[Type[Backend]]:
+def from_name(name: str) -> Type[Backend]:
     backend = REGISTRY.get(name, None)
-    if not backend:
+    if backend is None:
         raise NotImplementedError(
             f"Backend {name} is not implemented, options are: {REGISTRY.names}"
         )
@@ -64,12 +64,11 @@ def register(backend_cls: Type[Backend]) -> Type[Backend]:
         gt_storage.register(backend_cls.name, backend_cls.storage_info)
         return REGISTRY.register(backend_cls.name, backend_cls)
 
-    else:
-        raise ValueError(
-            "Invalid 'name' attribute ('{name}') in backend class '{cls}'".format(
-                name=backend_cls.name, cls=backend_cls
-            )
+    raise ValueError(
+        "Invalid 'name' attribute ('{name}') in backend class '{cls}'".format(
+            name=backend_cls.name, cls=backend_cls
         )
+    )
 
 
 class Backend(abc.ABC):

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Type
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, disabled, register
@@ -141,14 +141,11 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     MODULE_GENERATOR_CLASS = CUDAPyExtModuleGenerator
     GT_BACKEND_T = "gpu"
 
-    def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
+    def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return self.make_extension(uses_cuda=True)
 
     def generate(self) -> Type[StencilObject]:
         self.check_options(self.builder.options)
-
-        pyext_module_name: Optional[str]
-        pyext_file_path: Optional[str]
 
         # TODO(havogt) add bypass if computation has no effect
         pyext_module_name, pyext_file_path = self.generate_extension()

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Type
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, disabled, register
@@ -144,7 +144,7 @@ class CudaBackend(BaseGTBackend, CLIBackendMixin):
     def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return self.make_extension(uses_cuda=True)
 
-    def generate(self) -> Type[StencilObject]:
+    def generate(self) -> type[StencilObject]:
         self.check_options(self.builder.options)
 
         # TODO(havogt) add bypass if computation has no effect

--- a/src/gt4py/cartesian/backend/cuda_backend.py
+++ b/src/gt4py/cartesian/backend/cuda_backend.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple, Type
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, disabled, register
@@ -37,12 +37,12 @@ if TYPE_CHECKING:
 
 
 class CudaExtGenerator(BackendCodegen):
-    def __init__(self, class_name, module_name, backend):
+    def __init__(self, class_name: str, module_name: str, backend: CudaBackend) -> None:
         self.class_name = class_name
         self.module_name = module_name
         self.backend = backend
 
-    def __call__(self, stencil_ir: gtir.Stencil) -> Dict[str, Dict[str, str]]:
+    def __call__(self, stencil_ir: gtir.Stencil) -> dict[str, dict[str, str]]:
         stencil_ir = GtirPipeline(stencil_ir, self.backend.builder.stencil_id).full()
         base_oir = GTIRToOIR().visit(stencil_ir)
         oir_pipeline = self.backend.builder.options.backend_opts.get(

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -12,7 +12,7 @@ import copy
 import os
 import pathlib
 import re
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Type
 
 import dace
 import dace.data
@@ -228,7 +228,7 @@ def _sdfg_add_arrays_and_edges(
                 )
 
 
-def _sdfg_specialize_symbols(wrapper_sdfg, domain: Tuple[int, ...]):
+def _sdfg_specialize_symbols(wrapper_sdfg, domain: tuple[int, ...]):
     ival, jval, kval = domain[0], domain[1], domain[2]
     for sdfg in wrapper_sdfg.all_sdfgs_recursive():
         if sdfg.parent_nsdfg_node is not None:
@@ -316,7 +316,7 @@ def freeze_origin_domain_sdfg(inner_sdfg, arg_names, field_info, *, origin, doma
 
 class SDFGManager:
     # Cache loaded SDFGs across all instances
-    _loaded_sdfgs: ClassVar[Dict[str, dace.SDFG]] = dict()
+    _loaded_sdfgs: ClassVar[dict[str, dace.SDFG]] = dict()
 
     def __init__(self, builder):
         self.builder = builder
@@ -374,7 +374,7 @@ class SDFGManager:
     def expanded_sdfg(self):
         return copy.deepcopy(self._expanded_sdfg())
 
-    def _frozen_sdfg(self, *, origin: Dict[str, Tuple[int, ...]], domain: Tuple[int, ...]):
+    def _frozen_sdfg(self, *, origin: dict[str, tuple[int, ...]], domain: tuple[int, ...]):
         frozen_hash = shash(origin, domain)
         # check if same sdfg already cached on disk
         path = self.builder.module_path
@@ -398,7 +398,7 @@ class SDFGManager:
             SDFGManager._loaded_sdfgs[path] = sdfg
         return SDFGManager._loaded_sdfgs[path]
 
-    def frozen_sdfg(self, *, origin: Dict[str, Tuple[int, ...]], domain: Tuple[int, ...]):
+    def frozen_sdfg(self, *, origin: dict[str, tuple[int, ...]], domain: tuple[int, ...]):
         return copy.deepcopy(self._frozen_sdfg(origin=origin, domain=domain))
 
 
@@ -571,7 +571,7 @@ namespace gt = gridtools;
 
         return generated_code
 
-    def generate_dace_args(self, stencil_ir: gtir.Stencil, sdfg: dace.SDFG) -> List[str]:
+    def generate_dace_args(self, stencil_ir: gtir.Stencil, sdfg: dace.SDFG) -> list[str]:
         oir = GTIRToOIR().visit(stencil_ir)
         field_extents = compute_fields_extents(oir, add_k=True)
 
@@ -579,7 +579,7 @@ namespace gt = gridtools;
             field_name: max(boundary[0], 0)
             for field_name, boundary in compute_k_boundary(stencil_ir).items()
         }
-        offset_dict: Dict[str, Tuple[int, int, int]] = {
+        offset_dict: dict[str, tuple[int, int, int]] = {
             k: (max(-v[0][0], 0), max(-v[1][0], 0), k_origins[k] if k in k_origins else 0)
             for k, v in field_extents.items()
         }
@@ -661,8 +661,8 @@ class DaCeBindingsCodegen:
 
     mako_template = bindings_main_template()
 
-    def generate_entry_params(self, stencil_ir: gtir.Stencil, sdfg: dace.SDFG) -> List[str]:
-        res: Dict[str, str] = {}
+    def generate_entry_params(self, stencil_ir: gtir.Stencil, sdfg: dace.SDFG) -> list[str]:
+        res: dict[str, str] = {}
 
         for name in sdfg.signature_arglist(with_types=False, for_call=True):
             if name in sdfg.arrays:
@@ -682,8 +682,8 @@ class DaCeBindingsCodegen:
                 res[name] = "{dtype} {name}".format(dtype=sdfg.symbols[name].ctype, name=name)
         return list(res[node.name] for node in stencil_ir.params if node.name in res)
 
-    def generate_sid_params(self, sdfg: dace.SDFG) -> List[str]:
-        res: List[str] = []
+    def generate_sid_params(self, sdfg: dace.SDFG) -> list[str]:
+        res: list[str] = []
 
         for name, array in sdfg.arrays.items():
             if array.transient:
@@ -757,9 +757,6 @@ class BaseDaceBackend(BaseGTBackend, CLIBackendMixin):
     def generate(self) -> Type[StencilObject]:
         self.check_options(self.builder.options)
 
-        pyext_module_name: Optional[str]
-        pyext_file_path: Optional[str]
-
         # TODO(havogt) add bypass if computation has no effect
         pyext_module_name, pyext_file_path = self.generate_extension()
 
@@ -785,7 +782,7 @@ class DaceCPUBackend(BaseDaceBackend):
 
     options = BaseGTBackend.GT_BACKEND_OPTS
 
-    def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
+    def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return self.make_extension(uses_cuda=False)
 
 
@@ -809,5 +806,5 @@ class DaceGPUBackend(BaseDaceBackend):
         "device_sync": {"versioning": True, "type": bool},
     }
 
-    def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
+    def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return self.make_extension(uses_cuda=True)

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -403,16 +403,15 @@ class SDFGManager:
 
 
 class DaCeExtGenerator(BackendCodegen):
-    def __init__(self, class_name, module_name, backend):
+    def __init__(self, class_name: str, module_name: str, backend: BaseDaceBackend) -> None:
         self.class_name = class_name
         self.module_name = module_name
         self.backend = backend
 
-    def __call__(self, stencil_ir: gtir.Stencil) -> Dict[str, Dict[str, str]]:
+    def __call__(self, stencil_ir: gtir.Stencil) -> dict[str, dict[str, str]]:
         manager = SDFGManager(self.backend.builder)
         sdfg = manager.expanded_sdfg()
 
-        sources: Dict[str, Dict[str, str]]
         implementation = DaCeComputationCodegen.apply(stencil_ir, self.backend.builder, sdfg)
 
         bindings = DaCeBindingsCodegen.apply(
@@ -420,11 +419,10 @@ class DaCeExtGenerator(BackendCodegen):
         )
 
         bindings_ext = "cu" if self.backend.storage_info["device"] == "gpu" else "cpp"
-        sources = {
+        return {
             "computation": {"computation.hpp": implementation},
             "bindings": {f"bindings.{bindings_ext}": bindings},
         }
-        return sources
 
 
 class DaCeComputationCodegen:

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -12,7 +12,7 @@ import copy
 import os
 import pathlib
 import re
-from typing import TYPE_CHECKING, Any, ClassVar, Type
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import dace
 import dace.data
@@ -754,7 +754,7 @@ class BaseDaceBackend(BaseGTBackend, CLIBackendMixin):
     GT_BACKEND_T = "dace"
     PYEXT_GENERATOR_CLASS = DaCeExtGenerator
 
-    def generate(self) -> Type[StencilObject]:
+    def generate(self) -> type[StencilObject]:
         self.check_options(self.builder.options)
 
         # TODO(havogt) add bypass if computation has no effect

--- a/src/gt4py/cartesian/backend/dace_stencil_object.py
+++ b/src/gt4py/cartesian/backend/dace_stencil_object.py
@@ -181,7 +181,6 @@ class DaCeStencilObject(StencilObject, SDFGConvertible):
         **kwargs,
     ):
         backend_cls = gt_backend.from_name(backend)
-        assert backend_cls is not None
         args_iter = iter(args)
         args_as_kwargs = {
             name: (kwargs[name] if name in kwargs else next(args_iter)) for name in arg_names

--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -199,14 +199,14 @@ class PyExtModuleGenerator(BaseModuleGenerator):
 
 
 class BackendCodegen:
-    TEMPLATE_FILES: Dict[str, str]
+    TEMPLATE_FILES: dict[str, str]
 
     @abc.abstractmethod
-    def __init__(self, class_name: str, module_name: str, backend: Any):
+    def __init__(self, class_name: str, module_name: str, backend: Backend) -> None:
         pass
 
     @abc.abstractmethod
-    def __call__(self, ir: gtir.Stencil) -> Dict[str, Dict[str, str]]:
+    def __call__(self, ir: gtir.Stencil) -> dict[str, dict[str, str]]:
         """Return a dict with the keys 'computation' and 'bindings' to dicts of filenames to source."""
         pass
 

--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -12,7 +12,7 @@ import abc
 import os
 import textwrap
 import time
-from typing import TYPE_CHECKING, Any, Final, Type
+from typing import TYPE_CHECKING, Any, Final
 
 from gt4py.cartesian import backend as gt_backend, config as gt_config, utils as gt_utils
 from gt4py.cartesian.backend import Backend
@@ -229,10 +229,10 @@ class BaseGTBackend(gt_backend.BasePyExtBackend, gt_backend.CLIBackendMixin):
 
     MODULE_GENERATOR_CLASS = PyExtModuleGenerator
 
-    PYEXT_GENERATOR_CLASS: Type[BackendCodegen]
+    PYEXT_GENERATOR_CLASS: type[BackendCodegen]
 
     @abc.abstractmethod
-    def generate(self) -> Type[StencilObject]:
+    def generate(self) -> type[StencilObject]:
         pass
 
     def generate_computation(self) -> dict[str, str | dict]:

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Type
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, register
@@ -129,14 +129,11 @@ class GTBaseBackend(BaseGTBackend, CLIBackendMixin):
     options = BaseGTBackend.GT_BACKEND_OPTS
     PYEXT_GENERATOR_CLASS = GTExtGenerator
 
-    def _generate_extension(self, uses_cuda: bool) -> Tuple[str, str]:
+    def _generate_extension(self, uses_cuda: bool) -> tuple[str, str]:
         return self.make_extension(uses_cuda=uses_cuda)
 
     def generate(self) -> Type[StencilObject]:
         self.check_options(self.builder.options)
-
-        pyext_module_name: Optional[str]
-        pyext_file_path: Optional[str]
 
         # TODO(havogt) add bypass if computation has no effect
         pyext_module_name, pyext_file_path = self.generate_extension()
@@ -156,7 +153,7 @@ class GTCpuIfirstBackend(GTBaseBackend):
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
     storage_info = gt_storage.layout.CPUIFirstLayout
 
-    def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
+    def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return super()._generate_extension(uses_cuda=False)
 
 
@@ -169,7 +166,7 @@ class GTCpuKfirstBackend(GTBaseBackend):
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
     storage_info = gt_storage.layout.CPUKFirstLayout
 
-    def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
+    def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return super()._generate_extension(uses_cuda=False)
 
 
@@ -187,5 +184,5 @@ class GTGpuBackend(GTBaseBackend):
     }
     storage_info = gt_storage.layout.CUDALayout
 
-    def generate_extension(self, **kwargs: Any) -> Tuple[str, str]:
+    def generate_extension(self, **kwargs: Any) -> tuple[str, str]:
         return super()._generate_extension(uses_cuda=True)

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple, Type
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, register
@@ -35,12 +35,12 @@ if TYPE_CHECKING:
 
 
 class GTExtGenerator(BackendCodegen):
-    def __init__(self, class_name, module_name, backend):
+    def __init__(self, class_name: str, module_name: str, backend: BaseGTBackend) -> None:
         self.class_name = class_name
         self.module_name = module_name
         self.backend = backend
 
-    def __call__(self, stencil_ir: gtir.Stencil) -> Dict[str, Dict[str, str]]:
+    def __call__(self, stencil_ir: gtir.Stencil) -> dict[str, dict[str, str]]:
         stencil_ir = GtirPipeline(stencil_ir, self.backend.builder.stencil_id).full()
         base_oir = GTIRToOIR().visit(stencil_ir)
         oir_pipeline = self.backend.builder.options.backend_opts.get(

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Type
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import CLIBackendMixin, register
@@ -132,7 +132,7 @@ class GTBaseBackend(BaseGTBackend, CLIBackendMixin):
     def _generate_extension(self, uses_cuda: bool) -> tuple[str, str]:
         return self.make_extension(uses_cuda=uses_cuda)
 
-    def generate(self) -> Type[StencilObject]:
+    def generate(self) -> type[StencilObject]:
         self.check_options(self.builder.options)
 
         # TODO(havogt) add bypass if computation has no effect

--- a/src/gt4py/cartesian/frontend/base.py
+++ b/src/gt4py/cartesian/frontend/base.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Type
+from typing import Any
 
 from gt4py.cartesian import utils as gt_utils
 from gt4py.cartesian.definitions import BuildOptions, StencilID
@@ -58,7 +58,7 @@ class Frontend(abc.ABC):
         cls,
         definition: AnyStencilFunc,
         externals: dict[str, Any],
-        dtypes: dict[Type, Type],
+        dtypes: dict[type, type],
         options: BuildOptions,
         backend_name: str,
     ) -> gtir.Stencil:
@@ -97,10 +97,10 @@ class Frontend(abc.ABC):
         pass
 
 
-REGISTRY = gt_utils.Registry[Type[Frontend]]()
+REGISTRY = gt_utils.Registry[type[Frontend]]()
 
 
-def from_name(name: str) -> Type[Frontend]:
+def from_name(name: str) -> type[Frontend]:
     """Return frontend by name."""
     frontend_cls = REGISTRY.get(name, None)
     if frontend_cls is None:
@@ -110,6 +110,6 @@ def from_name(name: str) -> Type[Frontend]:
     return frontend_cls
 
 
-def register(frontend_cls: Type[Frontend]) -> Type[Frontend]:
+def register(frontend_cls: type[Frontend]) -> type[Frontend]:
     """Register a new frontend."""
     return REGISTRY.register(frontend_cls.name, frontend_cls)

--- a/src/gt4py/cartesian/loader.py
+++ b/src/gt4py/cartesian/loader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import types
 from typing import TYPE_CHECKING, Any, Dict, Type
 
-from gt4py.cartesian import backend as gt_backend, frontend as gt_frontend
+from gt4py.cartesian import frontend as gt_frontend
 from gt4py.cartesian.stencil_builder import StencilBuilder
 from gt4py.cartesian.type_hints import StencilFunc
 
@@ -37,13 +37,7 @@ def load_stencil(
 ) -> Type[StencilObject]:
     """Generate a new class object implementing the provided definition."""
     # Load components
-    backend_cls = gt_backend.from_name(backend_name)
-    if backend_cls is None:
-        raise ValueError(f"Unknown backend name ({backend_name})")
-
     frontend = gt_frontend.from_name(frontend_name)
-    if frontend is None:
-        raise ValueError(f"Invalid frontend name ({frontend_name})")
 
     builder = (
         StencilBuilder(

--- a/src/gt4py/cartesian/loader.py
+++ b/src/gt4py/cartesian/loader.py
@@ -15,7 +15,7 @@ a high-level stencil function definition using a specific code generating backen
 from __future__ import annotations
 
 import types
-from typing import TYPE_CHECKING, Any, Dict, Type
+from typing import TYPE_CHECKING, Any
 
 from gt4py.cartesian import frontend as gt_frontend
 from gt4py.cartesian.stencil_builder import StencilBuilder
@@ -31,10 +31,10 @@ def load_stencil(
     frontend_name: str,
     backend_name: str,
     definition_func: StencilFunc,
-    externals: Dict[str, Any],
-    dtypes: Dict[Type, Type],
+    externals: dict[str, Any],
+    dtypes: dict[type, type],
     build_options: BuildOptions,
-) -> Type[StencilObject]:
+) -> type[StencilObject]:
     """Generate a new class object implementing the provided definition."""
     # Load components
     frontend = gt_frontend.from_name(frontend_name)
@@ -54,8 +54,8 @@ def gtscript_loader(
     definition_func: StencilFunc,
     backend: str,
     build_options: BuildOptions,
-    externals: Dict[str, Any],
-    dtypes: Dict[Type, Type],
+    externals: dict[str, Any],
+    dtypes: dict[type, type],
 ) -> StencilObject:
     if not isinstance(definition_func, types.FunctionType):
         raise ValueError("Invalid stencil definition object ({obj})".format(obj=definition_func))

--- a/src/gt4py/cartesian/stencil_builder.py
+++ b/src/gt4py/cartesian/stencil_builder.py
@@ -9,13 +9,13 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any
 
 from gt4py import cartesian as gt4pyc
 from gt4py.cartesian.definitions import BuildOptions, StencilID
 from gt4py.cartesian.gtc import gtir
 from gt4py.cartesian.gtc.passes.gtir_pipeline import GtirPipeline
-from gt4py.cartesian.type_hints import AnnotatedStencilFunc, StencilFunc
+from gt4py.cartesian.type_hints import AnnotatedStencilFunc, AnyStencilFunc
 
 
 if TYPE_CHECKING:
@@ -50,11 +50,11 @@ class StencilBuilder:
 
     def __init__(
         self,
-        definition_func: Union[StencilFunc, AnnotatedStencilFunc],
+        definition_func: AnyStencilFunc,
         *,
-        backend: Optional[Union[str, Type[BackendType]]] = None,
-        options: Optional[BuildOptions] = None,
-        frontend: Optional[Type[FrontendType]] = None,
+        backend: str | type[BackendType] | None = None,
+        options: BuildOptions | None = None,
+        frontend: type[FrontendType] | None = None,
     ):
         self._definition = definition_func
         self.options = options or BuildOptions(**self.default_options_dict(definition_func))
@@ -63,12 +63,12 @@ class StencilBuilder:
         frontend = frontend or gt4pyc.frontend.from_name("gtscript")
 
         self.backend: BackendType = backend(self)
-        self.frontend: Type[FrontendType] = frontend
+        self.frontend: type[FrontendType] = frontend
         self.with_caching("jit")
-        self._externals: Dict[str, Any] = {}
-        self._dtypes: Dict[Type, Type] = {}
+        self._externals: dict[str, Any] = {}
+        self._dtypes: dict[type, type] = {}
 
-    def build(self) -> Type[StencilObject]:
+    def build(self) -> type[StencilObject]:
         """Generate, compile and/or load everything necessary to provide a usable stencil class."""
         # load or generate
         stencil_class = None if self.options.rebuild else self.backend.load()
@@ -80,11 +80,11 @@ class StencilBuilder:
             stencil_class = self.backend.generate()
         return stencil_class
 
-    def generate_computation(self) -> Dict[str, Union[str, Dict]]:
+    def generate_computation(self) -> dict[str, str | dict]:
         """Generate the stencil source code, fail if backend does not support CLI."""
         return self.cli_backend.generate_computation()
 
-    def generate_bindings(self, targe_language: str) -> Dict[str, Union[str, Dict]]:
+    def generate_bindings(self, targe_language: str) -> dict[str, str | dict]:
         """Generate ``target_language`` bindings source, fail if backend does not support CLI."""
         return self.cli_backend.generate_bindings(targe_language)
 
@@ -109,7 +109,7 @@ class StencilBuilder:
         -----
         Resets all cached build data.
         """
-        self._build_data: Dict[str, Any] = {}
+        self._build_data: dict[str, Any] = {}
         kwargs = {**self.options.cache_settings, **kwargs}
         self.caching = gt4pyc.caching.strategy_factory(caching_strategy_name, self, *args, **kwargs)
         return self
@@ -136,7 +136,7 @@ class StencilBuilder:
         self.options = BuildOptions(name=name, module=module, **kwargs)  # type: ignore
         return self
 
-    def with_changed_options(self: StencilBuilder, **kwargs: Dict[str, Any]) -> StencilBuilder:
+    def with_changed_options(self: StencilBuilder, **kwargs: dict[str, Any]) -> StencilBuilder:
         old_options = self.options.as_dict()
         # BuildOptions constructor expects ``impl_opts`` keyword
         # but BuildOptions.as_dict outputs ``_impl_opts`` key
@@ -162,13 +162,11 @@ class StencilBuilder:
         return self
 
     @classmethod
-    def default_options_dict(
-        cls, definition_func: Union[StencilFunc, AnnotatedStencilFunc]
-    ) -> Dict[str, Any]:
+    def default_options_dict(cls, definition_func: AnyStencilFunc) -> dict[str, Any]:
         return {"name": definition_func.__name__, "module": definition_func.__module__}
 
     @classmethod
-    def name_to_options_args(cls, name: Optional[str]) -> Dict[str, str]:
+    def name_to_options_args(cls, name: str | None) -> dict[str, str]:
         """Check for qualified name, extract also module option in that case."""
         if not name:
             return {}
@@ -179,7 +177,7 @@ class StencilBuilder:
         return data
 
     @classmethod
-    def nest_impl_options(cls, options_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def nest_impl_options(cls, options_dict: dict[str, Any]) -> dict[str, Any]:
         impl_opts = options_dict.setdefault("impl_opts", {})
         # The following is not a dict comprehension because:
         # The backend-specific options (starting with ``_``) are nested under
@@ -197,18 +195,18 @@ class StencilBuilder:
         )
 
     @property
-    def externals(self) -> Dict[str, Any]:
+    def externals(self) -> dict[str, Any]:
         return self._build_data.get("externals") or self._build_data.setdefault(
             "externals", self._externals.copy()
         )
 
     @property
-    def dtypes(self) -> Dict[Type, Type]:
+    def dtypes(self) -> dict[type, type]:
         return self._build_data.get("dtypes") or self._build_data.setdefault(
             "dtypes", self._dtypes.copy()
         )
 
-    def with_externals(self: StencilBuilder, externals: Dict[str, Any]) -> StencilBuilder:
+    def with_externals(self: StencilBuilder, externals: dict[str, Any]) -> StencilBuilder:
         """
         Fluidly set externals for this build.
 
@@ -219,17 +217,17 @@ class StencilBuilder:
         self.with_caching(self.caching.name)
         return self
 
-    def with_dtypes(self: StencilBuilder, dtypes: Dict[Type, Type]) -> StencilBuilder:
+    def with_dtypes(self: StencilBuilder, dtypes: dict[type, type]) -> StencilBuilder:
         self._build_data = {}
         self._dtypes = dtypes
         self.with_caching(self.caching.name)
         return self
 
     @property
-    def backend_data(self) -> Dict[str, Any]:
+    def backend_data(self) -> dict[str, Any]:
         return self._build_data.get("backend_data", {}).copy()
 
-    def with_backend_data(self: StencilBuilder, data: Dict[str, Any]) -> StencilBuilder:
+    def with_backend_data(self: StencilBuilder, data: dict[str, Any]) -> StencilBuilder:
         self._build_data["backend_data"] = {**self.backend_data, **data}
         return self
 

--- a/src/gt4py/cartesian/stencil_builder.py
+++ b/src/gt4py/cartesian/stencil_builder.py
@@ -60,12 +60,7 @@ class StencilBuilder:
         self.options = options or BuildOptions(**self.default_options_dict(definition_func))
         backend = backend or "numpy"
         backend = gt4pyc.backend.from_name(backend) if isinstance(backend, str) else backend
-        if backend is None:
-            raise RuntimeError(f"Unknown backend: {backend}")
-
         frontend = frontend or gt4pyc.frontend.from_name("gtscript")
-        if frontend is None:
-            raise RuntimeError(f"Unknown frontend: {frontend}")
 
         self.backend: BackendType = backend(self)
         self.frontend: Type[FrontendType] = frontend
@@ -163,7 +158,6 @@ class StencilBuilder:
         """
         self._build_data = {}
         backend = gt4pyc.backend.from_name(backend_name)
-        assert backend is not None
         self.backend = backend(self)
         return self
 

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -399,9 +399,6 @@ class StencilObject(abc.ABC):
                 arg_info = arg_infos[name]
                 assert arg_info is not None
 
-                backend_cls = gt_backend.from_name(self.backend)
-                assert backend_cls is not None
-
                 if not backend_cls.storage_info["is_optimal_layout"](
                     arg_info.array,
                     tuple(
@@ -560,7 +557,6 @@ class StencilObject(abc.ABC):
         if exec_info is not None:
             exec_info["call_run_start_time"] = time.perf_counter()
         backend_cls = gt_backend.from_name(self.backend)
-        assert backend_cls is not None
         device = backend_cls.storage_info["device"]
         array_infos = _extract_array_infos(field_args, device)
 

--- a/src/gt4py/cartesian/type_hints.py
+++ b/src/gt4py/cartesian/type_hints.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Dict
+from typing import Any
 
 from typing_extensions import Protocol
 
@@ -15,8 +15,11 @@ class StencilFunc(Protocol):
     __name__: str
     __module__: str
 
-    def __call__(self, *args: Any, **kwargs: Dict[str, Any]) -> None: ...
+    def __call__(self, *args: Any, **kwargs: dict[str, Any]) -> None: ...
 
 
 class AnnotatedStencilFunc(StencilFunc, Protocol):
-    _gtscript_: Dict[str, Any]
+    _gtscript_: dict[str, Any]
+
+
+AnyStencilFunc = StencilFunc | AnnotatedStencilFunc

--- a/src/gt4py/cartesian/utils/base.py
+++ b/src/gt4py/cartesian/utils/base.py
@@ -19,6 +19,7 @@ import string
 import sys
 import time
 import types
+from typing import Generic, TypeVar
 
 from gt4py.cartesian import config as gt_config
 
@@ -333,12 +334,15 @@ def restore_module(patch, *, verify=True):
             current.__dict__[name] = original_value
 
 
-class Registry(dict):
+T = TypeVar("T")
+
+
+class Registry(Generic[T], dict[str, T]):
     @property
     def names(self) -> list[str]:
         return list(self.keys())
 
-    def register(self, name: str, item=NOTHING):
+    def register(self, name: str, item: T) -> T:
         if name in self.keys():
             raise ValueError(f"Name {name} already exists in registry.")
 
@@ -346,7 +350,7 @@ class Registry(dict):
             self[name] = obj
             return obj
 
-        return _wrapper if item is NOTHING else _wrapper(item)
+        return _wrapper(item)
 
 
 class ClassProperty:

--- a/src/gt4py/cartesian/utils/base.py
+++ b/src/gt4py/cartesian/utils/base.py
@@ -335,12 +335,12 @@ def restore_module(patch, *, verify=True):
 
 class Registry(dict):
     @property
-    def names(self):
+    def names(self) -> list[str]:
         return list(self.keys())
 
-    def register(self, name, item=NOTHING):
+    def register(self, name: str, item=NOTHING):
         if name in self.keys():
-            raise ValueError("Name already exists in registry")
+            raise ValueError(f"Name {name} already exists in registry.")
 
         def _wrapper(obj):
             self[name] = obj

--- a/tests/cartesian_tests/definitions.py
+++ b/tests/cartesian_tests/definitions.py
@@ -60,7 +60,6 @@ def id_version():
 def get_array_library(backend: str):
     """Return device ready array maker library"""
     backend_cls = gt4pyc.backend.from_name(backend)
-    assert backend_cls is not None
     if backend_cls.storage_info["device"] == "gpu":
         assert cp is not None
         return cp

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -39,7 +39,6 @@ def test_numpy_allocators(backend, order):
 def test_bad_layout_warns(backend):
     xp = get_array_library(backend)
     backend_cls = gt4pyc.backend.from_name(backend)
-    assert backend_cls is not None
 
     shape = (10, 10, 10)
 

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_definitive_assignment_analysis.py
@@ -7,11 +7,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import typing
-from typing import Callable, List, Tuple, TypedDict
+from typing import Callable, List, Tuple
 
 import pytest
 
-from gt4py.cartesian.backend import from_name
 from gt4py.cartesian.gtc.passes import gtir_definitive_assignment_analysis as daa
 from gt4py.cartesian.gtscript import PARALLEL, Field, computation, interval, stencil
 from gt4py.cartesian.stencil_builder import StencilBuilder

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_definitive_assignment_analysis.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_definitive_assignment_analysis.py
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import typing
-from typing import Callable, List, Tuple
+from typing import Callable
 
 import pytest
 
@@ -17,7 +17,7 @@ from gt4py.cartesian.stencil_builder import StencilBuilder
 
 
 # A list of dictionaries containing a stencil definition and the expected test case outputs
-test_data: List[Tuple[Callable, bool]] = []
+test_data: list[tuple[Callable, bool]] = []
 
 
 def register_test_case(*, valid):


### PR DESCRIPTION
## Description

In the latest gt4py/dace bridge refactor (on the cartesian side)[^1], we slipped in a bunch of type enhancements. This PR pull out what is independent of the bridge refactor. In particular this PR brings

- generically typed base registry -> typed frontend and backend registries
- typed `BackendCodegen` constructors
- new-style type hints in touched files

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A

[^1]: see https://github.com/GridTools/gt4py/pull/2067 if you are interested
