### PR TITLE
fix[next][dace]: move cuda-codegen setting to gt4py config

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -75,6 +75,9 @@ def set_dace_config(
     )
 
     # By design, we do not allow converting Memlets to Maps during code generation.
+    #  If needed, Memles are converted to Maps explicitly by gt4py in the `gt_auto_optimize`
+    #  pipeline, so that the iteration order is configured correctly for the GPU device.
+    #  This setting allows to throw an exception if any implicit Copy-Map slips thorugh.
     dace.Config.set("compiler.cuda.allow_implicit_memlet_to_map", value=False)
 
     # In some stencils, for example `apply_diffusion_to_w`, the cuda codegen messes


### PR DESCRIPTION
This PR is not fixing any known issue, since the setting set as default in the modified in the dace integration branch (see https://github.com/GridTools/dace/pull/6). However, for correctness, we enforce this setting from gt4py, to be independent from the default setting adopted by dace.

The setting for `match_exception` is already set in the gt4py `auto_optimize` pipeline.