### PR TITLE
CI: switch CSCS CI-Ext to daint vCluster

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -72,3 +72,7 @@ if [ ! -z "${EXTRA_UV_PIP_ARGS}" ]; then
     uv pip install --compile-bytecode ${EXTRA_UV_PIP_ARGS}
 fi
 EOF
+
+# Workaround for an issue in Container Engine
+RUN unlink /etc/localtime
+RUN touch /etc/localtime

--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -129,7 +129,7 @@ build_cscs_amd_rocm:
 
 test_cscs_gh200:
   extends:
-    - .container-runner-daint-gh200
+    - .container-runner-santis-gh200
     - .test_common
   needs:
     - build_cscs_gh200


### PR DESCRIPTION
The santis vCluster is affected by an issue with mountpoints. The [fix](https://git.cscs.ch/alps-platforms/wcp/santis/-/merge_requests/159) is available but it is not yet applied to the santis vCluster config.

As a workaround, the GT4Py CI can temporarily fall back to daint vCluster.