### PR TITLE
feat[next][dace]: collect sdfg execution time with tasklet

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/program.py
+++ b/src/gt4py/next/program_processors/runners/dace/program.py
@@ -15,13 +15,12 @@ from typing import Any, ClassVar, Optional, Sequence
 import dace
 import numpy as np
 
-from gt4py.next import backend as next_backend, common, config
+from gt4py.next import backend as next_backend, common
 from gt4py.next.ffront import decorator
 from gt4py.next.iterator import ir as itir, transforms as itir_transforms
 from gt4py.next.iterator.transforms import extractors as extractors
 from gt4py.next.otf import arguments, recipes, toolchain
 from gt4py.next.program_processors.runners.dace import utils as gtx_dace_utils
-from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 from gt4py.next.type_system import type_specifications as ts
 
 
@@ -97,10 +96,11 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
         # the other parts of the workaround when possible.
         sdfg = dace.SDFG.from_json(
             compile_workflow_translation.replace(
-                disable_itir_transforms=True, disable_field_origin_on_program_arguments=True
+                disable_itir_transforms=True,
+                disable_field_origin_on_program_arguments=True,
+                use_metrics=False,
             )(gtir_stage).source_code
         )
-        sdfg.add_constant(gtx_wfdcommon.SDFG_ARG_METRIC_LEVEL, config.COLLECT_METRICS_LEVEL)
 
         self.sdfg_closure_cache["arrays"] = sdfg.arrays
 

--- a/src/gt4py/next/program_processors/runners/dace/program.py
+++ b/src/gt4py/next/program_processors/runners/dace/program.py
@@ -15,12 +15,13 @@ from typing import Any, ClassVar, Optional, Sequence
 import dace
 import numpy as np
 
-from gt4py.next import backend as next_backend, common
+from gt4py.next import backend as next_backend, common, config
 from gt4py.next.ffront import decorator
 from gt4py.next.iterator import ir as itir, transforms as itir_transforms
 from gt4py.next.iterator.transforms import extractors as extractors
 from gt4py.next.otf import arguments, recipes, toolchain
 from gt4py.next.program_processors.runners.dace import utils as gtx_dace_utils
+from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 from gt4py.next.type_system import type_specifications as ts
 
 
@@ -99,6 +100,7 @@ class Program(decorator.Program, dace.frontend.python.common.SDFGConvertible):
                 disable_itir_transforms=True, disable_field_origin_on_program_arguments=True
             )(gtir_stage).source_code
         )
+        sdfg.add_constant(gtx_wfdcommon.SDFG_ARG_METRIC_LEVEL, config.COLLECT_METRICS_LEVEL)
 
         self.sdfg_closure_cache["arrays"] = sdfg.arrays
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -77,6 +77,7 @@ def make_dace_backend(
     use_memory_pool: bool,
     blocking_dim: common.Dimension | None,
     blocking_size: int = 10,
+    use_metrics: bool = True,
     use_zero_origin: bool = False,
 ) -> backend.Backend:
     """Helper function to create a dace cached backend with custom config for SDFG
@@ -98,6 +99,7 @@ def make_dace_backend(
             on this dimension.
         blocking_size: Block size to use in 'LoopBlocking' SDFG transformation,
             when enabled.
+        use_metrics: Add SDFG instrumention to collect the stencil compute time.
         use_zero_origin: Can be set to `True` when all fields passed as program
             arguments have zero-based origin. This setting will skip generation
             of range start-symbols `_range_0` since they can be assumed to be zero.
@@ -116,6 +118,7 @@ def make_dace_backend(
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,
         otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bare_translation__use_memory_pool=use_memory_pool,
+        otf_workflow__bare_translation__use_metrics=use_metrics,
         otf_workflow__bindings__make_persistent=make_persistent,
     )
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -72,6 +72,7 @@ def make_dace_backend(
     auto_optimize: bool,
     cached: bool,
     gpu: bool,
+    async_sdfg_call: bool,
     make_persistent: bool,
     use_memory_pool: bool,
     blocking_dim: common.Dimension | None,
@@ -81,10 +82,16 @@ def make_dace_backend(
     """Helper function to create a dace cached backend with custom config for SDFG
     lowering and auto-optimize.
 
