### PR TITLE
refactor[cartesian, dace]: avoid duplicate transient check in `replace_strides()`

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -62,7 +62,7 @@ def _specialize_transient_strides(
             for array in sdfg.arrays.values()
             if isinstance(array, data.Array) and array.transient
         ],
-        layout_info["layout_map"],
+        layout_info,
     )
 
     # In case of nested SDFGs (see below), merge with replacement dict that was passed down.

--- a/src/gt4py/storage/cartesian/layout.py
+++ b/src/gt4py/storage/cartesian/layout.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 class LayoutInfo(TypedDict):
     alignment: int  # measured in bytes
     device: Literal["cpu", "gpu"]
-    layout_map: Callable[[Tuple[str, ...]], Tuple[Optional[int], ...]]
+    layout_map: Callable[[Tuple[str, ...]], Tuple[int, ...]]
     is_optimal_layout: Callable[[Any, Tuple[str, ...]], bool]
 
 
@@ -128,7 +128,7 @@ def make_gtcpu_ifirst_layout_map(dimensions: Tuple[str, ...]) -> Tuple[int, ...]
     return _permute_layout_to_dimensions(layout, dimensions)
 
 
-def make_cuda_layout_map(dimensions: Tuple[str, ...]) -> Tuple[Optional[int], ...]:
+def make_cuda_layout_map(dimensions: Tuple[str, ...]) -> Tuple[int, ...]:
     layout = tuple(reversed(range(len(dimensions))))
     return _permute_layout_to_dimensions(layout, dimensions)
 


### PR DESCRIPTION
## Description

We replacing transient strides, we assemble a list of transient arrays in `replace_transient_strides()`, which we then pass to `replace_strides()`. Replace strides will (contrary to it's name) check again and only replace strides of transient arrays. This is unexpected and duplicate work. We don't use `replace_strides()` from anywhere else than `replace_transient_strides()`, so it's "safe" to remove `if array.transient` even if this alters the functionality of that function because it doesn't matter in the one use-case that we have.

The change includes fully typing `replace_strides()`, which is achieved by changing the second argument from `get_layout_map` to include the full `layout_info` object. That `layout_info` object just has a simpler type. Doing so, `mypy` started complaining about inconsistent types of `layout_map` functions, which I fixed as part of this PR.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
