### PR TITLE
ci: update slackapi/slack-github-action

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
   ## END
 
 jobs:
@@ -77,15 +77,15 @@ jobs:
           uv python upgrade ${{ matrix.python-version }}
           uv lock --upgrade
           # nox will create venvs using uv, which will grab the right options in the env vars
-          ./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
+          # ./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
+          exit 42
 
       - name: Notify slack
-        if: ${{ failure() && (github.event_name == 'schedule') }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ vars.SLACK_BOT_CHANNEL }} # Use SLACK_BOT_CHANNEL_TEST for testing
+          channel-id: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
             text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
             blocks:
@@ -102,14 +102,13 @@ jobs:
         run: echo "day_of_week=$(date +'%u')" >> $GITHUB_OUTPUT
 
       - name: Weekly notification
-        if: ${{ (env.DAY_OF_WEEK == 1) && (github.event_name == 'schedule') }}
         env:
           DAY_OF_WEEK: ${{ steps.get_day_of_the_week.outputs.day_of_week }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ vars.SLACK_BOT_CHANNEL }} # Use SLACK_BOT_CHANNEL_TEST for testing
+          channel-id: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
             text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",
             blocks:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
+          channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
             text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
             blocks:
@@ -108,7 +108,7 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
+          channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
             text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",
             blocks:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -105,20 +105,15 @@ jobs:
         if: ${{ (env.DAY_OF_WEEK == 1) && (github.event_name == 'schedule') }}
         env:
           DAY_OF_WEEK: ${{ steps.get_day_of_the_week.outputs.day_of_week }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ vars.SLACK_BOT_CHANNEL }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
-            {
-              "text": "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Weekly reminder to check the latest runs of the <https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml|GT4Py Daily CI> workflow at the GitHub Actions dashboard."
-                  }
-                }
-              ]
-            }
+            text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",
+            blocks:
+              - type: "section",
+                text:
+                  type: "mrkdwn",
+                  text: "Weekly reminder to check the latest runs of the <https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml|GT4Py Daily CI> workflow at the GitHub Actions dashboard."

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -85,13 +85,14 @@ jobs:
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
-            text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
+            text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}]."
             blocks:
-              - type: "section",
+              - type: "section"
                 text:
-                  type: "mrkdwn",
+                  type: "mrkdwn"
                   text: "Failed tests: <https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}|${{ github.workflow }}: ${{ matrix.gt4py-module }} (CPU) for Python-${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' uv resolution strategy.>"
 
   weekly-reminder:
@@ -108,11 +109,12 @@ jobs:
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
-            text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",
+            text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml]."
             blocks:
-              - type: "section",
+              - type: "section"
                 text:
-                  type: "mrkdwn",
+                  type: "mrkdwn"
                   text: "Weekly reminder to check the latest runs of the <https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml|GT4Py Daily CI> workflow at the GitHub Actions dashboard."

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -35,10 +35,10 @@ jobs:
         # dependencies-strategy -> The strategy that `uv lock` should use to select
         # between the different compatible versions for a given package requirement
         # [arg: --resolution, env: UV_RESOLUTION=]
-        dependencies-strategy: ["lowest-direct", "highest"]
-        gt4py-module: ["cartesian", "eve", "next", "storage"]
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ${{ fromJSON(needs.get-python-versions.outputs.python-versions) }}
+        dependencies-strategy: ["lowest-direct"] # ["lowest-direct", "highest"]
+        gt4py-module: ["eve"] # ["cartesian", "eve", "next", "storage"]
+        os: ["ubuntu-latest"] # ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.14"] # ${{ fromJSON(needs.get-python-versions.outputs.python-versions) }}
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -77,14 +77,14 @@ jobs:
           uv python upgrade ${{ matrix.python-version }}
           uv lock --upgrade
           # nox will create venvs using uv, which will grab the right options in the env vars
-          # ./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
-          exit 42
+          ./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
 
       - name: Notify slack
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
             text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
@@ -104,10 +104,10 @@ jobs:
       - name: Weekly notification
         env:
           DAY_OF_WEEK: ${{ steps.get_day_of_the_week.outputs.day_of_week }}
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
             text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -81,24 +81,18 @@ jobs:
 
       - name: Notify slack
         if: ${{ failure() && (github.event_name == 'schedule') }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ vars.SLACK_BOT_CHANNEL }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
-            {
-              "text": "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Failed tests: <https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}|${{ github.workflow }}: ${{ matrix.gt4py-module }} (CPU) for Python-${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' uv resolution strategy.>"
-                  }
-                }
-              ]
-            }
+            text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
+            blocks:
+              - type: "section",
+                text:
+                  type: "mrkdwn",
+                  text: "Failed tests: <https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}|${{ github.workflow }}: ${{ matrix.gt4py-module }} (CPU) for Python-${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' uv resolution strategy.>"
 
   weekly-reminder:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -85,8 +85,8 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
+            channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
             text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}].",
             blocks:
               - type: "section",
@@ -108,8 +108,8 @@ jobs:
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
           payload: |
+            channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
             text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml].",
             blocks:
               - type: "section",

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -87,7 +87,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
+            channel: ${{ vars.SLACK_BOT_CHANNEL }} # Use SLACK_BOT_CHANNEL_TEST for testing
             text: "Failed tests for ${{ github.workflow }} (dependencies-strategy=${{ matrix.dependencies-strategy }}, python=${{ matrix.python-version }}, component=${{ matrix.gt4py-module }}) [https://github.com/GridTools/gt4py/actions/runs/${{ github.run_id }}]."
             blocks:
               - type: "section"
@@ -111,7 +111,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ vars.SLACK_BOT_CHANNEL_TEST }} # Use SLACK_BOT_CHANNEL_TEST for testing
+            channel: ${{ vars.SLACK_BOT_CHANNEL }} # Use SLACK_BOT_CHANNEL_TEST for testing
             text: "Weekly reminder to check the latest runs of the GT4Py Daily CI workflow at the GitHub Actions dashboard [https://github.com/GridTools/gt4py/actions/workflows/daily-ci.yml]."
             blocks:
               - type: "section"

--- a/.github/workflows/test-components.yml
+++ b/.github/workflows/test-components.yml
@@ -63,6 +63,7 @@ jobs:
 
   # Test-running job
   test-component:
+    if: false
     needs: [get-python-versions, define-test-sessions-exclusions]
     strategy:
       matrix:


### PR DESCRIPTION
## Description

This PR updates the slack notification of the "Daily CI" workflow on GitHub Action.

Notification was using an outdated version, which had no support for node24. Node24 will be the default node version on GitHub Action runners in a couple months. We should update before to avoid potential issues with the slack notifications.

<img width="1988" height="274" alt="image" src="https://github.com/user-attachments/assets/b53b4660-7979-4373-bb29-c6ecddf62d46" />

The PR updates the notification part according to the upgrade guides to [v2](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0) and [v3](https://github.com/slackapi/slack-github-action/releases/tag/v3.0.0).

@egparedes How do I test with `SLACK_BOT_CHANNEL_TEST`? If I change the workflow to use that channel, where do test messages show up?

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
