### PR TITLE
build: new-style license, bump setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,11 @@
 
 [build-system]
 build-backend = 'setuptools.build_meta'
-requires = ['cython>=3.0.0', 'setuptools>=70.0.0', 'versioningit>=3.1.1', 'wheel>=0.33.6']
+requires = ['cython>=3.0.0', 'setuptools>=77.0.3', 'versioningit>=3.1.1', 'wheel>=0.33.6']
 
 # -- Dependency groups --
 [dependency-groups]
-build = ['cython>=3.0.0', 'pip>=22.1.1', 'setuptools>=70.0.0', 'wheel>=0.33.6']
+build = ['cython>=3.0.0', 'pip>=22.1.1', 'setuptools>=77.0.3', 'wheel>=0.33.6']
 dace-cartesian = [
   'dace>=1.0.2,<2'  # renfined in [tool.uv.sources]
 ]
@@ -73,7 +73,6 @@ classifiers = [
   'Environment :: Console',
   'Environment :: GPU :: NVIDIA CUDA',
   'Intended Audience :: Science/Research',
-  'License :: OSI Approved :: BSD License',
   'Operating System :: POSIX',
   'Programming Language :: Python',
   'Programming Language :: Python :: 3.10',
@@ -108,7 +107,7 @@ dependencies = [
   'numpy>=1.26.4',
   'packaging>=20.0',
   'pybind11>=2.10.1',
-  'setuptools>=70.0.0',
+  'setuptools>=77.0.3',
   'tabulate>=0.8.10',
   'toolz>=0.12.1',
   'typing-extensions>=4.12.0',
@@ -126,7 +125,7 @@ keywords = [
   'portable',
   'hpc'
 ]
-license = {text = 'BSD-3 License'}  # TODO: waiting for PEP 639 being implemented by setuptools (https://github.com/codecov/codecov-cli/issues/605)
+license = 'BSD-3-Clause'
 name = 'gt4py'
 readme = 'README.md'
 requires-python = '>=3.10, <3.14'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ keywords = [
   'hpc'
 ]
 license = 'BSD-3-Clause'
+license-files = ['LICENSE']
 name = 'gt4py'
 readme = 'README.md'
 requires-python = '>=3.10, <3.14'

--- a/uv.lock
+++ b/uv.lock
@@ -1460,7 +1460,7 @@ requires-dist = [
     { name = "pybind11", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=7.0" },
     { name = "scipy", marker = "extra == 'standard'", specifier = ">=1.14.1" },
-    { name = "setuptools", specifier = ">=70.0.0" },
+    { name = "setuptools", specifier = ">=77.0.3" },
     { name = "tabulate", specifier = ">=0.8.10" },
     { name = "toolz", specifier = ">=0.12.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
@@ -1473,7 +1473,7 @@ provides-extras = ["cartesian", "cuda11", "cuda12", "jax", "jax-cuda12", "next",
 build = [
     { name = "cython", specifier = ">=3.0.0" },
     { name = "pip", specifier = ">=22.1.1" },
-    { name = "setuptools", specifier = ">=70.0.0" },
+    { name = "setuptools", specifier = ">=77.0.3" },
     { name = "wheel", specifier = ">=0.33.6" },
 ]
 dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg" }]
@@ -1502,7 +1502,7 @@ dev = [
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.5.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.8.0" },
-    { name = "setuptools", specifier = ">=70.0.0" },
+    { name = "setuptools", specifier = ">=77.0.3" },
     { name = "sphinx", specifier = ">=7.3.7" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.1" },
     { name = "sphinx-toolbox", specifier = ">=3.8.1" },
@@ -3449,11 +3449,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "75.8.0"
+version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/ec/089608b791d210aec4e7f97488e67ab0d33add3efccb83a056cbafe3a2a6/setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6", size = 1343222, upload-time = "2025-01-08T18:28:23.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/8a/b9dc7678803429e4a3bc9ba462fa3dd9066824d3c607490235c6a796be5a/setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3", size = 1228782, upload-time = "2025-01-08T18:28:20.912Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Use new-style license format as suggested by the official python packaging user guide [1]. To do so, we need to bump the minimal version of setuptools.

[1] https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
