### PR TITLE
fix[cartesian]: Merge DaCe schedule tree roundtrip work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -454,7 +454,7 @@ url = 'https://test.pypi.org/simple'
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
 dace = [
-  {git = "https://github.com/GridTools/dace", branch = "romanc/stree-to-sdfg", group = "dace-cartesian"},
+  {git = "https://github.com/GridTools/dace", branch = "romanc/stree-roundtrip", group = "dace-cartesian"},
   {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_08_28", group = "dace-next"}
 ]
 

--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -38,7 +38,10 @@ class Context:
     """Mapping connector names to memlets flowing out of the Tasklet."""
 
     tree: tir.TreeRoot
-    """Schedule tree in which this Tasklet will be inserted."""
+    """Schedule tree (root) in which this Tasklet will be inserted."""
+
+    scope: tir.TreeScope
+    """Schedule tree scope in which this Tasklet will be inserted."""
 
 
 class OIRToTasklet(eve.NodeVisitor):
@@ -50,10 +53,10 @@ class OIRToTasklet(eve.NodeVisitor):
     """
 
     def visit_CodeBlock(
-        self, node: oir.CodeBlock, root: tir.TreeRoot
+        self, node: oir.CodeBlock, root: tir.TreeRoot, scope: tir.TreeScope
     ) -> tuple[nodes.Tasklet, dict[str, Memlet], dict[str, Memlet]]:
         """Entry point to gather all code, inputs and outputs."""
-        ctx = Context(code=[], targets=set(), inputs={}, outputs={}, tree=root)
+        ctx = Context(code=[], targets=set(), inputs={}, outputs={}, tree=root, scope=scope)
 
         self.visit(node.body, ctx=ctx)
 
@@ -100,7 +103,7 @@ class OIRToTasklet(eve.NodeVisitor):
 
         # Variable K offset subscript
         if isinstance(node.offset, oir.VariableKOffset):
-            symbol = tir.Axis.K.iteration_dace_symbol()
+            symbol = tir.k_symbol(ctx.scope)
             shift = ctx.tree.shift[node.name][tir.Axis.K]
             offset = self.visit(node.offset.k, ctx=ctx, is_target=False)
             name_parts.append(f"[({symbol}) + ({shift}) + ({offset})]")
@@ -345,7 +348,12 @@ def _memlet_subset_cartesian(
     # Handle cartesian indices
     for index, axis in enumerate(tir.Axis.dims_3d()):
         if dimensions[index]:
-            i = f"({axis.iteration_dace_symbol()}) + ({shift[axis]}) + ({offset_dict[axis.lower()]})"
+            iteration_symbol = (
+                utils.get_dace_symbol(tir.k_symbol(ctx.scope))
+                if axis == tir.Axis.K
+                else axis.iteration_dace_symbol()
+            )
+            i = f"({iteration_symbol}) + ({shift[axis]}) + ({offset_dict[axis.lower()]})"
             ranges.append((i, i, 1))
 
     # Append data dimensions

--- a/src/gt4py/cartesian/gtc/dace/treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir.py
@@ -130,6 +130,12 @@ class HorizontalLoop(TreeScope):
 
 
 class VerticalLoop(TreeScope):
+    iteration_variable: eve.SymbolRef
+    """
+    DaCe 1.x (without CFGs) maps sequential loops to a state machine with the iteration variable
+    on interstate edges. Having unique symbols makes DaCe 1.x happy and allows to rename symbols
+    via search & replace.
+    """
     loop_order: common.LoopOrder
     bounds_k: Bounds
 
@@ -150,3 +156,13 @@ class TreeRoot(TreeScope):
 
     symbols: SymbolDict
     """Mapping between type and symbol name."""
+
+
+def k_symbol(scope: TreeScope) -> eve.SymbolRef:
+    if scope.parent is None:
+        raise ValueError("No vertical loop found in (parents of) current scope.")
+
+    if isinstance(scope, VerticalLoop):
+        return scope.iteration_variable
+
+    return k_symbol(scope.parent)

--- a/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
@@ -90,7 +90,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
 
     def visit_VerticalLoop(self, node: tir.VerticalLoop, ctx: Context) -> None:
         # In any case, define the iteration symbol
-        ctx.tree.symbols[tir.Axis.K.iteration_symbol()] = dtypes.int32
+        ctx.tree.symbols[node.iteration_variable] = dtypes.int32
 
         # For serial loops, create a ForScope and add it to the tree
         if node.loop_order != common.LoopOrder.PARALLEL:
@@ -104,7 +104,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
         # For parallel loops, create a map and add it to the tree
         dace_map = nodes.Map(
             label=f"vertical_loop_{id(node)}",
-            params=[tir.Axis.K.iteration_symbol()],
+            params=[node.iteration_variable],
             ndrange=subsets.Range(
                 # -1 because range bounds are inclusive
                 [(node.bounds_k.start, f"{node.bounds_k.end} - 1", 1)]
@@ -162,7 +162,7 @@ def _for_scope_header(node: tir.VerticalLoop) -> dcf.ForScope:
 
     plus_minus = "+" if node.loop_order == common.LoopOrder.FORWARD else "-"
     comparison = "<" if node.loop_order == common.LoopOrder.FORWARD else ">="
-    iteration_var = tir.Axis.K.iteration_symbol()
+    iteration_var = node.iteration_variable
 
     for_scope = dcf.ForScope(
         condition=CodeBlock(

--- a/uv.lock
+++ b/uv.lock
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "dace"
 version = "1.0.2"
-source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg#82541a9401dcadca43edc33cf1db61a0fe21d0e5" }
+source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip#54c669ed0f0bc97eb077e84ace58f7596744c8b5" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1436,7 +1436,7 @@ build = [
     { name = "wheel" },
 ]
 dace-cartesian = [
-    { name = "dace", version = "1.0.2", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg#82541a9401dcadca43edc33cf1db61a0fe21d0e5" } },
+    { name = "dace", version = "1.0.2", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip#54c669ed0f0bc97eb077e84ace58f7596744c8b5" } },
 ]
 dace-next = [
     { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_08_28#58ae225e62cb6114fef31807306d4b9a03f1af8d" } },
@@ -1580,7 +1580,7 @@ build = [
     { name = "setuptools", specifier = ">=77.0.3" },
     { name = "wheel", specifier = ">=0.33.6" },
 ]
-dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg" }]
+dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip" }]
 dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_08_28" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },


### PR DESCRIPTION
## Description

De-duplicating k-axis iteration symbols in the Tree IR because DaCe (v1) uses search & replace to rename variables when building a schedule tree from a given SDFG. Without this change we get into situations that have variable shadowing and then the search & replace algorithm of DaCe is too simplistic to handle the de-duplication correctly, e.g. when replacing `__k` in the following

```cpp
int __k;

for(__k = 0; __k < 10; __k += 1) {
	// use __k ...
}

for(int __k = 0; __k < 10; __k += 1) {
	// __k accesses here were replaced leading to issues
}

```

Instead we now do the work upfront and build a different k-axis iteration symbol into the SDFG that is then transformed into a schedule tree in orchestration.

This PR also updates DaCe to `romanc/stree-roundtrip` (on the GT4Py fork) to include fixes on the DaCe side. These include:

- memory de-allocation fix
- support for de-aliasing SDFGs with in/out connectors of the same name
- support for NView and Copy nodes

Note: This is part of untangling the [`milestone2`](https://github.com/GridTools/gt4py/pull/2202) branch.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Tested with upstream workflows/tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
