### PR TITLE
bug[next][dace]: Use session cache for SDFG build

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -49,8 +49,8 @@ def set_dace_config(
 
     # We rely on gt4py function `get_cache_folder` to get a unique build folder
     #   for each SDFG. Within this folder, by setting 'cache=single', dace will
-    #   cache the generated code and build binaries, without creating any sub-folder
-    #   structure.
+    #   cache the generated code and binary objects, without creating any further
+    #   sub-folder the SDFG to compile.
     dace.Config.set("cache", value="single")
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -48,9 +48,9 @@ def set_dace_config(
     dace.Config.set("compiler.use_cache", value=True)
 
     # We rely on gt4py function `get_cache_folder` to get a unique build folder
-    #   for each SDFG. Within this folder, by setting 'cache=single', dace will
-    #   cache the generated code and binary objects, without creating any further
-    #   sub-folder the SDFG to compile.
+    #   for each program. Within this folder, by setting 'cache=single', dace will
+    #   cache the generated code and binary objects for the program SDFG, without
+    #   creating any further sub-folder to compile the SDFG.
     dace.Config.set("cache", value="single")
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -40,13 +40,14 @@ def set_dace_config(
     #   a thread local variable. This means it is safe to set values that are different
     #   for each thread.
 
+    # We rely on gt4py to get a unique build folder for each SDFG
+    dace.Config.set("cache", value="single")
+
     # We rely on dace cache to avoid recompiling the SDFG.
     #   Note that the workflow step with the persistent `FileCache` store
     #   is translating from `CompilableProgram` (ITIR.Program + CompileTimeArgs)
     #   to `ProgramSource`, so this step is storing in cache only the result
     #   of the SDFG transformations, not the compiled program binary.
-    dace.Config.set("cache", value="hash")  # use the SDFG hash as cache key
-    dace.Config.set("default_build_folder", value=str(config.BUILD_CACHE_DIR / "dace_cache"))
     dace.Config.set("compiler.use_cache", value=True)
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -40,15 +40,18 @@ def set_dace_config(
     #   a thread local variable. This means it is safe to set values that are different
     #   for each thread.
 
-    # We rely on gt4py to get a unique build folder for each SDFG
-    dace.Config.set("cache", value="single")
-
     # We rely on dace cache to avoid recompiling the SDFG.
     #   Note that the workflow step with the persistent `FileCache` store
     #   is translating from `CompilableProgram` (ITIR.Program + CompileTimeArgs)
     #   to `ProgramSource`, so this step is storing in cache only the result
     #   of the SDFG transformations, not the compiled program binary.
     dace.Config.set("compiler.use_cache", value=True)
+
+    # We rely on gt4py function `get_cache_folder` to get a unique build folder
+    #   for each SDFG. Within this folder, by setting 'cache=single', dace will
+    #   cache the generated code and build binaries, without creating any sub-folder
+    #   structure.
+    dace.Config.set("cache", value="single")
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by
     #  `gt4py.next.program_processors.runners.dace.transfromations.gpu_utils.gt_gpu_transform_non_standard_memlet()`.

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -16,7 +16,7 @@ import dace
 import factory
 
 from gt4py._core import definitions as core_defs, locking
-from gt4py.next import config as gtx_config
+from gt4py.next import config
 from gt4py.next.otf import languages, stages, step_types, workflow
 from gt4py.next.otf.compilation import cache as gtx_cache
 from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
@@ -109,9 +109,9 @@ class DaCeCompiler(
     """Use the dace build system to compile a GT4Py program to a ``gt4py.next.otf.stages.CompiledProgram``."""
 
     bind_func_name: str
-    cache_lifetime: gtx_config.BuildCacheLifetime
+    cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
-    cmake_build_type: gtx_config.CMakeBuildType = gtx_config.CMakeBuildType.DEBUG
+    cmake_build_type: config.CMakeBuildType = config.CMakeBuildType.DEBUG
 
     def __call__(
         self,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -10,15 +10,15 @@ from __future__ import annotations
 
 import dataclasses
 import os
-import pathlib
 from typing import Any, Callable, Sequence
 
 import dace
 import factory
 
 from gt4py._core import definitions as core_defs, locking
-from gt4py.next import config
+from gt4py.next import config as gtx_config
 from gt4py.next.otf import languages, stages, step_types, workflow
+from gt4py.next.otf.compilation import cache as gtx_cache
 from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 
 
@@ -111,9 +111,9 @@ class DaCeCompiler(
     """Use the dace build system to compile a GT4Py program to a ``gt4py.next.otf.stages.CompiledProgram``."""
 
     bind_func_name: str
-    cache_lifetime: config.BuildCacheLifetime
+    cache_lifetime: gtx_config.BuildCacheLifetime
     device_type: core_defs.DeviceType
-    cmake_build_type: config.CMakeBuildType = config.CMakeBuildType.DEBUG
+    cmake_build_type: gtx_config.CMakeBuildType = gtx_config.CMakeBuildType.DEBUG
 
     def __call__(
         self,
@@ -123,9 +123,11 @@ class DaCeCompiler(
             device_type=self.device_type,
             cmake_build_type=self.cmake_build_type,
         ):
-            sdfg = dace.SDFG.from_json(inp.program_source.source_code)
-            sdfg_build_folder = pathlib.Path(sdfg.build_folder)
+            sdfg_build_folder = gtx_cache.get_cache_folder(inp, self.cache_lifetime)
             sdfg_build_folder.mkdir(parents=True, exist_ok=True)
+
+            sdfg = dace.SDFG.from_json(inp.program_source.source_code)
+            sdfg.build_folder = sdfg_build_folder
             with locking.lock(sdfg_build_folder):
                 sdfg_program = sdfg.compile(validate=False)
 


### PR DESCRIPTION
Session cache, which is used in pytest parallel execution, was not set in the dace backend.

This PR changes the configuration of the dace cache:
- let gt4py function create a unique folder for each program to compile, with the given lifetime (session or persistent)
- within this folder, rely on dace to cache the generated code and binary objects, without creating any sub-folder structure

This PR addresses an issue found by @philip-paul-mueller in icon4py datatest CI, where some tests would fail randomly. It was observed that in such case the stencil program was called with the wrong connectivity array in the SDFG argument list. By design, the SDFG fast call does not set the parameters of the offset provider. These are set only on the first call, and on subsequent calls (that use the SDFG fast call) they are supposed to remain constant because the offset provider does not change. It must be noted that in datatest CI workflow the same stencil program is called with different offset providers (icon global grid and icon regional grid), using pytest parallel execution. The offset provider hash is part of the gt4py program cache key, which means that once a stencil program has passed through all OTF workflow stages, it is cached in a dictionary: one stencil program compiled with two different offset providers results in two different cache entries. However, before being cached into program cache, the stencil is first lowered to SDFG and then compiled to a binary library. The issue was probably in the compilation stage which was caching the compiled SDFG, using a cache key based on the SDFG hash: recompiling an SDFG with a different connectivity array (assuming that `max_neighbors` in offset provider is the same) results in the same SDFG hash, therefore the SDFG was not recompiled for the above case. Then, it could happen that the same program handle in memory (a `CompiledSDFG` object) was used for two different test cases with icon global and icon regional grids, but pointing to the same connectivity array. Two parallel pytest worker would set first one connectivity array then a different one, resulting in error for the first worker.

This PR chances the configuration the dace cache for SDFG build. The SDFG binary is still cached but we no longer rely on the SDFG hash, we rely instead on the gt4py build folder name. In particular, this PR re-enables the gt4py session cache which is used in pytest parallel execution with other backends. The session cache uses a temporary folder for program build: this means that one stencil program is always recompiled for two different test cases, which could potentially use different offset providers in test mode, as explained above.