### PR TITLE
fix[dace][next]: Fixed `DeadMapElimination`

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/dead_dataflow_elimination.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/dead_dataflow_elimination.py
@@ -142,6 +142,7 @@ class DeadMapElimination(dace_transformation.SingleStateTransformation):
 
         # Now find all notes that are producer or consumer of the Map, after we removed
         #  the nodes of the Maps we need to check if they have become isolated.
+        # NOTE: Needs to be a `set` to handle multiple connections with the MapEntry node.
         adjacent_nodes: set[dace_nodes.AccessNode] = {
             iedge.src for iedge in graph.in_edges(map_entry)
         }


### PR DESCRIPTION
The case of a Map that had multiple connections to an AccessNode was not properly handled.
A `list` was used which means that a node could appear twice which lead to a NetworkX error. 
This bug was exposed by the [`MapToCopy`](https://github.com/GridTools/gt4py/pull/2311) transformation (this PR must be merged before the `MapToCopy` PR).