### PR TITLE
refactor[cartesian]: invalid frontend/backend raise `ValueError`

### DIFF
--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -135,8 +135,8 @@ def from_name(name: str) -> type[Backend]:
     """Return a backend by name."""
     backend_cls = REGISTRY.get(name, None)
     if backend_cls is None:
-        raise NotImplementedError(
-            f"Backend '{name}' is not implemented. Options are: {REGISTRY.names}."
+        raise ValueError(
+            f"Backend '{name}' is not registered. Valid options are: {REGISTRY.names}."
         )
     return backend_cls
 

--- a/src/gt4py/cartesian/frontend/base.py
+++ b/src/gt4py/cartesian/frontend/base.py
@@ -104,8 +104,8 @@ def from_name(name: str) -> type[Frontend]:
     """Return frontend by name."""
     frontend_cls = REGISTRY.get(name, None)
     if frontend_cls is None:
-        raise NotImplementedError(
-            f"Frontend '{name} is not implemented. Options are: {REGISTRY.names}."
+        raise ValueError(
+            f"Frontend '{name} is not registered. Valid options are: {REGISTRY.names}."
         )
     return frontend_cls
 

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_backend.py
@@ -187,5 +187,5 @@ def test_bad_backend_feedback():
     existing_backend = backend_from_name("numpy")
     assert existing_backend
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         backend_from_name("xxxxx")

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_frontend.py
@@ -1,0 +1,19 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from gt4py.cartesian import frontend
+
+
+def test_bad_frontend_feedback():
+    existing_backend = frontend.from_name("gtscript")
+    assert existing_backend
+
+    with pytest.raises(ValueError):
+        frontend.from_name("xxxxx")


### PR DESCRIPTION
## Description

This PR changes the error for an invalid frontend/backend choice from `NotImplementedError` to `ValueError`. While it could happen that the requested frontend/backend is not yet implemented, the more likely scenario is that users misspelled an existing frontend/backend name. Imo this should thus be a value error, in accordance with how the [python docs](https://docs.python.org/3/library/exceptions.html#ValueError) describe it.

From a practical point of view, `NotImplementedError` is commonly used in tests with `xfail(raises=NotImplementedError)`, which could - if the backend is misspelled - hide problems.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A