### PR TITLE
refactor[cartesian|eve]: drop support for python version < 3.10

### DIFF
--- a/src/gt4py/cartesian/backend/module_generator.py
+++ b/src/gt4py/cartesian/backend/module_generator.py
@@ -9,16 +9,10 @@
 from __future__ import annotations
 
 import abc
+import importlib.resources as importlib_resources
 import numbers
-import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, cast
-
-
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources  # type: ignore[no-redef]
 
 import jinja2
 import numpy

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1745,7 +1745,7 @@ class GTScriptParser(ast.NodeVisitor):
             assert isinstance(ann_assign.target, ast.Name)
             name = ann_assign.target.id
 
-            source = gt_meta.ast_unparse(ann_assign.annotation)
+            source = ast.unparse(ann_assign.annotation)
             descriptor = eval(source, ann_assign_context)
             temp_annotations[name] = descriptor
             if descriptor.axes != gtscript.IJK:

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -34,7 +34,7 @@ from gt4py.cartesian.frontend.exceptions import (
 from gt4py.cartesian.utils import meta as gt_meta
 
 
-PYTHON_AST_VERSION: Final = (3, 8)
+PYTHON_AST_VERSION: Final = (3, 10)
 
 
 class AssertionChecker(ast.NodeTransformer):

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -12,11 +12,8 @@ import ast
 import copy
 import inspect
 import operator
-import platform
 import textwrap
 from typing import Callable, Dict, Final, List, Tuple, Type
-
-from packaging import version
 
 from gt4py.cartesian.utils.base import shashed_id
 
@@ -115,16 +112,6 @@ def ast_dump(
     dumped_ast = _dump(get_ast(definition, feature_version=feature_version), skip_node_names)
 
     return dumped_ast
-
-
-def ast_unparse(ast_node):
-    """Call ast.unparse, but use astunparse for Python prior to 3.9."""
-    if version.parse(platform.python_version()) < version.parse("3.9"):
-        import astunparse
-
-        return astunparse.unparse(ast_node)
-    else:
-        return ast.unparse(ast_node)
 
 
 def ast_shash(ast_node, *, skip_decorators=True):

--- a/src/gt4py/eve/datamodels/core.py
+++ b/src/gt4py/eve/datamodels/core.py
@@ -1255,9 +1255,12 @@ def _make_concrete_with_cache(
     if not is_generic_datamodel_class(datamodel_cls):
         raise TypeError(f"'{datamodel_cls.__name__}' is not a generic model class.")
     for t in type_args:
-        _accepted_types: tuple[type, ...] = (type, type(None), xtyping.StdGenericAliasType)
-        if sys.version_info >= (3, 10):
-            _accepted_types = (*_accepted_types, types.UnionType)
+        _accepted_types: tuple[type, ...] = (
+            type,
+            type(None),
+            xtyping.StdGenericAliasType,
+            types.UnionType,
+        )
         if not (
             isinstance(t, _accepted_types)
             or (getattr(type(t), "__module__", None) in ("typing", "typing_extensions"))

--- a/src/gt4py/eve/datamodels/core.py
+++ b/src/gt4py/eve/datamodels/core.py
@@ -151,10 +151,7 @@ Unchecked = xtyping.Annotated[_T, _UNCHECKED_TYPE_TAG]
 """Type hint marker to define fields that should NOT be type-checked at initialization."""
 
 
-if sys.version_info >= (3, 10):
-    _dataclass_opts: Final[dict[str, Any]] = {"slots": True}
-else:
-    _dataclass_opts: Final[Dict[str, Any]] = {}
+_dataclass_opts: Final[dict[str, Any]] = {"slots": True}
 
 
 @dataclasses.dataclass(**_dataclass_opts)
@@ -348,7 +345,7 @@ def datamodel(  # redefinition of unused symbol
             for all fields.
         generic: If ``True`` (default is ``False``) the class should be a ``Generic[]`` class,
             and the generated Data Model will support creation of new Data Model subclasses
-            when using concrete types as arguments of ``DataModelClass[some_concret_type]``.
+            when using concrete types as arguments of ``DataModelClass[some_concrete_type]``.
         type_validation_factory: Type validation factory used to build the field type validators.
             If ``None``, type validators will not be generators.
 

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -465,7 +465,7 @@ def get_partial_type_hints(
     if getattr(obj, "__no_type_check__", None):
         return {}
     if not hasattr(obj, "__annotations__"):
-        return get_type_hints(  # type: ignore[call-arg]  # Python 3.8 does not define `include-extras`
+        return get_type_hints(
             obj, globalns=globalns, localns=localns, include_extras=include_extras
         )
 
@@ -474,7 +474,7 @@ def get_partial_type_hints(
     for name, hint in annotations.items():
         obj.__annotations__ = {name: hint}
         try:
-            resolved_hints = get_type_hints(  # type: ignore[call-arg]  # Python 3.8 does not define `include-extras`
+            resolved_hints = get_type_hints(
                 obj, globalns=globalns, localns=localns, include_extras=include_extras
             )
             hints[name] = resolved_hints[name]
@@ -530,7 +530,7 @@ def eval_forward_ref(
     else:
         safe_localns = {"typing": _sys.modules[__name__], "NoneType": type(None)}
 
-    actual_type = get_type_hints(_f, globalns, safe_localns, include_extras=include_extras)["ref"]  # type: ignore[call-arg]  # Python 3.8 does not define `include-extras`
+    actual_type = get_type_hints(_f, globalns, safe_localns, include_extras=include_extras)["ref"]
     assert not isinstance(actual_type, ForwardRef)
 
     return actual_type

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -326,13 +326,11 @@ class DevToolsPrettyPrintable(Protocol):
 
 
 # -- Added functionality --
-_ArtefactTypes: tuple[type, ...] = tuple()
-if _sys.version_info >= (3, 9):
-    _ArtefactTypes = (_types.GenericAlias,)  # type: ignore[attr-defined]  # GenericAlias only from >= 3.8
+_ArtefactTypes: tuple[type, ...] = (_types.GenericAlias,)
 
-    # `Any` is a class since Python 3.11
-    if isinstance(_typing.Any, type):  # Python >= 3.11
-        _ArtefactTypes = (*_ArtefactTypes, _typing.Any)
+# `Any` is a class since Python 3.11
+if isinstance(_typing.Any, type):  # Python >= 3.11
+    _ArtefactTypes = (*_ArtefactTypes, _typing.Any)
 
 # `Any` is a class since typing_extensions >= 4.4 and Python 3.11
 if (typing_exts_any := getattr(_typing_extensions, "Any", None)) is not _typing.Any and isinstance(

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -139,31 +139,23 @@ MaybeNestedInList = Union[_T_co, NestedList[_T_co]]
 MaybeNestedInTuple = Union[_T_co, NestedTuple[_T_co]]
 
 # -- Typing annotations --
-if _sys.version_info >= (3, 9):
-    SolvedTypeAnnotation = Union[
-        Type,
-        _typing._SpecialForm,
-        _types.GenericAlias,  # type: ignore[name-defined]  # Python 3.8 does not include `_types.GenericAlias`
-        _typing._BaseGenericAlias,  # type: ignore[name-defined]  # _BaseGenericAlias is not exported in stub
-    ]
-else:
-    SolvedTypeAnnotation = Union[  # type: ignore[misc]  # mypy consider this assignment a redefinition
-        Type, _typing._SpecialForm, _typing._GenericAlias  # type: ignore[attr-defined]  # _GenericAlias is not exported in stub
-    ]
+SolvedTypeAnnotation = Union[
+    Type,
+    _typing._SpecialForm,
+    _types.GenericAlias,
+    _typing._BaseGenericAlias,  # type: ignore[name-defined]  # _BaseGenericAlias is not exported in stub
+]
 
 TypeAnnotation = Union[ForwardRef, SolvedTypeAnnotation]
 SourceTypeAnnotation = Union[str, TypeAnnotation]
 
 StdGenericAliasType: Final[Type] = type(List[int])
 
-if _sys.version_info >= (3, 9):
-    if TYPE_CHECKING:
-        StdGenericAlias: TypeAlias = _types.GenericAlias  # type: ignore[name-defined,attr-defined]  # Python 3.8 does not include `_types.GenericAlias`
+if TYPE_CHECKING:
+    StdGenericAlias: TypeAlias = _types.GenericAlias
 
 _TypingSpecialFormType: Final[Type] = _typing._SpecialForm
-_TypingGenericAliasType: Final[Type] = (
-    _typing._BaseGenericAlias if _sys.version_info >= (3, 9) else _typing._GenericAlias  # type: ignore[attr-defined]  # _BaseGenericAlias / _GenericAlias are not exported in stub
-)
+_TypingGenericAliasType: Final[Type] = _typing._BaseGenericAlias  # type: ignore[attr-defined]  # _BaseGenericAlias / _GenericAlias are not exported in stub
 
 
 # -- Standard Python protocols --

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -468,7 +468,7 @@ def get_partial_type_hints(
 ) -> Dict[str, Union[Type, ForwardRef]]:
     """Return a dictionary with type hints (using forward refs for undefined names) for a function, method, module or class object.
 
-    For each member type hint in the object a :class:`typing.ForwarRef` instance will be
+    For each member type hint in the object a :class:`typing.ForwardRef` instance will be
     returned if some names in the string annotation have not been found. For additional
     information see :func:`typing.get_type_hints`.
     """

--- a/src/gt4py/eve/type_definitions.py
+++ b/src/gt4py/eve/type_definitions.py
@@ -12,27 +12,14 @@ from __future__ import annotations
 
 import abc
 import re
-import sys
 from enum import Enum as Enum, IntEnum as IntEnum
 
 from boltons.typeutils import classproperty as classproperty
-from frozendict import frozendict as _frozendict
 
-from .extended_typing import (
-    Any,
-    ClassVar,
-    Generic,
-    NoReturn,
-    Optional,
-    Tuple,
-    TypeAlias,
-    TypeVar,
-    final,
-)
+from .extended_typing import Any, ClassVar, NoReturn, Optional, Tuple, TypeVar, final
 
 
 # -- Frozen collections --
-_T = TypeVar("_T")
 _Tc = TypeVar("_Tc", covariant=True)
 
 
@@ -44,16 +31,6 @@ class FrozenList(Tuple[_Tc, ...], metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, C: type) -> bool:
         return tuple in C.__mro__
-
-
-if sys.version_info >= (3, 9):
-    frozendict: TypeAlias = _frozendict
-else:
-    _KeyT = TypeVar("_KeyT")
-
-    @final
-    class frozendict(_frozendict, Generic[_KeyT, _T]):
-        __slots__ = ()
 
 
 # -- Sentinels --

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -14,7 +14,6 @@ import abc
 import collections.abc
 import dataclasses
 import functools
-import sys
 import types
 import typing
 
@@ -195,11 +194,10 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
             if type_annotation is None:
                 type_annotation = type(None)
 
-            if sys.version_info >= (3, 10):
-                if isinstance(
-                    type_annotation, types.UnionType
-                ):  # see https://github.com/python/cpython/issues/105499
-                    type_annotation = typing.Union[type_annotation.__args__]
+            if isinstance(
+                type_annotation, types.UnionType
+            ):  # see https://github.com/python/cpython/issues/105499
+                type_annotation = typing.Union[type_annotation.__args__]
 
             # Non-generic types
             if xtyping.is_actual_type(type_annotation):

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -22,7 +22,6 @@ import operator
 import pickle
 import pprint
 import re
-import sys
 import types
 import typing
 import uuid
@@ -858,21 +857,9 @@ class FrozenNamespace(Namespace[T]):
 class UIDGenerator:
     """Simple unique id generator using different methods."""
 
-    prefix: Optional[str] = (
-        dataclasses.field(default=None, kw_only=True)
-        if sys.version_info >= (3, 10)
-        else dataclasses.field(default=None)
-    )
-    width: Optional[int] = (
-        dataclasses.field(default=None, kw_only=True)
-        if sys.version_info >= (3, 10)
-        else dataclasses.field(default=None)
-    )
-    warn_unsafe: Optional[bool] = (
-        dataclasses.field(default=None, kw_only=True)
-        if sys.version_info >= (3, 10)
-        else dataclasses.field(default=None)
-    )
+    prefix: Optional[str] = dataclasses.field(default=None, kw_only=True)
+    width: Optional[int] = dataclasses.field(default=None, kw_only=True)
+    warn_unsafe: Optional[bool] = dataclasses.field(default=None, kw_only=True)
 
     _counter: Iterator[int] = dataclasses.field(
         default_factory=functools.partial(itertools.count, 1), init=False

--- a/tests/eve_tests/unit_tests/test_extended_typing.py
+++ b/tests/eve_tests/unit_tests/test_extended_typing.py
@@ -390,11 +390,7 @@ def test_eval_forward_ref():
             globalns={"Annotated": Annotated, "Callable": Callable},
             localns={"MissingRef": MissingRef},
         )
-    ) == Callable[[int], MissingRef] or (  # some patch versions of cpython3.9 show weird behaviors
-        sys.version_info >= (3, 9)
-        and sys.version_info < (3, 10)
-        and (ref == Callable[[Annotated[int, "Foo"]], MissingRef])
-    )
+    ) == Callable[[int], MissingRef]
 
     assert (
         xtyping.eval_forward_ref(


### PR DESCRIPTION
## Description

`gt4py` currently supports python version 3.10 and 3.11. There were a couple of code paths that were specializing for python versions lower than this. This PR cleans almost all of them up. There's one big chunk to be done, namely this block

https://github.com/GridTools/gt4py/blob/795977bfbb656b63de3d210fddcfe73e6eaddd9f/src/gt4py/eve/extended_typing.py#L34-L80

I think we should have a conversation whether or not we would like to keep exposing `Dict` and friends from `typings_extended`. If I just remove the `if _sys.version_info >= (3, 9):` guard, then `ruff` will attempt to sort imports, which messes things up for `mypy`. 

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
