### PR TITLE
ci: run pre-commit manually

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,8 +38,16 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
-      - name: "Run pre-commit"
-        uses: pre-commit/action@v3.0.1
+      - name: Restore cache folder
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit_${{ env.pythonLocation }}_${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
   typing-exports:
     needs: [get-python-versions]


### PR DESCRIPTION
## Description

We are currently using the `pre-commit/action`. The action is in [maintenance mode](https://github.com/pre-commit/action) and effectively unmaintained. Last month, all pending issues and PRs were closed as "duplicates" or [without any reason](https://github.com/pre-commit/action/pull/242), presumably to move users over to [precommit.ci](https://pre-commit.ci/).

The action is causing a warning because it uses `actions/cache@v4` under the hood, which isn't (marked as) compatible with node24. Node24 will be the default in a couple months. We should thus update to avoid potential issues once node24 gets to be the new default.

<img width="1796" height="277" alt="image" src="https://github.com/user-attachments/assets/ed9b891e-7c30-4fd5-8bd2-c5a356f7d355" />

This PR suggests to just drop the dependency on `pre-commit/action` and instead call `pre-commit` by hand. The PR preserves caching the pre-commit cache and thus the functionality is as before.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A