### PR TITLE
feat[cartesian]: Support for `round()` / ` round_away_from_zero()` in gtscript

### DIFF
--- a/docs/development/ADRs/cartesian/frontend-round-behavior.md
+++ b/docs/development/ADRs/cartesian/frontend-round-behavior.md
@@ -1,0 +1,104 @@
+# Behavior of the `round()` function in GT4Py
+
+TODO: To be written after we came to a conclusion in the discussions.
+
+## Context
+
+The default behavior of the `round()` function in python is to split ties by rounding to the nearest even value, e.g.
+
+- `round(-0.5) == 0.0`
+- `round(0.5) == 0.0`
+- `round(1.5) == 2.0`
+- `round(2.5) == 2.0`
+
+This is in contrast to C++ and Fortran where the default is to split ties by rounding away from zero, e.g.
+
+- `round(-0.5) == -1.0`
+- `round(0.5) == 0.0`
+- `round(1.5) == 2.0`
+- `round(2.5) == 3.0`
+
+From a DSL point of view, it is paramount to implement a consistent rounding behavior in all backends, especially in the context of chaotic systems such as NWPs.
+
+## Decision
+
+TODO: To be written after we came to a conclusion in the discussions.
+
+## Consequences
+
+As a consequence
+
+- all backends use the same rounding behavior
+
+TODO: The above is a given (we all agree that all backends should show the same behavior). Other consequences depend on the decision we take.
+
+## Alternatives considered
+
+### Adopt the python behavior of the `round()` function
+
+One argument in favor of this option is that it aligns with the choice of the frontend language: If GT4Py stencils look like python code, they should also behave like python code.
+
+One argument against this option is that the behavior of python's `round()` function is surprising to domain scientist. Atmospheric scientists, unaware of the intricacies of the floating point standard, are confused by the fact that both 1.5 and 2.5 round up/down to 2.0.
+
+From a technical point of view, this option can be implemented with standard library calls in all current backends.
+
+### Adopt the C++ behavior of the `round()` function
+
+One argument in favor of this option is that the behavior of `std::round()` is expected by domain scientists. Atmospheric scientists, unaware of the intricacies of the floating point standard, expect 1.5 and 2.5 to round up to 2.0 and 3.0 respectively.
+
+One argument against this option is that is doesn't align with the behavior fo the frontend language: While GT4Py stencils look like python code, in this particular case, they don't behave like python code.
+
+From a technical point of view, this option can be implemented with standard library calls in the `gt:*` and `dace:*` backends. The `numpy` and `debug` backends will need a custom implementation of the `round()` function.
+
+### Allow users to configure the behavior of the `round()` function
+
+One argument in favor of this option is that users can choose: Given that there are good reasons for python and C++ behavior of the `round()` function, we let our users choose what works best for their use-case. By choosing a default, GT4Py can still nudge its users towards one option or another.
+
+One argument against this option is the maintenance overhead of supporting both options.
+
+From a technical point of view, this option can be implemented with an optional second argument of round function that GT4Py exposes, i.e.
+
+```py
+def round(x, rounding_mode = ROUND_MODE_DEFAULT):
+    """Computes the integer value nearest to `x` (in floating-point format), rounding halfway cases based on rounding_mode.
+
+    This function finds the nearest integer value (in floating point format) to the given number `x`, e.g. `round(2.3) returns `2.0` since
+    2.3 is between 2.0 and 3.0 and 2.3 is closer. The behavior in case of 2.5 (exactly halfway between 2.0 and 3.0) is defined by
+    the `rounding_mode`. There are two options:
+
+    `ROUND_AWAY_FROM_ZERO` always rounds away from 0.0, e.g. round(-0.5) evaluates to -1.0 and round(0.5) evaluates to 1
+
+    `ROUND_TO_EVEN` rounds to the closest even value, e.g. round(1.5) and round(2.5) both round to 2.0
+
+    Args:
+        x: Number to round.
+        rounding_mode (optional): How to treat halfway cases (see description). See RoundingMode for options.
+    """
+    pass
+```
+
+The default rounding mode will be centrally defined in `src/gt4py/cartesian/definitions.py` (value subject to discussions) and can be changed with the environment variable `GT4PY_ROUND_MODE_DEFAULT` (let me know if you find a better name).
+
+```py
+@enum.unique
+class RoundingMode(enum.Enum):
+    ROUND_AWAY_FROM_ZERO = enum.auto()
+    ROUND_TO_EVEN = enum.auto()
+
+def _get_default_rounding_mode() -> RoundingMode:
+    # TODO: fill in the default once the discussion settles
+    default = os.environ.get("GT4PY_ROUND_MODE_DEFAULT", default="SUBJECT_TO_DISCUSSION")
+
+    if default == "ROUND_AWAY_FROM_ZERO":
+        return RoundingMode.ROUND_AWAY_FROM_ZERO
+
+    if default == "ROUND_TO_EVEN":
+        return RoundingMode.ROUND_TO_EVEN
+
+    known = ["ROUND_AWAY_FROM_ZERO", "ROUND_TO_EVEN"]
+    raise ValueError(f"Unexpected rounding mode default '{default}'. Expected one of {", ".join(known)}.")
+
+ROUND_MODE_DEFAULT: RoundingMode = _get_default_rounding_mode()
+```
+
+That way, users of GT4Py can adjust the rounding mode to their use-cases, both globally and on a case-by-case basis.

--- a/docs/development/ADRs/cartesian/frontend-round-functions.md
+++ b/docs/development/ADRs/cartesian/frontend-round-functions.md
@@ -2,7 +2,6 @@
 
 In the context of adding support for a `round()` function in `gtscript`, facing divergent implementations in backend languages, we decided to implement `round()` with tie-breaking to even and `round_away_from_zero()` with tie-breaking away from zero to achieve consistent results while leaving the choice of behavior up to users. We considered multiple alternatives (see below), which all have their advantages and disadvantages.
 
-Why-statement: In the context of [use case/user story], facing [concern], we decided to [do thing X] to achieve [system qualities/desired consequences]. We considered [thing Y] and accept [downsides / undesired consequences].
 
 ## Context
 

--- a/docs/development/ADRs/cartesian/frontend-round-functions.md
+++ b/docs/development/ADRs/cartesian/frontend-round-functions.md
@@ -2,7 +2,6 @@
 
 In the context of adding support for a `round()` function in `gtscript`, facing divergent implementations in backend languages, we decided to implement `round()` with tie-breaking to even and `round_away_from_zero()` with tie-breaking away from zero to achieve consistent results while leaving the choice of behavior up to users. We considered multiple alternatives (see below), which all have their advantages and disadvantages.
 
-
 ## Context
 
 There are basically two predominant ways to round ties (e.g. when rounding 1.5 to an integer it's as close to 1.0 as it is to 2.0). The default in python, Kotlin, Julia, and C# is to split ties by rounding to the nearest even value, e.g.
@@ -86,17 +85,16 @@ class RoundingMode(enum.Enum):
     ROUND_TO_EVEN = enum.auto()
 
 def _get_default_rounding_mode() -> RoundingMode:
-    # TODO: fill in the default once the discussion settles
-    default = os.environ.get("GT4PY_ROUND_MODE_DEFAULT", default="SUBJECT_TO_DISCUSSION")
+    mode = os.environ.get("GT4PY_ROUND_MODE_DEFAULT", default="ROUND_TO_EVEN")
 
-    if default == "ROUND_AWAY_FROM_ZERO":
+    if mode == "ROUND_AWAY_FROM_ZERO":
         return RoundingMode.ROUND_AWAY_FROM_ZERO
 
-    if default == "ROUND_TO_EVEN":
+    if mode == "ROUND_TO_EVEN":
         return RoundingMode.ROUND_TO_EVEN
 
     known = ["ROUND_AWAY_FROM_ZERO", "ROUND_TO_EVEN"]
-    raise ValueError(f"Unexpected rounding mode default '{default}'. Expected one of {", ".join(known)}.")
+    raise ValueError(f"Unexpected rounding mode default '{mode}'. Expected one of {", ".join(known)}.")
 
 ROUND_MODE_DEFAULT: RoundingMode = _get_default_rounding_mode()
 ```

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -346,6 +346,7 @@ class DefIRToGTIR(IRNodeVisitor):
         NativeFunction.FLOAT64: common.NativeFunction.FLOAT64,
         NativeFunction.ERF: common.NativeFunction.ERF,
         NativeFunction.ERFC: common.NativeFunction.ERFC,
+        NativeFunction.ROUND: common.NativeFunction.ROUND,
     }
 
     GT4PY_BUILTIN_TO_GTIR: Final[dict[Builtin, common.BuiltInLiteral]] = {

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -347,6 +347,7 @@ class DefIRToGTIR(IRNodeVisitor):
         NativeFunction.ERF: common.NativeFunction.ERF,
         NativeFunction.ERFC: common.NativeFunction.ERFC,
         NativeFunction.ROUND: common.NativeFunction.ROUND,
+        NativeFunction.ROUND_AWAY_FROM_ZERO: common.NativeFunction.ROUND_AWAY_FROM_ZERO,
     }
 
     GT4PY_BUILTIN_TO_GTIR: Final[dict[Builtin, common.BuiltInLiteral]] = {

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -791,6 +791,7 @@ class IRMaker(ast.NodeVisitor):
             "erf": nodes.NativeFunction.ERF,
             "erfc": nodes.NativeFunction.ERFC,
             "round": nodes.NativeFunction.ROUND,
+            "round_away_from_zero": nodes.NativeFunction.ROUND_AWAY_FROM_ZERO,
         }  # Conversion table for functions to NativeFunctions
 
         self.temporary_type_to_native_type = {

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -790,6 +790,7 @@ class IRMaker(ast.NodeVisitor):
             ),
             "erf": nodes.NativeFunction.ERF,
             "erfc": nodes.NativeFunction.ERFC,
+            "round": nodes.NativeFunction.ROUND,
         }  # Conversion table for functions to NativeFunctions
 
         self.temporary_type_to_native_type = {

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -41,7 +41,7 @@ NativeFunction enumeration (:class:`NativeFunction`)
     Native function identifier
     [`ABS`, `MAX`, `MIN, `MOD`, `SIN`, `COS`, `TAN`, `ARCSIN`, `ARCCOS`, `ARCTAN`,
     `SQRT`, `EXP`, `LOG`, `LOG10`, `ISFINITE`, `ISINF`, `ISNAN`, `FLOOR`, `CEIL`,
-    `TRUNC`, `ERF`, `ERFC`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`]
+    `TRUNC`, `ERF`, `ERFC`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `ROUND`]
 
 LevelMarker enumeration (:class:`LevelMarker`)
     Special axis levels
@@ -432,6 +432,7 @@ class NativeFunction(enum.Enum):
     TRUNC = enum.auto()
     ERF = enum.auto()
     ERFC = enum.auto()
+    ROUND = enum.auto()
 
     # Cast operations - share a keyword with type hints
     INT32 = enum.auto()
@@ -479,6 +480,7 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
     NativeFunction.FLOAT64: 1,
     NativeFunction.ERF: 1,
     NativeFunction.ERFC: 1,
+    NativeFunction.ROUND: 1,
 }
 
 

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -41,7 +41,8 @@ NativeFunction enumeration (:class:`NativeFunction`)
     Native function identifier
     [`ABS`, `MAX`, `MIN, `MOD`, `SIN`, `COS`, `TAN`, `ARCSIN`, `ARCCOS`, `ARCTAN`,
     `SQRT`, `EXP`, `LOG`, `LOG10`, `ISFINITE`, `ISINF`, `ISNAN`, `FLOOR`, `CEIL`,
-    `TRUNC`, `ERF`, `ERFC`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `ROUND`]
+    `TRUNC`, `ERF`, `ERFC`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `ROUND`,
+    `ROUND_AWAY_FROM_ZERO`]
 
 LevelMarker enumeration (:class:`LevelMarker`)
     Special axis levels
@@ -433,6 +434,7 @@ class NativeFunction(enum.Enum):
     ERF = enum.auto()
     ERFC = enum.auto()
     ROUND = enum.auto()
+    ROUND_AWAY_FROM_ZERO = enum.auto()
 
     # Cast operations - share a keyword with type hints
     INT32 = enum.auto()
@@ -481,6 +483,7 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
     NativeFunction.ERF: 1,
     NativeFunction.ERFC: 1,
     NativeFunction.ROUND: 1,
+    NativeFunction.ROUND_AWAY_FROM_ZERO: 1,
 }
 
 

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -180,6 +180,7 @@ class NativeFunction(eve.StrEnum):
     TRUNC = "trunc"
     ERF = "erf"
     ERFC = "erfc"
+    ROUND = "round"
 
     INT32 = "int32"
     INT64 = "int64"
@@ -231,6 +232,7 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
         NativeFunction.FLOAT64: 1,
         NativeFunction.ERF: 1,
         NativeFunction.ERFC: 1,
+        NativeFunction.ROUND: 1,
     }.items()
 }
 
@@ -924,6 +926,7 @@ OP_TO_UFUNC_NAME: Final[
         NativeFunction.FLOAT64: "float64",
         NativeFunction.ERF: "erf",
         NativeFunction.ERFC: "erfc",
+        NativeFunction.ROUND: "round",
     },
 }
 

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -181,6 +181,7 @@ class NativeFunction(eve.StrEnum):
     ERF = "erf"
     ERFC = "erfc"
     ROUND = "round"
+    ROUND_AWAY_FROM_ZERO = "round_away_from_zero"
 
     INT32 = "int32"
     INT64 = "int64"
@@ -233,6 +234,7 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
         NativeFunction.ERF: 1,
         NativeFunction.ERFC: 1,
         NativeFunction.ROUND: 1,
+        NativeFunction.ROUND_AWAY_FROM_ZERO: 1,
     }.items()
 }
 
@@ -927,6 +929,7 @@ OP_TO_UFUNC_NAME: Final[
         NativeFunction.ERF: "erf",
         NativeFunction.ERFC: "erfc",
         NativeFunction.ROUND: "round",
+        NativeFunction.ROUND_AWAY_FROM_ZERO: "round_away_from_zero",
     },
 }
 

--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -226,6 +226,7 @@ class OIRToTasklet(eve.NodeVisitor):
             common.NativeFunction.FLOAT64: "dace.float64",
             common.NativeFunction.ERF: "erf",
             common.NativeFunction.ERFC: "erfc",
+            common.NativeFunction.ROUND: "round",
         }
         if node not in native_functions:
             raise NotImplementedError(f"NativeFunction '{node}' not (yet) implemented.")

--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -226,7 +226,8 @@ class OIRToTasklet(eve.NodeVisitor):
             common.NativeFunction.FLOAT64: "dace.float64",
             common.NativeFunction.ERF: "erf",
             common.NativeFunction.ERFC: "erfc",
-            common.NativeFunction.ROUND: "round",
+            common.NativeFunction.ROUND: "nearbyint",
+            common.NativeFunction.ROUND_AWAY_FROM_ZERO: "round",
         }
         if node not in native_functions:
             raise NotImplementedError(f"NativeFunction '{node}' not (yet) implemented.")

--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
@@ -182,6 +182,7 @@ class GTCppCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
                 NativeFunction.FLOAT64: "double",
                 NativeFunction.ERF: "std::erf",
                 NativeFunction.ERFC: "std::erfc",
+                NativeFunction.ROUND: "std::round",
             }[func]
         except KeyError as error:
             raise NotImplementedError(

--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
@@ -182,7 +182,8 @@ class GTCppCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
                 NativeFunction.FLOAT64: "double",
                 NativeFunction.ERF: "std::erf",
                 NativeFunction.ERFC: "std::erfc",
-                NativeFunction.ROUND: "std::round",
+                NativeFunction.ROUND: "std::nearbyint",
+                NativeFunction.ROUND_AWAY_FROM_ZERO: "std::round",
             }[func]
         except KeyError as error:
             raise NotImplementedError(

--- a/src/gt4py/cartesian/gtc/ufuncs.py
+++ b/src/gt4py/cartesian/gtc/ufuncs.py
@@ -14,7 +14,6 @@ from gt4py._core.definitions import float32, float64, int8, int16, int32, int64 
 
 try:
     from scipy.special import erf as erf_, erfc as erfc_, gamma as gamma_
-
 except ImportError:
     import math
 
@@ -28,6 +27,24 @@ except ImportError:
     erfc_ = np.vectorize(math.erfc)
     erfc_.types = ["f->f", "d->d", "F->F", "D->D"]
 
+
+def _round_away_from_zero(num):
+    """Computes the nearest integer value to num, rounding halfway cases away from zero.
+
+    Examples:
+        -0.5 -> -1.0, 0.5 -> 0.0, 1.5 -> 2.0, 2.5 -> 3.0
+
+    This is in alignment with C(++) and FORTRAN standard round functions that round away
+    from zero by default.
+
+    In contrast, python (since v3) and numpy use "Banker's rounding", and round to the nearest
+    even value, e.g. 1.5 and 2.5 round to 2.0, -0.5 and 0.5 round to 0.0.
+    """
+    return np.copysign(np.floor(np.abs(num) + 0.5), num)
+
+
+round_ = _round_away_from_zero
+round_.types = ["f->f", "d->d", "F->F", "D->D"]  # type: ignore[attr-defined]
 
 positive: np.ufunc = np.positive
 negative: np.ufunc = np.negative
@@ -79,3 +96,4 @@ ceil: np.ufunc = np.ceil
 trunc: np.ufunc = np.trunc
 erf: np.ufunc = erf_
 erfc: np.ufunc = erfc_
+round: np.ufunc = round_  # type: ignore[assignment] # noqa: A001

--- a/src/gt4py/cartesian/gtc/ufuncs.py
+++ b/src/gt4py/cartesian/gtc/ufuncs.py
@@ -29,17 +29,7 @@ except ImportError:
 
 
 def _round_away_from_zero(num):
-    """Computes the nearest integer value to num, rounding halfway cases away from zero.
-
-    Examples:
-        -0.5 -> -1.0, 0.5 -> 0.0, 1.5 -> 2.0, 2.5 -> 3.0
-
-    This is in alignment with C(++) and FORTRAN standard round functions that round away
-    from zero by default.
-
-    In contrast, python (since v3) and numpy use "Banker's rounding", and round to the nearest
-    even value, e.g. 1.5 and 2.5 round to 2.0, -0.5 and 0.5 round to 0.0.
-    """
+    """Computes the nearest integer value to num, rounding halfway cases away from zero."""
     return np.copysign(np.floor(np.abs(num) + 0.5), num)
 
 

--- a/src/gt4py/cartesian/gtc/ufuncs.py
+++ b/src/gt4py/cartesian/gtc/ufuncs.py
@@ -43,8 +43,11 @@ def _round_away_from_zero(num):
     return np.copysign(np.floor(np.abs(num) + 0.5), num)
 
 
-round_ = _round_away_from_zero
+round_ = np.round
 round_.types = ["f->f", "d->d", "F->F", "D->D"]  # type: ignore[attr-defined]
+
+round_away_from_zero_ = _round_away_from_zero
+round_away_from_zero_.types = ["f->f", "d->d", "F->F", "D->D"]  # type: ignore[attr-defined]
 
 positive: np.ufunc = np.positive
 negative: np.ufunc = np.negative
@@ -96,4 +99,5 @@ ceil: np.ufunc = np.ceil
 trunc: np.ufunc = np.trunc
 erf: np.ufunc = erf_
 erfc: np.ufunc = erfc_
-round: np.ufunc = round_  # type: ignore[assignment] # noqa: A001
+round: np.ufunc = round_  # type: ignore # noqa: A001
+round_away_from_zero: np.ufunc = round_away_from_zero_  # type: ignore

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -61,6 +61,7 @@ MATH_BUILTINS = {
     "trunc",
     "erf",
     "erfc",
+    "round",
 }
 
 TYPE_HINT_AND_CAST_BUILTINS = {
@@ -955,11 +956,16 @@ def trunc(x) -> _gt_all_op_types:  # type: ignore[empty-body]
     pass
 
 
-def erf(x):
+def erf(x) -> _gt_all_op_types:  # type: ignore[empty-body]
     """Computes the error function of `x`."""
     pass
 
 
-def erfc(x):
+def erfc(x) -> _gt_all_op_types:  # type: ignore[empty-body]
     """Computes the complementary error function of `x`, which is `1.0 - erf(x)`."""
+    pass
+
+
+def round(x) -> _gt_all_op_types:  # type: ignore[empty-body] # noqa: A001 [builtin-variable-shadowing]
+    """Computes the nearest integer value to `x`, rounding halfway cases away from zero."""
     pass

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -968,10 +968,31 @@ def erfc(x) -> _gt_all_op_types:  # type: ignore[empty-body]
 
 
 def round(x) -> _gt_all_op_types:  # type: ignore[empty-body] # noqa: A001 [builtin-variable-shadowing]
-    """Computes the nearest integer value to `x`, rounding halfway cases to even numbers."""
+    """
+    Computes the nearest integer value to `x`, rounding halfway cases to even numbers.
+
+        Examples:
+        -0.5 -> -0.0, 0.5 -> 0.0, 1.5 -> 2.0, 2.5 -> 2.0
+
+    This is in alignment with the IEEE754 standard python's built-in round() function.
+
+    In contrast, `round_away_from_zero()` splits ties away from zero e.g. 2.5 will
+    round to 3.0 and -0.5 will round to -1.0.
+    """
     pass
 
 
 def round_away_from_zero(x) -> _gt_all_op_types:  # type: ignore[empty-body]
-    """Computes the nearest integer value to `x`, rounding halfway cases away from zero."""
+    """
+    Computes the nearest integer value to `x`, rounding halfway cases away from zero.
+
+        Examples:
+        -0.5 -> -1.0, 0.5 -> 0.0, 1.5 -> 2.0, 2.5 -> 3.0
+
+    This is in alignment with C(++) and FORTRAN standard round functions that round away
+    from zero by default.
+
+    In contrast, `round()` implements "Banker's rounding" and splits ties to the nearest
+    even integer, e.g. 1.5 and 2.5 both round to 2.0.
+    """
     pass

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -62,6 +62,7 @@ MATH_BUILTINS = {
     "erf",
     "erfc",
     "round",
+    "round_away_from_zero",
 }
 
 TYPE_HINT_AND_CAST_BUILTINS = {
@@ -967,5 +968,10 @@ def erfc(x) -> _gt_all_op_types:  # type: ignore[empty-body]
 
 
 def round(x) -> _gt_all_op_types:  # type: ignore[empty-body] # noqa: A001 [builtin-variable-shadowing]
+    """Computes the nearest integer value to `x`, rounding halfway cases to even numbers."""
+    pass
+
+
+def round_away_from_zero(x) -> _gt_all_op_types:  # type: ignore[empty-body]
     """Computes the nearest integer value to `x`, rounding halfway cases away from zero."""
     pass

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
@@ -42,6 +42,7 @@ from gt4py.cartesian.gtscript import (
     mod,
     region,
     round,
+    round_away_from_zero,
     sin,
     sinh,
     sqrt,
@@ -163,7 +164,8 @@ def native_functions(field_a: Field3D, field_b: Field3D):
         ceil_res = ceil(floor_res)
         trunc_res = trunc(ceil_res)
         round_res = round(trunc_res)
-        erf_res = erf(round_res)
+        round_afz_res = round_away_from_zero(round_res)
+        erf_res = erf(round_afz_res)
         erfc_res = erfc(erf_res)
         field_b = (
             trunc_res

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
@@ -41,6 +41,7 @@ from gt4py.cartesian.gtscript import (
     log10,
     mod,
     region,
+    round,
     sin,
     sinh,
     sqrt,
@@ -161,7 +162,8 @@ def native_functions(field_a: Field3D, field_b: Field3D):
         floor_res = floor(cbrt_res)
         ceil_res = ceil(floor_res)
         trunc_res = trunc(ceil_res)
-        erf_res = erf(trunc_res)
+        round_res = round(trunc_res)
+        erf_res = erf(round_res)
         erfc_res = erfc(erf_res)
         field_b = (
             trunc_res

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
@@ -45,7 +45,7 @@ def test_erf(backend):
     B = storage_utils.cpu_copy(B)
 
     assert (A[0, 0, :] == initial_values).all()
-    np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values
+    np.testing.assert_allclose(B[0, 0, :], expected)  # gpu generates slightly different values
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
@@ -18,6 +18,7 @@ from gt4py.cartesian.gtscript import (
     erf,
     erfc,
     interval,
+    round,
     stencil,
     Field,
 )
@@ -69,3 +70,25 @@ def test_erfc(backend):
     assert (A[0, 0, :] == initial_values).all()
     B_ = storage_utils.cpu_copy(B)
     np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_round(backend):
+    xp = get_array_library(backend)  # numpy or cupy depending on backend
+
+    @stencil(backend=backend)
+    def stencil_round(field_a: Field[np.float32], field_b: Field[np.float32]):
+        with computation(PARALLEL), interval(...):
+            field_b = round(field_a)
+
+    initial_values = xp.array([-1.5, -0.5, 0.3, 0.5, 0.8, 1.2, 1.5], dtype=xp.float32)
+    array_shape = (1, 1, len(initial_values))
+    A = storage.zeros(array_shape, np.float32, backend=backend)
+    A[:, :, :] = initial_values
+    B = storage.full(array_shape, -1.0, np.float32, backend=backend)
+
+    stencil_round(A, B)
+
+    expected = xp.array([-2.0, -1.0, 0.0, 1.0, 1.0, 1.0, 2.0], dtype=xp.float32)
+    assert (A[0, 0, :] == initial_values).all()
+    assert (B[0, 0, :] == expected).all()

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
@@ -22,6 +22,7 @@ from gt4py.cartesian.gtscript import (
     stencil,
     Field,
 )
+from gt4py.storage.cartesian import utils as storage_utils
 
 from ...definitions import ALL_BACKENDS
 
@@ -40,9 +41,11 @@ def test_erf(backend):
     stencil_erf(A, B)
 
     expected = np.array([math.erf(n) for n in initial_values[0, 0, :]], dtype=np.float32)
+    A = storage_utils.cpu_copy(A)
+    B = storage_utils.cpu_copy(B)
 
     assert (A[0, 0, :] == initial_values).all()
-    np.testing.assert_allclose(B[0, 0, :], expected)  # gpu generates slightly different values
+    np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
@@ -59,6 +62,9 @@ def test_erfc(backend):
     stencil_erfc(A, B)
 
     expected = np.array([math.erfc(n) for n in initial_values[0, 0, :]], dtype=np.float32)
+    A = storage_utils.cpu_copy(A)
+    B = storage_utils.cpu_copy(B)
+
     assert (A[0, 0, :] == initial_values).all()
     np.testing.assert_allclose(B[0, 0, :], expected)  # gpu generates slightly different values
 
@@ -77,6 +83,9 @@ def test_round(backend):
     stencil_round(A, B)
 
     expected = np.array([-2.0, 0.0, 0.0, 0.0, 1.0, 1.0, 2.0], dtype=np.float32)
+    A = storage_utils.cpu_copy(A)
+    B = storage_utils.cpu_copy(B)
+
     assert (A[0, 0, :] == initial_values).all()
     assert (B[0, 0, :] == expected).all()
 
@@ -95,5 +104,8 @@ def test_round_away_from_zero(backend):
     stencil_round(A, B)
 
     expected = np.array([-2.0, -1.0, 0.0, 1.0, 1.0, 1.0, 2.0], dtype=np.float32)
+    A = storage_utils.cpu_copy(A)
+    B = storage_utils.cpu_copy(B)
+
     assert (A[0, 0, :] == initial_values).all()
     assert (B[0, 0, :] == expected).all()

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
@@ -75,43 +75,35 @@ def test_erfc(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_round(backend):
-    xp = get_array_library(backend)  # numpy or cupy depending on backend
-
     @stencil(backend=backend)
     def stencil_round(field_a: Field[np.float32], field_b: Field[np.float32]):
         with computation(PARALLEL), interval(...):
             field_b = round(field_a)
 
-    initial_values = xp.array([-1.5, -0.5, 0.3, 0.5, 0.8, 1.2, 1.5], dtype=xp.float32)
-    array_shape = (1, 1, len(initial_values))
-    A = storage.zeros(array_shape, np.float32, backend=backend)
-    A[:, :, :] = initial_values
-    B = storage.full(array_shape, -1.0, np.float32, backend=backend)
+    initial_values = np.array([[[-1.5, -0.5, 0.3, 0.5, 0.8, 1.2, 1.5]]], dtype=np.float32)
+    A = storage.from_array(initial_values, np.float32, backend=backend)
+    B = storage.full(initial_values.shape, -1.0, np.float32, backend=backend)
 
     stencil_round(A, B)
 
-    expected = xp.array([-2.0, 0.0, 0.0, 0.0, 1.0, 1.0, 2.0], dtype=xp.float32)
+    expected = np.array([-2.0, 0.0, 0.0, 0.0, 1.0, 1.0, 2.0], dtype=np.float32)
     assert (A[0, 0, :] == initial_values).all()
     assert (B[0, 0, :] == expected).all()
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_round_away_form_zero(backend):
-    xp = get_array_library(backend)  # numpy or cupy depending on backend
-
+def test_round_away_from_zero(backend):
     @stencil(backend=backend)
     def stencil_round(field_a: Field[np.float32], field_b: Field[np.float32]):
         with computation(PARALLEL), interval(...):
             field_b = round_away_from_zero(field_a)
 
-    initial_values = xp.array([-1.5, -0.5, 0.3, 0.5, 0.8, 1.2, 1.5], dtype=xp.float32)
-    array_shape = (1, 1, len(initial_values))
-    A = storage.zeros(array_shape, np.float32, backend=backend)
-    A[:, :, :] = initial_values
-    B = storage.full(array_shape, -1.0, np.float32, backend=backend)
+    initial_values = np.array([[[-1.5, -0.5, 0.3, 0.5, 0.8, 1.2, 1.5]]], dtype=np.float32)
+    A = storage.from_array(initial_values, np.float32, backend=backend)
+    B = storage.full(initial_values.shape, -1.0, np.float32, backend=backend)
 
     stencil_round(A, B)
 
-    expected = xp.array([-2.0, -1.0, 0.0, 1.0, 1.0, 1.0, 2.0], dtype=xp.float32)
+    expected = np.array([-2.0, -1.0, 0.0, 1.0, 1.0, 1.0, 2.0], dtype=np.float32)
     assert (A[0, 0, :] == initial_values).all()
     assert (B[0, 0, :] == expected).all()

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
@@ -11,7 +11,6 @@ import numpy as np
 import pytest
 
 from gt4py import storage
-from gt4py.storage.cartesian import utils as storage_utils
 from gt4py.cartesian.gtscript import (
     computation,
     PARALLEL,
@@ -24,53 +23,44 @@ from gt4py.cartesian.gtscript import (
     Field,
 )
 
-from ...definitions import ALL_BACKENDS, get_array_library
+from ...definitions import ALL_BACKENDS
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_erf(backend):
-    xp = get_array_library(backend)  # numpy or cupy depending on backend
-
     @stencil(backend=backend)
     def stencil_erf(field_a: Field[np.float32], field_b: Field[np.float32]):
         with computation(PARALLEL), interval(...):
             field_b = erf(field_a)
 
-    initial_values = xp.array([-1, 0, 1, 2], dtype=xp.float32)
-    array_shape = (1, 1, len(initial_values))
-    A = storage.zeros(array_shape, np.float32, backend=backend)
-    A[:, :, :] = initial_values
-    B = storage.full(array_shape, 42.0, np.float32, backend=backend)
+    initial_values = np.array([[[-1, 0, 1, 2]]], dtype=np.float32)
+    A = storage.from_array(initial_values, np.float32, backend=backend)
+    B = storage.full(initial_values.shape, 42.0, np.float32, backend=backend)
 
     stencil_erf(A, B)
 
-    expected = np.array([math.erf(n) for n in initial_values], dtype=xp.float32)
+    expected = np.array([math.erf(n) for n in initial_values[0, 0, :]], dtype=np.float32)
+
     assert (A[0, 0, :] == initial_values).all()
-    B_ = storage_utils.cpu_copy(B)
-    np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values
+    np.testing.assert_allclose(B[0, 0, :], expected)  # gpu generates slightly different values
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_erfc(backend):
-    xp = get_array_library(backend)  # numpy or cupy depending on backend
-
     @stencil(backend=backend)
     def stencil_erfc(field_a: Field[np.float32], field_b: Field[np.float32]):
         with computation(PARALLEL), interval(...):
             field_b = erfc(field_a)
 
-    initial_values = xp.array([-1, 0, 1, 2], dtype=xp.float32)
-    array_shape = (1, 1, len(initial_values))
-    A = storage.zeros(array_shape, np.float32, backend=backend)
-    A[:, :, :] = initial_values
-    B = storage.full(array_shape, 42.0, np.float32, backend=backend)
+    initial_values = np.array([[[-1, 0, 1, 2]]], dtype=np.float32)
+    A = storage.from_array(initial_values, np.float32, backend=backend)
+    B = storage.full(initial_values.shape, 42.0, np.float32, backend=backend)
 
     stencil_erfc(A, B)
 
-    expected = np.array([math.erfc(n) for n in initial_values], dtype=xp.float32)
+    expected = np.array([math.erfc(n) for n in initial_values[0, 0, :]], dtype=np.float32)
     assert (A[0, 0, :] == initial_values).all()
-    B_ = storage_utils.cpu_copy(B)
-    np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values
+    np.testing.assert_allclose(B[0, 0, :], expected)  # gpu generates slightly different values
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)


### PR DESCRIPTION
# Description

This PR adds support `round()` and `round_away_from_zero()` in `gtscript`. This PR got a bit of traction because there are basically two predominant ways to round ties (e.g. when rounding 1.5 to an integer it's as close to 1.0 as it is to 2.0). The default in python, Kotlin, Julia, and C# is to split ties by rounding to the nearest even value, e.g.

- `round(-0.5) == 0.0`
- `round(0.5) == 0.0`
- `round(1.5) == 2.0`
- `round(2.5) == 2.0`

This is also what the IEEE754 floating point standard defines. In contrast, programming languages like Go, Rust, Ruby, C++, and Fortran default to round away from zero, e.g.

- `round(-0.5) == -1.0`
- `round(0.5) == 0.0`
- `round(1.5) == 2.0`
- `round(2.5) == 3.0`

From a DSL point of view, it is paramount to implement the same behavior in all backends, regardless of the programming language of the backend. We choose to implement `round()` with the tie breaking as suggested by the standard. In addition, we implement a function `round_away_from_zero()` which breaks ties by rounding away from zero. This allows, for example, to truthfully port FORTRAN-based code. The full discussion and evaluation of other alternatives can be found in the ADR.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [x] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
