### PR TITLE
ci: Add beverin (AMD MI300)

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -30,8 +30,6 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     ${EXTRA_APTGET} && \
     apt-get clean && \
     apt-get autoremove -y && \
-    # reinstall git dependencies
-    apt-get install -y --reinstall git libcurl4-gnutls-dev libnghttp2-14 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -65,7 +65,6 @@ uv sync --compile-bytecode --frozen --no-install-project \
     --group dev \
     --extra standard \
     --extra jax \
-    --extra performance \
     --extra testing \
     ${EXTRA_UV_SYNC_ARGS}
 if [ ! -z "${EXTRA_UV_PIP_ARGS}" ]; then

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -63,7 +63,7 @@ fi
 uv pip install --compile-bytecode setuptools wheel pip
 uv sync --compile-bytecode --frozen --no-install-project \
     --group dev \
-    --extra formatting \
+    --extra standard \
     --extra jax \
     --extra performance \
     --extra testing \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     ${EXTRA_APTGET} && \
     apt-get clean && \
     apt-get autoremove -y && \
+    # reinstall git dependencies
+    apt-get install -y --reinstall git libcurl4-gnutls-dev libnghttp2-14 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -57,6 +57,7 @@ ARG EXTRA_UV_PIP_ARGS=""
 ARG EXTRA_UV_SYNC_ARGS=""
 RUN --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml <<EOF
+set -euo pipefail
 if [ ! -z "${EXTRA_UV_ENV_VARS}" ]; then
     eval "export ${EXTRA_UV_ENV_VARS}"
 fi

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -57,7 +57,7 @@ ARG EXTRA_UV_PIP_ARGS=""
 ARG EXTRA_UV_SYNC_ARGS=""
 RUN --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml <<EOF
-set -euo pipefail
+set -eu
 if [ ! -z "${EXTRA_UV_ENV_VARS}" ]; then
     eval "export ${EXTRA_UV_ENV_VARS}"
 fi

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -92,17 +92,17 @@ build_cscs_amd_rocm:
     matrix:
       - SUBPACKAGE: [cartesian]
         VARIANT: ["internal", "dace"]
-        SUBVARIANT: ["rocm6_0", "cpu"] # TODO cuda
+        SUBVARIANT: ["cuda12", "rocm6_0", "cpu"]
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: eve
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: next
         VARIANT: ["internal", "dace"]
-        SUBVARIANT: ["rocm6_0", "cpu"]
+        SUBVARIANT: ["cuda12", "rocm6_0", "cpu"]
         DETAIL: ["nomesh", "atlas"]
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: [storage]
-        VARIANT: ["rocm6_0", "cpu"]
+        VARIANT: ["cuda12", "rocm6_0", "cpu"]
         PY_VERSION: *test_python_versions
   rules:
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
@@ -127,6 +127,9 @@ test_cscs_gh200:
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
+  rules:
+    - if: $SUBVARIANT == 'rocm6_0'
+      when: never
 
 test_cscs_amd_rocm:
   extends:
@@ -142,6 +145,8 @@ test_cscs_amd_rocm:
     CUDA_HOME: /opt/rocm # for cartesian
     CUDA_ARCH: gfx942 # MI300A
   rules:
+    - if: $SUBVARIANT == 'cuda12'
+      when: never
     - if: $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
       when: never
     - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'internal' && $SUBVARIANT == 'cpu'

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,7 +109,7 @@ build_cscs_amd_rocm:
   rules: &exclude_variants_rules
     # - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
     #   when: never
-    - if: '($SUBVARIANT == "cuda12") || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12") && (" $TEST_VARIANTS " !~ " cuda12 ")'
+    - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && (" $TEST_VARIANTS " !~ " cuda12 ")'
       when: never
     # - if: '(($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
     #   when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -93,25 +93,25 @@ build_cscs_amd_rocm:
   parallel:
     matrix:
       - SUBPACKAGE: [cartesian]
