### PR TITLE
feat[next][dace]: enable overriding of cxx/cuda compiler arguments

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -71,7 +71,7 @@ def set_dace_config(
         dace.Config.set("compiler.cpu.args", value=gt_cxxargs)
     else:
         dace.Config.set(
-            "compiler.cuda.args",
+            "compiler.cpu.args",
             value="-std=c++14 -fPIC -O3 -march=native -Wall -Wextra -Wno-unused-parameter -Wno-unused-label",
         )
     if gt_cudaargs := os.environ.get("CUDAFLAGS", None):


### PR DESCRIPTION
Add the possibility to pass user-defined compiler arguments to dace build, by setting the environment variables `CXXFLAGS`/`CUDAFLAGS` for CPU/CUDA compiler.