### PR TITLE
fix[next][dace]: Unconditional execution of else-branch in if-statements

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/gtir_dataflow.py
@@ -891,7 +891,8 @@ class LambdaToDataflow(eve.NodeVisitor):
 
         else_body = dace.sdfg.state.ControlFlowRegion("else_body", sdfg=nsdfg)
         fstate = else_body.add_state("false_branch", is_start_block=True)
-        if_region.add_branch(None, else_body)  # `None` corresponds to else-branch, unconditionally executed
+        # Use `None` for unconditional execution of else-branch, if the condition is not met.
+        if_region.add_branch(None, else_body)
 
         input_memlets: dict[str, MemletExpr | ValueExpr] = {}
         nsdfg_symbols_mapping: Optional[dict[str, dace.symbol]] = None


### PR DESCRIPTION
The lowering in baseline was producing this code:
```
    if (__cond) {
        ...
    } else if ((! __cond)) {
        ...
    }
```

with the change in this PR:
```
    if (__cond) {
        ...
    } else {
        ...
    }
```

- [x] Check performance regression in ICON-blueline