### PR TITLE
fix[cartesian]: gtscript ValueInliner np.bool_ support

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -296,6 +296,8 @@ class ValueInliner(ast.NodeTransformer):
                 value, (bool, numbers.Number, gtscript.AxisIndex, gtscript.Axis)
             ):
                 new_node = ast.Constant(value=value)
+            elif isinstance(value, np.bool_):
+                new_node = ast.Constant(value=bool(value))
             elif hasattr(value, "_gtscript_"):
                 pass
             else:

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -223,6 +223,25 @@ class TestInlinedExternals:
                 module=self.__class__.__name__,
             )
 
+    def test_np_bool_external(self):
+        def stencil(input_field: gtscript.Field[float], output_field: gtscript.Field[float]):
+            from __externals__ import flag
+
+            with computation(PARALLEL), interval(...):
+                add_me = 1 if flag else 5
+                output_field = input_field + add_me
+
+        def_ir = parse_definition(
+            stencil,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            externals={
+                "flag": np.bool_(True),
+            },
+        )
+
+        assert set(def_ir.externals.keys()) == {"flag"}
+
 
 class TestFunction:
     def test_error_invalid(self):


### PR DESCRIPTION
## Description

`ValueInliner` in `gtscript` was missing support for `np.bool_` types. Stencils with externals of type `np.bool_` would end up with an error saying "Failed to inline {external}.", see [upstream issue](https://github.com/NOAA-GFDL/NDSL/issues/203).  Since `np.bool_` is part of gtscript's `_VALID_DATA_TYPES`, we should support externals of type `np.bool_`.

This PR adds support as well as a test to cover regressions in the future.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
