### PR TITLE
fix[cartesian]: upcast arguments of cast operations

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1333,15 +1333,18 @@ def test_iterator_access(backend: str) -> None:
 
     field_A = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
     field_B = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
+    offsets = gt_storage.zeros(backend=backend, shape=(domain[2],), dtype=np.int32)
 
     @gtscript.stencil(backend=backend)
-    def test_all_valid_usage(field_A: Field[np.float64], field_B: Field[np.float64]) -> None:
+    def test_all_valid_usage(
+        field_A: Field[np.float64], field_B: Field[np.float64], offsets: Field[K, np.int32]
+    ) -> None:
         with computation(PARALLEL), interval(...):
             if K == 2:
                 field_A = 20.20
-            field_B = K
+            field_B = float(K + offsets)
 
-    test_all_valid_usage(field_A, field_B)
+    test_all_valid_usage(field_A, field_B, offsets)
     assert field_A[0, 0, 1] == 0
     assert field_A[0, 0, 2] == 20.20
     for _k in range(domain[2]):


### PR DESCRIPTION
## Description

Cast operations are except from upcasting (because they cast explicitly). With skipping upcasting for cast operations, we also stopped the recursion, essentially skipping the upcasting of any arguments to cast functions. Most of the time, we cast single values so we didn't run into this until late.

This was reported upstream in NDSL as part of issue https://github.com/NOAA-GFDL/NDSL/issues/195.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
