### PR TITLE
test[cartesian]: print cache location at start of test session

### DIFF
--- a/tests/cartesian_tests/conftest.py
+++ b/tests/cartesian_tests/conftest.py
@@ -40,12 +40,12 @@ def pytest_addoption(parser):
     parser.addoption("--keep-gtcache", action="store_true", default=False, dest="keep_gtcache")
 
 
-def pytest_sessionstart():
+def pytest_sessionstart(session):
     gt_config.cache_settings["dir_name"] = pytest_gt_cache_dir
+    if session.config.option.keep_gtcache:
+        print(f"\nNOTE: gt4py caches will be retained at {pytest_gt_cache_dir}")
 
 
 def pytest_sessionfinish(session):
     if not session.config.option.keep_gtcache:
         shutil.rmtree(pytest_gt_cache_dir, ignore_errors=True)
-    else:
-        print(f"\nNOTE: gt4py caches were retained at {pytest_gt_cache_dir}")


### PR DESCRIPTION
## Description

In cartesian tests, if caches are to be retained, print the location of caches at test session start instead at the end. This allows to easily see where tests are written too even in cases where they crash (and `pytest_sessionfinish()` isn't called anymore).

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
