### PR TITLE
fix[next][dace]: follow new canonical field domain order

### DIFF
--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -15,7 +15,7 @@ import enum
 import functools
 import math
 import types
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 import numpy as np
 
@@ -1149,17 +1149,17 @@ class GridType(StrEnum):
     UNSTRUCTURED = "unstructured"
 
 
-def _ordered_dims(dims: list[Dimension] | set[Dimension]) -> list[Dimension]:
+def order_dimensions(dims: Iterable[Dimension]) -> list[Dimension]:
+    """Find the canonical ordering of the dimensions in `dims`."""
+    if sum(1 for dim in dims if dim.kind == DimensionKind.LOCAL) > 1:
+        raise ValueError("There are more than one dimension with DimensionKind 'LOCAL'.")
     return sorted(dims, key=lambda dim: (_DIM_KIND_ORDER[dim.kind], dim.value))
 
 
-def check_dims(dims: list[Dimension]) -> None:
-    if sum(1 for dim in dims if dim.kind == DimensionKind.LOCAL) > 1:
-        raise ValueError("There are more than one dimension with DimensionKind 'LOCAL'.")
-
-    if dims != _ordered_dims(dims):
+def check_dims(dims: Sequence[Dimension]) -> None:
+    if dims != order_dimensions(dims):
         raise ValueError(
-            f"Dimensions '{', '.join(map(str, dims))}' are not ordered correctly, expected '{', '.join(map(str, _ordered_dims(dims)))}'."
+            f"Dimensions '{', '.join(map(str, dims))}' are not ordered correctly, expected '{', '.join(map(str, order_dimensions(dims)))}'."
         )
 
 
@@ -1196,7 +1196,7 @@ def promote_dims(*dims_list: Sequence[Dimension]) -> list[Dimension]:
         check_dims(list(dims))
     unique_dims = {dim for dims in dims_list for dim in dims}
 
-    promoted_dims = _ordered_dims(unique_dims)
+    promoted_dims = order_dimensions(unique_dims)
     check_dims(promoted_dims)
     return promoted_dims
 

--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -268,12 +268,7 @@ class DataflowOutputEdge:
         map_exit: Optional[dace.nodes.MapExit],
         dest: dace.nodes.AccessNode,
         dest_subset: dace_subsets.Range,
-    ) -> bool:
-        """Create the connection.
-
-        Might remove the last data container. Returns `True` is it was removed,
-        `False` if kept.
-        """
+    ) -> None:
         write_edge = self.state.in_edges(self.result.dc_node)[0]
         write_size = (
             dace.symbolic.SymExpr(1)  # subset `None` not expected, but it can appear for scalars
@@ -331,8 +326,6 @@ class DataflowOutputEdge:
                 src_conn=src_node_connector,
                 memlet=dace.Memlet(data=dest.data, subset=dest_subset, other_subset=src_subset),
             )
