### PR TITLE
fix[cartesian]: do upcasting on both sides of assignments

### DIFF
--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -291,23 +291,23 @@ def verify_and_get_common_dtype(
         if strict:
             if all(dt == dtype for dt in dtypes):
                 return dtype
-            else:
-                raise ValueError(
-                    f"Type mismatch in `{node_cls.__name__}`. Types are "
-                    + ", ".join(dt.name for dt in dtypes)
-                )
-        else:
-            # upcasting
-            return max(dt for dt in dtypes)
-    else:
-        return None
+
+            raise ValueError(
+                f"Type mismatch in `{node_cls.__name__}`. Types are "
+                + ", ".join(dt.name for dt in dtypes)
+            )
+
+        # upcasting
+        return max(dt for dt in dtypes)
+
+    return None
 
 
 def compute_kind(*values: Expr) -> ExprKind:
     if any(v.kind == ExprKind.FIELD for v in values):
         return ExprKind.FIELD
-    else:
-        return ExprKind.SCALAR
+
+    return ExprKind.SCALAR
 
 
 class Literal(eve.Node):


### PR DESCRIPTION
## Description

In the GTIR layer there's a system to handle operations with different types. This "GTIR upcaster" was only running on the right hand side of parallel assignments. However, there are situations where we also have situations on that left hand side that need upcasting. For example, users reported an offset calculation with an int32 field and an int64 scalar. This PR fixes the issue by running the GTIR upcaster on both sides of an assignment.

Related upstream issue: https://github.com/NOAA-GFDL/NDSL/issues/224

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. N/A
