### PR TITLE
fix[cartesian]: memlets of data dims in jit workflow

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -132,7 +132,10 @@ def _sdfg_add_arrays_and_edges(
                 ranges = []
 
             # Add data dimensions to the range
-            ranges += [(0, d, 1) for d in field_info[name].data_dims]
+            ranges += [
+                (0, d - 1, 1)  # d - 1 because ranges are inclusive
+                for d in field_info[name].data_dims
+            ]
 
             if name in inputs:
                 state.add_edge(


### PR DESCRIPTION
## Description

Memlets of data_dims in jit workflows were off by one. The memlet was configured to include one too many because ranges in dace are inclusive on both ends (in contrast to many half-open range definitions that are inclusive at the start and exclusive at the end).

Note: This is part of untangling the [`milestone2`](https://github.com/GridTools/gt4py/pull/2202) branch.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  New test added at the NDSL-level where we use the jit workflow
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A