### PR TITLE
fix[next][dace]: Wrong Argument Handling in  `gt_substitute_compiletime_symbols()`.

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
@@ -319,7 +319,7 @@ def gt_substitute_compiletime_symbols(
     #   we initially call simplify and hope for the best.
     # For testing purposes we need to be able to disable this initial simplify.
     #  This is an implementation detail that we should get rid of.
-    if not kwargs.get("simplify_at_entry", False):
+    if kwargs.get("simplify_at_entry", True):
         # NOTE: To ensure uniform behaviour and as a performance optimization,
         #   `gt_auto_optimizer()` performs the initial simplification before this
         #   function is called. If something is changed here then the change might


### PR DESCRIPTION
The `gt_substitute_compiletime_symbols()` function provides the undocumented argument `simplify_at_entry` which allows to disable the initial simplification, before the actual substitution. This is needed to overcome [issue#1817 in DaCe](https://github.com/spcl/dace/issues/1817) and an issue when the substitution of an AccessNode is attempted, an issue that should be fixed by [PR#2079](https://github.com/spcl/dace/pull/2079). This initial simplification is not needed if the function is called in the context of `gt_auto_optimize()`, where that is done as a first step. However, for some reason it was using a `not` in front of the check.
