### PR TITLE
feat[dace][next]: Demotion of Fields

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -188,6 +188,14 @@ def gt_auto_optimize(
                 original_demoted_descriptors[field_to_demote] = field_desc.clone()
                 field_desc.transient = True
 
+            if len(original_demoted_descriptors) != 0:
+                gtx_transformations.gt_simplify(
+                    sdfg=sdfg,
+                    validate=False,
+                    skip=gtx_transformations.constants._GT_AUTO_OPT_INITIAL_STEP_SIMPLIFY_SKIP_LIST,
+                    validate_all=validate_all,
+                )
+
         gtx_transformations.gt_reduce_distributed_buffering(
             sdfg, validate=False, validate_all=validate_all
         )


### PR DESCRIPTION
Adding the `demote_fields` argument to `gt_auto_optimizer()`.

The flag instructs the optimizer to handle SDFG arguments, which are globals, as transients and by that allows more possible transformations.
After the has concluded they _might_ be put back, i.e. turned back into a non-transient.
It is not generally possible to put them back as the optimization process might have modified them.

NOTE:
This feature is an experiential unsafe expert feature.