### PR TITLE
fix[dace][next]: Fixed Multithreading Issue with `DaCe.Config`

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
@@ -17,8 +17,7 @@ from gt4py._core import definitions as core_defs
 from gt4py.next import common as gtx_common, config, metrics, utils as gtx_utils
 from gt4py.next.otf import arguments, stages
 from gt4py.next.program_processors.runners.dace import sdfg_callable, workflow as dace_worflow
-
-from . import common as dace_common
+from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 
 
 def convert_args(
@@ -69,10 +68,9 @@ def convert_args(
         ):
             # Observe that dace instrumentation adds runtime overhead:
             # DaCe writes an instrumentation report file for each SDFG run.
-            with dace.config.temporary_config():
+            with gtx_wfdcommon.dace_context(device_type=device):
                 # We need to set the cache folder and key config in order to retrieve
                 # the SDFG report file.
-                dace_common.set_dace_config(device_type=device)
                 prof_report = fun.sdfg_program.sdfg.get_latest_report()
             if prof_report is None:
                 raise RuntimeError(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -25,7 +25,7 @@ from gt4py.next.program_processors.runners.dace import (
     transformations as gtx_transformations,
     utils as gtx_dace_utils,
 )
-from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfcommon
+from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 from gt4py.next.type_system import type_specifications as ts
 
 
@@ -187,12 +187,8 @@ class DaCeTranslator(
         *args: Any,
         **kwargs: Any,
     ) -> dace.SDFG:
-        # NOTE: We should actually create a new configuration context here, such that
-        #   we do not influence anyone else. However, because [DaCe issue#2125](https://github.com/spcl/dace/issues/2125)
-        #   we can not do this. Instead we simply set the configuration and hope
-        #   for the best.
-        gtx_wfcommon.set_dace_config(device_type=self.device_type)
-        return self._generate_sdfg_without_configuring_dace(*args, **kwargs)
+        with gtx_wfdcommon.dace_context(device_type=self.device_type):
+            return self._generate_sdfg_without_configuring_dace(*args, **kwargs)
 
     def _generate_sdfg_without_configuring_dace(
         self,


### PR DESCRIPTION
In [PR#2201](https://github.com/GridTools/gt4py/pull/2201) it was noticed that the there are issues when `dace.Config` was used using multiple threads.
The PR solved that issue by removing the DaCe configuration contexts, i.e. `dace.config.temporary_config()`, which was not a safe solution.
After updating the DaCe work in [PR#2213](https://github.com/GridTools/gt4py/pull/2213) the fix that enables to use DaCe's configuration contexts with multiple threads this PR restores them, which makes multi threaded execution safer.

See also:
- [Underlying DaCe issue#2125](https://github.com/spcl/dace/issues/2125)
