### PR TITLE
test[next][dace]: fix test expectation

### DIFF
--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -2151,11 +2151,11 @@ def test_gtir_index():
     sdfg = build_dace_sdfg(testee, CARTESIAN_OFFSETS)
 
     ref = np.concatenate(
-        (v[:MARGIN], np.arange(MARGIN, N - MARGIN, dtype=np.int32), v[N - MARGIN :])
+        (v[:MARGIN], np.arange(MARGIN, N - MARGIN, dtype=np.int32) * 2 + 1, v[N - MARGIN :])
     )
 
     sdfg(v, **FSYMBOLS)
-    np.allclose(v, ref)
+    assert np.all(v == ref)
 
 
 def test_gtir_concat_where():


### PR DESCRIPTION
Issue found in #2217. One test expectation was wrong, but the test was still passing because the assert was also wrong.

Co-authored by @philip-paul-mueller 