### PR TITLE
fix[next][dace]: Missing symbolic args in lambda nested scope

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_sdfg.py
@@ -382,7 +382,7 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
     ) -> SDFGBuilder:
         nsdfg_builder = GTIRToSDFG(self.offset_provider_type, self.column_axis, scope_symbols)
         params = [gtir.Sym(id=p_name, type=p_type) for p_name, p_type in scope_symbols.items()]
-        symbolic_arguments = _collect_symbols_in_domain_expressions(node, node.params) | {
+        symbolic_arguments = _collect_symbols_in_domain_expressions(node, params) | {
             # scalar values represented as dace symbols in parent SDFG are mapped
             # to dace symbols in the nested SDFG
             pname

--- a/src/gt4py/next/program_processors/runners/dace/gtir_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_sdfg.py
@@ -381,6 +381,9 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         scope_symbols: dict[str, ts.DataType],
     ) -> SDFGBuilder:
         nsdfg_builder = GTIRToSDFG(self.offset_provider_type, self.column_axis, scope_symbols)
+        # We pass to the nested SDFG all symbols in scope, which includes the values
+        # mapped to the parameters of the lambda expression (`node.params`) and
+        # the symbols defined in the parent SDFG.
         params = [gtir.Sym(id=p_name, type=p_type) for p_name, p_type in scope_symbols.items()]
         symbolic_arguments = _collect_symbols_in_domain_expressions(node, params) | {
             # scalar values represented as dace symbols in parent SDFG are mapped


### PR DESCRIPTION
Some scalar arguments of a lambda nested SDFG were not represented as symbols, although used in domain symbolic expressions. The unittest `test_concat_where.py:test_lap_like` In the `concat_where` PR (#1713) was failing in lowering to SDFG because of this bug.