### PR TITLE
bug[next]: fix symlink issue in tmp directory

### DIFF
--- a/src/gt4py/next/otf/compilation/cache.py
+++ b/src/gt4py/next/otf/compilation/cache.py
@@ -74,4 +74,6 @@ def get_cache_folder(
     complete_path = base_path / folder_name
     complete_path.mkdir(exist_ok=True)
 
-    return complete_path
+    # Resolve symlinks to workaround an issue on MacOS where the default tmp directory is a symlink
+    # which might sometimes get resolved in a way we don't control.
+    return complete_path.resolve()


### PR DESCRIPTION
Resolve symlinks to workaround an issue on MacOS where the default tmp directory is a symlink which might sometimes get resolved in a way we don't control. The issue showed in the Compiledb, when trying to substitute CMake generated paths with a relative path.

See #2153 for enabling MacOS in ci.