### PR TITLE
refactor[cartesian, dace]: simplify after specializing strides in stencil mode

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -18,6 +18,7 @@ from dace import SDFG, Memlet, SDFGState, config, data, dtypes, nodes, subsets, 
 from dace.codegen import codeobject
 from dace.sdfg.analysis.schedule_tree import treenodes as tn
 from dace.sdfg.utils import inline_sdfgs
+from dace.transformation.passes import SimplifyPass
 
 from gt4py._core import definitions as core_defs
 from gt4py.cartesian import config as gt_config, definitions
@@ -352,10 +353,14 @@ class SDFGManager:
         SDFGManager._strip_history(sdfg)
         sdfg.save(path)
 
-    def sdfg_via_schedule_tree(self) -> SDFG:
+    def sdfg_via_schedule_tree(self, *, validate: bool = True, simplify: bool = True) -> SDFG:
         """Lower OIR into an SDFG via Schedule Tree transpile first.
 
         Cache the SDFG into the manager for re-use, unless the builder has a no-caching policy.
+
+        Args:
+            validate: Validate resulting SDFG
+            simplify: Simplify resulting SDFG
         """
         filename = f"{self.builder.module_name}.sdfg"
         path = (
@@ -370,8 +375,8 @@ class SDFGManager:
         # Create SDFG
         stree = self.schedule_tree()
         sdfg = stree.as_sdfg(
-            validate=True,
-            simplify=True,
+            validate=validate,
+            simplify=simplify,
             skip={"ScalarToSymbolPromotion"},
         )
 
@@ -430,6 +435,7 @@ class DaCeExtGenerator(BackendCodegen):
             sdfg,
             self.backend.storage_info,
         )
+        SimplifyPass(validate=True, skip={"ScalarToSymbolPromotion"}).apply_pass(sdfg, {})
 
         # NOTE
         # The glue code in DaCeComputationCodegen.apply() (just below) will define all the


### PR DESCRIPTION
## Description

The `dace:*` backends have two modes: classic "stencil mode" and "jit mode" used for what [NDSL](https://github.com/NOAA-GFDL/NDSL) calls "orchestration". This PR concerns the classic stencil mode. In that mode, we use the oir -> schedule tree -> sdfg pipeline to get a symbolic SDFG of the given stencil. In that symbolic SDFG, we can specialize (read "replace symbols with numbers") strides of transient arrays. This PR suggest to run `SDFG.simplify()` after specializing the strides, which potentially allows for further optimizations after the strides have been propagated.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
