### PR TITLE
build[dace][next]: Updated DaCe Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dace-cartesian = [
   'dace>=1.0.2,<2'  # renfined in [tool.uv.sources]
 ]
 dace-next = [
-  'dace==2025.11.04'  # refined in [tool.uv.sources]
+  'dace==2025.11.05'  # refined in [tool.uv.sources]
 ]
 dev = [
   {include-group = 'build'},
@@ -448,7 +448,7 @@ url = 'https://test.pypi.org/simple'
 atlas4py = {index = "test.pypi"}
 dace = [
   {git = "https://github.com/GridTools/dace", branch = "romanc/stree-roundtrip", group = "dace-cartesian"},
-  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_11_04", group = "dace-next"}
+  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_11_05", group = "dace-next"}
 ]
 
 # -- versioningit --

--- a/uv.lock
+++ b/uv.lock
@@ -947,8 +947,8 @@ dependencies = [
 
 [[package]]
 name = "dace"
-version = "25.11.4"
-source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_04#4f9c76f91de70b99a3ed483c349af30c25648ec1" }
+version = "2025.11.5"
+source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_05#7a0d751271cda13a57349d1e90169f8ded2c3865" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1429,7 +1429,7 @@ dace-cartesian = [
     { name = "dace", version = "1.0.2", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip#1033dfcf9d118856d82c6ee8d6f6cfacec662335" } },
 ]
 dace-next = [
-    { name = "dace", version = "25.11.4", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_04#4f9c76f91de70b99a3ed483c349af30c25648ec1" } },
+    { name = "dace", version = "2025.11.5", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_05#7a0d751271cda13a57349d1e90169f8ded2c3865" } },
 ]
 dev = [
     { name = "atlas4py" },
@@ -1572,7 +1572,7 @@ build = [
     { name = "wheel", specifier = ">=0.33.6" },
 ]
 dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip" }]
-dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_04" }]
+dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_05" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },


### PR DESCRIPTION
Update of DaCe to the new tag [__gt4py-next-integration_2025_11_05](https://github.com/GridTools/dace/tree/__gt4py-next-integration_2025_11_05) of the fork.

It should solve some flaky tests in ICON4Py.




