### PR TITLE
feat[next][dace]: extend CopyChainRemover to remove full-write copies

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
@@ -121,6 +121,8 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
         single_use_data: dict[dace.SDFG, set[str]],
         **kwargs: Any,
     ) -> None:
+        if direction not in {"read", "write"}:
+            raise ValueError("Direction must be either 'read' or 'write'.")
         super().__init__(*args, **kwargs)
         self._direction = direction
         self._single_use_data = single_use_data

--- a/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Optional, Sequence
+from typing import Any, Literal, Optional, Sequence
 
 import dace
 from dace import (
@@ -23,6 +23,7 @@ from gt4py.next.program_processors.runners.dace import transformations as gtx_tr
 
 def gt_remove_copy_chain(
     sdfg: dace.SDFG,
+    direction: Literal["read", "write"],
     validate: bool = True,
     validate_all: bool = False,
     single_use_data: Optional[dict[dace.SDFG, set[str]]] = None,
@@ -34,6 +35,8 @@ def gt_remove_copy_chain(
 
     Args:
         sdfg: The SDFG to process.
+        direction: One of "read" or "write". When "read", try to remove a transient
+            node which is fully read; otherwise a transient which is fully written.
         validate: Perform validation after the pass has run.
         validate_all: Perform extensive validation.
         single_use_data: Which data descriptors are used only once.
@@ -51,7 +54,7 @@ def gt_remove_copy_chain(
         single_use_data = find_single_use_data.apply_pass(sdfg, None)
 
     result: int = sdfg.apply_transformations_repeated(
-        CopyChainRemover(single_use_data=single_use_data),
+        CopyChainRemover(direction=direction, single_use_data=single_use_data),
         validate=validate,
         validate_all=validate_all,
     )
@@ -76,8 +79,15 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
     requirements before it can be applied:
     - Through the merging of `A1` and `A2` no cycles are created.
     - `A1` can not be used anywhere else.
-    - `A1` is a transient and must have the same dimensionality than `A2`.
+    - `A1` is a transient and must have the same dimensionality as `A2`.
     - `A1` is fully read by `A2`.
+
+    In a second iteraton, the transformation was extended to support the mirror
+    case, where A2 is removed if the following requirements are satisfied:
+    - Through the merging of `A1` and `A2` no cycles are created.
+    - `A2` can not be used anywhere else.
+    - `A2` is a transient and must have the same dimensionality as `A1`.
+    - `A2` is fully written by `A1`.
 
     Notes:
         The transformation assumes that the domain inference adjusted the ranges of
@@ -97,6 +107,8 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
     node_a1 = dace_transformation.PatternNode(dace_nodes.AccessNode)
     node_a2 = dace_transformation.PatternNode(dace_nodes.AccessNode)
 
+    _direction: str
+
     # Name of all data that is used at only one place. Is computed by the
     #  `FindSingleUseData` pass and be passed at construction time. Needed until
     #  [issue#1911](https://github.com/spcl/dace/issues/1911) has been solved.
@@ -105,10 +117,12 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
     def __init__(
         self,
         *args: Any,
+        direction: Literal["read", "write"],
         single_use_data: dict[dace.SDFG, set[str]],
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self._direction = direction
         self._single_use_data = single_use_data
 
     @classmethod
@@ -137,11 +151,19 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
         a1_desc = a1.desc(sdfg)
         a2_desc = a2.desc(sdfg)
 
-        # We remove `a1` so it must be a transient and used only once.
-        if not a1_desc.transient:
-            return False
-        if not self.is_single_use_data(sdfg, a1):
-            return False
+        if self._direction == "read":
+            # We remove `a1`, a data access node which is read in its full shape.
+            #  It must be a transient and used only once.
+            if not a1_desc.transient:
+                return False
+            if not self.is_single_use_data(sdfg, a1):
+                return False
+        else:
+            # We remove `a2`, a data access node which is written in its full shape.
+            if not a2_desc.transient:
+                return False
+            if not self.is_single_use_data(sdfg, a2):
+                return False
 
         # This avoids that we have to modify the subsets in a fancy way.
         # TODO(phimuell): Lift this limitation.
@@ -186,19 +208,26 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
         if dst_subset is None:
             return False
 
-        # Checking if the whole array is read.
-        # NOTE: The main benefit of requiring that the whole array is read is that we
-        #   do not have to adjust maps.
-        # NOTE: In previous versions there was an ad hoc rule, to bypass the "full
-        #   read rule". However, it caused problems, so it was removed.
-        # TODO: We have to improve this test, because sometimes the expressions are
-        #   so complex that without information about relations, such as
-        #   `vertical_start <= vertical_end` it is not possible to prove this check.
-        a1_range = dace_sbs.Range.from_array(a1_desc)
-        if not src_subset.covers(a1_range):
-            return False
+        if self._direction == "read":
+            # Checking if the whole array is read.
+            # NOTE: The main benefit of requiring that the whole array is read is that we
+            #   do not have to adjust maps.
+            # NOTE: In previous versions there was an ad hoc rule, to bypass the "full
+            #   read rule". However, it caused problems, so it was removed.
+            # TODO: We have to improve this test, because sometimes the expressions are
+            #   so complex that without information about relations, such as
+            #   `vertical_start <= vertical_end` it is not possible to prove this check.
+            a1_range = dace_sbs.Range.from_array(a1_desc)
+            if not src_subset.covers(a1_range):
+                return False
 
-        # We have to ensure that no cycle is created through the removal of `a1`.
+        else:
+            # Checking if the whole array is written.
+            a2_range = dace_sbs.Range.from_array(a2_desc)
+            if not dst_subset.covers(a2_range):
+                return False
+
+        # We have to ensure that no cycle is created through the removal of one node.
         #  For this we have to ensure that there is no connection, beside the direct
         #  one between `a1` and `a2`.
         # NOTE: We only check the outgoing edges of `a1`, it is not needed to also
@@ -210,10 +239,10 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
         ):
             return False
 
-        # NOTE: In case `a2` is a non transient we do not have to check if it is read
-        #   or written to somewhere else in this state. The reason is that ADR18
-        #   guarantees us that everything is point wise, therefore `a1` is never
-        #   used as double buffer.
+        # NOTE: In case the node we keep is a non-transient we do not have to
+        #   check if it is read or written to somewhere else in this state.
+        #   The reason is that ADR18 guarantees that every access is point-wise,
+        #   therefore the temporary we remove is never used as double buffer.
         return True
 
     def is_single_use_data(
@@ -238,6 +267,7 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
             oedge for oedge in graph.out_edges(a1) if oedge.dst is a2
         )
         a1_to_a2_memlet: dace.Memlet = a1_to_a2_edge.data
+        a1_to_a2_src_subset: dace_sbs.Range = a1_to_a2_memlet.get_src_subset(a1_to_a2_edge, graph)
         a1_to_a2_dst_subset: dace_sbs.Range = a1_to_a2_memlet.get_dst_subset(a1_to_a2_edge, graph)
 
         # Note that it is possible that `a1` is connected to the same node multiple
@@ -249,29 +279,42 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
 
         # Now we compose the new subset.
         #  We build on the fact that we have ensured that the whole array `a1` is
-        #  copied into `a2`. Thus the destination of the original source, i.e.
-        #  whatever write into `a1`, is just offset by the beginning of the range
-        #  `a1` writes into `a2`.
+        #  copied into `a2` for the read direction. Thus the destination of the
+        #  original source, i.e. whatever write into `a1`, is just offset by the
+        #  beginning of the range `a1` writes into `a2`.
         #       (s1) ------[c:d]-> (A1) -[0:N]------[a:b]-> (A2)
         #       (s1) ---------[(a + c):(a + c + (d - c))]-> (A2)
         #  Thus the offset is simply given by `a`, the start where `a1` is written into
         #  `a2`.
         #  NOTE: If we ever allow the that `a1` is not fully read, then we would have
         #   to modify this computation slightly.
-        a2_offsets: Sequence[dace_sym.SymExpr] = a1_to_a2_dst_subset.min_element()
+        new_node: dace_nodes.AccessNode
+        old_node: dace_nodes.AccessNode
+        new_node_offsets: Sequence[dace_sym.SymExpr]
+        if self._direction == "read":
+            old_node = a1
+            new_node = a2
+            new_node_offsets = a1_to_a2_dst_subset.min_element()
+        else:
+            old_node = a2
+            new_node = a1
+            new_node_offsets = a1_to_a2_src_subset.min_element()
 
         # Handle the producer side of things.
-        for producer_edge in list(graph.in_edges(a1)):
+        for producer_edge in list(graph.in_edges(old_node)):
             producer: dace_nodes.Node = producer_edge.src
             producer_conn = producer_edge.src_conn
+            if old_node == a2 and producer is new_node:
+                assert producer_edge is a1_to_a2_edge
+                continue
             new_producer_edge = gtx_transformations.utils.reroute_edge(
                 is_producer_edge=True,
                 current_edge=producer_edge,
-                ss_offset=a2_offsets,
+                ss_offset=new_node_offsets,
                 state=graph,
                 sdfg=sdfg,
-                old_node=a1,
-                new_node=a2,
+                old_node=old_node,
+                new_node=new_node,
             )
             if (producer, producer_conn) not in reconfigured_neighbour:
                 gtx_transformations.utils.reconfigure_dataflow_after_rerouting(
@@ -279,28 +322,28 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
                     new_edge=new_producer_edge,
                     sdfg=sdfg,
                     state=graph,
-                    ss_offset=a2_offsets,
-                    old_node=a1,
-                    new_node=a2,
+                    ss_offset=new_node_offsets,
+                    old_node=old_node,
+                    new_node=new_node,
                 )
                 reconfigured_neighbour.add((producer, producer_conn))
 
         # Handle the consumer side of things, as they now have to read from `a2`.
         #  It is important that the offset is still the same.
-        for consumer_edge in list(graph.out_edges(a1)):
+        for consumer_edge in list(graph.out_edges(old_node)):
             consumer: dace_nodes.Node = consumer_edge.dst
             consumer_conn = consumer_edge.dst_conn
-            if consumer is a2:
+            if old_node == a1 and consumer is new_node:
                 assert consumer_edge is a1_to_a2_edge
                 continue
             new_consumer_edge = gtx_transformations.utils.reroute_edge(
                 is_producer_edge=False,
                 current_edge=consumer_edge,
-                ss_offset=a2_offsets,
+                ss_offset=new_node_offsets,
                 state=graph,
                 sdfg=sdfg,
-                old_node=a1,
-                new_node=a2,
+                old_node=old_node,
+                new_node=new_node,
             )
             if (consumer, consumer_conn) not in reconfigured_neighbour:
                 gtx_transformations.utils.reconfigure_dataflow_after_rerouting(
@@ -308,23 +351,23 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
                     new_edge=new_consumer_edge,
                     sdfg=sdfg,
                     state=graph,
-                    ss_offset=a2_offsets,
-                    old_node=a1,
-                    new_node=a2,
+                    ss_offset=new_node_offsets,
+                    old_node=old_node,
+                    new_node=new_node,
                 )
                 reconfigured_neighbour.add((consumer, consumer_conn))
 
-        # After the rerouting we have to delete the `a1` data node and descriptor,
+        # After the rerouting we have to delete the transient data node and descriptor,
         #  this will also remove all the old edges.
-        graph.remove_node(a1)
-        sdfg.remove_data(a1.data, validate=False)
+        graph.remove_node(old_node)
+        sdfg.remove_data(old_node.data, validate=False)
 
-        # We will now propagate the strides starting from the access nodes `a2`.
-        #  Essentially, this will replace the strides from `a1` with the ones of
-        #  `a2`. We do it outside to make sure that we do not forget a case and
-        #  that we propagate the change into every NestedSDFG only once.
+        # We will now propagate the strides starting from the access node we keep.
+        #  Essentially, this will replace the strides from `old_node` with the ones
+        #  of `new_node`. We do it outside to make sure that we do not forget a
+        #  case and that we propagate the change into every NestedSDFG only once.
         gtx_transformations.gt_propagate_strides_from_access_node(
             sdfg=sdfg,
             state=graph,
-            outer_node=a2,
+            outer_node=new_node,
         )

--- a/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/redundant_array_removers.py
@@ -6,7 +6,8 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, Literal, Optional, Sequence
+from enum import Enum
+from typing import Any, Optional, Sequence
 
 import dace
 from dace import (
@@ -23,7 +24,6 @@ from gt4py.next.program_processors.runners.dace import transformations as gtx_tr
 
 def gt_remove_copy_chain(
     sdfg: dace.SDFG,
-    direction: Literal["read", "write"],
     validate: bool = True,
     validate_all: bool = False,
     single_use_data: Optional[dict[dace.SDFG, set[str]]] = None,
@@ -35,8 +35,6 @@ def gt_remove_copy_chain(
 
     Args:
         sdfg: The SDFG to process.
-        direction: One of "read" or "write". When "read", try to remove a transient
-            node which is fully read; otherwise a transient which is fully written.
         validate: Perform validation after the pass has run.
         validate_all: Perform extensive validation.
         single_use_data: Which data descriptors are used only once.
@@ -54,11 +52,27 @@ def gt_remove_copy_chain(
         single_use_data = find_single_use_data.apply_pass(sdfg, None)
 
     result: int = sdfg.apply_transformations_repeated(
-        CopyChainRemover(direction=direction, single_use_data=single_use_data),
+        CopyChainRemover(single_use_data=single_use_data),
         validate=validate,
         validate_all=validate_all,
     )
     return result if result != 0 else None
+
+
+class _CopyChainRemoverMode(Enum):
+    """Switch for `CopyChainRemover` mode.
+
+    The `NONE` mode is invalid, it is there for signaling that the transformation
+    cannot be applied.
+    The `PULL` mode corresponds to the case where `a1` is transient, single-use
+    data and its full shape is copied to `a2`, thus `a1` can be replaced with `a2`.
+    The `PUSH` mode corresponds to the case where `a2` is transient, single-use
+    data and its full shape is copied from `a1`, thus `a2` can be replaced with `a1`.
+    """
+
+    NONE = 0
+    PULL = 1
+    PUSH = 2
 
 
 @dace_properties.make_properties
@@ -82,8 +96,9 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
     - `A1` is a transient and must have the same dimensionality as `A2`.
     - `A1` is fully read by `A2`.
 
+    This transformation corresponds to the `PULL` mode of `_CopyChainRemoverMode`.
     In a second iteraton, the transformation was extended to support the mirror
-    case, where A2 is removed if the following requirements are satisfied:
+    case (`PUSH`), where A2 is removed if the following requirements are satisfied:
     - Through the merging of `A1` and `A2` no cycles are created.
     - `A2` can not be used anywhere else.
     - `A2` is a transient and must have the same dimensionality as `A1`.
@@ -107,8 +122,6 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
     node_a1 = dace_transformation.PatternNode(dace_nodes.AccessNode)
     node_a2 = dace_transformation.PatternNode(dace_nodes.AccessNode)
 
-    _direction: str
-
     # Name of all data that is used at only one place. Is computed by the
     #  `FindSingleUseData` pass and be passed at construction time. Needed until
     #  [issue#1911](https://github.com/spcl/dace/issues/1911) has been solved.
@@ -117,14 +130,10 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
     def __init__(
         self,
         *args: Any,
-        direction: Literal["read", "write"],
         single_use_data: dict[dace.SDFG, set[str]],
         **kwargs: Any,
     ) -> None:
-        if direction not in {"read", "write"}:
-            raise ValueError("Direction must be either 'read' or 'write'.")
         super().__init__(*args, **kwargs)
-        self._direction = direction
         self._single_use_data = single_use_data
 
     @classmethod
@@ -152,20 +161,6 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
 
         a1_desc = a1.desc(sdfg)
         a2_desc = a2.desc(sdfg)
-
-        if self._direction == "read":
-            # We remove `a1`, a data access node which is read in its full shape.
-            #  It must be a transient and used only once.
-            if not a1_desc.transient:
-                return False
-            if not self.is_single_use_data(sdfg, a1):
-                return False
-        else:
-            # We remove `a2`, a data access node which is written in its full shape.
-            if not a2_desc.transient:
-                return False
-            if not self.is_single_use_data(sdfg, a2):
-                return False
 
         # This avoids that we have to modify the subsets in a fancy way.
         # TODO(phimuell): Lift this limitation.
@@ -210,24 +205,8 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
         if dst_subset is None:
             return False
 
-        if self._direction == "read":
-            # Checking if the whole array is read.
-            # NOTE: The main benefit of requiring that the whole array is read is that we
-            #   do not have to adjust maps.
-            # NOTE: In previous versions there was an ad hoc rule, to bypass the "full
-            #   read rule". However, it caused problems, so it was removed.
-            # TODO: We have to improve this test, because sometimes the expressions are
-            #   so complex that without information about relations, such as
-            #   `vertical_start <= vertical_end` it is not possible to prove this check.
-            a1_range = dace_sbs.Range.from_array(a1_desc)
-            if not src_subset.covers(a1_range):
-                return False
-
-        else:
-            # Checking if the whole array is written.
-            a2_range = dace_sbs.Range.from_array(a2_desc)
-            if not dst_subset.covers(a2_range):
-                return False
+        if self._get_copy_chain_mode(sdfg, graph) == _CopyChainRemoverMode.NONE:
+            return False
 
         # We have to ensure that no cycle is created through the removal of one node.
         #  For this we have to ensure that there is no connection, beside the direct
@@ -279,27 +258,35 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
         #  counter example would be a Map with different connector names.
         reconfigured_neighbour: set[tuple[dace_nodes.Node, Optional[str]]] = set()
 
-        # Now we compose the new subset.
-        #  We build on the fact that we have ensured that the whole array `a1` is
-        #  copied into `a2` for the read direction. Thus the destination of the
-        #  original source, i.e. whatever write into `a1`, is just offset by the
-        #  beginning of the range `a1` writes into `a2`.
-        #       (s1) ------[c:d]-> (A1) -[0:N]------[a:b]-> (A2)
-        #       (s1) ---------[(a + c):(a + c + (d - c))]-> (A2)
-        #  Thus the offset is simply given by `a`, the start where `a1` is written into
-        #  `a2`.
-        #  NOTE: If we ever allow the that `a1` is not fully read, then we would have
-        #   to modify this computation slightly.
+        #  In this section, `old_node` refers to the node, one of `a1` or `a2`,
+        #  which will be replaced by the other one. The node which is kept is
+        #  referred to as `new_node`.
         new_node: dace_nodes.AccessNode
         old_node: dace_nodes.AccessNode
-        new_node_offsets: Sequence[dace_sym.SymExpr]
-        if self._direction == "read":
+        new_node_offsets: Sequence[dace_sym.SymbolicType]
+        copy_chain_mode = self._get_copy_chain_mode(sdfg, graph)
+        if copy_chain_mode == _CopyChainRemoverMode.PULL:
             old_node = a1
             new_node = a2
+            # Now we compose the new subset.
+            #  For the `PULL` mode, we build on the fact that we have ensured that
+            #  the whole array `old_node` (`a1`) is copied into `new_node` (`a2`).
+            #  Thus the destination of the original source, i.e. whatever writes
+            #  into `a1`, is just offset by the beginning of the range `a1` writes
+            #  into `a2`.
+            #       (s1) ------[c:d]-> (A1) -[0:N]------[a:b]-> (A2)
+            #       (s1) ---------[(a + c):(a + c + (d - c))]-> (A2)
+            #  Thus the offset is simply given by `a`, the start index where `a1`
+            #  is written into `a2`.
+            #  NOTE: If we ever allow the that `a1` is not fully read, then we would
+            #   have to modify this computation slightly.
             new_node_offsets = a1_to_a2_dst_subset.min_element()
         else:
+            assert copy_chain_mode == _CopyChainRemoverMode.PUSH
             old_node = a2
             new_node = a1
+            # We compose the new subset in a similar way, but using the index where
+            #  `a2` starts reading from `a1`.
             new_node_offsets = a1_to_a2_src_subset.min_element()
 
         # Handle the producer side of things.
@@ -373,3 +360,58 @@ class CopyChainRemover(dace_transformation.SingleStateTransformation):
             state=graph,
             outer_node=new_node,
         )
+
+    def _get_copy_chain_mode(self, sdfg: dace.SDFG, state: dace.SDFG) -> _CopyChainRemoverMode:
+        """
+        Helper function to detect whether the `CopyChainRemover` tranbsformation
+        should be applied in `PULL` or `PUSH` mode, for details see `_CopyChainRemoverMode`.
+        """
+        a1: dace_nodes.AccessNode = self.node_a1
+        a2: dace_nodes.AccessNode = self.node_a2
+
+        a1_desc = a1.desc(sdfg)
+        a1_range = dace_sbs.Range.from_array(a1_desc)
+
+        a2_desc = a2.desc(sdfg)
+        a2_range = dace_sbs.Range.from_array(a2_desc)
+
+        # There shall only be one edge connecting `a1` and `a2`.
+        #  We even strengthen this requirement by not checking for the node `a2`,
+        #  but for the data.
+        connecting_edges = [
+            oedge
+            for oedge in state.out_edges(a1)
+            if isinstance(oedge.dst, dace_nodes.AccessNode) and (oedge.dst.data == a2.data)
+        ]
+        assert len(connecting_edges) == 1
+
+        # The full array `a1` is copied into `a2`. Note that it is allowed, that
+        #  `a2` is bigger than `a1`, it is just important that everything that was
+        #  written into `a1` is also accessed.
+        connecting_edge = connecting_edges[0]
+        assert connecting_edge.dst is a2
+        connecting_memlet = connecting_edge.data
+
+        # If the destination or the source subset of the connection is not fully
+        #  specified, we do not apply.
+        src_subset = connecting_memlet.get_src_subset(connecting_edge, state)
+        assert src_subset is not None
+        dst_subset = connecting_memlet.get_dst_subset(connecting_edge, state)
+        assert dst_subset is not None
+
+        # Checking if the whole array is read.
+        # NOTE: The main benefit of requiring that the whole array is read is that we
+        #   do not have to adjust maps.
+        # NOTE: In previous versions there was an ad hoc rule, to bypass the "full
+        #   read rule". However, it caused problems, so it was removed.
+        # TODO: We have to improve this test, because sometimes the expressions are
+        #   so complex that without information about relations, such as
+        #   `vertical_start <= vertical_end` it is not possible to prove this check.
+        if a1_desc.transient and self.is_single_use_data(sdfg, a1) and src_subset.covers(a1_range):
+            return _CopyChainRemoverMode.PULL
+
+        # Checking if the whole array is written.
+        if a2_desc.transient and self.is_single_use_data(sdfg, a2) and dst_subset.covers(a2_range):
+            return _CopyChainRemoverMode.PUSH
+
+        return _CopyChainRemoverMode.NONE

--- a/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
@@ -153,17 +153,19 @@ def gt_simplify(
                 result["GT4PyDeadDataflowElimination"] += eliminate_dead_dataflow_res
 
         if "CopyChainRemover" not in skip:
-            copy_chain_remover_result = gtx_transformations.gt_remove_copy_chain(
-                sdfg=sdfg,
-                validate=False,
-                validate_all=validate_all,
-            )
-            if copy_chain_remover_result is not None:
-                at_least_one_xtrans_run = True
-                result = result or {}
-                if "CopyChainRemover" not in result:
-                    result["CopyChainRemover"] = 0
-                result["CopyChainRemover"] += copy_chain_remover_result
+            for direction in "read", "write":
+                copy_chain_remover_result = gtx_transformations.gt_remove_copy_chain(
+                    sdfg=sdfg,
+                    direction=direction,
+                    validate=False,
+                    validate_all=validate_all,
+                )
+                if copy_chain_remover_result is not None:
+                    at_least_one_xtrans_run = True
+                    result = result or {}
+                    if "CopyChainRemover" not in result:
+                        result["CopyChainRemover"] = 0
+                    result["CopyChainRemover"] += copy_chain_remover_result
 
         if "SingleStateGlobalDirectSelfCopyElimination" not in skip:
             direct_self_copy_removal_result = sdfg.apply_transformations_repeated(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
@@ -153,19 +153,17 @@ def gt_simplify(
                 result["GT4PyDeadDataflowElimination"] += eliminate_dead_dataflow_res
 
         if "CopyChainRemover" not in skip:
-            for direction in "read", "write":
-                copy_chain_remover_result = gtx_transformations.gt_remove_copy_chain(
-                    sdfg=sdfg,
-                    direction=direction,
-                    validate=False,
-                    validate_all=validate_all,
-                )
-                if copy_chain_remover_result is not None:
-                    at_least_one_xtrans_run = True
-                    result = result or {}
-                    if "CopyChainRemover" not in result:
-                        result["CopyChainRemover"] = 0
-                    result["CopyChainRemover"] += copy_chain_remover_result
+            copy_chain_remover_result = gtx_transformations.gt_remove_copy_chain(
+                sdfg=sdfg,
+                validate=False,
+                validate_all=validate_all,
+            )
+            if copy_chain_remover_result is not None:
+                at_least_one_xtrans_run = True
+                result = result or {}
+                if "CopyChainRemover" not in result:
+                    result["CopyChainRemover"] = 0
+                result["CopyChainRemover"] += copy_chain_remover_result
 
         if "SingleStateGlobalDirectSelfCopyElimination" not in skip:
             direct_self_copy_removal_result = sdfg.apply_transformations_repeated(

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_copy_chain_remover.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_copy_chain_remover.py
@@ -31,7 +31,7 @@ def _make_simple_linear_chain_sdfg() -> dace.SDFG:
     """
     sdfg = dace.SDFG(util.unique_name("simple_linear_chain_sdfg"))
 
-    for name in ["a", "b", "c", "d", "e", "f"]:
+    for name in ["a", "b", "c", "d", "e"]:
         sdfg.add_array(
             name,
             shape=(10,),
@@ -39,7 +39,7 @@ def _make_simple_linear_chain_sdfg() -> dace.SDFG:
             transient=True,
         )
     sdfg.arrays["a"].transient = False
-    sdfg.arrays["f"].transient = False
+    sdfg.arrays["e"].transient = False
 
     state = sdfg.add_state(is_start_block=True)
     b, c, d, e = (state.add_access(name) for name in "bcde")
@@ -56,20 +56,11 @@ def _make_simple_linear_chain_sdfg() -> dace.SDFG:
     state.add_nedge(b, c, dace.Memlet("b[0:10] -> [0:10]"))
     state.add_nedge(c, d, dace.Memlet("c[0:10] -> [0:10]"))
     state.add_nedge(d, e, dace.Memlet("d[0:10] -> [0:10]"))
-    state.add_mapped_tasklet(
-        "comp2",
-        map_ranges={"__i": "0:10"},
-        inputs={"__in": dace.Memlet("e[__i]")},
-        input_nodes={e},
-        code="__out = __in",
-        outputs={"__out": dace.Memlet("f[__i]")},
-        external_edges=True,
-    )
     sdfg.validate()
     return sdfg
 
 
-def _make_diff_sizes_read_chain_sdfg() -> tuple[
+def _make_diff_sizes_pull_chain_sdfg() -> tuple[
     dace.SDFG, dace.SDFGState, dace_nodes.AccessNode, dace_nodes.Tasklet
 ]:
     """Creates a linear chain of copies.
@@ -84,7 +75,7 @@ def _make_diff_sizes_read_chain_sdfg() -> tuple[
     - The AccessNode that is used as final output, refers to `e`.
     - The Tasklet that is within the Map.
     """
-    sdfg = dace.SDFG(util.unique_name("diff_size_linear_read_chain_sdfg"))
+    sdfg = dace.SDFG(util.unique_name("diff_size_linear_pull_chain_sdfg"))
 
     array_size_increment = 10
     array_size = 10
@@ -119,15 +110,15 @@ def _make_diff_sizes_read_chain_sdfg() -> tuple[
     return sdfg, state, e, tasklet
 
 
-def _make_diff_sizes_write_chain_sdfg() -> tuple[
+def _make_diff_sizes_push_chain_sdfg() -> tuple[
     dace.SDFG, dace.SDFGState, dace_nodes.AccessNode, dace_nodes.Tasklet
 ]:
     """Creates a linear chain of copies.
 
-    Same as `_make_simple_linear_read_chain_sdfg()` but the intermediates become
+    Same as `_make_simple_linear_pull_chain_sdfg()` but the intermediates become
     smaller and smaller, so the full shape of the destination array is always written.
     """
-    sdfg = dace.SDFG(util.unique_name("diff_size_linear_write_chain_sdfg"))
+    sdfg = dace.SDFG(util.unique_name("diff_size_linear_push_chain_sdfg"))
 
     array_size_decrement = 10
     array_size = 50
@@ -508,26 +499,23 @@ def _make_copy_chain_with_reduction_node(
     return sdfg, state, red0, accumulators[0], red1, accumulators[1], output_ac
 
 
-@pytest.mark.parametrize("direction", ["read", "write"])
-def test_simple_linear_chain(direction):
+def test_simple_linear_chain():
     sdfg = _make_simple_linear_chain_sdfg()
 
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, direction, validate_all=True)
-    assert nb_applies == 3
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
         sdfg, dace_nodes.AccessNode, return_nodes=True
     )
-    assert len(acnodes) == 3
-    transient_data = [ac.data for ac in acnodes if ac.desc(sdfg).transient]
-    assert len(transient_data) == 1
-    assert transient_data[0] == ("e" if direction == "read" else "b")
+    assert len(acnodes) == 2
+    assert not any(ac.desc(sdfg).transient for ac in acnodes)
+    assert nb_applies == 3
 
 
-def test_diff_size_linear_read_chain():
-    sdfg, state, output, tasklet = _make_diff_sizes_read_chain_sdfg()
+def test_diff_size_linear_pull_chain():
+    sdfg, state, output, tasklet = _make_diff_sizes_pull_chain_sdfg()
 
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "read", validate_all=True)
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
         sdfg, dace_nodes.AccessNode, return_nodes=True
@@ -549,10 +537,10 @@ def test_diff_size_linear_read_chain():
     assert str(tasklet_memlet.subset[0][0] - 18).strip() == "__i"
 
 
-def test_diff_size_linear_write_chain():
-    sdfg, state, input, tasklet = _make_diff_sizes_write_chain_sdfg()
+def test_diff_size_linear_push_chain():
+    sdfg, state, input, tasklet = _make_diff_sizes_push_chain_sdfg()
 
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "write", validate_all=True)
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
         sdfg, dace_nodes.AccessNode, return_nodes=True
@@ -591,7 +579,7 @@ def test_multi_stage_reduction():
     util.compile_and_run_sdfg(sdfg, **ref)
 
     # Apply the transformation.
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "read", validate_all=True)
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     # Run the processed SDFG
     util.compile_and_run_sdfg(sdfg, **res)
@@ -625,7 +613,7 @@ def test_not_fully_copied():
     # Apply the transformation.
     #  It will only remove `d` all the others are retained, because they are not read
     #  correctly, i.e. fully.
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "read", validate_all=True)
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     # Perform all the checks.
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
@@ -647,17 +635,18 @@ def test_possible_cyclic_sdfg():
     sdfg = _make_possible_cyclic_sdfg()
 
     # Apply the transformation.
-    #  It will not remove `a1`, because it it would and replace it with `a2` then
-    #  the resulting SDFG is cyclic. It will, however, replace `a2` with `o1`.
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "read", validate_all=True)
+    #  The first iteration will replace `a2` with `o1`, in pull mode, since the
+    #  full shape of `a2` is copied into `o1`. In a second iteration, the transformation
+    #  will be applied in push mode: the full shape of the global `i1` is copied
+    #  into `a1`, thus `a1` will be replaced with `i1`.
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
+    assert nb_applies == 2
 
     # Perform all the checks.
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
         sdfg, dace_nodes.AccessNode, return_nodes=True
     )
-    assert len(acnodes) == 3
-    assert nb_applies == 1
-    assert "o1" not in acnodes
+    assert {node.data for node in acnodes} == {"i1", "o1"}
 
 
 def test_a1_additional_output():
@@ -677,7 +666,7 @@ def test_a1_additional_output():
 
     # Apply the transformation.
     #  The transformation removes `a1` and `a2`.
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "read", validate_all=True)
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     # Perform the tests.
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
@@ -727,7 +716,7 @@ def test_linear_chain_with_nested_sdfg():
 
     # Apply the transformation.
     #  It should remove all non transient arrays.
-    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, "read", validate_all=True)
+    nb_applies = gtx_transformations.gt_remove_copy_chain(sdfg, validate_all=True)
 
     # Perform the tests.
     acnodes: list[dace_nodes.AccessNode] = util.count_nodes(
@@ -762,7 +751,6 @@ def test_copy_chain_remover_with_reduction(output_an_array: bool):
             gtx_transformations.CopyChainRemover.node_a2: a2,
         }
         copy_chain_remover = gtx_transformations.CopyChainRemover(
-            direction="read",
             single_use_data={sdfg: {acc0.data, acc1.data}},
         )
         copy_chain_remover.setup_match(


### PR DESCRIPTION
The current design of `CopyChainRemover` allowed to remove temporary arrays which are used as source node of full-read copies. Suppose a temporary `__tmp` which is single-use data, with shape `(10,)`: `__tmp` can be removed in `__tmp[0:10] -> A[x:x+10]`

With this change, `CopyChainRemover` can also be applied in the _write_ direction, that is to remove temporary arrays which are used as destination node of full-write copies. For example, still using the single-use temporary `__tmp` as above: `__tmp` can be removed in `A[x:x+10] -> __tmp[0:10]`.