-        VARIANT: ["internal", "dace"]
-        SUBVARIANT: ["cuda12", "rocm6_0", "cpu"]
+        VARIANT: ['internal', 'dace']
+        SUBVARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: eve
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: next
-        VARIANT: ["internal", "dace"]
-        SUBVARIANT: ["cuda12", "rocm6_0", "cpu"]
+        VARIANT: ['internal', 'dace']
+        SUBVARIANT: ['cuda12', 'rocm6_0', 'cpu']
         DETAIL: ["nomesh", "atlas"]
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: [storage]
-        VARIANT: ["cuda12", "rocm6_0", "cpu"]
+        VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
+    - if: (($SUBVARIANT == 'cpu' || ($SUBVARIANT == "" && $VARIANT == 'cpu')) && " $TEST_VARIANTS " !~ " cpu "
       when: never
-    - if: '(($SUBVARIANT == "cuda12" || ($SUBVARIANT == "" && $VARIANT == "cuda12")) && " $TEST_VARIANTS " !~ " cuda12 "'
+    - if: (($SUBVARIANT == 'cuda12' || ($SUBVARIANT == "" && $VARIANT == 'cuda12')) && " $TEST_VARIANTS " !~ " cuda12 "
       when: never
-    - if: '(($SUBVARIANT == "rocm_6" || ($SUBVARIANT == "" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
+    - if: (($SUBVARIANT == 'rocm_6' || ($SUBVARIANT == "" && $VARIANT == 'rocm_6')) && " $TEST_VARIANTS " !~ " rocm_6 "
       when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -142,3 +142,4 @@ test_cscs_amd_rocm:
     CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
     CUDA_ROOT: /opt/rocm # for cartesian
+    CUDA_ARCH: gfx942 # MI300A

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -65,6 +65,7 @@ stages:
     BASE_IMAGE: jfrog.svc.cscs.ch/dockerhub/rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
     EXTRA_UV_SYNC_ARGS: "--extra rocm6_0"
     EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx90a ROCM_HOME=/opt/rocm"
+    UBUNTU_VERSION: '22.04'
 
 # TODO re-enable
 # build_cscs_gh200:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -144,7 +144,7 @@ test_cscs_amd_rocm:
     CUDA_HOME: /opt/rocm # for cartesian
     CUDA_ARCH: gfx942 # MI300A
   rules:
-    - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
+    - if: $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
       when: never
     - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'internal' && $SUBVARIANT == 'cpu'
       variables:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -67,7 +67,7 @@ stages:
     EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx942 ROCM_HOME=/opt/rocm"
     UBUNTU_VERSION: '22.04'
 
-# TODO(havogt): re-enable one santis is back
+# TODO(havogt): re-enable once santis is back
 # build_cscs_gh200:
 #   extends:
 #     - .container-builder-cscs-gh200
@@ -120,7 +120,7 @@ build_cscs_amd_rocm:
     - export NOX_SESSION_ARGS="${VARIANT:+($VARIANT}${SUBVARIANT:+, $SUBVARIANT}${DETAIL:+, $DETAIL}${VARIANT:+)}"
     - cd "${WORKDIR}/gt4py" && uv run --script noxfile.py -s "test_${SUBPACKAGE}-${PY_VERSION}${NOX_SESSION_ARGS}"
 
-# TODO(havogt): re-enable one santis is back
+# TODO(havogt): re-enable once santis is back
 # test_cscs_gh200:
 #   extends:
 #     - .container-runner-santis-gh200

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -89,7 +89,7 @@ build_cscs_amd_rocm:
     CSCS_CUDA_MPS: 1
     SLURM_GPUS_PER_NODE: 4
     SLURM_JOB_NUM_NODES: 1
-    SLURM_TIMELIMIT: 5`
+    SLURM_TIMELIMIT: 5
   parallel:
     matrix:
       - SUBPACKAGE: [cartesian]
@@ -149,7 +149,7 @@ test_cscs_amd_rocm:
     CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
     CUDA_HOME: /opt/rocm # for cartesian
-    CUDA_ARCH: gfx942 # MI300A
+    SLURM_TIMELIMIT: 15 # relaxed relative to santis as there is no pressure on the queue
   rules:
     - if: $SUBVARIANT == 'cuda12'
       when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -162,9 +162,9 @@ test_cscs_amd_rocm:
     CUDA_HOME: /opt/rocm # for cartesian
     SLURM_TIMELIMIT: 20 # relaxed relative to santis as there is no pressure on the queue
   rules:
-    - *exclude_variants_rules
     - if: $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
       when: never
+    - *exclude_variants_rules
     - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'internal' && $SUBVARIANT == 'cpu'
       variables:
         CXX: g++

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -123,6 +123,8 @@ test_cscs_gh200:
   extends:
     - .container-runner-santis-gh200
     - .test_common
+  needs:
+    - build_cscs_gh200
   variables:
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
@@ -135,6 +137,8 @@ test_cscs_amd_rocm:
   extends:
     - .tds-container-runner-beverin-mi200
     - .test_common
+  needs:
+    - build_cscs_amd_rocm
   variables:
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,7 +109,7 @@ build_cscs_amd_rocm:
   rules: &exclude_variants_rules
     # - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
     #   when: never
-    - if: '$SUBVARIANT == "cuda12" && " $TEST_VARIANTS " !~ " cuda12 "'
+    - if: '($SUBVARIANT == "cuda12") && " $TEST_VARIANTS " !~ " cuda12 "'
       when: never
     # - if: '(($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
     #   when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -146,4 +146,10 @@ test_cscs_amd_rocm:
   rules:
     - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
       when: never
+    - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'internal' && $SUBVARIANT == 'cpu'
+      variables:
+        CXX: g++
     - when: on_success
+      variables:
+        CXX: /opt/rocm/bin/hipcc
+

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -137,3 +137,4 @@ test_cscs_amd_rocm:
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
+    SLURM_PARTITION: mi300

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -59,25 +59,25 @@ stages:
     BASE_IMAGE: jfrog.svc.cscs.ch/dockerhub/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
     EXTRA_UV_SYNC_ARGS: "--extra cuda12"
 
-# TODO: rocm steps are in draft state for now to show how to add support in the future
-# .build_extra_rocm:
-#   variables:
-#     # jfrog.svc.cscs.ch/dockerhub/rocm is the cached version of docker.io/rocm
-#     BASE_IMAGE: jfrog.svc.cscs.ch/dockerhub/rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
-#     EXTRA_UV_SYNC_ARGS: "--extra rocm6_0"
-#     EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx90a"
+.build_extra_rocm:
+  variables:
+    # jfrog.svc.cscs.ch/dockerhub/rocm is the cached version of docker.io/rocm
+    BASE_IMAGE: jfrog.svc.cscs.ch/dockerhub/rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
+    EXTRA_UV_SYNC_ARGS: "--extra rocm6_0"
+    EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx90a"
 
-build_cscs_gh200:
-  extends:
-    - .container-builder-cscs-gh200
-    - .build_common
-    - .build_extra_cuda
-
-# .build_cscs_amd_rocm:
+# TODO re-enable
+# build_cscs_gh200:
 #   extends:
-#     - .container-builder-cscs-zen2
+#     - .container-builder-cscs-gh200
 #     - .build_common
-#     - .build_extra_rocm
+#     - .build_extra_cuda
+
+build_cscs_amd_rocm:
+  extends:
+    - .container-builder-cscs-zen2
+    - .build_common
+    - .build_extra_rocm
 
 # -- Test stage --
 .test_common:
@@ -92,17 +92,17 @@ build_cscs_gh200:
     matrix:
       - SUBPACKAGE: [cartesian]
         VARIANT: ["internal", "dace"]
-        SUBVARIANT: ["cuda12", "cpu"]
+        SUBVARIANT: ["rocm6_0", "cpu"] # TODO cuda
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: eve
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: next
         VARIANT: ["internal", "dace"]
-        SUBVARIANT: ["cuda12", "cpu"]
+        SUBVARIANT: ["rocm6_0", "cpu"]
         DETAIL: ["nomesh", "atlas"]
         PY_VERSION: *test_python_versions
       - SUBPACKAGE: [storage]
-        VARIANT: ["cuda12", "cpu"]
+        VARIANT: ["rocm6_0", "cpu"]
         PY_VERSION: *test_python_versions
   rules:
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
@@ -119,21 +119,21 @@ build_cscs_gh200:
     - export NOX_SESSION_ARGS="${VARIANT:+($VARIANT}${SUBVARIANT:+, $SUBVARIANT}${DETAIL:+, $DETAIL}${VARIANT:+)}"
     - cd "${WORKDIR}/gt4py" && uv run --script noxfile.py -s "test_${SUBPACKAGE}-${PY_VERSION}${NOX_SESSION_ARGS}"
 
-test_cscs_gh200:
+# TODO add back
+# test_cscs_gh200:
+#   extends:
+#     - .container-runner-santis-gh200
+#     - .test_common
+#   variables:
+#     GT4PY_BUILD_JOBS: 8
+#     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
+#     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
+
+test_cscs_amd_rocm:
   extends:
-    - .container-runner-santis-gh200
+    - .tds-container-runner-beverin-mi200
     - .test_common
   variables:
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
-
-# .test_cscs_amd_rocm:
-#   extends:
-#     - .tds-container-runner-beverin-mi200
-#     - .test_common
-#   variables:
-#   variables:
-#     GT4PY_BUILD_JOBS: 8
-#     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-#     PYTEST_XDIST_AUTO_NUM_WORKERS: 32

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -64,7 +64,7 @@ stages:
     # jfrog.svc.cscs.ch/dockerhub/rocm is the cached version of docker.io/rocm
     BASE_IMAGE: jfrog.svc.cscs.ch/dockerhub/rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
     EXTRA_UV_SYNC_ARGS: "--extra rocm6_0"
-    EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx90a ROCM_HOME=/opt/rocm"
+    EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx942 ROCM_HOME=/opt/rocm"
     UBUNTU_VERSION: '22.04'
 
 # TODO re-enable

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,7 +109,7 @@ build_cscs_amd_rocm:
   rules: &exclude_variants_rules
     # - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
     #   when: never
-    - if: '(($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && " $TEST_VARIANTS " !~ " cuda12 "'
+    - if: '$SUBVARIANT == "cuda12" && " $TEST_VARIANTS " !~ " cuda12 "'
       when: never
     # - if: '(($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
     #   when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -67,7 +67,7 @@ stages:
     EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx942 ROCM_HOME=/opt/rocm"
     UBUNTU_VERSION: '22.04'
 
-# TODO re-enable
+# TODO(havogt): re-enable one santis is back
 # build_cscs_gh200:
 #   extends:
 #     - .container-builder-cscs-gh200
@@ -120,7 +120,7 @@ build_cscs_amd_rocm:
     - export NOX_SESSION_ARGS="${VARIANT:+($VARIANT}${SUBVARIANT:+, $SUBVARIANT}${DETAIL:+, $DETAIL}${VARIANT:+)}"
     - cd "${WORKDIR}/gt4py" && uv run --script noxfile.py -s "test_${SUBPACKAGE}-${PY_VERSION}${NOX_SESSION_ARGS}"
 
-# TODO add back
+# TODO(havogt): re-enable one santis is back
 # test_cscs_gh200:
 #   extends:
 #     - .container-runner-santis-gh200

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -149,7 +149,7 @@ test_cscs_amd_rocm:
     CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
     CUDA_HOME: /opt/rocm # for cartesian
-    SLURM_TIMELIMIT: 15 # relaxed relative to santis as there is no pressure on the queue
+    SLURM_TIMELIMIT: 20 # relaxed relative to santis as there is no pressure on the queue
   rules:
     - if: $SUBVARIANT == 'cuda12' || $VARIANT=='cuda12'
       when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -48,7 +48,7 @@ stages:
     # To override the defaults, just define these variables in the actual job.
     DOCKER_BUILD_ARGS: '["BASE_IMAGE", "CACHE_DIR", "EXTRA_APTGET", "EXTRA_UV_ENV_VARS", "EXTRA_UV_PIP_ARGS", "EXTRA_UV_SYNC_ARGS", "PY_VERSION", "UV_VERSION", "WORKDIR_PATH" ]'
     PERSIST_IMAGE_NAME: ${CSCS_REGISTRY_PATH}/public/${ARCH}/base/gt4py-ci-${PY_VERSION}  # The $DOCKER_TAG tag is added in the before_script of .dynamic-image-name
-    WATCH_FILECHANGES: 'ci/Dockerfile ci/cscs-ci.yml ci/cscs-ci-ext-config.yml uv.lock'
+    WATCH_FILECHANGES: 'ci/Dockerfile ci/cscs-ci-ext-config.yml uv.lock' # TODO add back the ci/cscs-ci.yml 
   parallel:
     matrix:
       - PY_VERSION: *test_python_versions
@@ -87,7 +87,7 @@ build_cscs_amd_rocm:
     CSCS_CUDA_MPS: 1
     SLURM_GPUS_PER_NODE: 4
     SLURM_JOB_NUM_NODES: 1
-    SLURM_TIMELIMIT: 5
+    SLURM_TIMELIMIT: 20
   parallel:
     matrix:
       - SUBPACKAGE: [cartesian]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -87,7 +87,7 @@ build_cscs_amd_rocm:
     CSCS_CUDA_MPS: 1
     SLURM_GPUS_PER_NODE: 4
     SLURM_JOB_NUM_NODES: 1
-    SLURM_TIMELIMIT: 20
+    SLURM_TIMELIMIT: 5`
   parallel:
     matrix:
       - SUBPACKAGE: [cartesian]

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -86,7 +86,7 @@ build_cscs_amd_rocm:
   stage: test
   image: ${CSCS_REGISTRY_PATH}/public/${ARCH}/base/gt4py-ci-${PY_VERSION}:${DOCKER_TAG}
   variables:
-    TEST_VARIANTS: 'cpu'  # Extended jobs should redefine which variants (cpu, cuda12, rocm6) to test 
+    TEST_VARIANTS: 'cpu'  # Extended jobs should redefine which variants (cpu, cuda12, rocm6_0) to test 
     CSCS_CUDA_MPS: 1
     SLURM_GPUS_PER_NODE: 4
     SLURM_JOB_NUM_NODES: 1

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -72,12 +72,14 @@ build_cscs_gh200:
     - .container-builder-cscs-gh200
     - .build_common
     - .build_extra_cuda
+  needs: []
 
 build_cscs_amd_rocm:
   extends:
     - .container-builder-cscs-zen2
     - .build_common
     - .build_extra_rocm
+  needs: []
 
 # -- Test stage --
 .test_common:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -107,12 +107,12 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    # - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
-    #   when: never
+    - if: '($SUBVARIANT == "cpu" || ($SUBPACKAGE == "storage" && $VARIANT == "cpu")) && (" $TEST_VARIANTS " !~ " cpu ")'
+      when: never
     - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && (" $TEST_VARIANTS " !~ " cuda12 ")'
       when: never
-    # - if: '(($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
-    #   when: never
+    - if: '($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && (" $TEST_VARIANTS " !~ " rocm_6 ")'
+      when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:
         # TODO: investigate why the dace tests seem to hang with multiple jobs

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -64,7 +64,7 @@ stages:
     # jfrog.svc.cscs.ch/dockerhub/rocm is the cached version of docker.io/rocm
     BASE_IMAGE: jfrog.svc.cscs.ch/dockerhub/rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
     EXTRA_UV_SYNC_ARGS: "--extra rocm6_0"
-    EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx90a"
+    EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx90a ROCM_HOME=/opt/rocm"
 
 # TODO re-enable
 # build_cscs_gh200:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -107,12 +107,12 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    # - if: (($SUBVARIANT == 'cpu' || ($SUBVARIANT == "" && $VARIANT == 'cpu')) && " $TEST_VARIANTS " !~ " cpu "
-    #   when: never
-    # - if: (($SUBVARIANT == 'cuda12' || ($SUBVARIANT == "" && $VARIANT == 'cuda12')) && " $TEST_VARIANTS " !~ " cuda12 "
-    #   when: never
-    # - if: (($SUBVARIANT == 'rocm_6' || ($SUBVARIANT == "" && $VARIANT == 'rocm_6')) && " $TEST_VARIANTS " !~ " rocm_6 "
-    #   when: never
+    - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
+      when: never
+    - if: '(($SUBVARIANT == "cuda12" || ($SUBVARIANT == "" && $VARIANT == "cuda12")) && " $TEST_VARIANTS " !~ " cuda12 "'
+      when: never
+    - if: '(($SUBVARIANT == "rocm_6" || ($SUBVARIANT == "" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
+      when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:
         # TODO: investigate why the dace tests seem to hang with multiple jobs

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -107,11 +107,11 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    - if: '($SUBVARIANT == "cpu" || ($SUBPACKAGE == "storage" && $VARIANT == "cpu")) && (" $TEST_VARIANTS " !~ " cpu ")'
+    - if: '($SUBVARIANT == "cpu" || ($SUBPACKAGE == "storage" && $VARIANT == "cpu")) && ($TEST_VARIANTS !~ /(^|\s)cpu(\s|$)/)'
       when: never
-    - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && (" $TEST_VARIANTS " !~ " cuda12 ")'
+    - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && ($TEST_VARIANTS !~ /(^|\s)cuda12(\s|$)/)'
       when: never
-    - if: '($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && (" $TEST_VARIANTS " !~ " rocm_6 ")'
+    - if: '($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && ($TEST_VARIANTS !~ /(^|\s)rocm_6(\s|$)/)'
       when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -67,12 +67,11 @@ stages:
     EXTRA_UV_ENV_VARS: "CUPY_INSTALL_USE_HIP=1 HCC_AMDGPU_TARGET=gfx942 ROCM_HOME=/opt/rocm"
     UBUNTU_VERSION: '22.04'
 
-# TODO(havogt): re-enable once santis is back
-# build_cscs_gh200:
-#   extends:
-#     - .container-builder-cscs-gh200
-#     - .build_common
-#     - .build_extra_cuda
+build_cscs_gh200:
+  extends:
+    - .container-builder-cscs-gh200
+    - .build_common
+    - .build_extra_cuda
 
 build_cscs_amd_rocm:
   extends:
@@ -120,15 +119,14 @@ build_cscs_amd_rocm:
     - export NOX_SESSION_ARGS="${VARIANT:+($VARIANT}${SUBVARIANT:+, $SUBVARIANT}${DETAIL:+, $DETAIL}${VARIANT:+)}"
     - cd "${WORKDIR}/gt4py" && uv run --script noxfile.py -s "test_${SUBPACKAGE}-${PY_VERSION}${NOX_SESSION_ARGS}"
 
-# TODO(havogt): re-enable once santis is back
-# test_cscs_gh200:
-#   extends:
-#     - .container-runner-santis-gh200
-#     - .test_common
-#   variables:
-#     GT4PY_BUILD_JOBS: 8
-#     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
-#     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
+test_cscs_gh200:
+  extends:
+    - .container-runner-santis-gh200
+    - .test_common
+  variables:
+    GT4PY_BUILD_JOBS: 8
+    # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
+    PYTEST_XDIST_AUTO_NUM_WORKERS: 32
 
 test_cscs_amd_rocm:
   extends:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -107,12 +107,12 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    - if: (($SUBVARIANT == 'cpu' || ($SUBVARIANT == "" && $VARIANT == 'cpu')) && " $TEST_VARIANTS " !~ " cpu "
-      when: never
-    - if: (($SUBVARIANT == 'cuda12' || ($SUBVARIANT == "" && $VARIANT == 'cuda12')) && " $TEST_VARIANTS " !~ " cuda12 "
-      when: never
-    - if: (($SUBVARIANT == 'rocm_6' || ($SUBVARIANT == "" && $VARIANT == 'rocm_6')) && " $TEST_VARIANTS " !~ " rocm_6 "
-      when: never
+    # - if: (($SUBVARIANT == 'cpu' || ($SUBVARIANT == "" && $VARIANT == 'cpu')) && " $TEST_VARIANTS " !~ " cpu "
+    #   when: never
+    # - if: (($SUBVARIANT == 'cuda12' || ($SUBVARIANT == "" && $VARIANT == 'cuda12')) && " $TEST_VARIANTS " !~ " cuda12 "
+    #   when: never
+    # - if: (($SUBVARIANT == 'rocm_6' || ($SUBVARIANT == "" && $VARIANT == 'rocm_6')) && " $TEST_VARIANTS " !~ " rocm_6 "
+    #   when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:
         # TODO: investigate why the dace tests seem to hang with multiple jobs

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -139,6 +139,6 @@ test_cscs_amd_rocm:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
     SLURM_PARTITION: mi300
-    CMAKE_PREFIX_PATH: /opt/rocm
+    CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
-
+    CUDA_ROOT: /opt/rocm # for cartesian

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -142,4 +142,4 @@ test_cscs_amd_rocm:
     CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
     CUDA_ROOT: /opt/rocm # for cartesian
-    CUDA_ARCH: gfx942 # MI300A
+    # CUDA_ARCH: gfx942 # MI300A

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -163,6 +163,8 @@ test_cscs_amd_rocm:
     SLURM_TIMELIMIT: 20 # relaxed relative to santis as there is no pressure on the queue
   rules:
     - *exclude_variants_rules
+    - if: $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
+      when: never
     - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'internal' && $SUBVARIANT == 'cpu'
       variables:
         CXX: g++

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -108,14 +108,14 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    # Extended jobs should reference this list anchor at the proper position of their `rules` section
+    # Extended jobs should reference this list anchor at the proper position of their
+    # `rules` section, and also add an extra `- when: on_success` rule at the end.
     - if: '($SUBVARIANT == "cpu" || ($SUBPACKAGE == "storage" && $VARIANT == "cpu")) && ($TEST_VARIANTS !~ /(^|\s)cpu(\s|$)/)'
       when: never
     - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && ($TEST_VARIANTS !~ /(^|\s)cuda12(\s|$)/)'
       when: never
     - if: '($SUBVARIANT == "rocm6_0" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm6_0")) && ($TEST_VARIANTS !~ /(^|\s)rocm6_0(\s|$)/)'
       when: never
-    # An extra `- when: on_success` rule should be added after this anchor in the extended jobs 
 
   script:
     # Since the image does not contain the repo, we need to clone it before running the tests.

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -107,12 +107,12 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
-    - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
+    # - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
+    #   when: never
+    - if: '(($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && " $TEST_VARIANTS " !~ " cuda12 "'
       when: never
-    - if: '(($SUBVARIANT == "cuda12" || ($SUBVARIANT == "" && $VARIANT == "cuda12")) && " $TEST_VARIANTS " !~ " cuda12 "'
-      when: never
-    - if: '(($SUBVARIANT == "rocm_6" || ($SUBVARIANT == "" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
-      when: never
+    # - if: '(($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
+    #   when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:
         # TODO: investigate why the dace tests seem to hang with multiple jobs

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -48,7 +48,7 @@ stages:
     # To override the defaults, just define these variables in the actual job.
     DOCKER_BUILD_ARGS: '["BASE_IMAGE", "CACHE_DIR", "EXTRA_APTGET", "EXTRA_UV_ENV_VARS", "EXTRA_UV_PIP_ARGS", "EXTRA_UV_SYNC_ARGS", "PY_VERSION", "UV_VERSION", "WORKDIR_PATH" ]'
     PERSIST_IMAGE_NAME: ${CSCS_REGISTRY_PATH}/public/${ARCH}/base/gt4py-ci-${PY_VERSION}  # The $DOCKER_TAG tag is added in the before_script of .dynamic-image-name
-    WATCH_FILECHANGES: 'ci/Dockerfile ci/cscs-ci-ext-config.yml uv.lock' # TODO add back the ci/cscs-ci.yml 
+    WATCH_FILECHANGES: 'ci/Dockerfile ci/cscs-ci.yml ci/cscs-ci-ext-config.yml uv.lock'
   parallel:
     matrix:
       - PY_VERSION: *test_python_versions

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -139,3 +139,6 @@ test_cscs_amd_rocm:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
     SLURM_PARTITION: mi300
+    CMAKE_PREFIX_PATH: /opt/rocm
+    CXX: /opt/rocm/bin/hipcc
+

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -86,6 +86,7 @@ build_cscs_amd_rocm:
   stage: test
   image: ${CSCS_REGISTRY_PATH}/public/${ARCH}/base/gt4py-ci-${PY_VERSION}:${DOCKER_TAG}
   variables:
+    TEST_VARIANTS: 'cpu'  # Extended jobs should redefine which variants (cpu, cuda12, rocm6) to test 
     CSCS_CUDA_MPS: 1
     SLURM_GPUS_PER_NODE: 4
     SLURM_JOB_NUM_NODES: 1
@@ -111,7 +112,7 @@ build_cscs_amd_rocm:
       when: never
     - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && ($TEST_VARIANTS !~ /(^|\s)cuda12(\s|$)/)'
       when: never
-    - if: '($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && ($TEST_VARIANTS !~ /(^|\s)rocm_6(\s|$)/)'
+    - if: '($SUBVARIANT == "rocm6_0" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm6_0")) && ($TEST_VARIANTS !~ /(^|\s)rocm6_0(\s|$)/)'
       when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -142,4 +142,8 @@ test_cscs_amd_rocm:
     CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
     CUDA_HOME: /opt/rocm # for cartesian
-    # CUDA_ARCH: gfx942 # MI300A
+    CUDA_ARCH: gfx942 # MI300A
+  rules:
+    - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
+      when: never
+    - when: on_success

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -141,5 +141,5 @@ test_cscs_amd_rocm:
     SLURM_PARTITION: mi300
     CMAKE_PREFIX_PATH: /opt/rocm # for next
     CXX: /opt/rocm/bin/hipcc
-    CUDA_ROOT: /opt/rocm # for cartesian
+    CUDA_HOME: /opt/rocm # for cartesian
     # CUDA_ARCH: gfx942 # MI300A

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -114,11 +114,6 @@ build_cscs_amd_rocm:
       when: never
     - if: '($SUBVARIANT == "rocm6_0" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm6_0")) && ($TEST_VARIANTS !~ /(^|\s)rocm6_0(\s|$)/)'
       when: never
-    - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
-      variables:
-        # TODO: investigate why the dace tests seem to hang with multiple jobs
-        GT4PY_BUILD_JOBS: 1
-        SLURM_TIMELIMIT: "00:15:00"
     # An extra `- when: on_success` rule should be added after this anchor in the extended jobs 
 
   script:
@@ -144,6 +139,11 @@ test_cscs_gh200:
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
   rules:
     - *exclude_variants_rules
+    - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
+      variables:
+        # TODO: investigate why the dace tests seem to hang with multiple jobs
+        GT4PY_BUILD_JOBS: 1
+        SLURM_TIMELIMIT: "00:15:00"
     - when: on_success
 
 test_cscs_amd_rocm:

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -108,6 +108,7 @@ build_cscs_amd_rocm:
         VARIANT: ['cuda12', 'rocm6_0', 'cpu']
         PY_VERSION: *test_python_versions
   rules: &exclude_variants_rules
+    # Extended jobs should reference this list anchor at the proper position of their `rules` section
     - if: '($SUBVARIANT == "cpu" || ($SUBPACKAGE == "storage" && $VARIANT == "cpu")) && ($TEST_VARIANTS !~ /(^|\s)cpu(\s|$)/)'
       when: never
     - if: '($SUBVARIANT == "cuda12" || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12")) && ($TEST_VARIANTS !~ /(^|\s)cuda12(\s|$)/)'

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -106,15 +106,24 @@ build_cscs_amd_rocm:
       - SUBPACKAGE: [storage]
         VARIANT: ["cuda12", "rocm6_0", "cpu"]
         PY_VERSION: *test_python_versions
-  rules:
+  rules: &exclude_variants_rules
+    - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
+      when: never
+    - if: '(($SUBVARIANT == "cuda12" || ($SUBVARIANT == "" && $VARIANT == "cuda12")) && " $TEST_VARIANTS " !~ " cuda12 "'
+      when: never
+    - if: '(($SUBVARIANT == "rocm_6" || ($SUBVARIANT == "" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
+      when: never
     - if: $SUBPACKAGE == 'next' && $VARIANT == 'dace' && $DETAIL == 'nomesh'
       variables:
         # TODO: investigate why the dace tests seem to hang with multiple jobs
         GT4PY_BUILD_JOBS: 1
         SLURM_TIMELIMIT: "00:15:00"
-    - when: on_success
+    # An extra `- when: on_success` rule should be added after this anchor in the extended jobs 
+
   script:
-    # Since the image does not contain the repo, we need to clone it before running the tests
+    # Since the image does not contain the repo, we need to clone it before running the tests.
+    # The output folder is inside the docker image (${WORKDIR}/gt4py), so it won't take up
+    # space on $SCRATCH but in a ephemeral tmpfs mount in the running node.
     # for git>=2.49: mkdir -p "${WORKDIR}/gt4py" && git clone --depth 1 --revision "${CI_COMMIT_SHA}" "${CSCS_CI_ORIG_CLONE_URL}" "${WORKDIR}/gt4py"
     - mkdir -p "${WORKDIR}/gt4py" && git clone --depth 1 "${CSCS_CI_ORIG_CLONE_URL}" "${WORKDIR}/gt4py"
     - cd "${WORKDIR}/gt4py" && git fetch --depth 1 origin "${CI_COMMIT_SHA}" && git checkout "${CI_COMMIT_SHA}"
@@ -128,11 +137,12 @@ test_cscs_gh200:
   needs:
     - build_cscs_gh200
   variables:
+    TEST_VARIANTS: 'cpu cuda12'
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
   rules:
-    - if: $SUBVARIANT == 'cuda12'
+    - *exclude_variants_rules
     - when: on_success
 
 test_cscs_amd_rocm:
@@ -142,6 +152,7 @@ test_cscs_amd_rocm:
   needs:
     - build_cscs_amd_rocm
   variables:
+    TEST_VARIANTS: 'cpu rocm6_0'
     GT4PY_BUILD_JOBS: 8
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
@@ -150,10 +161,7 @@ test_cscs_amd_rocm:
     CUDA_HOME: /opt/rocm # for cartesian
     SLURM_TIMELIMIT: 20 # relaxed relative to santis as there is no pressure on the queue
   rules:
-    - if: $SUBVARIANT == 'cuda12' || $VARIANT=='cuda12'
-      when: never
-    - if: $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
-      when: never
+    - *exclude_variants_rules
     - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'internal' && $SUBVARIANT == 'cpu'
       variables:
         CXX: g++

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -151,7 +151,7 @@ test_cscs_amd_rocm:
     CUDA_HOME: /opt/rocm # for cartesian
     SLURM_TIMELIMIT: 15 # relaxed relative to santis as there is no pressure on the queue
   rules:
-    - if: $SUBVARIANT == 'cuda12'
+    - if: $SUBVARIANT == 'cuda12' || $VARIANT=='cuda12'
       when: never
     - if: $VARIANT == 'dace' && $SUBVARIANT == 'rocm6_0'
       when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -109,7 +109,7 @@ build_cscs_amd_rocm:
   rules: &exclude_variants_rules
     # - if: '(($SUBVARIANT == "cpu" || ($SUBVARIANT == "" && $VARIANT == "cpu")) && " $TEST_VARIANTS " !~ " cpu "'
     #   when: never
-    - if: '($SUBVARIANT == "cuda12") && " $TEST_VARIANTS " !~ " cuda12 "'
+    - if: '($SUBVARIANT == "cuda12") || ($SUBPACKAGE == "storage" && $VARIANT == "cuda12") && (" $TEST_VARIANTS " !~ " cuda12 ")'
       when: never
     # - if: '(($SUBVARIANT == "rocm_6" || ($SUBPACKAGE == "storage" && $VARIANT == "rocm_6")) && " $TEST_VARIANTS " !~ " rocm_6 "'
     #   when: never

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -132,8 +132,8 @@ test_cscs_gh200:
     # Limit test parallelism to avoid "OSError: too many open files" in the gt4py build stage.
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
   rules:
-    - if: $SUBVARIANT == 'rocm6_0'
-      when: never
+    - if: $SUBVARIANT == 'cuda12'
+    - when: on_success
 
 test_cscs_amd_rocm:
   extends:
@@ -147,7 +147,6 @@ test_cscs_amd_rocm:
     PYTEST_XDIST_AUTO_NUM_WORKERS: 32
     SLURM_PARTITION: mi300
     CMAKE_PREFIX_PATH: /opt/rocm # for next
-    CXX: /opt/rocm/bin/hipcc
     CUDA_HOME: /opt/rocm # for cartesian
     SLURM_TIMELIMIT: 20 # relaxed relative to santis as there is no pressure on the queue
   rules:

--- a/noxfile.py
+++ b/noxfile.py
@@ -139,7 +139,7 @@ def install_session_venv(
 
 # -- Sessions --
 @nox.session(python=PYTHON_VERSIONS, tags=["cartesian"])
-@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12])
+@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12, DeviceNoxParam.rocm6_0])
 @nox.parametrize("codegen", [CodeGenNoxParam.internal, CodeGenNoxParam.dace])
 def test_cartesian(
     session: nox.Session,
@@ -221,7 +221,7 @@ def test_examples(session: nox.Session) -> None:
         nox.param("atlas", id="atlas", tags=["atlas"]),
     ],
 )
-@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12])
+@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12, DeviceNoxParam.rocm6_0])
 @nox.parametrize("codegen", [CodeGenNoxParam.internal, CodeGenNoxParam.dace])
 def test_next(
     session: nox.Session,
@@ -288,7 +288,7 @@ def test_package(session: nox.Session) -> None:
 
 
 @nox.session(python=PYTHON_VERSIONS, tags=["cartesian", "next"])
-@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12])
+@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12, DeviceNoxParam.rocm6_0])
 def test_storage(
     session: nox.Session,
     device: DeviceOption,

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,7 +68,7 @@ PYTHON_VERSIONS: Final[list[str]] = [
 ]
 
 # -- Parameter sets --
-DeviceOption: TypeAlias = Literal["cpu", "cuda11", "cuda12", "rocm4_3", "rocm5_0", "rocm6_0"]
+DeviceOption: TypeAlias = Literal["cpu", "cuda12", "rocm6_0"]
 DeviceNoxParam: Final = types.SimpleNamespace(
     **{device: nox.param(device, id=device, tags=[device]) for device in DeviceOption.__args__}
 )
@@ -139,7 +139,7 @@ def install_session_venv(
 
 # -- Sessions --
 @nox.session(python=PYTHON_VERSIONS, tags=["cartesian"])
-@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12, DeviceNoxParam.rocm6_0])
+@nox.parametrize("device", list(DeviceNoxParam.__dict__.values()))
 @nox.parametrize("codegen", [CodeGenNoxParam.internal, CodeGenNoxParam.dace])
 def test_cartesian(
     session: nox.Session,
@@ -221,7 +221,7 @@ def test_examples(session: nox.Session) -> None:
         nox.param("atlas", id="atlas", tags=["atlas"]),
     ],
 )
