### PR TITLE
perf[cartesian]: Align memory layout and loop structure

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -828,8 +828,8 @@ class DaceCPUBackend(BaseDaceBackend):
     storage_info: ClassVar[layout.LayoutInfo] = {
         "alignment": 1,
         "device": "cpu",
-        "layout_map": layout.layout_maker_factory((1, 0, 2)),
-        "is_optimal_layout": layout.layout_checker_factory(layout.layout_maker_factory((1, 0, 2))),
+        "layout_map": layout.layout_maker_factory((1, 2, 0)),
+        "is_optimal_layout": layout.layout_checker_factory(layout.layout_maker_factory((1, 2, 0))),
     }
     MODULE_GENERATOR_CLASS = DaCePyExtModuleGenerator
 


### PR DESCRIPTION
## Description

The loop structure in the `dace:cpu` backend is

```none
for k = 0; k < K; ++k
    for i = 0; i < I; ++i
        for j = 0; j < J; ++j
            // code here
```

so our memory layout / strides should be

- j-stride = 1
- i-stride = J
- k-stride = J*I

Note: This is part of untangling the [`milestone2`](https://github.com/GridTools/gt4py/pull/2202) branch.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.

If this PR contains code authored by new contributors please make sure:

- [ ] The PR contains an updated version of the `AUTHORS.md` file adding the names of all the new contributors.
