### PR TITLE
bug[next]: Fix dead-code elimination on some `concat_where` expressions

### DIFF
--- a/src/gt4py/next/iterator/transforms/collapse_tuple.py
+++ b/src/gt4py/next/iterator/transforms/collapse_tuple.py
@@ -63,8 +63,8 @@ def _is_trivial_or_tuple_thereof_expr(node: itir.Node) -> bool:
     """
     Return `true` if the expr is a trivial expression (`SymRef` or `Literal`) or tuple thereof.
 
-    Let forms with trivial body and args as well as `if` calls with trivial branches are also
-    considered trivial.
+    Let forms with trivial body and args as well as `if` and `concat_where` calls with trivial
+    branches are also considered trivial.
 
     >>> _is_trivial_or_tuple_thereof_expr(im.make_tuple("a", "b"))
     True
@@ -83,7 +83,7 @@ def _is_trivial_or_tuple_thereof_expr(node: itir.Node) -> bool:
         return _is_trivial_or_tuple_thereof_expr(node.args[1])
     # This will duplicate the condition and increase the size of the tree, but this is probably
     # acceptable.
-    if cpm.is_call_to(node, "if_"):
+    if cpm.is_call_to(node, ("if_", "concat_where")):
         return all(_is_trivial_or_tuple_thereof_expr(arg) for arg in node.args[1:])
     if cpm.is_let(node):
         return _is_trivial_or_tuple_thereof_expr(node.fun.expr) and all(

--- a/src/gt4py/next/iterator/transforms/dead_code_elimination.py
+++ b/src/gt4py/next/iterator/transforms/dead_code_elimination.py
@@ -41,6 +41,17 @@ def dead_code_elimination(
     ```
     inp1
     ```
+
+    Note: `concat_where.expand_tuple_args` is required to be executed before, in order to eliminate
+    dead-code in cases like:
+    ```
+    let tmp = concat_where(cond, {a, b, c}, {d, e, f})
+      non_trivial_expr(tmp[0], tmp[2])
+    end
+    ```
+    That `tmp` is referenced twice in this example is important as otherwise function inlining
+    and `tuple_get` propagation would also remove the tuple. Additionally, `non_trivial_expr`,
+    must be a non-trivial expression as otherwise cps tuple inlining would also resolve this case.
     """
     # ensure all constant let bindings are inlined
     # `let var=True in if_(var, val1, val2) end` -> `if_(True, val1, val2)`

--- a/src/gt4py/next/iterator/transforms/pass_manager.py
+++ b/src/gt4py/next/iterator/transforms/pass_manager.py
@@ -76,6 +76,7 @@ def apply_common_transforms(
     #  test_can_deref. We didn't notice previously as FieldOpFusion did this implicitly everywhere.
     ir = inline_lifts.InlineLifts().visit(ir)
 
+    ir = concat_where.expand_tuple_args(ir, offset_provider_type=offset_provider_type)  # type: ignore[assignment]  # always an itir.Program
     ir = dead_code_elimination.dead_code_elimination(
         ir, collapse_tuple_uids=collapse_tuple_uids, offset_provider_type=offset_provider_type
     )  # domain inference does not support dead-code
@@ -85,7 +86,6 @@ def apply_common_transforms(
     ir = infer_domain_ops.InferDomainOps.apply(ir)
     ir = concat_where.canonicalize_domain_argument(ir)
 
-    ir = concat_where.expand_tuple_args(ir, offset_provider_type=offset_provider_type)  # type: ignore[assignment]  # always an itir.Program
     ir = infer_domain.infer_program(
         ir,
         offset_provider=offset_provider,
@@ -174,6 +174,7 @@ def apply_fieldview_transforms(
 
     ir = inline_fundefs.InlineFundefs().visit(ir)
     ir = inline_fundefs.prune_unreferenced_fundefs(ir)
+    ir = concat_where.expand_tuple_args(ir, offset_provider_type=offset_provider_type)  # type: ignore[assignment]  # always an itir.Program
     ir = dead_code_elimination.dead_code_elimination(ir, offset_provider_type=offset_provider_type)
     ir = inline_dynamic_shifts.InlineDynamicShifts.apply(
         ir

--- a/src/gt4py/next/iterator/transforms/remove_broadcast.py
+++ b/src/gt4py/next/iterator/transforms/remove_broadcast.py
@@ -50,6 +50,7 @@ class RemoveBroadcast(PreserveLocationVisitor, NodeTranslator):
 
         if cpm.is_call_to(node, "broadcast"):
             expr = node.args[0]
+            assert isinstance(node.annex.domain, domain_utils.SymbolicDomain)
             node = im.as_fieldop("deref", domain_utils.SymbolicDomain.as_expr(node.annex.domain))(
                 expr
             )


### PR DESCRIPTION
Execute `concat_where.expand_tuple_args` before dead-code-elimination such in an expressions like
```
let tmp = concat_where(cond, {a, b, c}, {d, e, f})
  non_trivial_expr(tmp[0], tmp[2])
end
```
the `tmp[1]` value is removed. Otherwise domain inference fails. That `tmp` is referenced twice in this example is important as otherwise function inlining and `tuple_get` propagation would also remove the tuple. Additionally, `non_trivial_expr`, must be a non-trivial expression as otherwise cps tuple inlining would also resolve this case.