### PR TITLE
test[cartesian]: absolute k access with index field and computation

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1223,6 +1223,7 @@ def test_absolute_K_index(backend):
 
     in_arr = gt_storage.ones(backend=backend, shape=domain, dtype=np.float64)
     idx_arr = gt_storage.zeros(backend=backend, shape=(domain[0], domain[1]), dtype=np.int64)
+    idx_arr_32 = gt_storage.zeros(backend=backend, shape=(domain[0], domain[1]), dtype=np.int32)
     k_arr = gt_storage.zeros(backend=backend, shape=(domain[2],), dtype=np.float64)
     out_arr = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
 
@@ -1275,6 +1276,20 @@ def test_absolute_K_index(backend):
     in_arr[:, :, 1] = 42.42
     out_arr[:, :, :] = 0
     test_field_access(in_arr, idx_arr, out_arr)
+    assert (out_arr[:, :, :] == 42.42).all()
+
+    @gtscript.stencil(backend=backend)
+    def test_field_access_computation(
+        in_field: Field[np.float64], index_field: Field[IJ, np.int32], out_field: Field[np.float64]
+    ) -> None:
+        with computation(PARALLEL), interval(...):
+            out_field = in_field.at(K=index_field - 1)
+
+    in_arr[:, :, :] = 1
+    in_arr[:, :, 1] = 42.42
+    idx_arr_32[:, :] = 2
+    out_arr[:, :, :] = 0
+    test_field_access_computation(in_arr, idx_arr_32, out_arr)
     assert (out_arr[:, :, :] == 42.42).all()
 
     @gtscript.stencil(backend=backend)


### PR DESCRIPTION
## Description

This PR increases test coverage to ensure that we absolute k indexing works with expressions that contain field accesses. That case was missing and apparently there were issues with that in earlier implementations.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
