### PR TITLE
refactor[next]: Remove unconditionally_collapse_tuples

### DIFF
--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -261,7 +261,9 @@ class CollapseTuple(
 
             itir_type_inference.reinfer(first_expr)  # type is needed so reinfer on-demand
             assert isinstance(first_expr.type, (ts.TupleType, ts.DeferredType))
-            if  isinstance(first_expr.type, ts.TupleType) and len(first_expr.type.types) == len(node.args):
+            if isinstance(first_expr.type, ts.TupleType) and len(first_expr.type.types) == len(
+                node.args
+            ):
                 return first_expr
         return None
 

--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -171,7 +171,6 @@ class CollapseTuple(
             return functools.reduce(operator.or_, self.__members__.values())
 
     uids: eve_utils.UIDGenerator
-    ignore_tuple_size: bool
     enabled_transformations: Transformation = Transformation.all()  # noqa: RUF009 [function-call-in-dataclass-default-argument]
 
     REINFER_TYPES = True
@@ -183,7 +182,6 @@ class CollapseTuple(
         cls,
         node: itir.Node,
         *,
-        ignore_tuple_size: bool = False,
         remove_letified_make_tuple_elements: bool = True,
         offset_provider_type: Optional[common.OffsetProviderType] = None,
         within_stencil: Optional[bool] = None,
@@ -200,8 +198,6 @@ class CollapseTuple(
             node: The node to transform.
 
         Keyword arguments:
-            ignore_tuple_size: Apply the transformation even if length of the inner tuple is greater
-                than the length of the outer tuple.
             remove_letified_make_tuple_elements: Run `InlineLambdas` as a post-processing step
                 to remove left-overs from `LETIFY_MAKE_TUPLE_ELEMENTS` transformation.
                 `(λ(_tuple_el_1, _tuple_el_2) → {_tuple_el_1, _tuple_el_2})(1, 2)` -> {1, 2}`
@@ -217,15 +213,13 @@ class CollapseTuple(
             False,
         ], "Parameter 'within_stencil' mandatory if node is not a 'Program'."
 
-        if not ignore_tuple_size:
-            node = itir_type_inference.infer(
-                node,
-                offset_provider_type=offset_provider_type,
-                allow_undeclared_symbols=allow_undeclared_symbols,
-            )
+        node = itir_type_inference.infer(
+            node,
+            offset_provider_type=offset_provider_type,
+            allow_undeclared_symbols=allow_undeclared_symbols,
+        )
 
         new_node = cls(
-            ignore_tuple_size=ignore_tuple_size,
             enabled_transformations=enabled_transformations,
             uids=uids,
         ).visit(node, within_stencil=within_stencil)
@@ -266,13 +260,8 @@ class CollapseTuple(
                     return None
 
             itir_type_inference.reinfer(first_expr)  # type is needed so reinfer on-demand
-            assert self.ignore_tuple_size or isinstance(
-                first_expr.type, (ts.TupleType, ts.DeferredType)
-            )
-            if self.ignore_tuple_size or (
-                isinstance(first_expr.type, ts.TupleType)
-                and len(first_expr.type.types) == len(node.args)
-            ):
+            assert isinstance(first_expr.type, (ts.TupleType, ts.DeferredType))
+            if  isinstance(first_expr.type, ts.TupleType) and len(first_expr.type.types) == len(node.args):
                 return first_expr
         return None
 

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -54,7 +54,6 @@ def apply_common_transforms(
     unroll_reduce=False,
     common_subexpression_elimination=True,
     force_inline_lambda_args=False,
-    unconditionally_collapse_tuples=False,
     #: A dictionary mapping axes names to their length. See :func:`infer_domain.infer_expr` for
     #: more details.
     symbolic_domain_sizes: Optional[dict[str, str]] = None,
@@ -139,18 +138,6 @@ def apply_common_transforms(
             symbolic_domain_sizes=symbolic_domain_sizes,
             uids=tmp_uids,
         )
-
-    # Since `CollapseTuple` relies on the type inference which does not support returning tuples
-    # larger than the number of closure outputs as given by the unconditional collapse, we can
-    # only run the unconditional version here instead of in the loop above.
-    if unconditionally_collapse_tuples:
-        ir = CollapseTuple.apply(
-            ir,
-            ignore_tuple_size=True,
-            uids=collapse_tuple_uids,
-            enabled_transformations=~CollapseTuple.Transformation.PROPAGATE_TO_IF_ON_TUPLES,
-            offset_provider_type=offset_provider_type,
-        )  # type: ignore[assignment]  # always an itir.Program
 
     ir = NormalizeShifts().visit(ir)
 

--- a/src/gt4py/next/program_processors/codegens/gtfn/gtfn_module.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/gtfn_module.py
@@ -163,8 +163,6 @@ class GTFNTranslationStep(
             pass_manager.apply_common_transforms,
             extract_temporaries=True,
             offset_provider=offset_provider,
-            # sid::composite (via hymap) supports assigning from tuple with more elements to tuple with fewer elements
-            unconditionally_collapse_tuples=True,
             symbolic_domain_sizes=self.symbolic_domain_sizes,
         )
 

--- a/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_icon_like_scan.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/ffront_tests/test_icon_like_scan.py
@@ -78,7 +78,6 @@ def _solve_nonhydro_stencil_52_like_with_gtfn_tuple_merge(
     z_q: gtx.Field[[Cell, KDim], float],
     w: gtx.Field[[Cell, KDim], float],
 ) -> tuple[gtx.Field[[Cell, KDim], float], gtx.Field[[Cell, KDim], float]]:
-    """In inlining, relies on CollapseTuple with ignore_tuple_size=True (only working with gtfn)."""
     z_a = z_beta(Koff[-1]) * z_alpha(Koff[-1])
     z_c = z_beta * z_alpha(Koff[1])
     z_b = z_alpha * (z_beta(Koff[-1]) + z_beta)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_collapse_tuple.py
@@ -92,18 +92,6 @@ def test_incompatible_size_make_tuple_tuple_get():
     assert actual == testee  # did nothing
 
 
-def test_merged_with_smaller_outer_size_make_tuple_tuple_get():
-    testee = im.make_tuple(im.tuple_get(0, im.make_tuple("first", "second")))
-    actual = CollapseTuple.apply(
-        testee,
-        ignore_tuple_size=True,
-        enabled_transformations=CollapseTuple.Transformation.COLLAPSE_MAKE_TUPLE_TUPLE_GET,
-        allow_undeclared_symbols=True,
-        within_stencil=False,
-    )
-    assert actual == im.make_tuple("first", "second")
-
-
 def test_simple_tuple_get_make_tuple():
     expected = im.ref("bar")
     testee = im.tuple_get(1, im.make_tuple("foo", expected))


### PR DESCRIPTION
The `unconditionally_collapse_tuples` option in `apply_common_transforms` and 'ignore_tuple_size' in `CollapseTuple` were removed because that was no longer necessary.