### PR TITLE
fix[cartesian]: respect literal precision in dace backends

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -173,13 +173,12 @@ class OIRToTasklet(eve.NodeVisitor):
         return f"{dtype}({expression})"
 
     def visit_Literal(self, node: oir.Literal, **kwargs: Any) -> str:
-        if type(node.value) is str:
-            # Note: isinstance(node.value, str) also matches the string enum `BuiltInLiteral`
-            # which we don't want to match because it returns lower-case `true`, which isn't
-            # defined in (python) tasklet code.
-            return node.value
+        if isinstance(node.value, common.BuiltInLiteral):
+            return self.visit(node.value, **kwargs)
 
-        return self.visit(node.value, **kwargs)
+        # Resolve int and float literals to the correct precision
+        dtype = utils.data_type_to_dace_typeclass(node.dtype)
+        return f"{dtype}({node.value})"
 
     def visit_BuiltInLiteral(self, node: common.BuiltInLiteral, **_kwargs: Any) -> str:
         if node == common.BuiltInLiteral.TRUE:

--- a/tests/cartesian_tests/unit_tests/test_gtc/dace/test_oir_to_tasklet.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/dace/test_oir_to_tasklet.py
@@ -51,3 +51,20 @@ def test__tasklet_name(
     node: oir.FieldAccess | oir.ScalarAccess, is_target: bool, postfix: str, expected: str
 ) -> None:
     assert oir_to_tasklet._tasklet_name(node, is_target, postfix) == expected
+
+
+@pytest.mark.parametrize(
+    "literal,expected",
+    [
+        (oir.Literal(value=common.BuiltInLiteral.TRUE, dtype=common.DataType.BOOL), "True"),
+        (oir.Literal(value=common.BuiltInLiteral.FALSE, dtype=common.DataType.BOOL), "False"),
+        (oir.Literal(value="42.0", dtype=common.DataType.FLOAT32), "float(42.0)"),
+        (oir.Literal(value="42.0", dtype=common.DataType.FLOAT64), "double(42.0)"),
+        (oir.Literal(value="42", dtype=common.DataType.INT32), "int(42)"),
+        (oir.Literal(value="42", dtype=common.DataType.INT64), "int64_t(42)"),
+    ],
+)
+def test_visit_literal(literal: oir.Literal, expected: str):
+    visitor = oir_to_tasklet.OIRToTasklet()
+
+    assert visitor.visit_Literal(literal) == expected


### PR DESCRIPTION
## Description

PR https://github.com/GridTools/gt4py/pull/2187 added support for setting the default literal precision. DaCe backends would not respect literal precision (neither `literal_int_precision`, nor `literal_float_precision`). This leads to subtle changes in the numerics because some calculations aren't done at the right precision.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