+    Note that `async_sdfg_call=True` on GPU device relies on the dace configuration
+    with 1 cuda stream, so that all kernels and memory operations are executed
+    sequentially on the default stream.
+
     Args:
         auto_optimize: Enable SDFG auto-optimize pipeline.
         cached: Cache the lowered SDFG as a JSON file and the compiled programs.
         gpu: Enable GPU transformations and code generation.
+        async_sdfg_call: Enable asynchronous SDFG execution, only applicable
+            when `gpu=True` because it relies on the gpu kernel queue.
         make_persistent: Allocate persistent arrays with constant layout.
         use_memory_pool: Enable memory pool for allocation of temporary fields.
         blocking_dim: When not 'None', apply 'LoopBlocking' SDFG transformation
@@ -105,6 +112,7 @@ def make_dace_backend(
         otf_workflow__cached_translation=cached,
         otf_workflow__bare_translation__blocking_dim=blocking_dim,
         otf_workflow__bare_translation__blocking_size=blocking_size,
+        otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,
         otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bare_translation__use_memory_pool=use_memory_pool,
@@ -117,6 +125,7 @@ run_dace_cpu = make_dace_backend(
     cached=False,
     gpu=False,
     blocking_dim=None,
+    async_sdfg_call=False,
     make_persistent=False,
     use_memory_pool=False,
 )
@@ -125,6 +134,7 @@ run_dace_cpu_noopt = make_dace_backend(
     cached=False,
     gpu=False,
     blocking_dim=None,
+    async_sdfg_call=False,
     make_persistent=False,
     use_memory_pool=False,
 )
@@ -133,6 +143,7 @@ run_dace_cpu_cached = make_dace_backend(
     cached=True,
     gpu=False,
     blocking_dim=None,
+    async_sdfg_call=False,
     make_persistent=False,
     use_memory_pool=False,
 )
@@ -142,6 +153,7 @@ run_dace_gpu = make_dace_backend(
     cached=False,
     gpu=True,
     blocking_dim=None,
+    async_sdfg_call=True,
     make_persistent=False,
     use_memory_pool=(core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA),
 )
@@ -150,6 +162,7 @@ run_dace_gpu_noopt = make_dace_backend(
     cached=False,
     gpu=True,
     blocking_dim=None,
+    async_sdfg_call=True,
     make_persistent=False,
     use_memory_pool=(core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA),
 )
@@ -158,6 +171,7 @@ run_dace_gpu_cached = make_dace_backend(
     cached=True,
     gpu=True,
     blocking_dim=None,
+    async_sdfg_call=True,
     make_persistent=False,
     use_memory_pool=(core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA),
 )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -72,7 +72,6 @@ def make_dace_backend(
     auto_optimize: bool,
     cached: bool,
     gpu: bool,
-    async_sdfg_call: bool,
     make_persistent: bool,
     use_memory_pool: bool,
     blocking_dim: common.Dimension | None,
@@ -82,16 +81,10 @@ def make_dace_backend(
     """Helper function to create a dace cached backend with custom config for SDFG
     lowering and auto-optimize.
 
-    Note that `async_sdfg_call=True` on GPU device relies on the dace configuration
-    with 1 cuda stream, so that all kernels and memory operations are executed
-    sequentially on the default stream.
-
     Args:
         auto_optimize: Enable SDFG auto-optimize pipeline.
         cached: Cache the lowered SDFG as a JSON file and the compiled programs.
         gpu: Enable GPU transformations and code generation.
-        async_sdfg_call: Enable asynchronous SDFG execution, only applicable
-            when `gpu=True` because it relies on the gpu kernel queue.
         make_persistent: Allocate persistent arrays with constant layout.
         use_memory_pool: Enable memory pool for allocation of temporary fields.
         blocking_dim: When not 'None', apply 'LoopBlocking' SDFG transformation
@@ -112,7 +105,6 @@ def make_dace_backend(
         otf_workflow__cached_translation=cached,
         otf_workflow__bare_translation__blocking_dim=blocking_dim,
         otf_workflow__bare_translation__blocking_size=blocking_size,
-        otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,
         otf_workflow__bare_translation__make_persistent=make_persistent,
         otf_workflow__bare_translation__use_memory_pool=use_memory_pool,
@@ -125,7 +117,6 @@ run_dace_cpu = make_dace_backend(
     cached=False,
     gpu=False,
     blocking_dim=None,
-    async_sdfg_call=False,
     make_persistent=False,
     use_memory_pool=False,
 )
@@ -134,7 +125,6 @@ run_dace_cpu_noopt = make_dace_backend(
     cached=False,
     gpu=False,
     blocking_dim=None,
-    async_sdfg_call=False,
     make_persistent=False,
     use_memory_pool=False,
 )
@@ -143,7 +133,6 @@ run_dace_cpu_cached = make_dace_backend(
     cached=True,
     gpu=False,
     blocking_dim=None,
-    async_sdfg_call=False,
     make_persistent=False,
     use_memory_pool=False,
 )
@@ -153,7 +142,6 @@ run_dace_gpu = make_dace_backend(
     cached=False,
     gpu=True,
     blocking_dim=None,
-    async_sdfg_call=True,
     make_persistent=False,
     use_memory_pool=(core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA),
 )
@@ -162,7 +150,6 @@ run_dace_gpu_noopt = make_dace_backend(
     cached=False,
     gpu=True,
     blocking_dim=None,
-    async_sdfg_call=True,
     make_persistent=False,
     use_memory_pool=(core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA),
 )
@@ -171,7 +158,6 @@ run_dace_gpu_cached = make_dace_backend(
     cached=True,
     gpu=True,
     blocking_dim=None,
-    async_sdfg_call=True,
     make_persistent=False,
     use_memory_pool=(core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.CUDA),
 )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -16,7 +16,7 @@ from gt4py.next import config
 
 
 SDFG_ARG_METRIC_LEVEL: Final[str] = "gt_metrics_level"
-"""Name of SDFG argument to retrive the GT4Py metrics level to collect."""
+"""Name of SDFG argument to retrive the GT4Py metrics level."""
 
 
 def set_dace_config(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -7,12 +7,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import contextlib
-from typing import Any, Generator, Optional
+from typing import Any, Final, Generator, Optional
 
 import dace
 
 from gt4py._core import definitions as core_defs
 from gt4py.next import config
+
+
+SDFG_ARG_METRIC_LEVEL: Final[str] = "gt_metrics_level"
+"""Name of SDFG argument to retrive the GT4Py metrics level to collect."""
 
 
 def set_dace_config(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -14,10 +14,9 @@ from typing import Any, Callable, Sequence
 
 import dace
 import factory
-import numpy as np
 
 from gt4py._core import definitions as core_defs, locking
-from gt4py.next import config, metrics
+from gt4py.next import config
 from gt4py.next.otf import languages, stages, step_types, workflow
 from gt4py.next.otf.compilation import cache as gtx_cache
 from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
@@ -49,23 +48,6 @@ def _get_sdfg_ctype_arglist_callback(
     assert bind_func_name in global_namespace
     global_namespace[bind_func_name].__module__ = module_name
     return global_namespace[bind_func_name]
-
-
-def _collect_compute_time(fun: Callable[..., Any]) -> Callable[..., None]:
-    collect_time = config.COLLECT_METRICS_LEVEL >= metrics.PERFORMANCE
-
-    def inner(*args: Any, **kwargs: Any) -> None:
-        result = fun(*args, **kwargs)
-        if collect_time:
-            assert len(result) == 1
-            assert isinstance(result[0], np.float64)
-            metric_collection = metrics.get_active_metric_collection()
-            if metric_collection is not None:
-                metric_collection.add_sample(metrics.COMPUTE_METRIC, result[0].item())
-        else:
-            assert (result is None) or (config.COLLECT_METRICS_LEVEL != metrics.DISABLED)
-
-    return inner
 
 
 class CompiledDaceProgram(stages.CompiledProgram):
@@ -103,11 +85,9 @@ class CompiledDaceProgram(stages.CompiledProgram):
             binding_module_name, bind_func_name, binding_source.source_code
         )
 
-    @_collect_compute_time
     def __call__(self, **kwargs: Any) -> Any:
         return self.sdfg_program(**kwargs)
 
-    @_collect_compute_time
     def fast_call(self) -> Any:
         return self.sdfg_program.fast_call(*self.sdfg_program._lastargs)
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
@@ -29,16 +29,10 @@ def _collect_compute_time(fun: Callable[..., Any]) -> Callable[..., None]:
 
     def inner(*args: Any, **kwargs: Any) -> None:
         result = fun(*args, **kwargs)
-        if not collect_time:
-            return
-        if result is None:
-            raise RuntimeError(
-                "Config 'COLLECT_METRICS_LEVEL' is set but the SDFG did not return"
-                " the compute time as expected. This might indicate that the backend"
-                " is using a precompiled SDFG from persistent cache without instrumentation."
-            )
         assert len(result) == 1
         assert isinstance(result[0], np.float64)
+        if not collect_time:
+            return
         metric_collection = metrics.get_active_metric_collection()
         if metric_collection is not None:
             metric_collection.add_sample(metrics.COMPUTE_METRIC, result[0].item())

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -187,8 +187,8 @@ def make_sdfg_timer(sdfg: dace.SDFG) -> None:
     SDFG with a cpp timer (std::chrono). This timer measures only the computation
     time, it does not include the overhead of calling the SDFG from Python.
 
-    The execution time is measured in seconds and repsented as a 'float64' value.
-    It is returned from the SDFG as a single element array in the '__return' data node.
+    The execution time is measured in seconds and represented as a 'float64' value.
+    It is returned from the SDFG as a one-element array in the '__return' data node.
     """
     output, _ = sdfg.add_array("__return", [1], dace.float64)
     start_time, _ = sdfg.add_scalar("gt_start_time", dace.float64, transient=True)
@@ -348,14 +348,13 @@ class DaCeTranslator(
             gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
 
         # We have to wait for SDFG completion if we need to collect metrics.
-        async_sdfg_call = (
-            self.async_sdfg_call if config.COLLECT_METRICS_LEVEL == metrics.DISABLED else False
-        )
-        if async_sdfg_call:
+        if config.COLLECT_METRICS_LEVEL != metrics.DISABLED:
+            make_sdfg_call_sync(sdfg, on_gpu)
+            make_sdfg_timer(sdfg)
+        elif self.async_sdfg_call:
             make_sdfg_call_async(sdfg, on_gpu)
         else:
             make_sdfg_call_sync(sdfg, on_gpu)
-            make_sdfg_timer(sdfg)
 
         return sdfg
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -128,7 +128,7 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
     start_time, _ = sdfg.add_scalar("gt_start_time", dace.float64, transient=True)
     metrics_level = sdfg.add_symbol(gtx_wfdcommon.SDFG_ARG_METRIC_LEVEL, dace.int32)
 
-    #### 1. Set CUDA stram to default and create synchronization code for GPU target.
+    #### 1. Synchronize the CUDA device, in order to wait for kernels completion.
     # Even when the target device is GPU, it can happen that dace emits code without
     # GPU kernels. In this case, the cuda headers are not imported and the SDFG is
     # compiled as plain C++. Therefore, we also check here the schedule of SDFG maps.

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -133,30 +133,18 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
     # GPU kernels. In this case, the cuda headers are not imported and the SDFG is
     # compiled as plain C++. Therefore, we also check here the schedule of SDFG maps.
     if gpu and _has_gpu_schedule(sdfg):
-        # If we are using the default stream, things are a bit simpler/harder. For some
-        #  reasons when using the default stream, DaCe seems to skip _all_ synchronization,
-        #  for more see [DaCe issue#2120](https://github.com/spcl/dace/issues/2120).
-        #  Thus the `CompiledSDFG.fast_call()` call is truly asynchronous, i.e. just
-        #  launches the kernels and then exits. Thus we have to add a synchronization
-        #  at the end to have a synchronous call. We cannot use `SDFG.append_exit_code()`
-        #  because that code is only run at the `exit()` stage, not after a call. Thus we
-        #  will generate an SDFGState that contains a Tasklet with the sync call.
-        assert dace.Config.get("compiler.cuda.max_concurrent_streams") == -1, (
-            f"Expected `max_concurrent_streams == -1` but it was `{dace.Config.get('compiler.cuda.max_concurrent_streams')}`."
-        )
-
         dace_gpu_backend = dace.Config.get("compiler.cuda.backend")
         assert dace_gpu_backend in ["cuda", "hip"], f"GPU backend '{dace_gpu_backend}' is unknown."
 
-        # NOTE: We should actually wrap the `StreamSynchronize` function inside a
+        # NOTE: We should actually wrap the `DeviceSynchronize` function inside a
         #   `DACE_GPU_CHECK()` macro. However, this only works in GPU context, but
         #   here we are in CPU context. Thus we cannot do it.
-        sync_code = f"{dace_gpu_backend}StreamSynchronize({dace_gpu_backend}StreamDefault);"
-        has_side_effcts = True
+        sync_code = f"{dace_gpu_backend}DeviceSynchronize();"
+        has_side_effects = True
 
     else:
         sync_code = ""
-        has_side_effcts = False
+        has_side_effects = False
 
     #### 2. Timestamp the SDFG entry point.
     entry_state = sdfg.add_state("gt_timer_entry")
@@ -221,7 +209,7 @@ double run_cpp_end_time = static_cast<double>(
 duration = run_cpp_end_time - run_cpp_start_time;
         """,
         language=dace.dtypes.Language.CPP,
-        side_effects=has_side_effcts,
+        side_effects=has_side_effects,
     )
     end_state.add_edge(
         end_state.add_access(start_time),
@@ -235,6 +223,72 @@ duration = run_cpp_end_time - run_cpp_start_time;
     )
 
 
+def make_sdfg_call_sync(sdfg: dace.SDFG, gpu: bool) -> None:
+    """Process the SDFG such that the call is synchronous.
+
+    This means that `CompiledSDFG.fast_call()` will return only after all computations
+    have _finished_ and the results are available. This function only has an effect for
+    work that runs on the GPU. Furthermore, all work is scheduled on the default stream.
+
+    Todo: Revisit this function once DaCe changes its behaviour in this regard.
+    """
+
+    if not gpu:
+        # This is only a problem on GPU. Dace uses OpenMP on CPU and
+        # the OpenMP parallel region creates a synchronization point.
+        return
+    elif not _has_gpu_schedule(sdfg):
+        # Even when the target device is GPU, it can happen that dace
+        # emits code without GPU kernels. In this case, the cuda headers
+        # are not imported and the SDFG is compiled as plain C++.
+        return
+
+    assert dace.Config.get("compiler.cuda.max_concurrent_streams") == -1, (
+        f"Expected `max_concurrent_streams == -1` but it was `{dace.Config.get('compiler.cuda.max_concurrent_streams')}`."
+    )
+
+    # If we are using the default stream, things are a bit simpler/harder. For some
+    #  reasons when using the default stream, DaCe seems to skip _all_ synchronization,
+    #  for more see [DaCe issue#2120](https://github.com/spcl/dace/issues/2120).
+    #  Thus the `CompiledSDFG.fast_call()` call is truly asynchronous, i.e. just
+    #  launches the kernels and then exist. Thus we have to add a synchronization
+    #  at the end to have a synchronous call. We can not use `SDFG.append_exit_code()`
+    #  because that code is only run at the `exit()` stage, not after a call. Thus we
+    #  will generate an SDFGState that contains a Tasklet with the sync call.
+    sync_state = sdfg.add_state("sync_state")
+    for sink_state in sdfg.sink_nodes():
+        if sink_state is sync_state:
+            continue
+        sdfg.add_edge(sink_state, sync_state, dace.InterstateEdge())
+    assert sdfg.in_degree(sync_state) > 0
+
+    # NOTE: Since the synchronization is done through the Tasklet explicitly,
+    #   we can disable synchronization for the last state. Might be useless.
+    sync_state.nosync = True
+
+    # NOTE: We should actually wrap the `StreamSynchronize` function inside a
+    #   `DACE_GPU_CHECK()` macro. However, this only works in GPU context, but
+    #   here we are in CPU context. Thus we can not do it.
+    dace_gpu_backend = dace.Config.get("compiler.cuda.backend")
+    assert dace_gpu_backend in ["cuda", "hip"], f"GPU backend '{dace_gpu_backend}' is unknown."
+    sync_state.add_tasklet(
+        "sync_tlet",
+        inputs=set(),
+        outputs=set(),
+        code=f"{dace_gpu_backend}StreamSynchronize({dace_gpu_backend}StreamDefault);",
+        language=dace.dtypes.Language.CPP,
+        side_effects=True,
+    )
+
+    # DaCe [still generates a stream](https://github.com/spcl/dace/blob/54c935cfe74a52c5107dc91680e6201ddbf86821/dace/codegen/targets/cuda.py#L467)
+    #  despite not using it. Thus to be absolutely sure, we will not set that stream
+    #  to the default stream.
+    sdfg.append_init_code(
+        f"__dace_gpu_set_all_streams(__state, {dace_gpu_backend}StreamDefault);",
+        location="cuda",
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class DaCeTranslator(
     workflow.ChainableWorkflowMixin[
@@ -244,6 +298,7 @@ class DaCeTranslator(
 ):
     device_type: core_defs.DeviceType
     auto_optimize: bool
+    async_sdfg_call: bool = False
     use_metrics: bool = True
     disable_itir_transforms: bool = False
     disable_field_origin_on_program_arguments: bool = False
@@ -315,11 +370,12 @@ class DaCeTranslator(
             gtx_transformations.gt_simplify(sdfg)
             gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
 
-        make_sdfg_call_async(sdfg, on_gpu)
-
-        # Add instrumentation to collect time metrics, enabled thorugh GT4Py config.
         if self.use_metrics:
             add_instrumentation(sdfg, on_gpu)
+        elif self.async_sdfg_call:
+            make_sdfg_call_async(sdfg, on_gpu)
+        else:
+            make_sdfg_call_sync(sdfg, on_gpu)
 
         return sdfg
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -248,7 +248,7 @@ class DaCeTranslator(
 ):
     device_type: core_defs.DeviceType
     auto_optimize: bool
-    async_sdfg_call: bool = False
+    use_metrics: bool = True
     disable_itir_transforms: bool = False
     disable_field_origin_on_program_arguments: bool = False
 
@@ -322,7 +322,8 @@ class DaCeTranslator(
         make_sdfg_call_async(sdfg, on_gpu)
 
         # Add instrumentation to collect time metrics, enabled thorugh GT4Py config.
-        add_instrumentation(sdfg, on_gpu)
+        if self.use_metrics:
+            add_instrumentation(sdfg, on_gpu)
 
         return sdfg
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -298,8 +298,8 @@ class DaCeTranslator(
 ):
     device_type: core_defs.DeviceType
     auto_optimize: bool
-    async_sdfg_call: bool = False
-    use_metrics: bool = True
+    async_sdfg_call: bool
+    use_metrics: bool
     disable_itir_transforms: bool = False
     disable_field_origin_on_program_arguments: bool = False
 
@@ -370,12 +370,13 @@ class DaCeTranslator(
             gtx_transformations.gt_simplify(sdfg)
             gtx_transformations.gt_gpu_transformation(sdfg, try_removing_trivial_maps=True)
 
-        if self.use_metrics:
-            add_instrumentation(sdfg, on_gpu)
-        elif self.async_sdfg_call:
+        if self.async_sdfg_call:
             make_sdfg_call_async(sdfg, on_gpu)
         else:
             make_sdfg_call_sync(sdfg, on_gpu)
+
+        if self.use_metrics:
+            add_instrumentation(sdfg, on_gpu)
 
         return sdfg
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -212,18 +212,13 @@ time = static_cast<double>(
         "gt_stop_timer",
         inputs={"run_cpp_start_time"},
         outputs={"duration"},
-        code="\n".join(
-            [
-                sync_code,
-                """\
+        code=sync_code + """
 double run_cpp_end_time = static_cast<double>(
     std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::high_resolution_clock::now().time_since_epoch()).count()
 ) / 1e9;
 duration = run_cpp_end_time - run_cpp_start_time;
         """,
-            ]
-        ),
         language=dace.dtypes.Language.CPP,
         side_effects=has_side_effcts,
     )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -67,14 +67,6 @@ def find_constant_symbols(
     return constant_symbols
 
 
-def _has_gpu_schedule(sdfg: dace.SDFG) -> bool:
-    """Check if any node (e.g. maps) of the given SDFG is scheduled on GPU."""
-    return any(
-        getattr(node, "schedule", dace.dtypes.ScheduleType.Default) in dace.dtypes.GPU_SCHEDULES
-        for node, _ in sdfg.all_nodes_recursive()
-    )
-
-
 def make_sdfg_call_async(sdfg: dace.SDFG, gpu: bool) -> None:
     """Configure an SDFG to immediately return once all work has been scheduled.
 
@@ -110,6 +102,14 @@ def make_sdfg_call_async(sdfg: dace.SDFG, gpu: bool) -> None:
     sdfg.append_init_code(
         f"__dace_gpu_set_all_streams(__state, {dace_gpu_backend}StreamDefault);",
         location="cuda",
+    )
+
+
+def _has_gpu_schedule(sdfg: dace.SDFG) -> bool:
+    """Check if any node (e.g. maps) of the given SDFG is scheduled on GPU."""
+    return any(
+        getattr(node, "schedule", dace.dtypes.ScheduleType.Default) in dace.dtypes.GPU_SCHEDULES
+        for node, _ in sdfg.all_nodes_recursive()
     )
 
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -212,7 +212,8 @@ time = static_cast<double>(
         "gt_stop_timer",
         inputs={"run_cpp_start_time"},
         outputs={"duration"},
-        code=sync_code + """
+        code=sync_code
+        + """
 double run_cpp_end_time = static_cast<double>(
     std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::high_resolution_clock::now().time_since_epoch()).count()

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -220,6 +220,7 @@ def test_generate_sdfg_async_call(make_async_sdfg_call: bool, device_type: core_
         device_type=device_type,
         auto_optimize=False,
         async_sdfg_call=make_async_sdfg_call,
+        use_metrics=False,
     ).generate_sdfg(program, offset_provider={}, column_axis=None)
 
     if device_type == core_defs.DeviceType.CPU:
@@ -257,6 +258,7 @@ def test_generate_sdfg_async_call_no_map(device_type: core_defs.DeviceType):
         device_type=device_type,
         auto_optimize=False,
         async_sdfg_call=True,
+        use_metrics=False,
     ).generate_sdfg(program, offset_provider={}, column_axis=None)
 
     if device_type == core_defs.DeviceType.CPU:

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -144,15 +144,19 @@ def _check_sdfg_with_async_call(sdfg: dace.SDFG) -> None:
     #   edge. However, we do not have that case.
 
     # The synchronization calls are in the CPU not the GPU code.
-    cpu_code = sdfg.generate_code()[0].clean_code
-    assert re.match(r"\b(cuda|hip)StreamSynchronize\b", cpu_code) is None
+    assert all(
+        re.match(r"\b(cuda|hip)StreamSynchronize\b", codeobj.clean_code) is None
+        for codeobj in sdfg.generate_code()
+    )
     assert _are_streams_set_to_default_stream(sdfg)
 
 
 def _check_cpu_sdfg_call(sdfg: dace.SDFG) -> None:
     # Make sure that there are no CUDA synchronization calls in the generated code.
-    cpu_code = sdfg.generate_code()[0].clean_code
-    assert re.match(r"\b(cuda|hip)StreamSynchronize\b", cpu_code) is None
+    assert all(
+        re.match(r"\b(cuda|hip)StreamSynchronize\b", codeobj.clean_code) is None
+        for codeobj in sdfg.generate_code()
+    )
 
 
 def test_generate_sdfg_async_call(device_type: core_defs.DeviceType):

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -137,69 +137,29 @@ def _are_streams_set_to_default_stream(sdfg: dace.SDFG) -> bool:
 
 
 def _check_sdfg_with_async_call(sdfg: dace.SDFG) -> None:
-    # Because we are using the default stream, the launch is asynchronous. Thus we
-    #  have to check if there is no synchronization state. However, we will do a
-    #  stronger test. Instead we will make sure that there are no synchronization
-    #  calls in the _entire_ generated code.
+    # Because we are using the default stream, the launch is asynchronous. We will
+    # make sure that there are no synchronization calls in the _entire_ generated code.
     # NOTE: Even in asynchronous launch, there might be some need for synchronization,
     #   for example if something is computed in a kernel and used on an interstate
     #   edge. However, we do not have that case.
 
-    assert not any(
-        state.label == "sync_state"
-        for state in sdfg.sink_nodes()
-        if isinstance(state, dace.SDFGState)
-    )
     # The synchronization calls are in the CPU not the GPU code.
     cpu_code = sdfg.generate_code()[0].clean_code
     assert re.match(r"\b(cuda|hip)StreamSynchronize\b", cpu_code) is None
     assert _are_streams_set_to_default_stream(sdfg)
 
 
-def _check_sdfg_without_async_call(sdfg: dace.SDFG) -> None:
-    states = sdfg.states()
-    sink_states = sdfg.sink_nodes()
-
-    # Test if the distinctive sink node is present.
-    assert len(sink_states) == 1
-    assert len(sink_states) < len(states)
-    sync_state = sink_states[0]
-    assert isinstance(sync_state, dace.SDFGState)
-    assert sync_state.label == "sync_state"
-    assert sync_state.nosync == True  # Because sync is done through the tasklet.
-    assert sync_state.number_of_nodes() == 1
-
-    sync_tlet = next(iter(sync_state.nodes()))
-    assert isinstance(sync_tlet, dace_nodes.Tasklet)
-    assert sync_tlet.side_effects
-    assert sync_tlet.label == "sync_tlet"
-
-    assert re.match(r"(cuda|hip)StreamSynchronize\(\1StreamDefault\)", sync_tlet.code.as_string)
-    assert _are_streams_set_to_default_stream(sdfg)
-
-
 def _check_cpu_sdfg_call(sdfg: dace.SDFG) -> None:
-    # CPU is always synchron execution, thus we check that there is no sync state.
-    assert not any(
-        state.label == "sync_state"
-        for state in sdfg.sink_nodes()
-        if isinstance(state, dace.SDFGState)
-    )
+    # Make sure that there are no CUDA synchronization calls in the generated code.
     cpu_code = sdfg.generate_code()[0].clean_code
     assert re.match(r"\b(cuda|hip)StreamSynchronize\b", cpu_code) is None
 
 
-@pytest.mark.requires_gpu
-@pytest.mark.parametrize(
-    "make_async_sdfg_call",
-    [False, True],
-)
-def test_generate_sdfg_async_call(make_async_sdfg_call: bool, device_type: core_defs.DeviceType):
-    """Verify that the flag `async_sdfg_call` takes effect on the SDFG generation."""
-    program_name = "field_ir_{}_async_call".format("with" if make_async_sdfg_call else "without")
+def test_generate_sdfg_async_call(device_type: core_defs.DeviceType):
+    """Verify that the SDFG call is asynchronous for GPU target."""
 
     program = itir.Program(
-        id=program_name,
+        id="field_ir_with_async_call",
         declarations=[],
         function_definitions=[],
         params=[
@@ -219,20 +179,16 @@ def test_generate_sdfg_async_call(make_async_sdfg_call: bool, device_type: core_
     sdfg = dace_translation_stage.DaCeTranslator(
         device_type=device_type,
         auto_optimize=False,
-        async_sdfg_call=make_async_sdfg_call,
     ).generate_sdfg(program, offset_provider={}, column_axis=None)
 
     if device_type == core_defs.DeviceType.CPU:
         _check_cpu_sdfg_call(sdfg)
-    elif make_async_sdfg_call:
-        _check_sdfg_with_async_call(sdfg)
     else:
-        _check_sdfg_without_async_call(sdfg)
+        _check_sdfg_with_async_call(sdfg)
 
 
-@pytest.mark.requires_gpu
 def test_generate_sdfg_async_call_no_map(device_type: core_defs.DeviceType):
-    """Verify that the flag `async_sdfg_call=True` has no effect on an SDFG that does not contain any GPU map."""
+    """Verify code generation for an SDFG without maps."""
     program_name = "scalar_ir_with_async_call"
 
     program = itir.Program(
@@ -256,13 +212,13 @@ def test_generate_sdfg_async_call_no_map(device_type: core_defs.DeviceType):
     sdfg = dace_translation_stage.DaCeTranslator(
         device_type=device_type,
         auto_optimize=False,
-        async_sdfg_call=True,
     ).generate_sdfg(program, offset_provider={}, column_axis=None)
+    assert not any(
+        isinstance(node, (dace_nodes.MapEntry, dace_nodes.MapExit))
+        for node in sdfg.all_nodes_recursive()
+    )
 
-    if device_type == core_defs.DeviceType.CPU:
-        _check_cpu_sdfg_call(sdfg)
-    else:
-        _check_sdfg_with_async_call(sdfg)
+    _check_cpu_sdfg_call(sdfg)
 
 
 def _make_multi_state_sdfg_0(
@@ -356,7 +312,6 @@ def _make_multi_state_sdfg_3(
     return sdfg, first_state, second_state
 
 
-@pytest.mark.requires_gpu
 @pytest.mark.parametrize(
     "multi_state_config",
     [


### PR DESCRIPTION
This PR provides an alternative way to retrieve the SDFG execution time, which corresponds to the stencil compute time metric in GT4Py.
The previous solution relied on SDFG instrumentation, which is a complex framework designed to profile full-application SDFGs, to collect different kinds of counters, and to report metrics across several iterations of a benchmark run. This framework already exists in GT4Py, we only need to timestamp the start and end time of the SDFG execution.
The solution presented in this PR is much more lightweight. More importantly, it surpasses some limitation of the dace framework, namely the small precision of the time measurements (dace truncates the SDFG execution time to microseconds).
Another advantage is that the collection of compute time metric, and the corresponding synchronization point for SDFG execution, can be enabled or disabled by means of the GT4Py config option without recompiling the program. This aligns the behavior of the dace backend with the gtfn backend and makes it easier to collect metrics.