### PR TITLE
fix[dace][next]: `StateFusion` Less Strict

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
@@ -6,6 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from typing import Any
 
 import dace
@@ -215,9 +216,15 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
                     if first_scope_dict[dnode] is None and first_subgraph.out_degree(dnode) != 0
                 }
             )
-            assert all_data_producers.isdisjoint(data_producers[-1]), (
-                "Found multiple AccessNodes that writes to data in one state."
-            )
+            if not all_data_producers.isdisjoint(data_producers[-1]):
+                warnings.warn(
+                    f"While fusing states '{first_state}' and '{second_state}'"
+                    f"found data {', '.join(all_data_producers.intersection(data_producers[-1]))}"
+                    " that is written to in both states. This might be an error.",
+                    stacklevel=0,
+                )
+                # This might create a conflict, so reject the operation.
+                return True
             all_data_producers.update(data_producers[-1])
 
         # Now determine the concurrent subgraphs of the second state, i.e. the parts

--- a/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
@@ -217,13 +217,17 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
                 }
             )
             if not all_data_producers.isdisjoint(data_producers[-1]):
+                # TODO(phimuell): It is certainly possible to lift this restriction. A
+                #   possible cause is that we found once a source node and then an
+                #   AccessNode to the same data. In case it is global this is most likely
+                #   valid. However, I think that simply allow it, is not okay, because
+                #   it might break some assumption in the fuse code.
                 warnings.warn(
-                    f"While fusing states '{first_state}' and '{second_state}'"
-                    f"found data {', '.join(all_data_producers.intersection(data_producers[-1]))}"
-                    " that is written to in both states. This might be an error.",
+                    f"Detected that '{first_state}' writes to the data"
+                    f" `{', '.join(all_data_producers.intersection(data_producers[-1]))}`"
+                    " in multiple concurrent subgraphs. This might indicate an error.",
                     stacklevel=0,
                 )
-                # This might create a conflict, so reject the operation.
                 return True
             all_data_producers.update(data_producers[-1])
 


### PR DESCRIPTION
Before the transformation asserted some constraints set forth by ADR-18.
In rare cases this assert was triggered, leaded to a crash.

It was discovered by Giacomo Castiglioni and could be reproduced.
However, since the error only appeared on [some intermediate state of a development branch (PR#2129)](https://github.com/GridTools/gt4py/pull/2129/commits/8564f92d3d3bf11820bf7f321be092ba9e454581) it was decided to turn this hard error into a negative result, i.e. do not fuse the states.