-@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12, DeviceNoxParam.rocm6_0])
+@nox.parametrize("device", list(DeviceNoxParam.__dict__.values()))
 @nox.parametrize("codegen", [CodeGenNoxParam.internal, CodeGenNoxParam.dace])
 def test_next(
     session: nox.Session,
@@ -288,7 +288,7 @@ def test_package(session: nox.Session) -> None:
 
 
 @nox.session(python=PYTHON_VERSIONS, tags=["cartesian", "next"])
-@nox.parametrize("device", [DeviceNoxParam.cpu, DeviceNoxParam.cuda12, DeviceNoxParam.rocm6_0])
+@nox.parametrize("device", list(DeviceNoxParam.__dict__.values()))
 def test_storage(
     session: nox.Session,
     device: DeviceOption,

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -64,7 +64,9 @@ def get_gt_pyext_build_opts(
     is_rocm_gpu = core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM
 
     if uses_cuda:
-        if not is_rocm_gpu:
+        if is_rocm_gpu:
+            cuda_arch = gt_config.build_settings["cuda_arch"]
+        else:
             compute_capability = get_cuda_compute_capability()
             cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
             if not cuda_arch:
@@ -75,8 +77,6 @@ def get_gt_pyext_build_opts(
                 raise RuntimeError(
                     f"CUDA architecture {cuda_arch} exceeds compute capability {compute_capability}"
                 )
-        else:
-            cuda_arch = gt_config.build_settings["cuda_arch"]
     else:
         cuda_arch = ""
 
@@ -105,11 +105,8 @@ def get_gt_pyext_build_opts(
             "-isystem{}".format(gt_include_path),
             "-fvisibility=hidden",
             "-fPIC",
+            *([f"--offload-arch={cuda_arch}"] if cuda_arch else []),
         ]
-        if cuda_arch:
-            extra_compile_args["cuda"] += [
-                f"--offload-arch={cuda_arch}",
-            ]
     else:
         extra_compile_args["cuda"] += [
             "-isystem={}".format(gt_include_path),

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -64,17 +64,19 @@ def get_gt_pyext_build_opts(
     is_rocm_gpu = core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM
 
     if uses_cuda:
-        compute_capability = get_cuda_compute_capability()
-        cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
-        if not cuda_arch:
-            raise RuntimeError("CUDA architecture could not be determined")
         if not is_rocm_gpu:
+            compute_capability = get_cuda_compute_capability()
+            cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
+            if not cuda_arch:
+                raise RuntimeError("CUDA architecture could not be determined")
             if cuda_arch.startswith("sm_"):
                 cuda_arch = cuda_arch.replace("sm_", "")
             if compute_capability and int(compute_capability) < int(cuda_arch):
                 raise RuntimeError(
                     f"CUDA architecture {cuda_arch} exceeds compute capability {compute_capability}"
                 )
+        else:
+            cuda_arch = gt_config.build_settings["cuda_arch"]
     else:
         cuda_arch = ""
 

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -68,12 +68,13 @@ def get_gt_pyext_build_opts(
         cuda_arch = gt_config.build_settings["cuda_arch"] or compute_capability
         if not cuda_arch:
             raise RuntimeError("CUDA architecture could not be determined")
-        if cuda_arch.startswith("sm_"):
-            cuda_arch = cuda_arch.replace("sm_", "")
-        if compute_capability and int(compute_capability) < int(cuda_arch):
-            raise RuntimeError(
-                f"CUDA architecture {cuda_arch} exceeds compute capability {compute_capability}"
-            )
+        if not is_rocm_gpu:
+            if cuda_arch.startswith("sm_"):
+                cuda_arch = cuda_arch.replace("sm_", "")
+            if compute_capability and int(compute_capability) < int(cuda_arch):
+                raise RuntimeError(
+                    f"CUDA architecture {cuda_arch} exceeds compute capability {compute_capability}"
+                )
     else:
         cuda_arch = ""
 
@@ -103,6 +104,10 @@ def get_gt_pyext_build_opts(
             "-fvisibility=hidden",
             "-fPIC",
         ]
+        if cuda_arch:
+            extra_compile_args["cuda"] += [
+                f"--offload-arch={cuda_arch}",
+            ]
     else:
         extra_compile_args["cuda"] += [
             "-isystem={}".format(gt_include_path),

--- a/src/gt4py/next/otf/compilation/build_systems/cmake.py
+++ b/src/gt4py/next/otf/compilation/build_systems/cmake.py
@@ -35,7 +35,7 @@ def get_device_arch() -> str | None:
         # TODO(egparedes): Implement this properly, either parsing the output of `$ rocminfo`
         # or using the HIP low level bindings.
         # Check: https://rocm.docs.amd.com/projects/hip-python/en/latest/user_guide/1_usage.html
-        return "gfx90a"
+        return "gfx942"  # MI300A
 
     return None
 

--- a/src/gt4py/next/otf/compilation/build_systems/cmake.py
+++ b/src/gt4py/next/otf/compilation/build_systems/cmake.py
@@ -201,11 +201,16 @@ class CMakeProject(
 
     def _run_build(self) -> None:
         logfile = self.root_path / "log_build.txt"
-        with logfile.open(mode="w") as log_file_pointer:
-            subprocess.check_call(
-                ["cmake", "--build", self.root_path / "build"],
-                stdout=log_file_pointer,
-                stderr=log_file_pointer,
-            )
+        try:
+            with logfile.open(mode="w") as log_file_pointer:
+                subprocess.check_call(
+                    ["cmake", "--build", self.root_path / "build"],
+                    stdout=log_file_pointer,
+                    stderr=log_file_pointer,
+                )
+        except subprocess.CalledProcessError as e:
+            with logfile.open(mode="r") as log_file_pointer:
+                log = log_file_pointer.read()
+            raise errors.CompilationError(log) from e
 
         build_data.update_status(new_status=build_data.BuildStatus.COMPILED, path=self.root_path)

--- a/src/gt4py/next/otf/compilation/build_systems/cmake.py
+++ b/src/gt4py/next/otf/compilation/build_systems/cmake.py
@@ -15,7 +15,7 @@ import subprocess
 import warnings
 
 from gt4py._core import definitions as core_defs
-from gt4py.next import config
+from gt4py.next import config, errors
 from gt4py.next.otf import languages, stages
 from gt4py.next.otf.compilation import build_data, cache, common, compiler
 from gt4py.next.otf.compilation.build_systems import cmake_lists
@@ -185,12 +185,17 @@ class CMakeProject(
 
     def _run_config(self) -> None:
         logfile = self.root_path / "log_config.txt"
-        with logfile.open(mode="w") as log_file_pointer:
-            subprocess.check_call(
-                self._config_command,
-                stdout=log_file_pointer,
-                stderr=log_file_pointer,
-            )
+        try:
+            with logfile.open(mode="w") as log_file_pointer:
+                subprocess.check_call(
+                    self._config_command,
+                    stdout=log_file_pointer,
+                    stderr=log_file_pointer,
+                )
+        except subprocess.CalledProcessError as e:
+            with logfile.open(mode="r") as log_file_pointer:
+                log = log_file_pointer.read()
+            raise errors.CompilationError(log) from e
 
         build_data.update_status(new_status=build_data.BuildStatus.CONFIGURED, path=self.root_path)
 

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -13,6 +13,7 @@ from gt4py.cartesian import gtscript
 
 from cartesian_tests.definitions import ALL_BACKENDS, PERFORMANCE_BACKENDS, get_array_library
 from cartesian_tests.integration_tests.multi_feature_tests.stencil_definitions import copy_stencil
+from cartesian_tests import utils as test_utils
 
 
 try:
@@ -24,6 +25,11 @@ except ImportError:
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_numpy_allocators(backend, order):
+    if backend in ["gt:gpu", "dace:gpu"] and test_utils.is_rocm_cupy():
+        pytest.skip(
+            f"This test would need GT4Py's custom `__hip_array_interface__` on the cupy array. Using dlpack (via nanobind) would make this test work for ROCm."
+        )
+
     xp = get_array_library(backend)
     shape = (20, 10, 5)
     inp = xp.array(xp.random.randn(*shape), order=order, dtype=xp.float64)
@@ -37,6 +43,11 @@ def test_numpy_allocators(backend, order):
 
 @pytest.mark.parametrize("backend", PERFORMANCE_BACKENDS)
 def test_bad_layout_warns(backend):
+    if backend in ["gt:gpu", "dace:gpu"] and test_utils.is_rocm_cupy():
+        pytest.skip(
+            f"This test would need GT4Py's custom `__hip_array_interface__` on the cupy array. Using dlpack (via nanobind) would make this test work for ROCm."
+        )
+
     xp = get_array_library(backend)
     backend_cls = gt4pyc.backend.from_name(backend)
 

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -29,7 +29,7 @@ def is_rocm_cupy():
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_numpy_allocators(backend, order):
-    if backend in ["gt:gpu", "dace:gpu"] and test_utils.is_rocm_cupy():
+    if backend in ["gt:gpu", "dace:gpu"] and is_rocm_cupy():
         pytest.skip(
             f"This test would need GT4Py's custom `__hip_array_interface__` on the cupy array. Using dlpack (via nanobind) would make this test work for ROCm."
         )
@@ -47,7 +47,7 @@ def test_numpy_allocators(backend, order):
 
 @pytest.mark.parametrize("backend", PERFORMANCE_BACKENDS)
 def test_bad_layout_warns(backend):
-    if backend in ["gt:gpu", "dace:gpu"] and test_utils.is_rocm_cupy():
+    if backend in ["gt:gpu", "dace:gpu"] and is_rocm_cupy():
         pytest.skip(
             f"This test would need GT4Py's custom `__hip_array_interface__` on the cupy array. Using dlpack (via nanobind) would make this test work for ROCm."
         )

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -10,6 +10,7 @@ import pytest
 
 from gt4py import cartesian as gt4pyc, storage as gt_storage
 from gt4py.cartesian import gtscript
+from gt4py._core import definitions as core_defs
 
 from cartesian_tests.definitions import ALL_BACKENDS, PERFORMANCE_BACKENDS, get_array_library
 from cartesian_tests.integration_tests.multi_feature_tests.stencil_definitions import copy_stencil
@@ -20,6 +21,10 @@ try:
     import cupy as cp
 except ImportError:
     cp = None
+
+
+def is_rocm_cupy():
+    return core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM and core_defs.cp is not None
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -14,7 +14,6 @@ from gt4py._core import definitions as core_defs
 
 from cartesian_tests.definitions import ALL_BACKENDS, PERFORMANCE_BACKENDS, get_array_library
 from cartesian_tests.integration_tests.multi_feature_tests.stencil_definitions import copy_stencil
-from cartesian_tests import utils as test_utils
 
 
 try:

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -863,11 +863,12 @@ def test_k_offset_field_stencil(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_k_only_access_stencil(backend):
-    field_in = gt_storage.ones(dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,))
+    field_in = gt_storage.from_array(
+        [2, 3, 4, 5], dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,)
+    )
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
-    field_in[:] = np.array([2, 3, 4, 5])
 
     @gtscript.stencil(backend=backend)
     def test_stencil(
@@ -888,11 +889,12 @@ def test_k_only_access_stencil(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_table_access_stencil(backend):
-    table_view = gt_storage.ones(dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,))
+    table_view = gt_storage.from_array(
+        [2, 3, 4, 5], dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,)
+    )
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
-    table_view[:] = np.array([2, 3, 4, 5])
 
     @gtscript.stencil(backend=backend)
     def test_stencil(

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -867,7 +867,7 @@ def test_k_only_access_stencil(backend):
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
-    field_in[:] = [2, 3, 4, 5]
+    field_in[:] = np.array([2, 3, 4, 5])
 
     @gtscript.stencil(backend=backend)
     def test_stencil(
@@ -892,7 +892,7 @@ def test_table_access_stencil(backend):
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
-    table_view[:] = [2, 3, 4, 5]
+    table_view[:] = np.array([2, 3, 4, 5])
 
     @gtscript.stencil(backend=backend)
     def test_stencil(

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -864,7 +864,7 @@ def test_k_offset_field_stencil(backend):
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_k_only_access_stencil(backend):
     field_in = gt_storage.from_array(
-        [2, 3, 4, 5], dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,)
+        [2, 3, 4, 5], dtype=np.float64, backend=backend, aligned_index=(0,)
     )
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
@@ -890,7 +890,7 @@ def test_k_only_access_stencil(backend):
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_table_access_stencil(backend):
     table_view = gt_storage.from_array(
-        [2, 3, 4, 5], dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,)
+        [2, 3, 4, 5], dtype=np.float64, backend=backend, aligned_index=(0,)
     )
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -863,7 +863,7 @@ def test_k_offset_field_stencil(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_k_only_access_stencil(backend):
-    field_in = np.ones((4,), dtype=np.float64)
+    field_in = gt_storage.ones(dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,))
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -888,7 +888,7 @@ def test_k_only_access_stencil(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_table_access_stencil(backend):
-    table_view = np.ones((4,), dtype=np.float64)
+    table_view = gt_storage.ones(dtype=np.float64, backend=backend, shape=(4,), aligned_index=(0,))
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -864,7 +864,7 @@ def test_k_offset_field_stencil(backend):
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_k_only_access_stencil(backend):
     field_in = gt_storage.from_array(
-        [2, 3, 4, 5], dtype=np.float64, backend=backend, aligned_index=(0,)
+        np.array([2, 3, 4, 5]), dtype=np.float64, backend=backend, aligned_index=(0,)
     )
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
@@ -890,7 +890,7 @@ def test_k_only_access_stencil(backend):
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_table_access_stencil(backend):
     table_view = gt_storage.from_array(
-        [2, 3, 4, 5], dtype=np.float64, backend=backend, aligned_index=(0,)
+        np.array([2, 3, 4, 5]), dtype=np.float64, backend=backend, aligned_index=(0,)
     )
     field_out = gt_storage.zeros(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)

--- a/tests/cartesian_tests/utils.py
+++ b/tests/cartesian_tests/utils.py
@@ -6,6 +6,8 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from gt4py._core import definitions as core_defs
+
 try:
     import dace
 except ImportError:
@@ -43,3 +45,7 @@ class OriginWrapper(ArrayWrapper):
         res = super().__descriptor__()
         res.__gt_origin__ = self.__gt_origin__
         return res
+
+
+def is_rocm_cupy():
+    return core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM and core_defs.cp is not None

--- a/tests/cartesian_tests/utils.py
+++ b/tests/cartesian_tests/utils.py
@@ -6,7 +6,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-
 try:
     import dace
 except ImportError:

--- a/tests/cartesian_tests/utils.py
+++ b/tests/cartesian_tests/utils.py
@@ -6,7 +6,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from gt4py._core import definitions as core_defs
 
 try:
     import dace
@@ -45,7 +44,3 @@ class OriginWrapper(ArrayWrapper):
         res = super().__descriptor__()
         res.__gt_origin__ = self.__gt_origin__
         return res
-
-
-def is_rocm_cupy():
-    return core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM and core_defs.cp is not None


### PR DESCRIPTION
Additional changes:
- Noxfile parametrizations have been refactored
- Cartesian:
  - `CUDA_ARCH` environment flag can be used for the AMD gpu architecture as well
  - fixes field allocation in some tests
  - skip tests that are testing np/cp arrays as fields (as they don't have the custom `__hip_array_interface__`)
- Next: hard-codes `gfx942` (MI300A instead of MI250X), will be generalized in a next PR

DaCe tests are skipped for now on AMD.