### PR TITLE
fix[next][dace]: Do not crash if SDFG report not found

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import functools
+import warnings
 from typing import Any, Sequence
 
 import dace
@@ -73,14 +74,20 @@ def convert_args(
                 # We need to set the cache folder and key config in order to retrieve
                 # the SDFG report file.
                 dace_common.set_dace_config(device_type=device)
-                sdfg_events = fun.sdfg_program.sdfg.get_latest_report().events
-                assert len(sdfg_events) == 1
+                prof_report = fun.sdfg_program.sdfg.get_latest_report()
+            if prof_report is None:
+                warnings.warn(
+                    "Config 'COLLECT_METRICS_LEVEL' is set but SDFG profiling report not found.",
+                    stacklevel=2,
+                )
+            else:
+                assert len(prof_report.events) == 1
                 # The event name gets truncated in dace, so we only check that
                 # it corresponds to the beginning of SDFG label.
-                assert f"SDFG {fun.sdfg_program.sdfg.label}".startswith(sdfg_events[0].name)
-            duration_secs = (
-                sdfg_events[0].duration / 1e6
-            )  # dace timer returns the duration in microseconds
-            metric_collection.add_sample(metrics.COMPUTE_METRIC, duration_secs)
+                assert f"SDFG {fun.sdfg_program.sdfg.label}".startswith(prof_report.events[0].name)
+                duration_secs = (
+                    prof_report.events[0].duration / 1e6
+                )  # dace timer returns the duration in microseconds
+                metric_collection.add_sample(metrics.COMPUTE_METRIC, duration_secs)
 
     return decorated_program


### PR DESCRIPTION
This PR handles the case where the SDFG are precompiled without performance metrics `(config.COLLECT_METRICS_LEVEL == metrics.DISABLED)` but `config.COLLECT_METRICS_LEVEL` is set on another run, when the stencils are loaded from the binary library. The main baseline was crashing because the SDFG would return `None` as profiling report.