### PR TITLE
refactor[cartesian]: Better error message for out of bound read on stencils

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,6 +21,7 @@
 - Kardos, Péter. ETH Zurich - EXCLAIM
 - Kellerhals, Samuel. ETH Zurich - EXCLAIM
 - Kotsalos, Christos. ETH Zurich - CSCS
+- Kropiewnicki, Charles. SSAI/NASA-GSFC
 - Luz, Magdalena. ETH Zurich - EXCLAIM
 - Madonna, Alberto. ETH Zurich - CSCS
 - Mariotti, Kean. ETH Zurich - CSCS

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -376,13 +376,26 @@ class StencilObject(abc.ABC):
             raise ValueError(f"Compute domain contains zero sizes '{domain}')")
 
         if not domain <= (
-            max_domain := self._get_max_domain(
+            self._get_max_domain(
                 arg_infos, self.domain_info, self.field_info, origin, squeeze=False
             )
         ):
-            raise ValueError(
-                f"Compute domain too large (provided: {domain}, maximum: {max_domain}. Check stencil domain provided or adjust K interval as needed.)"
+            offending_fields = []
+            for name, info in self.field_info.items():
+                field_used_domain = self._get_max_domain(
+                    arg_infos, self.domain_info, {name: info}, origin, squeeze=False
+                )
+                if field_used_domain < domain:
+                    offending_fields.append((name, field_used_domain))
+
+            error = ValueError(
+                f"Compute domain too large for stencil {self.options['name']}: \n"
+                f"  Stencil domain is {domain} but field indexation leads to read outside of bounds.\n"
+                f"  Check region/horizontal offsets or interval/vertical offsets, or stencil domain.\n"
+                f"  Offending fields (name, size with offset removed): {offending_fields}"
             )
+
+            raise error
 
         if domain[2] < self.domain_info.min_sequential_axis_size:
             raise ValueError(


### PR DESCRIPTION
- Better error message for out of bound read: refactor [cartesian]

## Description

Changed the error message raised when a stencil attempts to read outside of the valid bounds of an array. The new message now provides information about which fields fail, their side, and some tips to guide users resolving the error.

Existing test suite covers this change, new tests should not be required to validate this change.
