### PR TITLE
refactor[cartesian]: delete unused tile symbol function

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir.py
@@ -81,9 +81,6 @@ class Axis(eve.StrEnum):
     def iteration_dace_symbol(self):
         return utils.get_dace_symbol(self.iteration_symbol())
 
-    def tile_dace_symbol(self):
-        return utils.get_dace_symbol(self.tile_symbol())
-
 
 class Bounds(eve.Node):
     start: str


### PR DESCRIPTION
## Description

The DaCe backends currently don't support tiling, so this function is unused. Even when we add tiling back, we won't do it at the Tree IR level, but later using existing transformations on the resulting SDFG. This method will therefore most likely never be used and can safely be deleted.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
