### PR TITLE
refactor[cartesian]: appropriate types for `interval` / `horizontal`

### DIFF
--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -786,12 +786,12 @@ def computation(order):
 
 def interval(*args):
     """Define the interval of computation in the 'K' sequential axis."""
-    pass
+    return _ComputationContextManager()
 
 
 def horizontal(*args):
     """Define a block of code that is restricted to a set of regions in the parallel axes."""
-    pass
+    return _ComputationContextManager()
 
 
 class _Region:


### PR DESCRIPTION
## Description

GTScript offers context managers like

- `with computation(...)`
- `with interval(...)`
- `with horizontal(...)`

while the first one correctly returns (a trivial) context manager, the other two functions just `pass` and don't return anything. Because these context managers are just used for parsing, this isn't important. However, it trips static code analysis like `pyright` and adds squiggly red lines that could be avoided.

<img width="1808" height="312" alt="image" src="https://github.com/user-attachments/assets/39b3b5c0-caed-4e18-a810-f9421b643f81" />

This PR suggests for `interval()` and `horizontal()` to also return a trivial context manager, which will avoid the squiggly lines.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
