### PR TITLE
build[dace][next]: Updated the DaCe dependency. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -446,7 +446,7 @@ url = 'https://test.pypi.org/simple'
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
 dace = [
-  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_21", group = "dace-next"}
+  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_21_I", group = "dace-next"}
 ]
 
 # -- versioningit --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -446,7 +446,7 @@ url = 'https://test.pypi.org/simple'
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
 dace = [
-  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_16", group = "dace-next"}
+  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_21", group = "dace-next"}
 ]
 
 # -- versioningit --

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21#33b63a1512445793744c9c1eeaf2d26d5b2391cc" }
+source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21_I#2417e09be55abbfe5ff5f6944141a999d01e66aa" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1351,7 +1351,7 @@ dace-cartesian = [
     { name = "dace", version = "1.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 dace-next = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21#33b63a1512445793744c9c1eeaf2d26d5b2391cc" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21_I#2417e09be55abbfe5ff5f6944141a999d01e66aa" } },
 ]
 dev = [
     { name = "atlas4py" },
@@ -1485,7 +1485,7 @@ build = [
     { name = "wheel", specifier = ">=0.33.6" },
 ]
 dace-cartesian = [{ name = "dace", specifier = ">=1.0.2,<2" }]
-dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21" }]
+dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21_I" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -840,7 +840,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_16#ff441fe0fa21c9f30ab0b08d8cc3681253b82877" }
+source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21#33b63a1512445793744c9c1eeaf2d26d5b2391cc" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1351,7 +1351,7 @@ dace-cartesian = [
     { name = "dace", version = "1.0.2", source = { registry = "https://pypi.org/simple" } },
 ]
 dace-next = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_16#ff441fe0fa21c9f30ab0b08d8cc3681253b82877" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21#33b63a1512445793744c9c1eeaf2d26d5b2391cc" } },
 ]
 dev = [
     { name = "atlas4py" },
@@ -1485,7 +1485,7 @@ build = [
     { name = "wheel", specifier = ">=0.33.6" },
 ]
 dace-cartesian = [{ name = "dace", specifier = ">=1.0.2,<2" }]
-dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_16" }]
+dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_21" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },


### PR DESCRIPTION
This brings DaCe to [`__gt4py-next-integration_2025_07_21_I`](https://github.com/GridTools/dace/tree/__gt4py-next-integration_2025_07_21_I).
The main feature that is introduced is, that it is now possible to specify `assume_always_single_use_data`, which might speed up some calls, as it is now possible to avoid some scans.