### PR TITLE
refactor[cartesian]: fix some type errors in frontend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ follow_imports = 'silent'
 module = 'gt4py.cartesian.*'
 
 [[tool.mypy.overrides]]
-ignore_errors = true
+disable_error_code = "call-arg"
 module = 'gt4py.cartesian.frontend.nodes'
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@ ignore_errors = true
 module = 'gt4py.cartesian.frontend.gtscript_frontend'
 
 [[tool.mypy.overrides]]
-ignore_errors = true
+disable_error_code = "call-arg"
 module = 'gt4py.cartesian.frontend.defir_to_gtir'
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,10 +240,6 @@ disable_error_code = "call-arg"
 module = 'gt4py.cartesian.frontend.defir_to_gtir'
 
 [[tool.mypy.overrides]]
-ignore_errors = true
-module = 'gt4py.cartesian.frontend.meta'
-
-[[tool.mypy.overrides]]
 module = 'gt4py.eve.extended_typing'
 warn_unused_ignores = false
 

--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -10,7 +10,7 @@ import copy
 import functools
 import itertools
 import numbers
-from typing import Any, Final, List, Optional, Tuple, Union, cast
+from typing import Any, Final, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -66,9 +66,7 @@ def _convert_dtype(data_type) -> common.DataType:
     if dtype == common.DataType.DEFAULT:
         # TODO: this will be a frontend choice later
         # in non-GTC parts, this is set in the backend
-        dtype = cast(
-            common.DataType, common.DataType.FLOAT64
-        )  # see https://github.com/GridTools/gtc/issues/100
+        dtype = common.DataType.FLOAT64
     return dtype
 
 
@@ -161,7 +159,7 @@ class UnrollVectorAssignments(IRNodeMapper):
 
     def visit_Assign(
         self, node: Assign, *, fields_decls: dict[str, FieldDecl], **kwargs
-    ) -> Union[gtir.ParAssignStmt, List[gtir.ParAssignStmt]]:
+    ) -> Assign | list[Assign]:
         if self._is_vector_assignment(node, fields_decls):
             assert isinstance(node.target, FieldRef) or isinstance(node.target, VarRef)
             target_dims = fields_decls[node.target.name].data_dims
@@ -249,20 +247,20 @@ class UnrollVectorExpressions(IRNodeMapper):
 
     def visit_UnaryOpExpr(self, node: UnaryOpExpr, *, fields_decls: dict[str, FieldDecl], **kwargs):
         if node.op == UnaryOperator.TRANSPOSED:
