### PR TITLE
fix[next][dace]: ensure unique names for conditional blocks and loop regions

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -888,7 +888,7 @@ class LambdaToDataflow(eve.NodeVisitor):
 
         # create states inside the nested SDFG for the if-branches
         if_region = dace.sdfg.state.ConditionalBlock("if")
-        nsdfg.add_node(if_region)
+        nsdfg.add_node(if_region, ensure_unique_name=True)
         entry_state = nsdfg.add_state("entry", is_start_block=True)
         nsdfg.add_edge(entry_state, if_region, dace.InterstateEdge())
 

--- a/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_to_sdfg_scan.py
@@ -425,7 +425,7 @@ def _lower_lambda_to_nested_sdfg(
             update_expr=f"{scan_loop_var} = {scan_loop_var} - 1",
             inverted=False,
         )
-    lambda_ctx.sdfg.add_node(scan_loop)
+    lambda_ctx.sdfg.add_node(scan_loop, ensure_unique_name=True)
     lambda_ctx.sdfg.add_edge(init_state, scan_loop, dace.InterstateEdge())
 
     # Inside the loop region, create a 'compute' and an 'update' state.


### PR DESCRIPTION
This PR is not fixing any known issue, however it is a code improvement that prevents potential issues in the future.

This was found while analyzing a dace issue, for which we have a bugfix in dace repository: https://github.com/spcl/dace/pull/2158