### PR TITLE
ci[cartesian]: increase time limit for cartesian / dace tests on gh200

### DIFF
--- a/ci/cscs-ci.yml
+++ b/ci/cscs-ci.yml
@@ -16,7 +16,7 @@ include:
 #   block-name-with-dashes      -> defined in remote cscs-ci ext include
 #   block_name_with_underscores -> defined in this file or other file in this repo
 
-variables:  # Default values for base variables (can be overriden in jobs definitions)
+variables:  # Default values for base variables (can be overridden in jobs definitions)
   CUDA_VERSION: '12.6.2'
   ROCM_VERSION: '6.2.4'
   UBUNTU_VERSION: '24.04'
@@ -145,6 +145,9 @@ test_cscs_gh200:
         # TODO: investigate why the dace tests seem to hang with multiple jobs
         GT4PY_BUILD_JOBS: 1
         SLURM_TIMELIMIT: "00:15:00"
+    - if: $SUBPACKAGE == 'cartesian' && $VARIANT == 'dace' && $SUBVARIANT == 'cuda12'
+      variables:
+        SLURM_TIMELIMIT: "00:10:00"
     - when: on_success
 
 test_cscs_amd_rocm:


### PR DESCRIPTION
## Description

Cartesian dace tests are regularly timing out with the default time limit on the gh200 box. It looks like recent increased development (including better test coverage) in `gt4py.cartesian` are pushing the limit of the standard 5min slurm time limit. We suggest to increase the time limit to 10 minutes.

An example of running into the time limit can be found [here](https://cicd-ext-mw.cscs.ch/ci/pipeline/results/4525297225819146/42923301/2115650769?iid=17994&type=gitlab). It's a run associated with PR #2314. Multiple re-runs have shown the same behavior.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A

/cc @FlorianDeconinck @twicki as discussed