### PR TITLE
fix[cartesian]: correct cachedir tag signature

### DIFF
--- a/src/gt4py/cartesian/utils/base.py
+++ b/src/gt4py/cartesian/utils/base.py
@@ -239,8 +239,7 @@ def make_dir(dir_name, *, mode=0o777, is_package=False, is_cache=False):
     if is_cache:
         with open(os.path.join(dir_name, "CACHEDIR.TAG"), "w") as f:
             f.write(
-                """Signature: 8
-a477f597d28d172789f06886806bc55
+                """Signature: 8a477f597d28d172789f06886806bc55
 # This file is a cache directory tag created by GT4Py.
 # For information about cache directory tags, see:
 #	http://www.brynosaurus.com/cachedir/


### PR DESCRIPTION
## Description

According to [convention](http://www.brynosaurus.com/cachedir/), `CHACHEDIR.TAG` files should start with

```
Signature: 8a477f597d28d172789f06886806bc55
```

We had a line break at the start of the hash, breaking this convention. The proper signature is now restored.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  No. Changes are likely to have no impact. Tested locally by looking at the contents of the generated file.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
