### PR TITLE
fix[next][dace]: Wrong memlet offset in lowering of let-lambda

### DIFF
--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -29,6 +29,7 @@ from next_tests.integration_tests.feature_tests.ffront_tests.ffront_test_utils i
     Edge,
     IDim,
     JDim,
+    KDim,
     MeshDescriptor,
     V2EDim,
     Vertex,
@@ -1820,6 +1821,68 @@ def test_gtir_let_lambda_with_connectivity():
         **FSYMBOLS,
         **make_mesh_symbols(SIMPLE_MESH),
     )
+    assert np.allclose(c, ref)
+
+
+def test_gtir_let_lambda_with_origin():
+    C2E_neighbor_idx = 1
+    cell_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED, ranges={Cell: (0, "ncells"), KDim: (1, "nlevels")}
+    )
+
+    CKFTYPE = ts.FieldType(dims=[Cell, KDim], dtype=FLOAT_TYPE)
+    EKFTYPE = ts.FieldType(dims=[Edge, KDim], dtype=FLOAT_TYPE)
+
+    testee = gtir.Program(
+        id="let_lambda_with_origin",
+        function_definitions=[],
+        params=[
+            gtir.Sym(id="cells", type=CKFTYPE),
+            gtir.Sym(id="edges", type=EKFTYPE),
+            gtir.Sym(id="ncells", type=SIZE_TYPE),
+            gtir.Sym(id="nedges", type=SIZE_TYPE),
+            gtir.Sym(id="nlevels", type=SIZE_TYPE),
+        ],
+        declarations=[],
+        body=[
+            gtir.SetAt(
+                expr=im.let("e1", im.op_as_fieldop("plus")("edges", 1.0))(
+                    im.as_fieldop(
+                        im.lambda_("it")(im.deref(im.shift("C2E", C2E_neighbor_idx)("it"))),
+                    )("e1")
+                ),
+                domain=cell_domain,
+                target=gtir.SymRef(id="cells"),
+            )
+        ],
+    )
+
+    sdfg = build_dace_sdfg(testee, SIMPLE_MESH.offset_provider_type)
+
+    c = np.random.rand(SIMPLE_MESH.num_cells, N)
+    e = np.random.rand(SIMPLE_MESH.num_edges, N)
+    connectivity_C2E = SIMPLE_MESH.offset_provider["C2E"]
+    ref = np.concatenate(
+        (c[:, :1], e[connectivity_C2E.asnumpy()[:, C2E_neighbor_idx], 1:] + 1.0), axis=1
+    )
+
+    symbols = make_mesh_symbols(SIMPLE_MESH) | {
+        "nlevels": N,
+        "__cells_1_range_1": N,
+        "__cells_stride_0": c.strides[0] // c.itemsize,
+        "__cells_stride_1": c.strides[1] // c.itemsize,
+        "__edges_1_range_1": N,
+        "__edges_stride_0": e.strides[0] // e.itemsize,
+        "__edges_stride_1": e.strides[1] // e.itemsize,
+    }
+
+    sdfg(
+        cells=c,
+        edges=e,
+        gt_conn_C2E=connectivity_C2E.ndarray,
+        **symbols,
+    )
+
     assert np.allclose(c, ref)
 
 


### PR DESCRIPTION
This PR provides a fix and a reproducer for an issue observed in icon4py:
`
tests/dycore/stencil_tests/test_compute_advection_in_vertical_momentum_equation.py::TestFusedVelocityAdvectionStencilVMomentum::test_TestFusedVelocityAdvectionStencilVMomentum - dace.sdfg.validation.InvalidSDFGEdgeError: Memlet subset negative out-of-bounds (at state stmt_0_pre_state, edge lambda_1___tmp5[0:10663, -Max(1, vertical_start):Max(0, vertical_end - Max(1, vertical_start)) - Max(1, vertical_start)] (map_8_fieldop[i_Edge_gtx_horizontal=0:31558, i_K_gtx_vertical=Max(1, vertical_start):vertical_end]:OUT_gtir_tmp_5 -> tlet_8_deref:__field))
`

This issue was caused by wrong lowering of memlet offset in deref expressions, where the argument to deref was the result of a let-lambda on a domain starting at non-zero origin.