### PR TITLE
style: update linting tools configuration and apply changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,18 @@ repos:
       - id: pretty-format-yaml
         args: [--autofix, --preserve-quotes, --indent, "2", --offset, "2"]
 
-  # We don't want to update this hook since newer versions of prettier are broken for pre-commit.
-  # TODO(egparedes): find a lightweight alternative to prettier
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22
     hooks:
-      - id: prettier
-        types_or: [markdown, json]
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-frontmatter
+          - mdformat-gfm
+          - mdformat-gfm-alerts
+          - mdformat-myst
+          - mdformat-ruff
+          - mdformat-tables
+        args: [--number]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ First version including the experimental `gt4py.next` aka _Declarative GT4Py_. T
 
 ### Cartesian
 
-- Parametrized dtype: see option 4 of [the gtscript concept workshop](https://github.com/GridTools/concepts/blob/master/collaboration/gtscript-workshop/GTScript-Syntax-Discussion.md#gtscript-syntax-discussed-issues-20200829])
+- Parametrized dtype: see option 4 of [the gtscript concept workshop](https://github.com/GridTools/concepts/blob/master/collaboration/gtscript-workshop/GTScript-Syntax-Discussion.md#gtscript-syntax-discussed-issues-20200829)
 
 ## [1.0.0] - 2022-12-21
 

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -35,15 +35,15 @@ We deviate from the [Google Python Style Guide][google-style-guide] only in the 
   ```python
   # Correct use of `...` as the empty body of an abstract method
   class AbstractFoo:
-     @abstractmethod
-     def bar(self) -> Bar:
-        ...
+      @abstractmethod
+      def bar(self) -> Bar: ...
+
 
   # Correct use of `pass` when mixed with other statements
   try:
-     resource.load(id=42)
+      resource.load(id=42)
   except ResourceException:
-     pass
+      pass
   ```
 
 - where to `import from gt4py.next` or `import gt4py.next as gtx`?
@@ -58,7 +58,9 @@ Error messages should be written as sentences, starting with a capital letter an
 Examples:
 
 ```python
-raise ValueError(f"Invalid argument 'dimension': should be of type 'Dimension', got '{dimension.type}'.")
+raise ValueError(
+    f"Invalid argument 'dimension': should be of type 'Dimension', got '{dimension.type}'."
+)
 ```
 
 Interpolated integer values do not need double quotes, if they are indicating an amount. Example:
@@ -77,7 +79,9 @@ The message should be kept to one sentence if reasonably possible. Ideally the s
 
 ```python
 # too many sentences
-raise ValueError(f"Received an unexpeted number of arguments. Should receive 5 arguments, but got {len(args)}. Please provide the correct number of arguments.")
+raise ValueError(
+    f"Received an unexpeted number of arguments. Should receive 5 arguments, but got {len(args)}. Please provide the correct number of arguments."
+)
 # better
 raise ValueError(f"Wrong number of arguments: expected 5, got {len(args)}.")
 
@@ -91,14 +95,14 @@ The terseness vs. helpfulness tradeoff should be more in favor of terseness for 
 
 ### Docstrings
 
-We generate the API documentation automatically from the docstrings using [Sphinx][sphinx] and some extensions such as [Sphinx-autodoc][sphinx-autodoc] and [Sphinx-napoleon][sphinx-napoleon]. These follow the Google Python Style Guide docstring conventions to automatically format the generated documentation. A complete overview can be found here: [Example Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
+We generate the API documentation automatically from the docstrings using [Sphinx] and some extensions such as [Sphinx-autodoc] and [Sphinx-napoleon]. These follow the Google Python Style Guide docstring conventions to automatically format the generated documentation. A complete overview can be found here: [Example Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
 
 Sphinx supports the [reStructuredText][sphinx-rest] (reST) markup language for defining additional formatting options in the generated documentation, however section [_3.8 Comments and Docstrings_](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) of the Google Python Style Guide does not specify how to use markups in docstrings. As a result, we decided to forbid reST markup in docstrings, except for the following cases:
 
 - Cross-referencing other objects using Sphinx text roles for the [Python domain](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#the-python-domain) (as explained [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#python-roles)).
-- Very basic formatting markup to improve _readability_ of the generated documentation without obscuring the source docstring (e.g. ` ``literal`` ` strings, bulleted lists).
+- Very basic formatting markup to improve _readability_ of the generated documentation without obscuring the source docstring (e.g. ``` ``literal`` ``` strings, bulleted lists).
 
-We highly encourage the [doctest][doctest] format for code examples in docstrings. In fact, doctest runs code examples and makes sure they are in sync with the codebase.
+We highly encourage the [doctest] format for code examples in docstrings. In fact, doctest runs code examples and makes sure they are in sync with the codebase.
 
 ### Module structure
 
@@ -129,7 +133,7 @@ Consider configuration files as another type of source code and apply the same c
 You may occasionally need to disable checks from _quality assurance_ (QA) tools (e.g. linters, type checkers, etc.) on specific lines as some tool might not be able to fully understand why a certain piece of code is needed. This is usually done with special comments, e.g. `# noqa: F401`, `# type: ignore`. However, you should **only** ignore QA errors when you fully understand their source and rewriting your code to pass QA checks would make it less readable. Additionally, you should add a short descriptive code if possible (check [ruff rules][ruff-rules] and [mypy error codes][mypy-error-codes] for reference):
 
 ```python
-f = lambda: 'empty'  # noqa: E731 [lambda-assignment]
+f = lambda: "empty"  # noqa: E731 [lambda-assignment]
 ```
 
 and, if needed, a brief comment for future reference:

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -145,7 +145,7 @@ Testing components is a critical part of a software development project. We foll
 
 ### Test suite folder structure
 
-There are separate test suites (each living in a subfolder) for the separate subpackages of GT4Py. This is so that not all subpackages have to be tested on CI all the time (see [`ci-docs`][the ci docs] for details).
+There are separate test suites (each living in a subfolder) for the separate subpackages of GT4Py. This is so that not all subpackages have to be tested on CI all the time (see [the ci docs](docs/development/tools/ci-infrastructure.md) for details).
 
 The `tests` folder should not be a package but the contained test suites are python packages.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,16 +170,16 @@ Before submitting a pull request, check that it meets the following criteria:
 
 As mentioned above, we use several tools to help us write high-quality code. New tools could be added in the future, especially if they do not add a large overhead to our workflow and they bring extra benefits to keep our codebase in shape. The most important ones which we currently rely on are:
 
-- [nox][nox] for testing and task automation with different environments.
-- [pre-commit][pre-commit] for automating the execution of QA tools.
-- [pytest][pytest] for writing readable tests, extended with:
-  - [Coverage.py][coverage] and [pytest-cov][pytest-cov] for test coverage reports.
-  - [pytest-xdist][pytest-xdist] for running tests in parallel.
-- [ruff][ruff] for style enforcement and code linting.
-- [sphinx][sphinx] for generating documentation, extended with:
-  - [sphinx-autodoc][sphinx-autodoc] and [sphinx-napoleon][sphinx-napoleon] for extracting API documentation from docstrings.
-  - [jupytext][jupytext] for writing new user documentation with code examples.
-- [uv][uv] for managing dependencies and environments.
+- [nox] for testing and task automation with different environments.
+- [pre-commit] for automating the execution of QA tools.
+- [pytest] for writing readable tests, extended with:
+  - [Coverage.py][coverage] and [pytest-cov] for test coverage reports.
+  - [pytest-xdist] for running tests in parallel.
+- [ruff] for style enforcement and code linting.
+- [sphinx] for generating documentation, extended with:
+  - [sphinx-autodoc] and [sphinx-napoleon] for extracting API documentation from docstrings.
+  - [jupytext] for writing new user documentation with code examples.
+- [uv] for managing dependencies and environments.
 
 <!-- Reference links -->
 

--- a/docs/development/ADRs/next/0001-Field_View_Frontend_Design.md
+++ b/docs/development/ADRs/next/0001-Field_View_Frontend_Design.md
@@ -50,7 +50,7 @@ Symbols as well as expressions must have a type in all dialects. This deviates f
 
 All nodes that represent code must hold the location of that code.
 
-##### Correspondence Python AST <-> dialect AST
+##### Correspondence Python AST \<-> dialect AST
 
 In some cases there are Python constructs which would directly map to a function call in the iterator model (such as binary operators). It was chosen to still represent them as binary operators to keep the analogy to Python AST and clearly separate parsing and lowering. The correspondence between Python and dialect AST also means it would be relatively easy to "unparse" the dialect AST into valid Python code for debugging.
 

--- a/docs/development/ADRs/next/0002-Field_View_Lowering.md
+++ b/docs/development/ADRs/next/0002-Field_View_Lowering.md
@@ -53,8 +53,8 @@ Example (type annotations omitted):
 ```python
 @fieldop
 def temp(a):
-  tmp = a
-  return tmp
+    tmp = a
+    return tmp
 ```
 
 Would need to be turned into a single expression. While this case is trivial to solve by hand by simply replacing of `a` for `tmp` (yielding `deref(a)`), we require an algorithm that works in all cases.
@@ -177,6 +177,6 @@ In the course of implementing the lowering it turned out that while it is clear 
 
 Since temporary variables are no longer inlined, the renaming that happens in the SSA pass now goes through into the lowered IR, requiring the new names to be valid `SymbolNames`. This renaming should consequently be checked for and made more robust against user variable name collisions.
 
-## Operator signature FOAST <-> ITIR
+## Operator signature FOAST \<-> ITIR
 
-On iterator level the arguments to all stencils / functions used inside a fencil closure need to be iterators (due to the compiled backend using a single SID composite to pass the arguments). Following the FOAST value <-> ITIR value, FOAST field <-> ITIR iterator correspondence, all field operator arguments whose type on FOAST level is a value, i.e. scalar or composite thereof, are expected to be values on ITIR level by the rest of the lowering. As a consequence we transform all values into iterators before calling field operators (to satisfy the former constraint) and deref them immediately inside every field operator (to satisfy the latter constraint).
+On iterator level the arguments to all stencils / functions used inside a fencil closure need to be iterators (due to the compiled backend using a single SID composite to pass the arguments). Following the FOAST value \<-> ITIR value, FOAST field \<-> ITIR iterator correspondence, all field operator arguments whose type on FOAST level is a value, i.e. scalar or composite thereof, are expected to be values on ITIR level by the rest of the lowering. As a consequence we transform all values into iterators before calling field operators (to satisfy the former constraint) and deref them immediately inside every field operator (to satisfy the latter constraint).

--- a/docs/development/ADRs/next/0003-Iterator_View_Tuple_Support_for_Fields.md
+++ b/docs/development/ADRs/next/0003-Iterator_View_Tuple_Support_for_Fields.md
@@ -48,7 +48,7 @@ We don't distinguish between field of tuple and tuple of fields. They are both t
 We could represent tuple of fields as tuple of iterators, but then we cannot shift the components in a single shift call, instead it would look like
 
 ```python
-make_tuple(shift(offset)(tuple_get(0,inp)), shift(offset)(tuple_get(1,inp)), ...)
+make_tuple(shift(offset)(tuple_get(0, inp)), shift(offset)(tuple_get(1, inp)), ...)
 ```
 
 This would only make sense if each component needs a different shift, however then most likely the input should be represented as separate fields, not as tuple.

--- a/docs/development/ADRs/next/0004-Lifted_Stencils_with_Tuple_Return.md
+++ b/docs/development/ADRs/next/0004-Lifted_Stencils_with_Tuple_Return.md
@@ -19,6 +19,7 @@ Example
 def stencil():
     return 42, 43
 
+
 # What is the type of
 lift(stencil)()
 ```
@@ -45,16 +46,17 @@ def foo(inp0, inp1, inp2):
 ### Iterator of tuples
 
 ```python
-def uniform(inp0,inp1,inp2):
-    res = lift(foo)(inp0,inp1,inp2)
+def uniform(inp0, inp1, inp2):
+    res = lift(foo)(inp0, inp1, inp2)
     shifted = shift(O)(res)
     return deref(shifted)
 
-def non_uniform(inp0,inp1,inp2):
-    res_it = lift(foo)(inp0,inp1,inp2)
-    shifted_vals_O = deref(shift(O)(res_it)) # everything is shifted
-    shifted_vals_L = deref(shift(L)(res_it)) # everything is shifted
-    return tuple_get(1, shifted_vals_O), tuple_get(2, shifted_vals_L) # we throw away element 0
+
+def non_uniform(inp0, inp1, inp2):
+    res_it = lift(foo)(inp0, inp1, inp2)
+    shifted_vals_O = deref(shift(O)(res_it))  # everything is shifted
+    shifted_vals_L = deref(shift(L)(res_it))  # everything is shifted
+    return tuple_get(1, shifted_vals_O), tuple_get(2, shifted_vals_L)  # we throw away element 0
 ```
 
 In a naive (non-optimized) implementation of the `non_uniform` case we pay for 4 extra shifts (ptr updates) that are not needed.
@@ -69,9 +71,10 @@ def uniform(inp0, inp1, inp2):
     shifted2 = shift(O)(tuple_get(2, res))
     return make_tuple(deref(shifted0), deref(shifted1), deref(shifted2))
 
+
 def non_uniform(inp0, inp1, inp2):
     res = lift(foo)(inp0, inp1, inp2)
-    return deref(shift(O)(tuple_get(1, res))),deref(shift(L)(tuple_get(2, res)))
+    return deref(shift(O)(tuple_get(1, res))), deref(shift(L)(tuple_get(2, res)))
 ```
 
 In a naive implementation of the `uniform` case we might do extra stride-computations/lookups for each of the shifts.

--- a/docs/development/ADRs/next/0007-Fencil-Processors.md
+++ b/docs/development/ADRs/next/0007-Fencil-Processors.md
@@ -16,8 +16,8 @@ In contrast to "backend" we can clearly define a **program processor**: Any func
 This was done to
 
 1. Give a single semantic meaning to calling a `@fendef` decorated function or FieldView program: executing the program.
-1. Reduce the potential for circular imports.
-1. Prepare for compiled backends integration, which needs to distinguish between these two (and possibly more) types of `program_processors`.
+2. Reduce the potential for circular imports.
+3. Prepare for compiled backends integration, which needs to distinguish between these two (and possibly more) types of `program_processors`.
 
 ## Changelog
 

--- a/docs/development/ADRs/next/0008-Mapping_Domain_to_Cpp-Backend.md
+++ b/docs/development/ADRs/next/0008-Mapping_Domain_to_Cpp-Backend.md
@@ -50,8 +50,11 @@ class Dimension:
     value: str
     kind: DimensionKind
 
+
 # the following field doesn't have correct default order, as without remapping we would interpret first dimension as dim::horizontal
-np_as_located_field(Dimension("K", DimensionKind.VERTICAL), Dimension("Vertex", DimensionKind.HORIZONTAL))
+np_as_located_field(
+    Dimension("K", DimensionKind.VERTICAL), Dimension("Vertex", DimensionKind.HORIZONTAL)
+)
 ```
 
 ### Mapping of Cartesian Offsets to Dimensions

--- a/docs/development/ADRs/next/0013-Scalar_vs_0d_Fields.md
+++ b/docs/development/ADRs/next/0013-Scalar_vs_0d_Fields.md
@@ -134,7 +134,7 @@ In the long-term, this alternative seems to combine the best features from other
 
 ## References <!-- optional -->
 
-- [\[Numpy-discussion\] A case for rank-0 arrays](https://mail.python.org/pipermail/numpy-discussion/2006-February/006384.html)
+- [[Numpy-discussion] A case for rank-0 arrays](https://mail.python.org/pipermail/numpy-discussion/2006-February/006384.html)
 - [Python - annotating the decorated function](https://github.com/python/typing/issues/412)
 - [Python array API standard - Array object](https://data-apis.org/array-api/latest/API_specification/array_object.html)
 - [GT4Py discussion and notes (HackMD)](https://hackmd.io/@gridtools/SyQ4vJ9Js)

--- a/docs/development/ADRs/next/0015-Test_Exclusion_Matrices.md
+++ b/docs/development/ADRs/next/0015-Test_Exclusion_Matrices.md
@@ -60,7 +60,11 @@ Following the previous example, the GTFN backend with temporaries does not suppo
 ```python
 BACKEND_SKIP_TEST_MATRIX = {
     GTFN_CPU_WITH_TEMPORARIES: [
-        ("uses_dynamic_offsets", pytest.XFAIL, "'{marker}' tests not supported by '{backend}' backend"),
+        (
+            "uses_dynamic_offsets",
+            pytest.XFAIL,
+            "'{marker}' tests not supported by '{backend}' backend",
+        ),
     ]
 }
 ```

--- a/docs/development/ADRs/next/0017-Toolchain-Configuration.md
+++ b/docs/development/ADRs/next/0017-Toolchain-Configuration.md
@@ -46,10 +46,10 @@ class ToolchainFactory(factory.Factory):
         model = ToolchainClass
 
     class Params:
-        high_level_parameters = ... # check factoryboy docs for possibilities
-        some_option = config.SOME_OPTION # default read from config module
+        high_level_parameters = ...  # check factoryboy docs for possibilities
+        some_option = config.SOME_OPTION  # default read from config module
 
-    attribute_defaults = ... # may use parameter values etc
+    attribute_defaults = ...  # may use parameter values etc
 ```
 
 ### Limit configuration options exposed to the end user
@@ -82,10 +82,12 @@ We are aware that this decision has significant drawbacks. The main justificatio
 ```python
 # gt4py.next.config
 MASTER_SWITCH = os.environ.get(f"{_PREFIX}_MASTER_SWITCH", "false")
-DEPENDENT_OPT = os.environ.get(f"{_PREFIX}_DEPENDENT_OPT", "one_default" if MASTER_SWITCH else "another_default")
+DEPENDENT_OPT = os.environ.get(
+    f"{_PREFIX}_DEPENDENT_OPT", "one_default" if MASTER_SWITCH else "another_default"
+)
 
 if MASTER_SWITCH:
-    ... # more complex config related side effects
+    ...  # more complex config related side effects
 ```
 
 ### Environment variables are the primary end user interface
@@ -120,10 +122,12 @@ Implementations of the two latter patterns can be designed to mitigate this but 
 ```python
 # gt4py.next.config
 MASTER_SWITCH = os.environ.get(f"{_PREFIX}_MASTER_SWITCH", "false")
-DEPENDENT_OPT = os.environ.get(f"{_PREFIX}_DEPENDENT_OPT", "one_default" if MASTER_SWITCH else "another_default")
+DEPENDENT_OPT = os.environ.get(
+    f"{_PREFIX}_DEPENDENT_OPT", "one_default" if MASTER_SWITCH else "another_default"
+)
 
 if MASTER_SWITCH:
-    ... # more complex config related side effects
+    ...  # more complex config related side effects
 
 # in client code
 from gt4py.next import config
@@ -231,24 +235,26 @@ Implementing tracking was briefly considered but looked like it would be too hea
 The first PoC used a function call to load user configuration just before using it. This would have increased testability at the cost of a less minimal implementation.
 
 ```python
-
 class Configuration:
     ...
+
     @property
-    def option_1(self):
-        ...
+    def option_1(self): ...
 
     @option_1.setter
     def option_1(self, value):
         self._option_1 = value
         self._dependent_option = ...
-        ... # more dependent behavior
+        ...  # more dependent behavior
+
 
 OPTION_1_DEFAULT
+
 
 def get_configuration():
     conf = Configuration()
     conf.option_1 = read_from_env() or read_from_other_source() or default
+
 
 current_configuration: Configuration = get_configuration()
 

--- a/docs/development/ADRs/next/0018-Canonical_SDFG_in_GT4Py_Transformations.md
+++ b/docs/development/ADRs/next/0018-Canonical_SDFG_in_GT4Py_Transformations.md
@@ -40,16 +40,16 @@ The following rules especially affects transformations and how they operate:
 
 1. Intrastate transformation and interstate transformations must run separately and can not be mixed in the same (DaCe) pipeline.
 
-   - [Rationale]: As a consequence the number of "interstate transients" (transients that are used in multiple states) remains constant during intrastate transformations.
-   - [Note 1]: It is allowed to run them one after another, as long as they are strictly separated.
-   - [Note 2]: It is allowed for an _intrastate_ transformation to act in a way that allows state fusion by later intrastate transformations.
-   - [Note 3]: The DaCe simplification pass violates this rule, for that reason this pass must always be called on its own, see also rule 2.
+   - \[Rationale\]: As a consequence the number of "interstate transients" (transients that are used in multiple states) remains constant during intrastate transformations.
+   - \[Note 1\]: It is allowed to run them one after another, as long as they are strictly separated.
+   - \[Note 2\]: It is allowed for an _intrastate_ transformation to act in a way that allows state fusion by later intrastate transformations.
+   - \[Note 3\]: The DaCe simplification pass violates this rule, for that reason this pass must always be called on its own, see also rule 2.
 
 2. It is invalid to call DaCe's simplification pass directly, i.e. the usage of `SDFG.simplify()` is not allowed. The only valid way to call _simplify()_ is to call the `gt_simplify()` function provided by GT4Py.
 
-   - [Rationale]: It was observed that some sub-passes in _simplify()_ have a negative impact and that additional passes might be needed in the future.
+   - \[Rationale\]: It was observed that some sub-passes in _simplify()_ have a negative impact and that additional passes might be needed in the future.
      By using a single function later modifications to _simplify()_ are easy.
-   - [Note]: One issue is that the remove redundant array transformation is not able to handle all cases.
+   - \[Note\]: One issue is that the remove redundant array transformation is not able to handle all cases.
 
 #### Global Memory
 
@@ -58,11 +58,11 @@ However, the following rule takes precedence, i.e. if this rule is fulfilled the
 
 3. The same global memory is allowed to be used as input and output at the same time, either in the SDFG or in a state, if and only if the output depends _elementwise_ on the input.
 
-   - [Rationale 1]: This allows the removal of double buffering, that DaCe may not remove. See also rule 2.
-   - [Rationale 2]: This formulation allows writing expressions such as `a += 1`, with only memory for `a`.
+   - \[Rationale 1\]: This allows the removal of double buffering, that DaCe may not remove. See also rule 2.
+   - \[Rationale 2\]: This formulation allows writing expressions such as `a += 1`, with only memory for `a`.
      Phrased more technically, using global memory for input and output is allowed if and only if the two computations `tmp = computation(global_memory); global_memory = tmp;` and `global_memory = computation(global_memory);` are equivalent.
-   - [Note 1]: This rule also forbids expressions such as `A[0:10] = A[1:11]`, where `A` refers to a global memory.
-   - [Note 2]: In the long term this rule will be changed to: Global memory (an array) is either used as input (only read from) or as output (only written to) but never for both.
+   - \[Note 1\]: This rule also forbids expressions such as `A[0:10] = A[1:11]`, where `A` refers to a global memory.
+   - \[Note 2\]: In the long term this rule will be changed to: Global memory (an array) is either used as input (only read from) or as output (only written to) but never for both.
 
 #### State Machine
 
@@ -70,54 +70,54 @@ For the SDFG state machine we assume that:
 
 4. An interstate edge can only access scalars, i.e. use them in their assignment or condition expressions, but not arrays, even if they have shape `(1,)`.
 
-   - [Rationale]: If an array is also used in interstate edges it became very tedious to verify if the array could be removed or not.
-   - [Note]: Running _simplify()_ might actually result in the violation of this rule, see note of rule 9.
+   - \[Rationale\]: If an array is also used in interstate edges it became very tedious to verify if the array could be removed or not.
+   - \[Note\]: Running _simplify()_ might actually result in the violation of this rule, see note of rule 9.
 
 5. The state graph does not contain any cycles, i.e. the implementation of a for/while loop using states is not allowed, the new loop construct or serial maps must be used in that case.
 
-   - [Rationale]: This is a simplification that makes it much simpler to define what "later in the computation" means, as we will never have a cycle.
-   - [Note]: Currently the code generator does not support the `LoopRegion` construct and it is transformed to a state machine.
+   - \[Rationale\]: This is a simplification that makes it much simpler to define what "later in the computation" means, as we will never have a cycle.
+   - \[Note\]: Currently the code generator does not support the `LoopRegion` construct and it is transformed to a state machine.
 
 #### Transients
 
 The rules we impose on transients are a bit more complicated, however, while sounding restrictive, they are very permissive.
 It is important to note that these rules only have to be met after _simplify()_ was called once on the SDFG:
 
-6. Downstream of a write access, i.e., in all states that follow the state where the access node is located, there are no other access nodes that are used to write to the same array.
+06. Downstream of a write access, i.e., in all states that follow the state where the access node is located, there are no other access nodes that are used to write to the same array.
 
-   - [Rationale 1]: This rule, together with rule 7 and 8, essentially ensures that the assignment in the SDFG follows SSA style, while allowing for expressions such as:
+    - \[Rationale 1\]: This rule, together with rule 7 and 8, essentially ensures that the assignment in the SDFG follows SSA style, while allowing for expressions such as:
 
-   ```python
-   if cond:
-       a = true_branch()
-   else:
-       a = false_branch()
-   ```
+    ```python
+    if cond:
+        a = true_branch()
+    else:
+        a = false_branch()
+    ```
 
-   (**NOTE:** This could also be done with references, however, they are strongly discouraged.)
+    (**NOTE:** This could also be done with references, however, they are strongly discouraged.)
 
-   - [Rationale 2]: This still allows reductions with WCR as they write to the same access node and loops, whose body modifies a transient that outlives the loop body, as they use the same access node.
+    - \[Rationale 2\]: This still allows reductions with WCR as they write to the same access node and loops, whose body modifies a transient that outlives the loop body, as they use the same access node.
 
-7. It is _recommended_ that a write access node should only have one incoming edge.
+07. It is _recommended_ that a write access node should only have one incoming edge.
 
-   - [Rationale]: This case is handled poorly by some DaCe transformations, thus we should avoid them as much as possible.
+    - \[Rationale\]: This case is handled poorly by some DaCe transformations, thus we should avoid them as much as possible.
 
-8. No two access nodes in a state can refer to the same array.
+08. No two access nodes in a state can refer to the same array.
 
-   - [Rationale]: Together with rule 5 this guarantees SSA style.
-   - [Note]: An SDFG can still be constructed using different access node for the same underlying data in the same state; _simplify()_ will combine them.
+    - \[Rationale\]: Together with rule 5 this guarantees SSA style.
+    - \[Note\]: An SDFG can still be constructed using different access node for the same underlying data in the same state; _simplify()_ will combine them.
 
-9. Every access node that reads from an array (having an outgoing edge) that was not written to in the same state must be a source node.
+09. Every access node that reads from an array (having an outgoing edge) that was not written to in the same state must be a source node.
 
-   - [Rationale]: Together with rule 1, 4, 5, 6, 7 and 8 this simplifies checking if a transient can be safely removed or if it is used somewhere else.
-     These rules guarantee that the number of "interstate transients" remains constant and this set is given by the _set of source nodes and all access nodes that have an outgoing degree larger than one_.
-   - [Note]: To prevent some issues caused by the violation of rule 4 by _simplify()_, this set is extended with the transient sink nodes and all scalars.
-     Excess interstate transients, that will be kept alive that way, will be removed by later calls to _simplify()_.
+    - \[Rationale\]: Together with rule 1, 4, 5, 6, 7 and 8 this simplifies checking if a transient can be safely removed or if it is used somewhere else.
+      These rules guarantee that the number of "interstate transients" remains constant and this set is given by the _set of source nodes and all access nodes that have an outgoing degree larger than one_.
+    - \[Note\]: To prevent some issues caused by the violation of rule 4 by _simplify()_, this set is extended with the transient sink nodes and all scalars.
+      Excess interstate transients, that will be kept alive that way, will be removed by later calls to _simplify()_.
 
 10. Every AccessNode within a map scope must refer to a data descriptor whose lifetime must be `dace.dtypes.AllocationLifetime.Scope` and its storage class should either be `dace.dtypes.StorageType.Default` or _preferably_ `dace.dtypes.StorageType.Register`.
 
-    - [Rationale 1]: This makes optimizations operating inside maps/kernels simpler, as it guarantees that the AccessNode does not propagate outside.
-    - [Rationale 2]: The storage type avoids the need to dynamically allocate memory inside a kernel.
+    - \[Rationale 1\]: This makes optimizations operating inside maps/kernels simpler, as it guarantees that the AccessNode does not propagate outside.
+    - \[Rationale 2\]: The storage type avoids the need to dynamically allocate memory inside a kernel.
 
 #### Maps
 
@@ -130,13 +130,13 @@ For maps we assume the following:
     - 11.3: The name of vertical dimensions (`kind` attribute) always end in `__gtx_vertical`.
     - 11.4: The name of local dimensions always ends in `__gtx_localdim`.
     - 11.5: No transformation is allowed to modify the name of an iteration variable that follows rules 11.2, 11.3 or 11.4.
-    - [Rationale]: Without this rule it is very hard to tell which map variable does what, this way we can transmit information from GT4Py to DaCe, see also rule 12.
+    - \[Rationale\]: Without this rule it is very hard to tell which map variable does what, this way we can transmit information from GT4Py to DaCe, see also rule 12.
 
 12. Two map ranges, i.e. the pair map/iteration variable and range, can only be fused if they have the same name _and_ cover the same range.
 
-    - [Rationale 1]: Because of rule 11, we will only fuse maps that actually makes sense to fuse.
-    - [Rationale 2]: This allows fusing maps without renaming the map variables.
-    - [Note]: This rule might be dropped in the future.
+    - \[Rationale 1\]: Because of rule 11, we will only fuse maps that actually makes sense to fuse.
+    - \[Rationale 2\]: This allows fusing maps without renaming the map variables.
+    - \[Note\]: This rule might be dropped in the future.
 
 ## Consequences
 

--- a/docs/development/tools/ci-infrastructure.md
+++ b/docs/development/tools/ci-infrastructure.md
@@ -12,7 +12,7 @@ A `Code Quality` workflow runs `pre-commit` to check code quality requirements t
 
 ### Tests
 
-The `Test code components (CPU)`, `Test Package Root` and `Test examples in documentation` workflows run the correspondent `nox` sessions testing different parts of GT4Py. `Test code components (CPU)` is a parameterized workflow (see more details in [_Code component test sessions_](#code-component-test-sessions]). `Test Package Root` tests the root package code and `Test examples in documentation` tests the code samples in the documentation. In all cases only tests are run that do not require the presence of a GPU.
+The `Test code components (CPU)`, `Test Package Root` and `Test examples in documentation` workflows run the correspondent `nox` sessions testing different parts of GT4Py. `Test code components (CPU)` is a parameterized workflow (see more details in [_Code component test sessions_](#code-component-test-sessions). `Test Package Root` tests the root package code and `Test examples in documentation` tests the code samples in the documentation. In all cases only tests are run that do not require the presence of a GPU.
 
 #### Code component test sessions
 

--- a/docs/user/next/QuickstartGuide.md
+++ b/docs/user/next/QuickstartGuide.md
@@ -138,7 +138,7 @@ When writing complex applications, you have to decompose it into _field operator
 
 ### Operations on unstructured meshes
 
-This section introduces additional APIs through a slightly more elaborate application that performs a laplacian-like operation on an unstructured mesh. Within the context of this guide, we define the _pseudo-laplacian_ for a cell as the sum of the _edge differences_ around the cell. For example, the pseudo-laplacian for cell \#1, which is surrounded by edges \#7, \#8 and \#9, is expressed by the formula:
+This section introduces additional APIs through a slightly more elaborate application that performs a laplacian-like operation on an unstructured mesh. Within the context of this guide, we define the _pseudo-laplacian_ for a cell as the sum of the _edge differences_ around the cell. For example, the pseudo-laplacian for cell #1, which is surrounded by edges #7, #8 and #9, is expressed by the formula:
 
 $$\begin{aligned}\text{pseudolap}(cell_1) =\,& \text{edge_diff}_7 + \text{edge_diff}_8 + \text{edge_diff}_9 \end{aligned}$$.
 
@@ -172,7 +172,7 @@ CellDim = gtx.Dimension("Cell")
 EdgeDim = gtx.Dimension("Edge")
 ```
 
-You can express connectivity between elements (i.e. cells or edges) of the mesh using connectivity (a.k.a. adjacency or neighborhood) tables. The table below, `edge_to_cell_table`, has one row for every edge where it lists the indices of cells adjacent to that edge. For example, this table says that edge \#6 connects to cells \#0 and \#5. Similarly, `cell_to_edge_table` lists the edges that are neighbors to a particular cell.
+You can express connectivity between elements (i.e. cells or edges) of the mesh using connectivity (a.k.a. adjacency or neighborhood) tables. The table below, `edge_to_cell_table`, has one row for every edge where it lists the indices of cells adjacent to that edge. For example, this table says that edge #6 connects to cells #0 and #5. Similarly, `cell_to_edge_table` lists the edges that are neighbors to a particular cell.
 
 Note, however, that the tables are dense matrices, so if an edge has fewer than 2 neighbor cells, the remaining entries are filled with -1. You can also specify all kinds of connectivities like edge-to-edge, cell-to-edge or even cell-to-cell. The adjacency relationships don't have to be reciprocal, so it's possible for example that a cell lists an edge as its neighbour, but the edge does not list that particular cell.
 
@@ -388,10 +388,10 @@ C2E_offset_provider = gtx.as_connectivity([CellDim, C2EDim], codomain=EdgeDim, d
 
 **Weights of edge differences:**
 
-Revisiting the example from the beginning of the section, the equation of the pseudo-laplacian for cell \#1 is:
-$$\text{pseudolap}(cell_1) = -\text{edge_diff}_{0,1} + \text{edge_diff}_{1,2} + \text{edge_diff}_{1,3}$$
+Revisiting the example from the beginning of the section, the equation of the pseudo-laplacian for cell #1 is:
+\$$\text{pseudolap}(cell_1) = -\text{edge_diff}_{0,1} + \text{edge_diff}_{1,2} + \text{edge_diff}_{1,3}$\$
 
-Notice how $\text{edge_diff}_{0,1}$ is actually subtracted from the sum rather than added. This is because the edge to cell connectivity table lists cell \#1 as the second argument to the subtraction rather than the first, so the difference calculated on the edge will be the opposite sign for this particular cell. To fix this, a table that has three elements for every cell is needed, specifying the sign of the difference on the three adjacent edges. If you look for cell \#1 in the `edge_weights` table below, you can see that the sign is negative for the first edge difference and positive for the second and third, just like in the equation above.
+Notice how $\text{edge_diff}_{0,1}$ is actually subtracted from the sum rather than added. This is because the edge to cell connectivity table lists cell #1 as the second argument to the subtraction rather than the first, so the difference calculated on the edge will be the opposite sign for this particular cell. To fix this, a table that has three elements for every cell is needed, specifying the sign of the difference on the three adjacent edges. If you look for cell #1 in the `edge_weights` table below, you can see that the sign is negative for the first edge difference and positive for the second and third, just like in the equation above.
 
 +++
 

--- a/docs/user/next/advanced/HackTheToolchain.md
+++ b/docs/user/next/advanced/HackTheToolchain.md
@@ -22,7 +22,9 @@ cached_lowering_toolchain = gtx.backend.DEFAULT_TRANSFORMS.replace(
 ## Skip Steps / Change Order
 
 ```python
-DUMMY_FOP = toolchain.CompilableProgram(data=ff_stages.FieldOperatorDefinition(definition=None), args=None)
+DUMMY_FOP = toolchain.CompilableProgram(
+    data=ff_stages.FieldOperatorDefinition(definition=None), args=None
+)
 ```
 
 ```python
@@ -38,29 +40,28 @@ class SkipLinting(gtx.backend.Transforms):
             order.remove("past_lint")  # not running "past_lint"
         return order
 
+
 same_steps = dataclasses.asdict(gtx.backend.DEFAULT_TRANSFORMS)
-skip_linting_transforms = SkipLinting(
-    **same_steps
-)
+skip_linting_transforms = SkipLinting(**same_steps)
 skip_linting_transforms.step_order(DUMMY_FOP)
 ```
 
 ## Alternative Factory
 
 ```python
-class MyCodeGen:
-    ...
+class MyCodeGen: ...
 
 
-class Cpp2BindingsGen:
-    ...
+class Cpp2BindingsGen: ...
 
 
 class PureCpp2WorkflowFactory(gtx.program_processors.runners.gtfn.GTFNCompileWorkflowFactory):
     translation: workflow.Workflow[
-        gtx.otf.stages.CompilableProgram, gtx.otf.stages.ProgramSource] = MyCodeGen()
-    bindings: workflow.Workflow[
-        gtx.otf.stages.ProgramSource, gtx.otf.stages.CompilableSource] = Cpp2BindingsGen()
+        gtx.otf.stages.CompilableProgram, gtx.otf.stages.ProgramSource
+    ] = MyCodeGen()
+    bindings: workflow.Workflow[gtx.otf.stages.ProgramSource, gtx.otf.stages.CompilableSource] = (
+        Cpp2BindingsGen()
+    )
 
 
 PureCpp2WorkflowFactory(cmake_build_type=gtx.config.CMAKE_BUILD_TYPE.DEBUG)
@@ -83,11 +84,12 @@ X_T = typing.TypeVar("X_T")
 Y_T = typing.TypeVar("Y_T")
 OUT_T = typing.TypeVar("OUT_T")
 
+
 @dataclasses.dataclass(frozen=True)
 class FullyModularDiamond(
     workflow.ChainableWorkflowMixin[IN_T, OUT_T],
     workflow.ReplaceEnabledWorkflowMixin[IN_T, OUT_T],
-    typing.Protocol[IN_T, OUT_T, A_T, B_T, X_T, Y_T]
+    typing.Protocol[IN_T, OUT_T, A_T, B_T, X_T, Y_T],
 ):
     split: workflow.Workflow[IN_T, tuple[A_T, X_T]]
     track_a: workflow.Workflow[A_T, B_T]
@@ -105,21 +107,16 @@ class FullyModularDiamond(
 class PartiallyModularDiamond(
     workflow.ChainableWorkflowMixin[IN_T, OUT_T],
     workflow.ReplaceEnabledWorkflowMixin[IN_T, OUT_T],
-    typing.Protocol[IN_T, OUT_T, A_T, B_T, X_T, Y_T]
+    typing.Protocol[IN_T, OUT_T, A_T, B_T, X_T, Y_T],
 ):
     track_a: workflow.Workflow[A_T, B_T]
     track_x: workflow.Workflow[X_T, Y_T]
 
-    def split(inp: IN_T) -> tuple[A_T, X_T]:
-        ...
+    def split(inp: IN_T) -> tuple[A_T, X_T]: ...
 
-    def combine(b: B_T, y: Y_T) -> OUT_T:
-        ...
+    def combine(b: B_T, y: Y_T) -> OUT_T: ...
 
     def __call__(inp: IN_T) -> OUT_T:
         a, x = self.split(inp)
-        return self.combine(
-            b=self.track_a(a),
-            y=self.track_x(x)
-        )
+        return self.combine(b=self.track_a(a), y=self.track_x(x))
 ```

--- a/docs/user/next/advanced/ToolchainWalkthrough.md
+++ b/docs/user/next/advanced/ToolchainWalkthrough.md
@@ -71,7 +71,6 @@ linkStyle 0 stroke:red,stroke-width:4px,color:pink
 ```
 
 ```python
-
 foast = backend.DEFAULT_TRANSFORMS.func_to_foast(
     gtx.otf.toolchain.CompilableProgram(start, gtx.otf.arguments.CompileTimeArgs.empty())
 )
@@ -137,7 +136,7 @@ So far we have gotten away with empty compile time arguments, now we need to sup
 jit_args = gtx.otf.arguments.JITArgs.from_signature(
     gtx.ones(domain={I: 10}, dtype=gtx.float64),
     out=gtx.zeros(domain={I: 10}, dtype=gtx.float64),
-    offset_provider=OFFSET_PROVIDER
+    offset_provider=OFFSET_PROVIDER,
 )
 
 aot_args = gtx.otf.arguments.CompileTimeArgs.from_concrete_no_size(
@@ -146,7 +145,9 @@ aot_args = gtx.otf.arguments.CompileTimeArgs.from_concrete_no_size(
 ```
 
 ```python
-pclos = backend.DEFAULT_TRANSFORMS.field_view_op_to_prog(gtx.otf.toolchain.CompilableProgram(data=foast.data, args=aot_args))
+pclos = backend.DEFAULT_TRANSFORMS.field_view_op_to_prog(
+    gtx.otf.toolchain.CompilableProgram(data=foast.data, args=aot_args)
+)
 ```
 
 ```python
@@ -281,9 +282,7 @@ linkStyle 0,2,3,4,5 stroke:red,stroke-width:4px,color:pink
 ### Starting from DSL
 
 ```python
-pitir2 = backend.DEFAULT_TRANSFORMS(
-    gtx.otf.toolchain.CompilableProgram(data=start, args=aot_args)
-)
+pitir2 = backend.DEFAULT_TRANSFORMS(gtx.otf.toolchain.CompilableProgram(data=start, args=aot_args))
 assert pitir2 == pitir
 ```
 
@@ -313,10 +312,7 @@ Note that it is the exact same call but with a different input stage
 
 ```python
 pitir3 = backend.DEFAULT_TRANSFORMS(
-    gtx.otf.toolchain.CompilableProgram(
-        data=foast.data,
-        args=aot_args
-    )
+    gtx.otf.toolchain.CompilableProgram(data=foast.data, args=aot_args)
 )
 assert pitir3 == pitir
 ```
@@ -360,7 +356,10 @@ linkStyle 6 stroke:red,stroke-width:4px,color:pink
 
 ```python
 p_past = backend.DEFAULT_TRANSFORMS.func_to_past(
-    gtx.otf.toolchain.CompilableProgram(data=p_start, args=gtx.otf.arguments.CompileTimeArgs.empty()))
+    gtx.otf.toolchain.CompilableProgram(
+        data=p_start, args=gtx.otf.arguments.CompileTimeArgs.empty()
+    )
+)
 ```
 
 ## Full Program Toolchain
@@ -388,19 +387,13 @@ linkStyle 3,4,5,6 stroke:red,stroke-width:4px,color:pink
 
 ```python
 p_itir1 = backend.DEFAULT_TRANSFORMS(
-    gtx.otf.toolchain.CompilableProgram(
-        data=p_start,
-        args=jit_args
-    )
+    gtx.otf.toolchain.CompilableProgram(data=p_start, args=jit_args)
 )
 ```
 
 ```python
 p_itir2 = backend.DEFAULT_TRANSFORMS(
-    gtx.otf.toolchain.CompilableProgram(
-        data=p_past.data,
-        args=aot_args
-    )
+    gtx.otf.toolchain.CompilableProgram(data=p_past.data, args=aot_args)
 )
 ```
 

--- a/docs/user/next/advanced/WorkflowPatterns.md
+++ b/docs/user/next/advanced/WorkflowPatterns.md
@@ -5,7 +5,7 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: "1.3"
+      format_version: '1.3'
       jupytext_version: 1.16.2
   kernelspec:
     display_name: Python 3 (ipykernel)
@@ -54,6 +54,7 @@ Where "Stage" describes any data structure, and where `StageA` contains all the 
 def simple_add_1(inp: int) -> int:
     return inp + 1
 
+
 simple_add_1(1)
 ```
 
@@ -70,9 +71,9 @@ inp(A: int) -->|simple_add_1| b(A + 1) -->|simple_add_1| c(A + 2) -->|simple_add
 <!-- #endregion -->
 
 ```python editable=true slideshow={"slide_type": ""}
-manual_add_3 = gtx.otf.workflow.StepSequence.start(
-    simple_add_1
-).chain(simple_add_1).chain(simple_add_1)
+manual_add_3 = (
+    gtx.otf.workflow.StepSequence.start(simple_add_1).chain(simple_add_1).chain(simple_add_1)
+)
 
 manual_add_3(1)
 ```
@@ -125,10 +126,8 @@ class MathOp(gtx.otf.workflow.ChainableWorkflowMixin[int, int]):
     def mul(self, lhs: int, rhs: int) -> int:
         return lhs * rhs
 
-add_3_times_2 = (
-    MathOp("add", 3)
-    .chain(MathOp("mul", 2))
-)
+
+add_3_times_2 = MathOp("add", 3).chain(MathOp("mul", 2))
 add_3_times_2(1)
 ```
 
@@ -168,9 +167,10 @@ def debug_print(inp: int) -> int:
     print("cache miss!")
     return inp
 
+
 cached_calc = gtx.otf.workflow.CachedStep(
     step=debug_print.chain(add_3_times_2),
-    hash_function=lambda i: str(i)  # using ints as their own hash
+    hash_function=lambda i: str(i),  # using ints as their own hash
 )
 
 cached_calc(1)
@@ -202,6 +202,7 @@ def to_int(inp: str) -> int:
     assert isinstance(inp, str), "Can not work with 'int'!"  # yes, this is horribly contrived
     return int(inp)
 
+
 str_calc = to_int.chain(add_3_times_2)
 
 str_calc("1")
@@ -228,9 +229,11 @@ What to do? What we want is a to conditionally skip the first step, so we replac
 class OptionalStrToInt(SkippableStep[str | int, int]):
     step: Workflow[str, int]
 
-    def skip_condition(self, inp: str | int) -> bool:
-        ... # return True to skip (if we get an int) or False to run the conversion (str case)
-
+    def skip_condition(
+        self, inp: str | int
+    ) -> (
+        bool
+    ): ...  # return True to skip (if we get an int) or False to run the conversion (str case)
 ```
 
 ```mermaid
@@ -257,6 +260,7 @@ class OptionalStrToInt(gtx.otf.workflow.SkippableStep[str | int, int]):
             case _:
                 # optionally raise an error with good advice
                 return False
+
 
 strint_calc = OptionalStrToInt().chain(add_3_times_2)
 strint_calc(1) == strint_calc("1")
@@ -296,13 +300,17 @@ class StrToIntFactory(factory.Factory):
     class Params:
         default_step = to_int
         optional: bool = False
-        optional_or_not = factory.LazyAttribute(lambda o: OptionalStrToInt(step=o.default_step) if o.optional else o.default_step)
+        optional_or_not = factory.LazyAttribute(
+            lambda o: OptionalStrToInt(step=o.default_step) if o.optional else o.default_step
+        )
         cached = factory.Trait(
-            inner_step = factory.LazyAttribute(
+            inner_step=factory.LazyAttribute(
                 lambda o: gtx.otf.workflow.CachedStep(step=(o.optional_or_not), hash_function=str)
             )
         )
+
     inner_step = factory.LazyAttribute(lambda o: o.optional_or_not)
+
 
 cached = StrToIntFactory(cached=True)
 optional = StrToIntFactory(optional=True)
@@ -332,8 +340,7 @@ Imagine swapping out `sub_third` in `complicated_workflow` below (without copy p
 
 ```python
 complicated_workflow = (
-    start_step
-    .chain(first_sub_first.chain(first_sub_second).chain(first_sub_third))
+    start_step.chain(first_sub_first.chain(first_sub_second).chain(first_sub_third))
     .chain(second_sub_first.chain(second_sub_second))
     .chain(last)
 )
@@ -383,20 +390,13 @@ class ComplicatedWorkflow(gtx.otf.workflow.NamedStepSequence[A, F]):
     second_sub: Workflow[E, G]
     last: Workflow[G, F]
 
+
 complicated_workflow = ComplicatedWorkflow(
     start_step=start_step,
-    first_sub=FirstSub(
-        first=first_sub_first,
-        second=first_sub_second,
-        third=first_sub_third
-    ),
-    second_sub=SecondSub(
-        first=second_sub_first,
-        second=second_sub_second
-    ),
-    last=last
+    first_sub=FirstSub(first=first_sub_first, second=first_sub_second, third=first_sub_third),
+    second_sub=SecondSub(first=second_sub_first, second=second_sub_second),
+    last=last,
 )
-
 ```
 
 ```mermaid
@@ -449,10 +449,7 @@ Note that with all this there comes an extra feature: We can easily create varia
 CUSTOM_COLORS = {"blue": "#55aaff", "green": "#00ff00", "red": "#ff0000"}
 
 proc = StrProcess(
-    hexify_colors=HexifyColors(
-        color_scheme=CUSTOM_COLORS
-    ),
-    replace_tabs=spaces_to_tabs
+    hexify_colors=HexifyColors(color_scheme=CUSTOM_COLORS), replace_tabs=spaces_to_tabs
 )
 
 proc("""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,26 +308,50 @@ respect-gitignore = true
 show-fixes = true
 # show-source = true
 target-version = 'py310'
+typing-modules = ['gt4py.eve.extended_typing']
 
 [tool.ruff.format]
 docstring-code-format = true
 
 [tool.ruff.lint]
-# # Rules sets:
-# E: pycodestyle
-# F: Pyflakes
-# I: isort
-# B: flake8-bugbear
+# -- Rules set to be considered --
 # A: flake8-builtins
-# T10: flake8-debugger
+# B: flake8-bugbear
+# C4: flake8-comprehensions
+# CPY: flake8-copyright
+# D: pydocstyle
+# DOC: pydoclint
+# E: pycodestyle
 # ERA: eradicate
+# F: Pyflakes
+# FA100: future-rewritable-type-annotation
+# FBT: flake8-boolean-trap
+# FLY: flynt
+# I: isort
+# ICN: flake8-import-conventions
+# ISC: flake8-implicit-str-concat
+# N: pep8-naming
 # NPY: NumPy-specific rules
+# PERF: Perflint
+# PGH: pygrep-hooks
+# PTH: flake8-use-pathlib
+# Q: flake8-quotes
 # RUF: Ruff-specific rules
+# SIM: flake8-simplify
+# T10: flake8-debugger
+# TD: flake8-todos
+# UP: pyupgrade
+# YTT: flake8-2020
+exclude = ['docs/**', "examples/**", "tests/**"]
+explicit-preview-rules = true
+extend-select = ["F822"]
 ignore = [
   'E501',  # [line-too-long]
-  'B905'  # [zip-without-explicit-strict]  # TODO(egparedes): Reevaluate this rule
+  'B905',  # [zip-without-explicit-strict]  # TODO(egparedes): remove when possible
+  'TD003'  # [missing-todo-link]
 ]
-select = ['E', 'F', 'I', 'B', 'A', 'T10', 'ERA', 'NPY', 'RUF']
+preview = true  # use only with explicit-preview-rules=true
+select = ['A', 'B', 'CPY', 'E', 'ERA', 'F', 'FA100', 'I', 'ISC', 'NPY', 'Q', 'RUF', 'T10', 'YTT']
 typing-modules = ['gt4py.eve.extended_typing']
 unfixable = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,6 @@ respect-gitignore = true
 show-fixes = true
 # show-source = true
 target-version = 'py310'
-typing-modules = ['gt4py.eve.extended_typing']
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -344,7 +343,7 @@ docstring-code-format = true
 # YTT: flake8-2020
 exclude = ['docs/**', "examples/**", "tests/**"]
 explicit-preview-rules = true
-extend-select = ["F822"]
+extend-select = ["F822"]  # TODO(egparedes): remove when not longer in preview
 ignore = [
   'E501',  # [line-too-long]
   'B905',  # [zip-without-explicit-strict]  # TODO(egparedes): remove when possible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,10 +405,6 @@ split-on-trailing-comma = false
 [tool.ruff.lint.mccabe]
 max-complexity = 15
 
-[tool.ruff.lint.per-file-ignores]
-'src/gt4py/eve/extended_typing.py' = ['F401', 'F405']
-'src/gt4py/next/__init__.py' = ['F401']
-
 # -- setuptools build backend --
 [tool.setuptools]
 platforms = ['Linux', 'Mac']

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1319,8 +1319,10 @@ class IRMaker(ast.NodeVisitor):
             condition = self.visit(node.test)
         except KeyError as e:
             raise GTScriptSyntaxError(
-                message="Using function calls in the condition of an if is not allowed,"
-                + " the function needs to be assigned to a variable outside the condition.",
+                message=(
+                    "Using function calls in the condition of an if is not allowed,"
+                    " the function needs to be assigned to a variable outside the condition."
+                ),
                 loc=nodes.Location.from_ast_node(node),
             ) from e
         result.append(
@@ -1642,7 +1644,7 @@ class GTScriptParser(ast.NodeVisitor):
         assert isinstance(definition, types.FunctionType)
         self.definition = definition
         self.filename = inspect.getfile(definition)
-        self.source, decorators_source = gt_meta.split_def_decorators(self.definition)
+        self.source, _decorators_source = gt_meta.split_def_decorators(self.definition)
         self.ast_root = ast.parse(self.source, feature_version=PYTHON_AST_VERSION)
         self.options = options
         self.build_info = options.build_info

--- a/src/gt4py/cartesian/gtc/passes/oir_optimizations/caches.py
+++ b/src/gt4py/cartesian/gtc/passes/oir_optimizations/caches.py
@@ -537,7 +537,7 @@ class FillFlushToLocalKCaches(eve.NodeTranslator, eve.VisitorWithSymbolTableTrai
             first_unfilled: Dict[str, int] = dict()
             split_sections: List[oir.VerticalLoopSection] = []
             for section in node.sections:
-                split_section, previous_fills = self._split_section_with_multiple_fills(
+                split_section, _previous_fills = self._split_section_with_multiple_fills(
                     node.loop_order, section, filling_fields, first_unfilled, new_symbol_name
                 )
                 split_sections += split_section

--- a/src/gt4py/eve/__init__.py
+++ b/src/gt4py/eve/__init__.py
@@ -71,9 +71,6 @@ from .visitors import NodeTranslator, NodeVisitor
 
 
 __all__ = [  # noqa: RUF022 `__all__` is not sorted
-    # version
-    "__version__",
-    "__version_info__",
     # concepts
     "AnnexManager",
     "AnySourceLocation",

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -14,6 +14,7 @@ Definitions in 'typing_extensions' take priority over those in 'typing'.
 
 from __future__ import annotations
 
+# ruff: noqa: F401, F405
 import array as _array
 import dataclasses as _dataclasses
 import functools as _functools

--- a/src/gt4py/next/__init__.py
+++ b/src/gt4py/next/__init__.py
@@ -18,6 +18,7 @@ to create a streamlined user experience. `from module import *` can be used but 
 module in question is a submodule, defines `__all__` and exports many public API objects.
 """
 
+# ruff: noqa: F401
 from . import common, ffront, iterator, program_processors
 from .common import (
     Connectivity,

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -144,15 +144,13 @@ def _column_axis(all_closure_vars: dict[str, Any]) -> Optional[common.Dimension]
         return None
 
     if len(scanops_per_axis.values()) != 1:
-        scanops_per_axis_strs = [
+        scanops_per_axis_str = "\n".join(
             f"- {dim.value}: {', '.join(scanops)}" for dim, scanops in scanops_per_axis.items()
-        ]
+        )
 
         raise TypeError(
             "Only 'ScanOperator's defined on the same axis "
-            + "can be used in a 'Program', found:\n"
-            + "\n".join(scanops_per_axis_strs)
-            + "."
+            f"can be used in a 'Program', found:\n{scanops_per_axis_str}\n"
         )
 
     return iter(scanops_per_axis.keys()).__next__()

--- a/src/gt4py/next/ffront/source_utils.py
+++ b/src/gt4py/next/ffront/source_utils.py
@@ -22,7 +22,7 @@ MISSING_FILENAME = "<string>"
 
 
 def get_closure_vars_from_function(function: Callable) -> dict[str, Any]:
-    (nonlocals, globals, builtins, unbound) = inspect.getclosurevars(function)  # noqa: A001 [builtin-variable-shadowing]
+    (nonlocals, globals, builtins, _unbound) = inspect.getclosurevars(function)  # noqa: A001 [builtin-variable-shadowing]
     return {**builtins, **globals, **nonlocals}  # nonlocals override globals
 
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
@@ -220,9 +220,8 @@ class LoopBlocking(dace_transformation.SingleStateTransformation):
         inner_label = f"inner_{outer_map.label}"
         inner_range = {
             self.blocking_parameter: dace_subsets.Range.from_string(
-                f"(({rng_start}) + ({coarse_block_var}) * ({self.blocking_size}))"
-                + ":"
-                + f"min(({rng_start}) + ({coarse_block_var} + 1) * ({self.blocking_size}), ({rng_stop}) + 1)"
+                f"(({rng_start}) + ({coarse_block_var}) * ({self.blocking_size})):"
+                f"min(({rng_start}) + ({coarse_block_var} + 1) * ({self.blocking_size}), ({rng_stop}) + 1)"
             )
         }
         inner_entry, inner_exit = state.add_map(


### PR DESCRIPTION
This PR replaces the deprecated `prettier` pre-commit hook by `mdformat` for the auto-formatting of markdown files, and adds a few more rules to `ruff check` (some of them in preview mode). All the other changes are a consequence of running the linting/formatting tools, specially `mdformat` since it formats the code inside code blocks in markdown documents.  

 