### PR TITLE
fix[cartesian]: respect percision of constants

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -436,6 +436,7 @@ class CallInliner(ast.NodeTransformer):
     def visit_Call(self, node: ast.Call, *, target_node=None):  # Cyclomatic complexity too high
         if _filter_absolute_K_index_method(node):
             return node
+
         call_name = gt_meta.get_qualified_name_from_node(node.func)
 
         if call_name in self.call_stack:
@@ -1073,12 +1074,12 @@ class IRMaker(ast.NodeVisitor):
             if self.dtypes and type(value) in self.dtypes.keys():
                 value_type = self.dtypes[type(value)]
             else:
-                if isinstance(value, int):
+                if hasattr(value, "dtype") and isinstance(value.dtype, np.dtype):
+                    value_type = value.dtype
+                elif isinstance(value, int):
                     value_type = np.dtype(f"i{int(self.literal_int_precision / 8)}")
                 elif isinstance(value, float):
                     value_type = np.dtype(f"f{int(self.literal_float_precision / 8)}")
-                elif hasattr(value, "dtype") and isinstance(value.dtype, np.dtype):
-                    value_type = value.dtype
                 else:
                     raise GTScriptSyntaxError(
                         f"Unexpected constant type `{type(value)}`. Expected integer or float."

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -26,10 +26,12 @@ def get_closure(func, *, include_globals=True, included_nonlocals=True, include_
         closure.update(closure_vars.globals)
     else:
         unbound |= set(closure_vars.globals.keys())
+
     if included_nonlocals:
         closure.update(closure_vars.nonlocals)
     else:
         unbound |= set(closure_vars.nonlocals.keys())
+
     if include_builtins:
         closure.update(closure_vars.builtins)
     else:


### PR DESCRIPTION
## Description

In the `IRMaker`, we discard type information that is potentially available from inlined constants because e.g. `np.float64` is of instance `float`, which means, that the old order of the `if` statements would trigger for `isinstance(..., (int, float))` in cases that we don't want. We flip the order to ensure that we keep potential type annotations on e.g. global constants.

This is fallout from literal precision work (see PR #2187) and was reported (first hidden by other issues) in upstream issue https://github.com/NOAA-GFDL/NDSL/issues/195.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A