-
-        return remove_last_node
 
 
 DACE_REDUCTION_MAPPING: dict[str, dace.dtypes.ReductionType] = {

--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -42,10 +42,13 @@ from gt4py.next.program_processors.runners.dace import (
 from gt4py.next.type_system import type_info as ti, type_specifications as ts
 
 
-# Magic local dimension for the result of a `make_const_list`.
-# A clean implementation will probably involve to tag the `make_const_list`
-# with the neighborhood it is meant to be used with.
-_CONST_DIM = gtx_common.Dimension(value="_CONST_DIM", kind=gtx_common.DimensionKind.LOCAL)
+# Magic local dimension used for list of values with length known at compile-time.
+_CONST_DIM: Final = gtx_common.Dimension(value="_CONST_DIM", kind=gtx_common.DimensionKind.LOCAL)
+
+# Data type of the index values in connectivity tables.
+_INDEX_DTYPE: Final = ts.ScalarType(
+    kind=getattr(ts.ScalarKind, gtir_builtins.INTEGER_INDEX_BUILTIN.upper())
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -67,21 +70,36 @@ class ValueExpr:
     dc_node: dace.nodes.AccessNode
     gt_dtype: ts.ListType | ts.ScalarType
 
+    def __post_init__(self) -> None:
+        if isinstance(self.gt_dtype, ts.ListType):
+            assert self.gt_dtype.offset_type is not None
+            assert self.gt_dtype.offset_type.kind == gtx_common.DimensionKind.LOCAL
+
 
 @dataclasses.dataclass(frozen=True)
 class MemletExpr:
     """
-    Scalar or array data access through a memlet.
+    Memlet to retrieve local data, either a scalar or a list, from a field.
 
     Args:
-        dc_node: Access node to the data container, can be either a scalar or a local list.
-        gt_dtype: GT4Py data type, which includes the `offset_type` local dimension for lists.
-        subset: Represents the subset to use in memlet to access the above data.
+        dc_node: Access node to the array data container of the source field.
+        gt_field: GT4Py field type definition, which includes the list of dimensions
+          according to the canonical field layout, used to modify the memlet subset.
+        subset: The memlet subset to retrieve the local data.
     """
 
     dc_node: dace.nodes.AccessNode
-    gt_dtype: ts.ListType | ts.ScalarType
+    gt_field: ts.FieldType
     subset: dace_subsets.Range
+
+    @property
+    def gt_dtype(self) -> ts.ScalarType | ts.ListType:
+        return self.gt_field.dtype
+
+    def __post_init__(self) -> None:
+        if isinstance(self.gt_dtype, ts.ListType):
+            assert self.gt_dtype.offset_type is not None
+            assert self.gt_dtype.offset_type.kind == gtx_common.DimensionKind.LOCAL
 
 
 @dataclasses.dataclass(frozen=True)
@@ -117,8 +135,15 @@ class IteratorExpr:
     field_domain: list[tuple[gtx_common.Dimension, dace.symbolic.SymbolicType]]
     indices: dict[gtx_common.Dimension, DataExpr]
 
+    def __post_init__(self) -> None:
+        gtx_common.check_dims([dim for dim, _ in self.field_domain])
+        if isinstance(self.gt_dtype, ts.ListType):
+            assert self.gt_dtype.offset_type is not None
+            assert self.gt_dtype.offset_type.kind == gtx_common.DimensionKind.LOCAL
+            assert all(dim != self.gt_dtype.offset_type for dim, _ in self.field_domain)
+
     def get_field_type(self) -> ts.FieldType:
-        return ts.FieldType([dim for dim, _ in self.field_domain], self.gt_dtype)
+        return ts.FieldType(dims=[dim for dim, _ in self.field_domain], dtype=self.gt_dtype)
 
     def get_memlet_subset(self, sdfg: dace.SDFG) -> dace_subsets.Range:
         if len(self.field_domain) == 0:  # zero-dimensional field
@@ -130,8 +155,17 @@ class IteratorExpr:
         field_desc = self.field.desc(sdfg)
         if isinstance(self.gt_dtype, ts.ListType):
             assert len(field_desc.shape) == len(self.field_domain) + 1
-            assert self.gt_dtype.offset_type is not None
-            field_domain = [*self.field_domain, (self.gt_dtype.offset_type, 0)]
+            local_dim: gtx_common.Dimension = self.gt_dtype.offset_type  # type: ignore[assignment]  # checked in __post_init__
+            # construct the full subset according to the canonical field domain
+            sorted_dims = gtx_common.order_dimensions(
+                [dim for dim, _ in self.field_domain] + [local_dim]
+            )
+            local_dim_index = sorted_dims.index(local_dim)
+            field_domain = [
+                *self.field_domain[:local_dim_index],
+                (local_dim, 0),
+                *self.field_domain[local_dim_index:],
+            ]
         else:
             assert len(field_desc.shape) == len(self.field_domain)
             field_domain = self.field_domain
@@ -234,7 +268,12 @@ class DataflowOutputEdge:
         map_exit: Optional[dace.nodes.MapExit],
         dest: dace.nodes.AccessNode,
         dest_subset: dace_subsets.Range,
-    ) -> None:
+    ) -> bool:
+        """Create the connection.
+
+        Might remove the last data container. Returns `True` is it was removed,
+        `False` if kept.
+        """
         write_edge = self.state.in_edges(self.result.dc_node)[0]
         write_size = (
             dace.symbolic.SymExpr(1)  # subset `None` not expected, but it can appear for scalars
@@ -292,6 +331,8 @@ class DataflowOutputEdge:
                 src_conn=src_node_connector,
                 memlet=dace.Memlet(data=dest.data, subset=dest_subset, other_subset=src_subset),
             )
+
+        return remove_last_node
 
 
 DACE_REDUCTION_MAPPING: dict[str, dace.dtypes.ReductionType] = {
@@ -481,7 +522,7 @@ class LambdaToDataflow(eve.NodeVisitor):
             local_view_node = self.state.add_access(view)
             self._add_input_data_edge(field.dc_node, field.subset, local_view_node)
 
-            return ValueExpr(local_view_node, desc.dtype)
+            return ValueExpr(local_view_node, field.gt_dtype)
 
         else:
             return field
@@ -552,7 +593,11 @@ class LambdaToDataflow(eve.NodeVisitor):
             # deref a zero-dimensional field
             assert len(arg_expr.field_domain) == 0
             assert isinstance(node.type, ts.ScalarType)
-            return MemletExpr(arg_expr.field, arg_expr.gt_dtype, subset="0")
+            return MemletExpr(
+                dc_node=arg_expr.field,
+                gt_field=ts.FieldType(dims=[], dtype=arg_expr.gt_dtype),
+                subset="0",
+            )
 
         # handle default case below: deref a field with one or more dimensions
 
@@ -561,7 +606,7 @@ class LambdaToDataflow(eve.NodeVisitor):
         if all(isinstance(index, SymbolExpr) for index in arg_expr.indices.values()):
             # when all indices are symbolic expressions, we can perform direct field access through a memlet
             field_subset = arg_expr.get_memlet_subset(self.sdfg)
-            return MemletExpr(arg_expr.field, arg_expr.gt_dtype, field_subset)
+            return MemletExpr(arg_expr.field, arg_expr.get_field_type(), field_subset)
 
         # when any of the indices is a runtime value (either a dynamic cartesian
         # offset or a connectivity offset), the deref is lowered to a tasklet
@@ -653,12 +698,12 @@ class LambdaToDataflow(eve.NodeVisitor):
                 # structures more explicit and thus makes it easier for MapFusion
                 # to correctly infer the data dependencies.
                 memlet_subset = arg.get_memlet_subset(self.sdfg)
-                arg_expr = MemletExpr(arg.field, arg.gt_dtype, memlet_subset)
+                arg_expr = MemletExpr(arg.field, arg.get_field_type(), memlet_subset)
             else:
                 # In order to shift the iterator inside the branch dataflow,
                 # we have to pass the full array shape.
                 arg_expr = MemletExpr(
-                    arg.field, arg.gt_dtype, dace_subsets.Range.from_array(arg_desc)
+                    arg.field, arg.get_field_type(), dace_subsets.Range.from_array(arg_desc)
                 )
                 use_full_shape = True
         else:
@@ -676,7 +721,9 @@ class LambdaToDataflow(eve.NodeVisitor):
                 arg.gt_dtype.offset_type.value
             )
             assert isinstance(offset_provider_type, gtx_common.NeighborConnectivityType)
-            inner_desc = dace.data.Array(arg_desc.dtype, [offset_provider_type.max_neighbors])
+            inner_desc = dace.data.Array(
+                dtype=arg_desc.dtype, shape=[offset_provider_type.max_neighbors]
+            )
 
         if param_name in if_sdfg.arrays:
             # the data desciptor was added by the visitor of the other branch expression
@@ -989,7 +1036,7 @@ class LambdaToDataflow(eve.NodeVisitor):
         field_slice = self._construct_local_view(
             MemletExpr(
                 dc_node=it.field,
-                gt_dtype=node.type,
+                gt_field=it.get_field_type(),
                 subset=dace_subsets.Range.from_string(
                     ",".join(
                         str(it.indices[dim].value - offset)  # type: ignore[union-attr]
@@ -1002,10 +1049,16 @@ class LambdaToDataflow(eve.NodeVisitor):
                 ),
             )
         )
+        # The layout of connectivity tables is known.
+        assert len(offset_provider.domain) == 2
+        assert offset_provider.domain[1].kind == gtx_common.DimensionKind.LOCAL
         connectivity_slice = self._construct_local_view(
             MemletExpr(
                 dc_node=self.state.add_access(connectivity),
-                gt_dtype=node.type,
+                gt_field=ts.FieldType(
+                    dims=[offset_provider.domain[0]],
+                    dtype=ts.ListType(element_type=_INDEX_DTYPE, offset_type=_CONST_DIM),
+                ),
                 subset=dace_subsets.Range.from_string(
                     f"{origin_index.value}, 0:{offset_provider.max_neighbors}"
                 ),
@@ -1020,10 +1073,11 @@ class LambdaToDataflow(eve.NodeVisitor):
         neighbor_idx = gtir_to_sdfg_utils.get_map_variable(offset_type)
 
         index_connector = "__index"
+        field_connector = "__field"
         output_connector = "__val"
-        tasklet_expression = f"{output_connector} = __field[{index_connector}]"
+        tasklet_expression = f"{output_connector} = {field_connector}[{index_connector}]"
         input_memlets = {
-            "__field": self.sdfg.make_array_memlet(field_slice.dc_node.data),
+            field_connector: self.sdfg.make_array_memlet(field_slice.dc_node.data),
             index_connector: dace.Memlet(data=connectivity_slice.dc_node.data, subset=neighbor_idx),
         }
         input_nodes = {
@@ -1063,19 +1117,22 @@ class LambdaToDataflow(eve.NodeVisitor):
         assert len(node.args) == 2
         index_arg = self.visit(node.args[0])
         src_arg = self.visit(node.args[1])
-        assert isinstance(src_arg, MemletExpr | ValueExpr)
+        assert isinstance(src_arg.gt_dtype, ts.ListType)
 
         src_desc = src_arg.dc_node.desc(self.sdfg)
         if isinstance(src_arg, MemletExpr):
             assert len(src_desc.shape) == len(src_arg.subset)
             src_subset = src_arg.subset
+            local_dim = src_arg.gt_dtype.offset_type
+            full_dims = gtx_common.order_dimensions([*src_arg.gt_field.dims, local_dim])  # type: ignore[list-item]  # checked in MemletExpr.__post_init__
+            local_dim_index = full_dims.index(local_dim)  # type: ignore[arg-type]  # checked in MemletExpr.__post_init__
         elif isinstance(src_arg, ValueExpr):
             assert len(src_desc.shape) == 1
             src_subset = dace_subsets.Range.from_array(src_desc)
+            local_dim_index = 0
         else:
             raise ValueError(f"Unexpected argument type {type(src_arg)} in 'list_get' expression.")
 
-        assert isinstance(src_arg.gt_dtype, ts.ListType)
         assert isinstance(src_arg.gt_dtype.element_type, ts.ScalarType)
         assert src_desc.dtype == gtx_dace_utils.as_dace_type(src_arg.gt_dtype.element_type)
         dst, _ = self.subgraph_builder.add_temp_scalar(self.sdfg, src_desc.dtype)
@@ -1083,8 +1140,10 @@ class LambdaToDataflow(eve.NodeVisitor):
 
         if isinstance(index_arg, SymbolExpr):
             assert index_arg.dc_dtype in dace.dtypes.INTEGER_TYPES
-            src_subset = dace_subsets.Range(src_subset[:-1]) + dace_subsets.Range.from_string(
-                index_arg.value
+            src_subset = (
+                dace_subsets.Range(src_subset[:local_dim_index])
+                + dace_subsets.Range.from_string(index_arg.value)
+                + dace_subsets.Range(src_subset[local_dim_index + 1 :])
             )
             if isinstance(src_arg, MemletExpr):
                 self._add_input_data_edge(src_arg.dc_node, src_subset, dst_node)
@@ -1223,11 +1282,15 @@ class LambdaToDataflow(eve.NodeVisitor):
 
             origin_map_index = gtir_to_sdfg_utils.get_map_variable(offset_provider_type.source_dim)
 
+            # The layout of connectivity tables is known.
+            assert len(offset_provider_type.domain) == 2
+            assert offset_provider_type.domain[1].kind == gtx_common.DimensionKind.LOCAL
             connectivity_slice = self._construct_local_view(
                 MemletExpr(
                     dc_node=self.state.add_access(connectivity),
-                    gt_dtype=ts.ListType(
-                        element_type=node.type.element_type, offset_type=offset_type
+                    gt_field=ts.FieldType(
+                        dims=[offset_provider_type.domain[0]],
+                        dtype=ts.ListType(element_type=_INDEX_DTYPE, offset_type=_CONST_DIM),
                     ),
                     subset=dace_subsets.Range.from_string(
                         f"{origin_map_index}, 0:{offset_provider_type.max_neighbors}"
@@ -1377,6 +1440,9 @@ class LambdaToDataflow(eve.NodeVisitor):
                 "values",
                 self.sdfg.make_array_memlet(input_expr.dc_node.data),
             )
+        # The layout of connectivity tables is known.
+        assert len(offset_provider_type.domain) == 2
+        assert offset_provider_type.domain[1].kind == gtx_common.DimensionKind.LOCAL
         self._add_input_data_edge(
             connectivity_node,
             dace_subsets.Range.from_string(
@@ -1595,7 +1661,10 @@ class LambdaToDataflow(eve.NodeVisitor):
             # use memlet to retrieve the neighbor index
             shifted_indices[neighbor_dim] = MemletExpr(
                 dc_node=offset_table_node,
-                gt_dtype=it.gt_dtype,
+                gt_field=ts.FieldType(
+                    dims=[origin_dim],
+                    dtype=ts.ListType(element_type=_INDEX_DTYPE, offset_type=_CONST_DIM),
+                ),
                 subset=dace_subsets.Range.from_string(f"{origin_index.value}, {offset_expr.value}"),
             )
         else:
@@ -1607,11 +1676,6 @@ class LambdaToDataflow(eve.NodeVisitor):
         return IteratorExpr(it.field, it.gt_dtype, it.field_domain, shifted_indices)
 
     def _visit_shift(self, node: gtir.FunCall) -> IteratorExpr:
-        # convert builtin-index type to dace type
-        IndexDType: Final = gtx_dace_utils.as_dace_type(
-            ts.ScalarType(kind=getattr(ts.ScalarKind, gtir_builtins.INTEGER_INDEX_BUILTIN.upper()))
-        )
-
         assert isinstance(node.fun, gtir.FunCall)
         # the iterator to be shifted is the node argument, while the shift arguments
         # are provided by the nested function call; the shift arguments consist of
@@ -1627,7 +1691,7 @@ class LambdaToDataflow(eve.NodeVisitor):
         offset_provider_type = self.subgraph_builder.get_offset_provider_type(offset)
         # second argument should be the offset value, which could be a symbolic expression or a dynamic offset
         offset_expr = (
-            SymbolExpr(offset_value_arg.value, IndexDType)
+            SymbolExpr(offset_value_arg.value, gtx_dace_utils.as_dace_type(_INDEX_DTYPE))
             if isinstance(offset_value_arg, gtir.OffsetLiteral)
             else self.visit(offset_value_arg)
         )

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg.py
@@ -277,20 +277,17 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             field_type = data_type
         elif len(local_dims) == 1:
             local_dim = local_dims[0]
-            local_dim_index = data_type.dims.index(local_dim)
             # the local dimension is converted into `ListType` data element
             if not isinstance(data_type.dtype, ts.ScalarType):
                 raise ValueError(f"Invalid field type {data_type}.")
-            if local_dim_index != (len(data_type.dims) - 1):
-                raise ValueError(
-                    f"Invalid field domain: expected the local dimension to be at the end, found at position {local_dim_index}."
-                )
             if local_dim.value not in self.offset_provider_type:
                 raise ValueError(
                     f"The provided local dimension {local_dim} does not match any offset provider type."
                 )
             local_type = ts.ListType(element_type=data_type.dtype, offset_type=local_dim)
-            field_type = ts.FieldType(dims=data_type.dims[:local_dim_index], dtype=local_type)
+            field_type = ts.FieldType(
+                dims=[dim for dim in data_type.dims if dim != local_dim], dtype=local_type
+            )
         else:
             raise NotImplementedError(
                 "Fields with more than one local dimension are not supported."
@@ -495,9 +492,10 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                 dims = gt_type.dims
             elif not transient:  # 'ts.ListType': use 'offset_type' as local dimension
                 assert gt_type.dtype.offset_type is not None
+                assert gt_type.dtype.offset_type.kind == gtx_common.DimensionKind.LOCAL
                 assert isinstance(gt_type.dtype.element_type, ts.ScalarType)
                 dc_dtype = gtx_dace_utils.as_dace_type(gt_type.dtype.element_type)
-                dims = [*gt_type.dims, gt_type.dtype.offset_type]
+                dims = gtx_common.order_dimensions([*gt_type.dims, gt_type.dtype.offset_type])
             else:
                 # By design, the domain of temporary fields used by SDFG lowering
                 # contains only the global dimensions. The local dimension is extracted,

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
@@ -136,25 +136,58 @@ def _create_scan_field_operator_impl(
         + dace_subsets.Range(field_subset[scan_dim_index + 1 :])
     )
 
+    # Create the final data storage, that is outside of the surrounding Map.
     field_name, field_desc = sdfg_builder.add_temp_array(
         ctx.sdfg, field_shape, dataflow_output_desc.dtype
     )
     field_node = ctx.state.add_access(field_name)
 
-    # Connect the final output node with the output of the nested SDFG. Note that
-    #  up to now the nested SDFG is writing into a transient data container that
+    # Now connect the final output node with the output of the nested SDFG.
+    #  Up to now the nested SDFG is writing into a transient data container that
     #  has the size to hold one column. The function below, that does the connection,
     #  will remove that data container.
     inner_map_output_temporary_removed = output_edge.connect(map_exit, field_node, field_subset)
-    assert inner_map_output_temporary_removed
+    assert ctx.state.in_degree(field_node) == 1
 
-    # The original output of the nested SDFG, the one that would be inside the Map,
-    #  has been deleted and the nested SDFG writes directly into the output. In
-    #  that case we have to adapt the stride of the data container on the inside.
-    outside_output_stride = field_desc.strides[scan_dim_index]
-    dataflow_output_desc.set_shape(
-        new_shape=dataflow_output_desc.shape, strides=(outside_output_stride,)
-    )
+    field_node_path = ctx.state.memlet_path(next(iter(ctx.state.in_edges(field_node))))
+    assert field_node_path[-1].dst is field_node
+
+    if inner_map_output_temporary_removed:
+        # The original output of the nested SDFG, the one that would be inside the Map,
+        #  has been deleted and the nested SDFG writes directly into the output.
+        #  In this case we have to adapt the stride of the array inside the nested SDFG.
+        nsdfg_scan = field_node_path[0].src
+        assert isinstance(nsdfg_scan, dace.nodes.NestedSDFG)
+        inner_output_name = field_node_path[0].src_conn
+        inner_output_desc = nsdfg_scan.sdfg.arrays[inner_output_name]
+        assert len(inner_output_desc.shape) == 1
+
+        outside_output_stride = field_desc.strides[scan_dim_index]
+        assert str(outside_output_stride).isdigit()
+        # The stride of the temporary array is constant, so we can just set it on the inside.
+        inner_output_desc.set_shape(
+            new_shape=inner_output_desc.shape, strides=(outside_output_stride,)
+        )
+    else:
+        # The AccessNode on the inside of the Map was not removed but remains there.
+        #  Thus we do not have to update the strides, we do however, make some checks.
+        # TODO(edopao): This case exists in icon4py, but a gt4py unittest is missing.
+        in_map_temporary_output_field = field_node_path[0].src
+        assert in_map_temporary_output_field == output_edge.result.dc_node
+
+        assert ctx.state.in_degree(in_map_temporary_output_field) == 1
+        assert ctx.state.out_degree(in_map_temporary_output_field) == 1
+        inner_edge = next(iter(ctx.state.in_edges(in_map_temporary_output_field)))
+        nsdfg_scan = inner_edge.src
+        assert isinstance(nsdfg_scan, dace.nodes.NestedSDFG)
+
+        inner_output_name = inner_edge.src_conn
+        inner_output_desc = nsdfg_scan.sdfg.arrays[inner_output_name]
+
+        assert len(inner_output_desc.shape) == 1
+        assert str(inner_output_desc.strides[0]).isdigit()
+        assert inner_output_desc.shape == dataflow_output_desc.shape
+        assert inner_output_desc.strides == dataflow_output_desc.strides
 
     return gtir_to_sdfg_types.FieldopData(
         field_node, ts.FieldType(field_dims, output_edge.result.gt_dtype), tuple(field_origin)

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
@@ -140,54 +140,13 @@ def _create_scan_field_operator_impl(
     field_name, field_desc = sdfg_builder.add_temp_array(
         ctx.sdfg, field_shape, dataflow_output_desc.dtype
     )
+    # the inner and outer strides have to match
+    scan_output_stride = field_desc.strides[scan_dim_index]
+    dataflow_output_desc.set_shape(dataflow_output_desc.shape, (scan_output_stride,))
+
+    # and here the edge writing the dataflow result data through the map exit node
     field_node = ctx.state.add_access(field_name)
-
-    # Now connect the final output node with the output of the nested SDFG.
-    #  Up to now the nested SDFG is writing into a transient data container that
-    #  has the size to hold one column. The function below, that does the connection,
-    #  will remove that data container.
-    inner_map_output_temporary_removed = output_edge.connect(map_exit, field_node, field_subset)
-    assert ctx.state.in_degree(field_node) == 1
-
-    field_node_path = ctx.state.memlet_path(next(iter(ctx.state.in_edges(field_node))))
-    assert field_node_path[-1].dst is field_node
-
-    if inner_map_output_temporary_removed:
-        # The original output of the nested SDFG, the one that would be inside the Map,
-        #  has been deleted and the nested SDFG writes directly into the output.
-        #  In this case we have to adapt the stride of the array inside the nested SDFG.
-        nsdfg_scan = field_node_path[0].src
-        assert isinstance(nsdfg_scan, dace.nodes.NestedSDFG)
-        inner_output_name = field_node_path[0].src_conn
-        inner_output_desc = nsdfg_scan.sdfg.arrays[inner_output_name]
-        assert len(inner_output_desc.shape) == 1
-
-        outside_output_stride = field_desc.strides[scan_dim_index]
-        assert str(outside_output_stride).isdigit()
-        # The stride of the temporary array is constant, so we can just set it on the inside.
-        inner_output_desc.set_shape(
-            new_shape=inner_output_desc.shape, strides=(outside_output_stride,)
-        )
-    else:
-        # The AccessNode on the inside of the Map was not removed but remains there.
-        #  Thus we do not have to update the strides, we do however, make some checks.
-        # TODO(edopao): This case exists in icon4py, but a gt4py unittest is missing.
-        in_map_temporary_output_field = field_node_path[0].src
-        assert in_map_temporary_output_field == output_edge.result.dc_node
-
-        assert ctx.state.in_degree(in_map_temporary_output_field) == 1
-        assert ctx.state.out_degree(in_map_temporary_output_field) == 1
-        inner_edge = next(iter(ctx.state.in_edges(in_map_temporary_output_field)))
-        nsdfg_scan = inner_edge.src
-        assert isinstance(nsdfg_scan, dace.nodes.NestedSDFG)
-
-        inner_output_name = inner_edge.src_conn
-        inner_output_desc = nsdfg_scan.sdfg.arrays[inner_output_name]
-
-        assert len(inner_output_desc.shape) == 1
-        assert str(inner_output_desc.strides[0]).isdigit()
-        assert inner_output_desc.shape == dataflow_output_desc.shape
-        assert inner_output_desc.strides == dataflow_output_desc.strides
+    output_edge.connect(map_exit, field_node, field_subset)
 
     return gtir_to_sdfg_types.FieldopData(
         field_node, ts.FieldType(field_dims, output_edge.result.gt_dtype), tuple(field_origin)
@@ -240,7 +199,6 @@ def _create_scan_field_operator(
                 if not sdfg_builder.is_column_axis(domain_range.dim)
             },
         )
-        assert (len(map_entry.params) + 1) == len(domain)
 
     # here we setup the edges passing through the map entry node
     for edge in input_edges:

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
@@ -65,8 +65,11 @@ def _parse_scan_fieldop_arg(
             return arg_expr
         # In scan field operator, the arguments to the vertical stencil are passed by value.
         # Therefore, the full field shape is passed as `MemletExpr` rather than `IteratorExpr`.
+        field_type = ts.FieldType(
+            dims=[dim for dim, _ in arg_expr.field_domain], dtype=arg_expr.gt_dtype
+        )
         return gtir_dataflow.MemletExpr(
-            arg_expr.field, arg_expr.gt_dtype, arg_expr.get_memlet_subset(ctx.sdfg)
+            arg_expr.field, field_type, arg_expr.get_memlet_subset(ctx.sdfg)
         )
 
     arg = sdfg_builder.visit(node, ctx=ctx)
@@ -104,6 +107,17 @@ def _create_scan_field_operator_impl(
     dataflow_output_desc = output_edge.result.dc_node.desc(ctx.sdfg)
     assert isinstance(dataflow_output_desc, dace.data.Array)
 
+    if isinstance(output_edge.result.gt_dtype, ts.ScalarType):
+        assert isinstance(output_type.dtype, ts.ScalarType)
+        if output_edge.result.gt_dtype != output_type.dtype:
+            raise TypeError(
+                f"Type mismatch, expected {output_type.dtype} got {output_edge.result.gt_dtype}."
+            )
+        # the scan field operator computes a column of scalar values
+        assert len(dataflow_output_desc.shape) == 1
+    else:
+        raise NotImplementedError("scan with list output is not supported")
+
     # the memory layout of the output field follows the field operator compute domain
     field_dims, field_origin, field_shape = gtir_domain.get_field_layout(
         field_domain, ctx.target_domain
@@ -122,48 +136,25 @@ def _create_scan_field_operator_impl(
         + dace_subsets.Range(field_subset[scan_dim_index + 1 :])
     )
 
-    if isinstance(output_edge.result.gt_dtype, ts.ScalarType):
-        assert isinstance(output_type.dtype, ts.ScalarType)
-        if output_edge.result.gt_dtype != output_type.dtype:
-            raise TypeError(
-                f"Type mismatch, expected {output_type.dtype} got {output_edge.result.gt_dtype}."
-            )
-        field_dtype = output_edge.result.gt_dtype
-        # the scan field operator computes a column of scalar values
-        assert len(dataflow_output_desc.shape) == 1
-    else:
-        assert isinstance(output_type.dtype, ts.ListType)
-        assert isinstance(output_edge.result.gt_dtype.element_type, ts.ScalarType)
-        field_dtype = output_edge.result.gt_dtype.element_type
-        if field_dtype != output_type.dtype.element_type:
-            raise TypeError(
-                f"Type mismatch, expected {output_type.dtype.element_type} got {field_dtype}."
-            )
-        # the scan field operator computes a list of scalar values for each column level
-        # 1st dim: column level, 2nd dim: list of scalar values (e.g. `neighbors`)
-        assert len(dataflow_output_desc.shape) == 2
-        # the lines below extend the array with the local dimension added by the field operator
-        assert output_edge.result.gt_dtype.offset_type is not None
-        field_shape = [*field_shape, dataflow_output_desc.shape[1]]
-        field_subset = field_subset + dace_subsets.Range.from_string(
-            f"0:{dataflow_output_desc.shape[1]}"
-        )
-
-    # allocate local temporary storage
     field_name, field_desc = sdfg_builder.add_temp_array(
         ctx.sdfg, field_shape, dataflow_output_desc.dtype
     )
-    # the inner and outer strides have to match
-    scan_output_stride = field_desc.strides[scan_dim_index]
-    # also consider the stride of the local dimension, in case the scan field operator computes a list
-    local_strides = field_desc.strides[len(field_dims) :]
-    assert len(local_strides) == (1 if isinstance(output_edge.result.gt_dtype, ts.ListType) else 0)
-    new_inner_strides = [scan_output_stride, *local_strides]
-    dataflow_output_desc.set_shape(dataflow_output_desc.shape, new_inner_strides)
-
-    # and here the edge writing the dataflow result data through the map exit node
     field_node = ctx.state.add_access(field_name)
-    output_edge.connect(map_exit, field_node, field_subset)
+
+    # Connect the final output node with the output of the nested SDFG. Note that
+    #  up to now the nested SDFG is writing into a transient data container that
+    #  has the size to hold one column. The function below, that does the connection,
+    #  will remove that data container.
+    inner_map_output_temporary_removed = output_edge.connect(map_exit, field_node, field_subset)
+    assert inner_map_output_temporary_removed
+
+    # The original output of the nested SDFG, the one that would be inside the Map,
+    #  has been deleted and the nested SDFG writes directly into the output. In
+    #  that case we have to adapt the stride of the data container on the inside.
+    outside_output_stride = field_desc.strides[scan_dim_index]
+    dataflow_output_desc.set_shape(
+        new_shape=dataflow_output_desc.shape, strides=(outside_output_stride,)
+    )
 
     return gtir_to_sdfg_types.FieldopData(
         field_node, ts.FieldType(field_dims, output_edge.result.gt_dtype), tuple(field_origin)
@@ -216,6 +207,7 @@ def _create_scan_field_operator(
                 if not sdfg_builder.is_column_axis(domain_range.dim)
             },
         )
+        assert (len(map_entry.params) + 1) == len(domain)
 
     # here we setup the edges passing through the map entry node
     for edge in input_edges:
@@ -443,13 +435,7 @@ def _lower_lambda_to_nested_sdfg(
             assert len(scan_output_shape) == 1
             output_subset = dace_subsets.Range.from_string(str(output_column_index))
         else:
-            assert isinstance(scan_carry_sym.type, ts.ListType)
-            assert scan_result.gt_dtype.element_type == scan_carry_sym.type.element_type
-            # the scan field operator computes a list of scalar values for each column level
-            assert len(scan_output_shape) == 2
-            output_subset = dace_subsets.Range.from_string(
-                f"{output_column_index}, 0:{scan_output_shape[1]}"
-            )
+            raise NotImplementedError("scan with list output is not supported.")
         scan_result_data = scan_result.dc_node.data
         scan_result_desc = scan_result.dc_node.desc(lambda_ctx.sdfg)
         scan_result_subset = dace_subsets.Range.from_array(scan_result_desc)

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_types.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_types.py
@@ -101,7 +101,7 @@ class FieldopData:
             assert isinstance(self.dc_node.desc(sdfg), dace.data.Scalar)
             return gtir_dataflow.MemletExpr(
                 dc_node=self.dc_node,
-                gt_dtype=self.gt_type,
+                gt_field=ts.FieldType(dims=[], dtype=self.gt_type),
                 subset=dace_subsets.Range.from_string("0"),
             )
 

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_gtir_to_sdfg.py
@@ -1211,15 +1211,24 @@ def test_gtir_connectivity_shift_chain():
 
 
 def test_gtir_neighbors_as_input():
+    MESH_NUM_LEVELS = 10
+    EKFTYPE = ts.FieldType(dims=[Edge, KDim], dtype=FLOAT_TYPE)
+    VKFTYPE = ts.FieldType(dims=[Vertex, KDim], dtype=FLOAT_TYPE)
+    V2E_KFTYPE = ts.FieldType(dims=[Vertex, V2EDim, KDim], dtype=EFTYPE.dtype)
+    gtx_common.check_dims(V2E_KFTYPE.dims)
+
     init_value = np.random.rand()
-    vertex_domain = im.domain(gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices")})
+    vertex_domain = im.domain(
+        gtx_common.GridType.UNSTRUCTURED, ranges={Vertex: (0, "nvertices"), KDim: (0, "nlevels")}
+    )
     testee = gtir.Program(
         id="neighbors_as_input",
         function_definitions=[],
         params=[
-            gtir.Sym(id="v2e_field", type=V2E_FTYPE),
-            gtir.Sym(id="edges", type=EFTYPE),
-            gtir.Sym(id="vertices", type=VFTYPE),
+            gtir.Sym(id="v2e_field", type=V2E_KFTYPE),
+            gtir.Sym(id="edges", type=EKFTYPE),
+            gtir.Sym(id="vertices", type=VKFTYPE),
+            gtir.Sym(id="nlevels", type=SIZE_TYPE),
             gtir.Sym(id="nvertices", type=SIZE_TYPE),
         ],
         declarations=[],
@@ -1246,27 +1255,33 @@ def test_gtir_neighbors_as_input():
 
     connectivity_V2E = SIMPLE_MESH.offset_provider["V2E"]
 
-    v2e_field = np.random.rand(SIMPLE_MESH.num_vertices, connectivity_V2E.shape[1])
-    e = np.random.rand(SIMPLE_MESH.num_edges)
-    v = np.empty(SIMPLE_MESH.num_vertices, dtype=v2e_field.dtype)
+    v2e_field = np.random.rand(SIMPLE_MESH.num_vertices, connectivity_V2E.shape[1], MESH_NUM_LEVELS)
+    e = np.random.rand(SIMPLE_MESH.num_edges, MESH_NUM_LEVELS)
+    v = np.empty([SIMPLE_MESH.num_vertices, MESH_NUM_LEVELS], dtype=v2e_field.dtype)
 
     v_ref = [
         functools.reduce(lambda x, y: x + y, v2e_values + e[v2e_neighbors], init_value)
         for v2e_neighbors, v2e_values in zip(connectivity_V2E.asnumpy(), v2e_field, strict=True)
     ]
 
-    sdfg(
-        v2e_field,
-        e,
-        v,
-        gt_conn_V2E=connectivity_V2E.ndarray,
-        **FSYMBOLS,
-        **make_mesh_symbols(SIMPLE_MESH),
-        __v2e_field_0_range_1=SIMPLE_MESH.num_vertices,
-        __v2e_field_size_1=connectivity_V2E.shape[1],
-        __v2e_field_stride_0=connectivity_V2E.shape[1],
-        __v2e_field_stride_1=1,
-    )
+    symbols = make_mesh_symbols(SIMPLE_MESH) | {
+        "nlevels": MESH_NUM_LEVELS,
+        # override SDFG symbols for array shape and strides because of extra K-dimension
+        "__edges_size_1": e.shape[1],
+        "__edges_stride_0": e.strides[0] // e.itemsize,
+        "__edges_stride_1": e.strides[1] // e.itemsize,
+        "__vertices_size_1": v.shape[1],
+        "__vertices_stride_0": v.strides[0] // v.itemsize,
+        "__vertices_stride_1": v.strides[1] // v.itemsize,
+        "__v2e_field_0_range_1": v2e_field.shape[0],
+        "__v2e_field_1_range_1": v2e_field.shape[1],
+        "__v2e_field_2_range_1": v2e_field.shape[2],
+        "__v2e_field_stride_0": v2e_field.strides[0] // v2e_field.itemsize,
+        "__v2e_field_stride_1": v2e_field.strides[1] // v2e_field.itemsize,
+        "__v2e_field_stride_2": v2e_field.strides[2] // v2e_field.itemsize,
+    }
+
+    sdfg(v2e_field, e, v, gt_conn_V2E=connectivity_V2E.ndarray, **symbols)
     assert np.allclose(v, v_ref)
 
 


### PR DESCRIPTION
In [PR#1847](github.com/GridTools/gt4py/pull/1847) the convention was established that the local dimension is always at the end.
However, in [PR#1922](https://github.com/GridTools/gt4py/pull/1847) this convention was changed such that the local dimension is between the horizontal and vertical.
However, this convention change was not propagated to the DaCe backend, which continued to work, since the case, where a field has a horizontal, vertical and a local was never hit.

This PR introduces this new canonical order into the DaCe backend. Credits to @philip-paul-mueller, see his original PR #2217.