-            node = self.visit(node.arg, fields_decls=fields_decls, **kwargs)
-            assert isinstance(node, list) and all(
-                isinstance(row, list) and len(row) == len(node[0]) for row in node
+            argument = self.visit(node.arg, fields_decls=fields_decls, **kwargs)
+            assert isinstance(argument, list) and all(
+                isinstance(row, list) and len(row) == len(argument[0]) for row in argument
             )
             # transpose list
-            node = [list(x) for x in zip(*node)]
-            return node
+            argument = [list(x) for x in zip(*argument)]
+            return argument
 
         return self.generic_visit(node, **kwargs)
 
     def visit_BinOpExpr(self, node: BinOpExpr, *, fields_decls: dict[str, FieldDecl], **kwargs):
         lhs = self.visit(node.lhs, fields_decls=fields_decls, **kwargs)
         rhs = self.visit(node.rhs, fields_decls=fields_decls, **kwargs)
-        result: Union[List[BinOpExpr], BinOpExpr] = []
+        result: list[BinOpExpr] = []
 
         if node.op == BinaryOperator.MATMULT:
             for j in range(len(lhs)):
@@ -587,20 +585,20 @@ class DefIRToGTIR(IRNodeVisitor):
     def visit_VarRef(self, node: VarRef, **kwargs) -> gtir.ScalarAccess:
         return gtir.ScalarAccess(name=node.name, loc=location_to_source_location(node.loc))
 
-    def visit_AxisInterval(self, node: AxisInterval) -> Tuple[gtir.AxisBound, gtir.AxisBound]:
+    def visit_AxisInterval(self, node: AxisInterval) -> tuple[common.AxisBound, common.AxisBound]:
         return self.visit(node.start), self.visit(node.end)
 
-    def visit_AxisBound(self, node: AxisBound) -> gtir.AxisBound:
+    def visit_AxisBound(self, node: AxisBound) -> common.AxisBound:
         # TODO(havogt) add support VarRef
-        return gtir.AxisBound(
+        return common.AxisBound(
             level=self.GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER[node.level], offset=node.offset
         )
 
-    def visit_RuntimeAxisBound(self, node: RuntimeAxisBound) -> gtir.RuntimeAxisBound:
+    def visit_RuntimeAxisBound(self, node: RuntimeAxisBound) -> common.RuntimeAxisBound:
         utils.warn_experimental_feature(
             feature="Runtime Interval Bounds", ADR="experimental/runtime-intervals.md"
         )
-        return gtir.RuntimeAxisBound(
+        return common.RuntimeAxisBound(
             level=self.GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER[node.level],
             offset=self.visit(node.offset),
         )

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -144,7 +144,7 @@ from typing import List, Optional, Sequence
 
 import numpy as np
 
-from gt4py.cartesian.definitions import CartesianSpace
+from gt4py.cartesian.gtc.definitions import CartesianSpace
 from gt4py.cartesian.utils.attrib import (
     Any as Any,
     Dict as DictOf,
@@ -309,7 +309,7 @@ def frontend_type_to_native_type(
     }
 
 
-DataType.NATIVE_TYPE_TO_NUMPY = {
+DataType.NATIVE_TYPE_TO_NUMPY = {  # type: ignore[attr-defined]
     DataType.DEFAULT: "float_",
     DataType.BOOL: "bool",
     DataType.INT8: "int8",
@@ -320,7 +320,7 @@ DataType.NATIVE_TYPE_TO_NUMPY = {
     DataType.FLOAT64: "float64",
 }
 
-DataType.NUMPY_TO_NATIVE_TYPE = {value: key for key, value in DataType.NATIVE_TYPE_TO_NUMPY.items()}
+DataType.NUMPY_TO_NATIVE_TYPE = {value: key for key, value in DataType.NATIVE_TYPE_TO_NUMPY.items()}  # type: ignore[attr-defined]
 
 
 # ---- IR: expressions ----
@@ -466,7 +466,7 @@ class NativeFunction(enum.Enum):
         return type(self).IR_OP_TO_NUM_ARGS[self]
 
 
-NativeFunction.IR_OP_TO_NUM_ARGS = {
+NativeFunction.IR_OP_TO_NUM_ARGS = {  # type: ignore[attr-defined]
     NativeFunction.ABS: 1,
     NativeFunction.MIN: 2,
     NativeFunction.MAX: 2,
@@ -536,13 +536,13 @@ class UnaryOperator(enum.Enum):
         return type(self).IR_OP_TO_PYTHON_SYMBOL[self]
 
 
-UnaryOperator.IR_OP_TO_PYTHON_OP = {
+UnaryOperator.IR_OP_TO_PYTHON_OP = {  # type: ignore[attr-defined]
     UnaryOperator.POS: operator.pos,
     UnaryOperator.NEG: operator.neg,
     UnaryOperator.NOT: operator.not_,
 }
 
-UnaryOperator.IR_OP_TO_PYTHON_SYMBOL = {
+UnaryOperator.IR_OP_TO_PYTHON_SYMBOL = {  # type: ignore[attr-defined]
     UnaryOperator.POS: "+",
     UnaryOperator.NEG: "-",
     UnaryOperator.NOT: "not",
@@ -586,7 +586,7 @@ class BinaryOperator(enum.Enum):
         return type(self).IR_OP_TO_PYTHON_SYMBOL[self]
 
 
-BinaryOperator.IR_OP_TO_PYTHON_OP = {
+BinaryOperator.IR_OP_TO_PYTHON_OP = {  # type: ignore[attr-defined]
     BinaryOperator.ADD: operator.add,
     BinaryOperator.SUB: operator.sub,
     BinaryOperator.MUL: operator.mul,
@@ -603,7 +603,7 @@ BinaryOperator.IR_OP_TO_PYTHON_OP = {
     BinaryOperator.NE: operator.ne,
 }
 
-BinaryOperator.IR_OP_TO_PYTHON_SYMBOL = {
+BinaryOperator.IR_OP_TO_PYTHON_SYMBOL = {  # type: ignore[attr-defined]
     BinaryOperator.ADD: "+",
     BinaryOperator.SUB: "-",
     BinaryOperator.MUL: "*",
@@ -721,12 +721,6 @@ class IterationOrder(enum.Enum):
 
     def __str__(self) -> str:
         return self.name
-
-    def __lshift__(self, steps: int):
-        return self.cycle(steps=-steps)
-
-    def __rshift__(self, steps: int):
-        return self.cycle(steps=steps)
 
 
 class BaseAxisBound(Node, ABC):


### PR DESCRIPTION
## Description

This PR changes the flat out "ignore all mypy errors" on `defir_to_gtir` and `nodes` with a more targeted ignore that only filters `"call-arg"` errors. These are generated by `@attribclass` classes, which - apparently - aren't understood by `mypy`.

In a follow-up PR, we can probably replace `@attribclass` classes with `@dataclass` classes. Those seem to serve a similar purpose and are natively understood by `mypy`.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A