### PR TITLE
feat[cartesian]: Expose `erf()` and `erfc()` functions

### DIFF
--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -340,6 +340,8 @@ class DefIRToGTIR(IRNodeVisitor):
         NativeFunction.FLOOR: common.NativeFunction.FLOOR,
         NativeFunction.CEIL: common.NativeFunction.CEIL,
         NativeFunction.TRUNC: common.NativeFunction.TRUNC,
+        NativeFunction.ERF: common.NativeFunction.ERF,
+        NativeFunction.ERFC: common.NativeFunction.ERFC,
     }
 
     GT4PY_BUILTIN_TO_GTIR: Final[dict[Builtin, common.BuiltInLiteral]] = {

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -759,7 +759,9 @@ class IRMaker(ast.NodeVisitor):
             "floor": nodes.NativeFunction.FLOOR,
             "ceil": nodes.NativeFunction.CEIL,
             "trunc": nodes.NativeFunction.TRUNC,
-        }
+            "erf": nodes.NativeFunction.ERF,
+            "erfc": nodes.NativeFunction.ERFC,
+        }  # Conversion table for functions to NativeFunctions
 
     def __call__(self, ast_root: ast.AST):
         assert (

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -40,7 +40,8 @@ BinaryOperator enumeration (:class:`BinaryOperator`)
 NativeFunction enumeration (:class:`NativeFunction`)
     Native function identifier
     [`ABS`, `MAX`, `MIN, `MOD`, `SIN`, `COS`, `TAN`, `ARCSIN`, `ARCCOS`, `ARCTAN`,
-    `SQRT`, `EXP`, `LOG`, `LOG10`, `ISFINITE`, `ISINF`, `ISNAN`, `FLOOR`, `CEIL`, `TRUNC`]
+    `SQRT`, `EXP`, `LOG`, `LOG10`, `ISFINITE`, `ISINF`, `ISNAN`, `FLOOR`, `CEIL`,
+    `TRUNC`, `ERF`, `ERFC`]
 
 LevelMarker enumeration (:class:`LevelMarker`)
     Special axis levels
@@ -407,6 +408,8 @@ class NativeFunction(enum.Enum):
     FLOOR = enum.auto()
     CEIL = enum.auto()
     TRUNC = enum.auto()
+    ERF = enum.auto()
+    ERFC = enum.auto()
 
     @property
     def arity(self):
@@ -442,6 +445,8 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
     NativeFunction.FLOOR: 1,
     NativeFunction.CEIL: 1,
     NativeFunction.TRUNC: 1,
+    NativeFunction.ERF: 1,
+    NativeFunction.ERFC: 1,
 }
 
 

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -178,6 +178,8 @@ class NativeFunction(eve.StrEnum):
     FLOOR = "floor"
     CEIL = "ceil"
     TRUNC = "trunc"
+    ERF = "erf"
+    ERFC = "erfc"
 
     IR_OP_TO_NUM_ARGS: ClassVar[Dict[NativeFunction, int]]
 
@@ -218,6 +220,8 @@ NativeFunction.IR_OP_TO_NUM_ARGS = {
         NativeFunction.FLOOR: 1,
         NativeFunction.CEIL: 1,
         NativeFunction.TRUNC: 1,
+        NativeFunction.ERF: 1,
+        NativeFunction.ERFC: 1,
     }.items()
 }
 
@@ -887,6 +891,8 @@ OP_TO_UFUNC_NAME: Final[
         NativeFunction.FLOOR: "floor",
         NativeFunction.CEIL: "ceil",
         NativeFunction.TRUNC: "trunc",
+        NativeFunction.ERF: "erf",
+        NativeFunction.ERFC: "erfc",
     },
 }
 

--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -221,6 +221,8 @@ class OIRToTasklet(eve.NodeVisitor):
             common.NativeFunction.FLOOR: "dace.math.ifloor",
             common.NativeFunction.CEIL: "ceil",
             common.NativeFunction.TRUNC: "trunc",
+            common.NativeFunction.ERF: "erf",
+            common.NativeFunction.ERFC: "erfc",
         }
         if node not in native_functions:
             raise NotImplementedError(f"NativeFunction '{node}' not (yet) implemented.")

--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp_codegen.py
@@ -176,6 +176,8 @@ class GTCppCodegen(codegen.TemplatedGenerator, eve.VisitorWithSymbolTableTrait):
                 NativeFunction.FLOOR: "std::floor",
                 NativeFunction.CEIL: "std::ceil",
                 NativeFunction.TRUNC: "std::trunc",
+                NativeFunction.ERF: "std::erf",
+                NativeFunction.ERFC: "std::erfc",
             }[func]
         except KeyError as error:
             raise NotImplementedError(

--- a/src/gt4py/cartesian/gtc/ufuncs.py
+++ b/src/gt4py/cartesian/gtc/ufuncs.py
@@ -10,13 +10,18 @@ import numpy as np
 
 
 try:
-    from scipy.special import gamma as gamma_
+    from scipy.special import erf as erf_, erfc as erfc_, gamma as gamma_
+
 except ImportError:
     import math
 
     # If scipy is not available, emulate gamma function using math.gamma
     gamma_ = np.vectorize(math.gamma)
     gamma_.types = ["f->f", "d->d", "F->F", "D->D"]
+    erf_ = np.vectorize(math.erf)
+    erf_.types = ["f->f", "d->d", "F->F", "D->D"]
+    erfc_ = np.vectorize(math.erfc)
+    erfc_.types = ["f->f", "d->d", "F->F", "D->D"]
 
 
 positive: np.ufunc = np.positive
@@ -67,3 +72,5 @@ isnan: np.ufunc = np.isnan
 floor: np.ufunc = np.floor
 ceil: np.ufunc = np.ceil
 trunc: np.ufunc = np.trunc
+erf: np.ufunc = erf_
+erfc: np.ufunc = erfc_

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -59,6 +59,8 @@ MATH_BUILTINS = {
     "floor",
     "ceil",
     "trunc",
+    "erf",
+    "erfc",
 }
 
 builtins = {
@@ -906,4 +908,14 @@ def ceil(x):
 
 def trunc(x):
     """Return the Real value x truncated to an Integral (usually an integer)"""
+    pass
+
+
+def erf(x):
+    """Computes the error function of `x`."""
+    pass
+
+
+def erfc(x):
+    """Computes the complementary error function of `x`, which is `1.0 - erf(x)`."""
     pass

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/stencil_definitions.py
@@ -27,6 +27,8 @@ from gt4py.cartesian.gtscript import (
     computation,
     cos,
     cosh,
+    erf,
+    erfc,
     exp,
     floor,
     gamma,
@@ -150,7 +152,7 @@ def native_functions(field_a: Field3D, field_b: Field3D):
         tanh_res = tanh(acosh_res)
         atanh_res = atanh(tanh_res)
         sqrt_res = a_gtscript_function(atanh_res)
-        pow10_res = 10 ** (atanh_res)
+        pow10_res = 10 ** (sqrt_res)
         log10_res = log10(pow10_res)
         exp_res = exp(log10_res)
         log_res = log(exp_res)
@@ -159,13 +161,15 @@ def native_functions(field_a: Field3D, field_b: Field3D):
         floor_res = floor(cbrt_res)
         ceil_res = ceil(floor_res)
         trunc_res = trunc(ceil_res)
+        erf_res = erf(trunc_res)
+        erfc_res = erfc(erf_res)
         field_b = (
             trunc_res
-            if isfinite(trunc_res)
+            if isfinite(erfc_res)
             else field_a
-            if isinf(trunc_res)
+            if isinf(erfc_res)
             else field_b
-            if isnan(trunc_res)
+            if isnan(erfc_res)
             else 0.0
         )
 

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_math_functions.py
@@ -1,0 +1,71 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import math
+import numpy as np
+import pytest
+
+from gt4py import storage
+from gt4py.storage.cartesian import utils as storage_utils
+from gt4py.cartesian.gtscript import (
+    computation,
+    PARALLEL,
+    erf,
+    erfc,
+    interval,
+    stencil,
+    Field,
+)
+
+from ...definitions import ALL_BACKENDS, get_array_library
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_erf(backend):
+    xp = get_array_library(backend)  # numpy or cupy depending on backend
+
+    @stencil(backend=backend)
+    def stencil_erf(field_a: Field[np.float32], field_b: Field[np.float32]):
+        with computation(PARALLEL), interval(...):
+            field_b = erf(field_a)
+
+    initial_values = xp.array([-1, 0, 1, 2], dtype=xp.float32)
+    array_shape = (1, 1, len(initial_values))
+    A = storage.zeros(array_shape, np.float32, backend=backend)
+    A[:, :, :] = initial_values
+    B = storage.full(array_shape, 42.0, np.float32, backend=backend)
+
+    stencil_erf(A, B)
+
+    expected = np.array([math.erf(n) for n in initial_values], dtype=xp.float32)
+    assert (A[0, 0, :] == initial_values).all()
+    B_ = storage_utils.cpu_copy(B)
+    np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_erfc(backend):
+    xp = get_array_library(backend)  # numpy or cupy depending on backend
+
+    @stencil(backend=backend)
+    def stencil_erfc(field_a: Field[np.float32], field_b: Field[np.float32]):
+        with computation(PARALLEL), interval(...):
+            field_b = erfc(field_a)
+
+    initial_values = xp.array([-1, 0, 1, 2], dtype=xp.float32)
+    array_shape = (1, 1, len(initial_values))
+    A = storage.zeros(array_shape, np.float32, backend=backend)
+    A[:, :, :] = initial_values
+    B = storage.full(array_shape, 42.0, np.float32, backend=backend)
+
+    stencil_erfc(A, B)
+
+    expected = np.array([math.erfc(n) for n in initial_values], dtype=xp.float32)
+    assert (A[0, 0, :] == initial_values).all()
+    B_ = storage_utils.cpu_copy(B)
+    np.testing.assert_allclose(B_[0, 0, :], expected)  # gpu generates slightly different values


### PR DESCRIPTION
## Description

This PR exposes two new math functions to be used in GT4Py stencils

- `erf(x)` - the error function
- `erfc(x)` - the complimentary error function, i.e. `1 - erf(x)`

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A