### PR TITLE
fix[next-dace]: Addressed Memlet Caching Issue

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -487,10 +487,10 @@ def _gt_auto_process_top_level_maps(
             validate_all=validate_all,
         )
 
-        # NOTE: This is done to avoid a Memlet caching issue, that will lead to an
-        #   invalid SDFG if `propagate_memlets_sdfg()` is run, in certain cases.
-        #   At this point the SDFG passes validation, but become invalid after
-        #   the propagation.
+        # NOTE: There is a Memlet caching issue at work here, see DaCe issue 1703 and
+        #   1708. Without clearing the cache, which is done through a side effect of
+        #   `to_json()`, running `propagate_memlets_sdfg()` would lead to an invalid
+        #   SDFG.
         sdfg.to_json(hash=False)
 
         # Promote Maps. This will remove transients between 1D and 2D Maps, at the


### PR DESCRIPTION
This PR mitigate an issue that was discovered while [updating ICON4Py](https://github.com/C2SM/icon4py/pull/989) to the newest GT4Py version.
It seems as if the bug was introduced by [PR#2383](https://github.com/GridTools/gt4py/pull/2383), deterministic `AccessNode` splitting, it was, however, there before, just hidden.
It surfaced because PR#2383 introduced an other bug that turned on validation in certain parts of the code and got [fixed here](https://github.com/GridTools/gt4py/pull/2445/changes/f5119e2e1a3973fe657e723bced7c03c151b6050).

The issue was traced back to [`DoubleWriteRemover`](https://github.com/GridTools/gt4py/blob/bfd684d108673e084d79a6408c77013d4ad9a404/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py#L482) it is important that right after the transformation the SDFG is valid and only becomes invalid after `propagate_memlets_sdfg()` has run.

Attempts on fixing the underlying issue have failed and this PR only introduces a mitigation by clearing the cache. 
    
---------
Co-authored-by: edopao <edoardo.paone@cscs.ch>