### PR TITLE
build[dace][next]: Updated DaCe Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dace-cartesian = [
   'dace>=1.0.2,<2'  # renfined in [tool.uv.sources]
 ]
 dace-next = [
-  'dace==2025.11.25'  # refined in [tool.uv.sources]
+  'dace==2025.11.26'  # refined in [tool.uv.sources]
 ]
 dev = [
   {include-group = 'build'},
@@ -448,7 +448,7 @@ url = 'https://test.pypi.org/simple'
 atlas4py = {index = "test.pypi"}
 dace = [
   {git = "https://github.com/GridTools/dace", branch = "romanc/stree-roundtrip", group = "dace-cartesian"},
-  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_11_25", group = "dace-next"}
+  {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_11_26", group = "dace-next"}
 ]
 
 # -- versioningit --

--- a/uv.lock
+++ b/uv.lock
@@ -947,8 +947,8 @@ dependencies = [
 
 [[package]]
 name = "dace"
-version = "2025.11.25"
-source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_25#85080da511dc9a554e6623393c7de101931ad9b6" }
+version = "2025.11.26"
+source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_26#3eec6f6dae18ac90e2f967ab8098505bd972b92f" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1429,7 +1429,7 @@ dace-cartesian = [
     { name = "dace", version = "1.0.2", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip#1033dfcf9d118856d82c6ee8d6f6cfacec662335" } },
 ]
 dace-next = [
-    { name = "dace", version = "2025.11.25", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_25#85080da511dc9a554e6623393c7de101931ad9b6" } },
+    { name = "dace", version = "2025.11.26", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_26#3eec6f6dae18ac90e2f967ab8098505bd972b92f" } },
 ]
 dev = [
     { name = "atlas4py" },
@@ -1572,7 +1572,7 @@ build = [
     { name = "wheel", specifier = ">=0.33.6" },
 ]
 dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip" }]
-dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_25" }]
+dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_11_26" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },


### PR DESCRIPTION
Update of DaCe to the new tag [__gt4py-next-integration_2025_11_26](https://github.com/GridTools/dace/tree/__gt4py-next-integration_2025_11_26) of the fork.





