### PR TITLE
refactor[next]: Make domain construction mirror input argument structure

### DIFF
--- a/src/gt4py/next/constructors.py
+++ b/src/gt4py/next/constructors.py
@@ -247,10 +247,10 @@ def as_field(
         else:
             origin = {}
         actual_domain = common.domain(
-            [
-                (d, (-(start_offset := origin.get(d, 0)), s - start_offset))
+            {
+                d: (-(start_offset := origin.get(d, 0)), s - start_offset)
                 for d, s in zip(domain, data.shape)
-            ]
+            }
         )
     else:
         if origin:
@@ -332,7 +332,7 @@ def as_connectivity(
             raise ValueError(
                 f"Cannot construct 'Field' from array of shape '{data.shape}' and domain '{domain}'."
             )
-        actual_domain = common.domain([(d, (0, s)) for d, s in zip(domain, data.shape)])
+        actual_domain = common.domain({d: (0, s) for d, s in zip(domain, data.shape)})
     else:
         actual_domain = common.domain(cast(common.DomainLike, domain))
 

--- a/tests/next_tests/integration_tests/cases.py
+++ b/tests/next_tests/integration_tests/cases.py
@@ -584,7 +584,7 @@ def _allocate_from_type(
         case ts.FieldType(dims=dims, dtype=arg_dtype):
             return strategy.field(
                 allocator=case.allocator,
-                domain=common.domain(tuple(domain[dim] for dim in dims)),
+                domain=domain[dims],
                 dtype=dtype or arg_dtype.kind.name.lower(),
             )
         case ts.ScalarType(kind=kind):

--- a/tests/next_tests/regression_tests/embedded_tests/test_domain_pickle.py
+++ b/tests/next_tests/regression_tests/embedded_tests/test_domain_pickle.py
@@ -15,7 +15,7 @@ J = common.Dimension("J")
 
 
 def test_domain_pickle_after_slice():
-    domain = common.domain(((I, (2, 4)), (J, (3, 5))))
+    domain = common.domain({I: (2, 4), J: (3, 5)})
     # use slice_at to populate cached property
     domain.slice_at[2:5, 5:7]
 

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -803,7 +803,7 @@ def test_connectivity_field_inverse_image():
 
     e2v_conn = common._connectivity(
         np.roll(np.arange(E_START, E_STOP), 1),
-        domain=common.domain([common.named_range((E, (E_START, E_STOP)))]),
+        domain=common.domain({E: (E_START, E_STOP)}),
         codomain=V,
     )
 
@@ -835,10 +835,10 @@ def test_connectivity_field_inverse_image_2d_domain():
     c2v_conn = common._connectivity(
         np.asarray([[0, 0, 2], [1, 1, 2], [2, 2, 2]]),
         domain=common.domain(
-            [
-                common.named_range((C, (C_START, C_STOP))),
-                common.named_range((C2V, (C2V_START, C2V_STOP))),
-            ]
+            {
+                C: (C_START, C_STOP),
+                C2V: (C2V_START, C2V_STOP),
+            }
         ),
         codomain=V,
     )
@@ -890,7 +890,7 @@ def test_connectivity_field_inverse_image_non_contiguous():
 
     e2v_conn = common._connectivity(
         np.asarray([0, 1, 2, 3, 4, 9, 7, 5, 8, 6]),
-        domain=common.domain([common.named_range((E, (E_START, E_STOP)))]),
+        domain=common.domain({E: (E_START, E_STOP)}),
         codomain=V,
     )
 

--- a/tests/next_tests/unit_tests/test_allocators.py
+++ b/tests/next_tests/unit_tests/test_allocators.py
@@ -155,7 +155,7 @@ class TestInvalidFieldBufferAllocator:
         )
         I = common.Dimension("I")
         J = common.Dimension("J")
-        domain = common.domain(((I, (2, 4)), (J, (3, 5))))
+        domain = common.domain({I: (2, 4), J: (3, 5)})
         dtype = float
         with pytest.raises(ValueError, match="test error"):
             allocator.__gt_allocate__(domain, dtype)
@@ -166,7 +166,7 @@ def test_allocate():
 
     I = common.Dimension("I")
     J = common.Dimension("J")
-    domain = common.domain(((I, (0, 2)), (J, (0, 3))))
+    domain = common.domain({I: (0, 2), J: (0, 3)})
     dtype = core_defs.dtype(float)
 
     # Test with a explicit field allocator

--- a/tests/next_tests/unit_tests/test_common.py
+++ b/tests/next_tests/unit_tests/test_common.py
@@ -277,14 +277,13 @@ def test_empty_domain(empty_domain, expected):
     "domain_like",
     [
         (Domain(dims=(IDim, JDim), ranges=(UnitRange(2, 4), UnitRange(3, 5)))),
-        ((IDim, (2, 4)), (JDim, (3, 5))),
         ({IDim: (2, 4), JDim: (3, 5)}),
     ],
 )
 def test_domain_like(domain_like):
-    assert domain(domain_like) == Domain(
-        dims=(IDim, JDim), ranges=(UnitRange(2, 4), UnitRange(3, 5))
-    )
+    expected = Domain(dims=(IDim, JDim), ranges=(UnitRange(2, 4), UnitRange(3, 5)))
+    assert domain(domain_like) == expected
+    assert domain((domain_like, (domain_like, domain_like))) == (expected, (expected, expected))
 
 
 def test_domain_iteration(a_domain):


### PR DESCRIPTION
Implementes this idea: https://github.com/GridTools/gt4py/pull/2225/files#r2411639314

`domain((domain_like1, domain_like2))` -> `(domain1, domain2)`

Not sure this is the right approach anymore. See the comment there for more info.