### PR TITLE
feat[next][dace]: Config the gpu backend with async sdfg call

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -81,6 +81,10 @@ def make_dace_backend(
     """Helper function to create a dace cached backend with custom config for SDFG
     lowering and auto-optimize.
 
+    Note that `async_sdfg_call=True` on GPU device relies on the dace configuration
+    with 1 cuda stream, so that all kernels and memory operations are executed
+    sequentially on the default stream.
+
     Args:
         auto_optimize: Enable SDFG auto-optimize pipeline.
         cached: Cache the lowered SDFG as a JSON file and the compiled programs.
@@ -142,7 +146,7 @@ run_dace_gpu = make_dace_backend(
     auto_optimize=True,
     cached=False,
     gpu=True,
-    async_sdfg_call=False,
+    async_sdfg_call=True,
     make_persistent=False,
     blocking_dim=None,
 )
@@ -150,7 +154,7 @@ run_dace_gpu_noopt = make_dace_backend(
     auto_optimize=False,
     cached=False,
     gpu=True,
-    async_sdfg_call=False,
+    async_sdfg_call=True,
     make_persistent=False,
     blocking_dim=None,
 )
@@ -158,7 +162,7 @@ run_dace_gpu_cached = make_dace_backend(
     auto_optimize=True,
     cached=True,
     gpu=True,
-    async_sdfg_call=False,
+    async_sdfg_call=True,
     make_persistent=False,
     blocking_dim=None,
 )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -72,10 +72,10 @@ def make_dace_backend(
     auto_optimize: bool,
     cached: bool,
     gpu: bool,
+    async_sdfg_call: bool,
+    make_persistent: bool,
     blocking_dim: common.Dimension | None,
     blocking_size: int = 10,
-    async_sdfg_call: bool = True,
-    make_persistent: bool = False,
     use_zero_origin: bool = False,
 ) -> backend.Backend:
     """Helper function to create a dace cached backend with custom config for SDFG
@@ -89,13 +89,13 @@ def make_dace_backend(
         auto_optimize: Enable SDFG auto-optimize pipeline.
         cached: Cache the lowered SDFG as a JSON file and the compiled programs.
         gpu: Enable GPU transformations and code generation.
+        async_sdfg_call: Enable asynchronous SDFG execution, only applicable
+            when `gpu=True` because it relies on the gpu kernel queue.
+        make_persistent: Allocate persistent arrays with constant layout.
         blocking_dim: When not 'None', apply 'LoopBlocking' SDFG transformation
             on this dimension.
         blocking_size: Block size to use in 'LoopBlocking' SDFG transformation,
             when enabled.
-        async_sdfg_call: Enable asynchronous SDFG execution, only applicable
-            when `gpu=True` because it relies on the gpu kernel queue.
-        make_persistent: Allocate persistent arrays with constant layout.
         use_zero_origin: Can be set to `True` when all fields passed as program
             arguments have zero-based origin. This setting will skip generation
             of range start-symbols `_range_0` since they can be assumed to be zero.
@@ -111,8 +111,8 @@ def make_dace_backend(
         otf_workflow__bare_translation__blocking_dim=blocking_dim,
         otf_workflow__bare_translation__blocking_size=blocking_size,
         otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
-        otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,
+        otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bindings__make_persistent=make_persistent,
     )
 
@@ -122,18 +122,24 @@ run_dace_cpu = make_dace_backend(
     cached=False,
     gpu=False,
     blocking_dim=None,
+    async_sdfg_call=False,
+    make_persistent=False,
 )
 run_dace_cpu_noopt = make_dace_backend(
     auto_optimize=False,
     cached=False,
     gpu=False,
     blocking_dim=None,
+    async_sdfg_call=False,
+    make_persistent=False,
 )
 run_dace_cpu_cached = make_dace_backend(
     auto_optimize=True,
     cached=True,
     gpu=False,
     blocking_dim=None,
+    async_sdfg_call=False,
+    make_persistent=False,
 )
 
 run_dace_gpu = make_dace_backend(
@@ -141,16 +147,22 @@ run_dace_gpu = make_dace_backend(
     cached=False,
     gpu=True,
     blocking_dim=None,
+    async_sdfg_call=True,
+    make_persistent=False,
 )
 run_dace_gpu_noopt = make_dace_backend(
     auto_optimize=False,
     cached=False,
     gpu=True,
     blocking_dim=None,
+    async_sdfg_call=True,
+    make_persistent=False,
 )
 run_dace_gpu_cached = make_dace_backend(
     auto_optimize=True,
     cached=True,
     gpu=True,
     blocking_dim=None,
+    async_sdfg_call=True,
+    make_persistent=False,
 )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -72,10 +72,10 @@ def make_dace_backend(
     auto_optimize: bool,
     cached: bool,
     gpu: bool,
-    async_sdfg_call: bool,
-    make_persistent: bool,
     blocking_dim: common.Dimension | None,
     blocking_size: int = 10,
+    async_sdfg_call: bool = True,
+    make_persistent: bool = False,
     use_zero_origin: bool = False,
 ) -> backend.Backend:
     """Helper function to create a dace cached backend with custom config for SDFG
@@ -89,13 +89,13 @@ def make_dace_backend(
         auto_optimize: Enable SDFG auto-optimize pipeline.
         cached: Cache the lowered SDFG as a JSON file and the compiled programs.
         gpu: Enable GPU transformations and code generation.
-        async_sdfg_call: Enable asynchronous SDFG execution, only applicable
-            when `gpu=True` because it relies on the gpu kernel queue.
-        make_persistent: Allocate persistent arrays with constant layout.
         blocking_dim: When not 'None', apply 'LoopBlocking' SDFG transformation
             on this dimension.
         blocking_size: Block size to use in 'LoopBlocking' SDFG transformation,
             when enabled.
+        async_sdfg_call: Enable asynchronous SDFG execution, only applicable
+            when `gpu=True` because it relies on the gpu kernel queue.
+        make_persistent: Allocate persistent arrays with constant layout.
         use_zero_origin: Can be set to `True` when all fields passed as program
             arguments have zero-based origin. This setting will skip generation
             of range start-symbols `_range_0` since they can be assumed to be zero.
@@ -108,10 +108,10 @@ def make_dace_backend(
         auto_optimize=auto_optimize,
         cached=cached,
         otf_workflow__cached_translation=cached,
-        otf_workflow__bare_translation__async_sdfg_call=(gpu if async_sdfg_call else False),
-        otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bare_translation__blocking_dim=blocking_dim,
         otf_workflow__bare_translation__blocking_size=blocking_size,
+        otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
+        otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,
         otf_workflow__bindings__make_persistent=make_persistent,
     )
@@ -121,24 +121,18 @@ run_dace_cpu = make_dace_backend(
     auto_optimize=True,
     cached=False,
     gpu=False,
-    async_sdfg_call=False,
-    make_persistent=False,
     blocking_dim=None,
 )
 run_dace_cpu_noopt = make_dace_backend(
     auto_optimize=False,
     cached=False,
     gpu=False,
-    async_sdfg_call=False,
-    make_persistent=False,
     blocking_dim=None,
 )
 run_dace_cpu_cached = make_dace_backend(
     auto_optimize=True,
     cached=True,
     gpu=False,
-    async_sdfg_call=False,
-    make_persistent=False,
     blocking_dim=None,
 )
 
@@ -146,23 +140,17 @@ run_dace_gpu = make_dace_backend(
     auto_optimize=True,
     cached=False,
     gpu=True,
-    async_sdfg_call=True,
-    make_persistent=False,
     blocking_dim=None,
 )
 run_dace_gpu_noopt = make_dace_backend(
     auto_optimize=False,
     cached=False,
     gpu=True,
-    async_sdfg_call=True,
-    make_persistent=False,
     blocking_dim=None,
 )
 run_dace_gpu_cached = make_dace_backend(
     auto_optimize=True,
     cached=True,
     gpu=True,
-    async_sdfg_call=True,
-    make_persistent=False,
     blocking_dim=None,
 )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -58,6 +58,9 @@ def set_dace_config(
     # In some stencils, mostly in `apply_diffusion_to_w` the cuda codegen messes
     #  up with the cuda streams, i.e. it allocates N streams but uses N+1.
     #  This is a workaround until this issue if fixed in DaCe.
+    # However, when using asynchronous SDFG call (see `backend.make_dace_backend()`),
+    #  we currently rely on this setting to ensure sequential execution of all kernels
+    #  and memory operations on the default cuda stream.
     dace.config.Config.set("compiler.cuda.max_concurrent_streams", value=1)
 
     if device_type == core_defs.DeviceType.ROCM:


### PR DESCRIPTION
Make asynchronous SDFG call the default config for gpu backend, in order to align the behavior of the dace and gtfn backends. Besides, this is also the icon4py config.