### PR TITLE
fix[next][dace]: Use correct dtype for connectivity tables

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -31,12 +31,13 @@ from dace import subsets as dace_subsets
 from gt4py import eve
 from gt4py.eve.extended_typing import MaybeNestedInTuple, NestedTuple
 from gt4py.next import common as gtx_common, utils as gtx_utils
-from gt4py.next.iterator import builtins as gtir_builtins, ir as gtir
+from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm, ir_makers as im
 from gt4py.next.iterator.transforms import symbol_ref_utils
 from gt4py.next.program_processors.runners.dace import (
     gtir_python_codegen,
     gtir_to_sdfg,
+    gtir_to_sdfg_types,
     gtir_to_sdfg_utils,
     utils as gtx_dace_utils,
 )
@@ -1686,7 +1687,7 @@ class LambdaToDataflow(eve.NodeVisitor):
         offset_provider_type = self.subgraph_builder.get_offset_provider_type(offset)
         # second argument should be the offset value, which could be a symbolic expression or a dynamic offset
         offset_expr = (
-            SymbolExpr(offset_value_arg.value, gtir_builtins.INTEGER_INDEX_BUILTIN)
+            SymbolExpr(offset_value_arg.value, gtir_to_sdfg_types.INDEX_DTYPE)
             if isinstance(offset_value_arg, gtir.OffsetLiteral)
             else self.visit(offset_value_arg)
         )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/bindings.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/bindings.py
@@ -13,15 +13,12 @@ from typing import Final
 import dace
 
 from gt4py.eve import codegen
-from gt4py.next.iterator import builtins as itir_builtins
 from gt4py.next.otf import languages, stages
 from gt4py.next.program_processors.runners.dace import utils as gtx_dace_utils
 from gt4py.next.type_system import type_specifications as ts
 
 
-FIELD_SYMBOL_GT_TYPE: Final[ts.ScalarType] = ts.ScalarType(
-    kind=getattr(ts.ScalarKind, itir_builtins.INTEGER_INDEX_BUILTIN.upper())
-)
+FIELD_SYMBOL_GT_TYPE: Final[ts.ScalarType] = ts.ScalarType(kind=ts.ScalarKind.UINT32)
 
 _cb_args: Final[str] = "args"
 _cb_device: Final[str] = "device"


### PR DESCRIPTION
Fixes the lowering of unstructured shift, by using the `dtype` attribute in the connectivity descriptor instead of the default index builtin type (`int32`). Search in the new code the pattern `tt.from_dtype(conn_type.dtype)`.

Additional change: some code refactoring to make more consistent naming of `NeighborConnectivityType` variables. This PR uses the `conn_` prefix in variable names.