### PR TITLE
Updated the DaCe dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -427,7 +427,7 @@ url = 'https://test.pypi.org/simple'
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
 dace = [
-  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_15", group = "dace-next"}
+  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_16", group = "dace-next"}
 ]
 
 # -- versioningit --

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_15#45e24e97d63547ba95c5b328b0e42f5f38a10d5c" }
+source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_16#ff441fe0fa21c9f30ab0b08d8cc3681253b82877" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1351,7 +1351,7 @@ dace-cartesian = [
     { name = "dace", version = "1.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 dace-next = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_15#45e24e97d63547ba95c5b328b0e42f5f38a10d5c" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_16#ff441fe0fa21c9f30ab0b08d8cc3681253b82877" } },
 ]
 dev = [
     { name = "atlas4py" },
@@ -1485,7 +1485,7 @@ build = [
     { name = "wheel", specifier = ">=0.33.6" },
 ]
 dace-cartesian = [{ name = "dace", specifier = ">=1.0.2,<2" }]
-dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_15" }]
+dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_16" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },


### PR DESCRIPTION
This PR updates DaCe to [`__gt4py-next-integration_2025_07_16`](https://github.com/GridTools/dace/tree/__gt4py-next-integration_2025_07_16). The main addition is that DaCe now also contains [PR#1987](https://github.com/spcl/dace/pull/1987) which adds parallel or horizontal map fusion.

This PR is needed for [to switch to DaCe's Map fusion transformations (PR#2148)](https://github.com/GridTools/gt4py/pull/2148).