### PR TITLE
build[dace][next]: Updated DaCe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -443,7 +443,7 @@ url = 'https://test.pypi.org/simple/'
 
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
-dace = {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_02", extra = "dace-next"}
+dace = {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_03", extra = "dace-next"}
 
 # -- versioningit --
 [tool.versioningit]

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_02#0deba9940088f7ff85d5fb028bd01905c8a02077" }
+source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_03#178037acd6dc0bf355e7c1b77801d10985ceb3f8" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1326,7 +1326,7 @@ dace = [
     { name = "dace", version = "1.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 dace-next = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_02#0deba9940088f7ff85d5fb028bd01905c8a02077" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_03#178037acd6dc0bf355e7c1b77801d10985ceb3f8" } },
 ]
 formatting = [
     { name = "clang-format" },
@@ -1459,7 +1459,7 @@ requires-dist = [
     { name = "cupy-rocm-5-0", marker = "extra == 'rocm5-0'", specifier = ">=13.3.0" },
     { name = "cytoolz", specifier = ">=1.0.1" },
     { name = "dace", marker = "extra == 'dace'", specifier = ">=1.0.2,<1.1.0" },
-    { name = "dace", marker = "extra == 'dace-next'", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_02" },
+    { name = "dace", marker = "extra == 'dace-next'", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_03" },
     { name = "deepdiff", specifier = ">=8.1.0" },
     { name = "devtools", specifier = ">=0.6" },
     { name = "diskcache", specifier = ">=5.6.3" },


### PR DESCRIPTION
Updates DaCe to [`__gt4py-next-integration_2025_07_03`](https://github.com/GridTools/dace/tree/__gt4py-next-integration_2025_07_03).
The main change is that now [PR#2066](https://github.com/spcl/dace/pull/2066) that fixes an error in `scope_tree_recursive()` is also included.