### PR TITLE
fix[next][dace]: Catch sympy parse error

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
@@ -775,6 +775,9 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                     symbolic_expr = gtir_to_sdfg_utils.get_symbolic(lambda_arg)
                 except TypeError:
                     # sympy parsing failed, it can happen with 'cast_' expressions
+                    assert any(
+                        eve.walk_values(lambda_arg).map(lambda node: cpm.is_call_to(node, "cast_"))
+                    )
                     continue
                 if all(str(s) in sdfg.symbols for s in symbolic_expr.free_symbols):
                     symbolic_args[str(p.id)] = symbolic_expr

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
@@ -771,7 +771,11 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                     continue
                 # Convert the scalar argument to a dace symbolic expression if all
                 # of its dependencies are symbols to.
-                symbolic_expr = gtir_to_sdfg_utils.get_symbolic(lambda_arg)
+                try:
+                    symbolic_expr = gtir_to_sdfg_utils.get_symbolic(lambda_arg)
+                except TypeError:
+                    # sympy parsing failed, it can happen with 'cast_' expressions
+                    continue
                 if all(str(s) in sdfg.symbols for s in symbolic_expr.free_symbols):
                     symbolic_args[str(p.id)] = symbolic_expr
             # All other lambda arguments are lowered to some dataflow that produces a data node.


### PR DESCRIPTION
This PR allows to catch errors in sympy parsing of scalar expressions that contain `cast_`:
`grf_nudge_start_e_wp = astype(grf_nudge_start_e, wpfloat)`