### PR TITLE
feat[next]: refreshing_lock

### DIFF
--- a/src/gt4py/eve/lock.py
+++ b/src/gt4py/eve/lock.py
@@ -15,7 +15,9 @@ from flufl import lock as flufl_lock
 
 
 @contextlib.contextmanager
-def refreshing_lock(path: pathlib.Path, lifetime: int = 10, refresh: int = 5) -> Generator[None]:
+def refreshing_lock(
+    path: pathlib.Path, lifetime: int = 10, refresh: int = 5
+) -> Generator[None, None, None]:
     lock = flufl_lock.Lock(str(path), lifetime=lifetime)  # type: ignore[attr-defined] # mypy doesn't understand flufl.lock's custom export mechanism
     lock.lock()
     stop_event = threading.Event()

--- a/src/gt4py/eve/lock.py
+++ b/src/gt4py/eve/lock.py
@@ -1,0 +1,32 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import contextlib
+import pathlib
+import threading
+from typing import Generator
+
+from flufl import lock as flufl_lock
+
+
+@contextlib.contextmanager
+def refreshing_lock(path: pathlib.Path, lifetime: int = 10, refresh: int = 5) -> Generator[None]:
+    lock = flufl_lock.Lock(str(path), lifetime=lifetime)  # type: ignore[attr-defined] # mypy doesn't understand flufl.lock's custom export mechanism
+    lock.lock()
+    stop_event = threading.Event()
+
+    def alive() -> None:
+        while not stop_event.wait(refresh):
+            lock.refresh(lifetime)
+
+    alive_thread = threading.Thread(target=alive, daemon=True)
+    alive_thread.start()
+    yield
+    stop_event.set()
+    alive_thread.join()
+    lock.unlock()

--- a/src/gt4py/next/otf/compilation/build_systems/compiledb.py
+++ b/src/gt4py/next/otf/compilation/build_systems/compiledb.py
@@ -16,8 +16,7 @@ import shutil
 import subprocess
 from typing import Optional, TypeVar
 
-from flufl import lock
-
+from gt4py.eve import lock
 from gt4py.next import config, errors
 from gt4py.next.otf import languages, stages
 from gt4py.next.otf.binding import interface
@@ -258,7 +257,7 @@ def _cc_get_compiledb(
 
     # In a multi-threaded environment, multiple threads may try to create the compiledb at the same time
     # leading to compilation errors.
-    with lock.Lock(str(cache_path / "compiledb.lock"), lifetime=120):  # type: ignore[attr-defined] # mypy not smart enough to understand custom export logic
+    with lock.refreshing_lock(cache_path / "compiledb.lock"):
         if renew_compiledb or not (compiled_db := _cc_find_compiledb(path=cache_path)):
             compiled_db = _cc_create_compiledb(
                 prototype_program_source=prototype_program_source,

--- a/src/gt4py/next/otf/compilation/compiler.py
+++ b/src/gt4py/next/otf/compilation/compiler.py
@@ -13,8 +13,8 @@ import pathlib
 from typing import Protocol, TypeVar
 
 import factory
-from flufl import lock
 
+from gt4py.eve import lock
 from gt4py.next import config
 from gt4py.next.otf import languages, stages, step_types, workflow
 from gt4py.next.otf.compilation import build_data, cache, importer
@@ -70,7 +70,7 @@ class Compiler(
 
         # If we are compiling the same program at the same time (e.g. multiple MPI ranks),
         # we need to make sure that only one of them accesses the same build directory for compilation.
-        with lock.Lock(str(src_dir / "compilation.lock"), lifetime=600):  # type: ignore[attr-defined] # mypy not smart enough to understand custom export logic
+        with lock.refreshing_lock(src_dir / "compilation.lock"):
             data = build_data.read_data(src_dir)
 
             if not data or not is_compiled(data) or self.force_recompile:

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -14,10 +14,10 @@ from typing import Any, Optional
 import diskcache
 import factory
 import numpy as np
-from flufl import lock
 
 import gt4py._core.definitions as core_defs
 import gt4py.next.allocators as next_allocators
+from gt4py.eve import lock
 from gt4py.next import backend, common, config, field_utils, metrics
 from gt4py.next.embedded import nd_array_field
 from gt4py.next.otf import arguments, recipes, stages, workflow
@@ -125,8 +125,7 @@ class FileCache(diskcache.Cache):
             lock_dir = pathlib.Path(tempfile.gettempdir())
 
         lock_dir.mkdir(parents=True, exist_ok=True)
-        lockfile = str(lock_dir / "file_cache.lock")
-        with lock.Lock(lockfile, lifetime=10):  # type: ignore[attr-defined] # mypy not smart enough to understand custom export logic
+        with lock.refreshing_lock(lock_dir / "filecache.lock"):
             super().__init__(directory=directory, **settings)
 
         self._init_complete = True


### PR DESCRIPTION
Wraps flufl.lock into a contexthandler that does refreshing.

Previously the compilation lock had an arbitrary and huge lifetime of 600s. In case compilation is aborted and restarted, the lock would be blocked for up to 600s. Now the default lifetime is 10s with refresh every 5s.