### PR TITLE
feat[cartesian]: Enforce cartesian layout to be given precedence in allocation striding

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -46,7 +46,7 @@ from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.cartesian.utils import shash
 from gt4py.eve import codegen
 from gt4py.eve.codegen import MakoTemplate as as_mako
-from gt4py.storage.cartesian import layout
+from gt4py.storage.cartesian import layout, layout_registry
 
 
 if TYPE_CHECKING:
@@ -894,12 +894,7 @@ class BaseDaceBackend(BaseGTBackend):
 class DaceCPUBackend(BaseDaceBackend):
     name = "dace:cpu"
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
-    storage_info: ClassVar[layout.LayoutInfo] = {
-        "alignment": 1,
-        "device": "cpu",
-        "layout_map": layout.layout_maker_factory((1, 2, 0)),  # Optimal loop order: K-I-J
-        "is_optimal_layout": layout.layout_checker_factory(layout.layout_maker_factory((1, 2, 0))),
-    }
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
     MODULE_GENERATOR_CLASS = DaCePyExtModuleGenerator
 
     options = BaseGTBackend.GT_BACKEND_OPTS
@@ -912,12 +907,7 @@ class DaceCPUBackend(BaseDaceBackend):
 class DaceCPUKFirstBackend(BaseDaceBackend):
     name = "dace:cpu_kfirst"
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
-    storage_info: ClassVar[layout.LayoutInfo] = {
-        "alignment": 1,
-        "device": "cpu",
-        "layout_map": layout.layout_maker_factory((0, 1, 2)),  # Optimal loop order: I-J-K
-        "is_optimal_layout": layout.layout_checker_factory(layout.layout_maker_factory((0, 1, 2))),
-    }
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
     MODULE_GENERATOR_CLASS = DaCePyExtModuleGenerator
 
     options = BaseGTBackend.GT_BACKEND_OPTS
@@ -930,12 +920,7 @@ class DaceCPUKFirstBackend(BaseDaceBackend):
 class DaceCPU_KJI(BaseDaceBackend):
     name = "dace:cpu_KJI"
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
-    storage_info: ClassVar[layout.LayoutInfo] = {
-        "alignment": 1,
-        "device": "cpu",
-        "layout_map": layout.layout_maker_factory((2, 1, 0)),  # Optimal loop order: K-J-I
-        "is_optimal_layout": layout.layout_checker_factory(layout.layout_maker_factory((2, 1, 0))),
-    }
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
     MODULE_GENERATOR_CLASS = DaCePyExtModuleGenerator
 
     options = BaseGTBackend.GT_BACKEND_OPTS
@@ -950,12 +935,7 @@ class DaceGPUBackend(BaseDaceBackend):
 
     name = "dace:gpu"
     languages: ClassVar[dict] = {"computation": "cuda", "bindings": ["python"]}
-    storage_info: ClassVar[layout.LayoutInfo] = {
-        "alignment": 32,
-        "device": "gpu",
-        "layout_map": layout.layout_maker_factory((2, 1, 0)),  # Optimal loop order: K-J-I
-        "is_optimal_layout": layout.layout_checker_factory(layout.layout_maker_factory((2, 1, 0))),
-    }
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
     MODULE_GENERATOR_CLASS = DaCeCUDAPyExtModuleGenerator
     options: ClassVar[GTBackendOptions] = {
         **BaseGTBackend.GT_BACKEND_OPTS,

--- a/src/gt4py/cartesian/backend/debug_backend.py
+++ b/src/gt4py/cartesian/backend/debug_backend.py
@@ -18,6 +18,7 @@ from gt4py.cartesian.gtc.gtir_to_oir import GTIRToOIR
 from gt4py.cartesian.gtc.passes import oir_optimizations
 from gt4py.eve import codegen
 from gt4py.storage import layout
+from gt4py.storage.cartesian import layout_registry
 
 
 if TYPE_CHECKING:
@@ -33,8 +34,7 @@ class DebugBackend(backend.BaseBackend):
         "oir_pipeline": {"versioning": True, "type": passes.OirPipeline},
         "ignore_np_errstate": {"versioning": True, "type": bool},
     }
-    storage_info = layout.NaiveCPULayout
-    languages: ClassVar[dict[str, Any]] = {"computation": "python", "bindings": ["python"]}
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
     MODULE_GENERATOR_CLASS = py_common.PythonModuleGenerator
 
     def _generate_computation(self) -> dict[str, str | dict]:

--- a/src/gt4py/cartesian/backend/debug_backend.py
+++ b/src/gt4py/cartesian/backend/debug_backend.py
@@ -35,6 +35,7 @@ class DebugBackend(backend.BaseBackend):
         "ignore_np_errstate": {"versioning": True, "type": bool},
     }
     storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
+    languages: ClassVar[dict] = {"computation": "python", "bindings": ["python"]}
     MODULE_GENERATOR_CLASS = py_common.PythonModuleGenerator
 
     def _generate_computation(self) -> dict[str, str | dict]:

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from gt4py import storage as gt_storage
 from gt4py.cartesian.backend.base import register
 from gt4py.cartesian.backend.gtc_common import (
     BackendCodegen,
@@ -26,6 +25,7 @@ from gt4py.cartesian.gtc.gtcpp.oir_to_gtcpp import OIRToGTCpp
 from gt4py.cartesian.gtc.gtir_to_oir import GTIRToOIR
 from gt4py.cartesian.gtc.passes.oir_pipeline import DefaultPipeline
 from gt4py.eve import codegen
+from gt4py.storage.cartesian import layout, layout_registry
 
 
 if TYPE_CHECKING:
@@ -146,7 +146,7 @@ class GTCpuIfirstBackend(GTBaseBackend):
     name = "gt:cpu_ifirst"
     GT_BACKEND_T = "cpu_ifirst"
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
-    storage_info = gt_storage.layout.CPUIFirstLayout
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
 
     def generate_extension(self) -> None:
         return super()._generate_extension(uses_cuda=False)
@@ -159,7 +159,7 @@ class GTCpuKfirstBackend(GTBaseBackend):
     name = "gt:cpu_kfirst"
     GT_BACKEND_T = "cpu_kfirst"
     languages: ClassVar[dict] = {"computation": "c++", "bindings": ["python"]}
-    storage_info = gt_storage.layout.CPUKFirstLayout
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
 
     def generate_extension(self) -> None:
         return super()._generate_extension(uses_cuda=False)
@@ -177,7 +177,7 @@ class GTGpuBackend(GTBaseBackend):
         **BaseGTBackend.GT_BACKEND_OPTS,
         "device_sync": {"versioning": True, "type": bool},
     }
-    storage_info = gt_storage.layout.GPULayout
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
 
     def generate_extension(self) -> None:
         return super()._generate_extension(uses_cuda=True)

--- a/src/gt4py/cartesian/backend/numpy_backend.py
+++ b/src/gt4py/cartesian/backend/numpy_backend.py
@@ -18,6 +18,7 @@ from gt4py.cartesian.gtc.numpy import npir
 from gt4py.cartesian.gtc.passes import oir_optimizations as oir_opt
 from gt4py.eve import codegen
 from gt4py.storage import layout
+from gt4py.storage.cartesian import layout_registry
 
 
 if TYPE_CHECKING:
@@ -34,7 +35,7 @@ class NumpyBackend(backend.BaseBackend):
         # TODO: Implement this option in source code
         "ignore_np_errstate": {"versioning": True, "type": bool},
     }
-    storage_info = layout.NaiveCPULayout
+    storage_info: ClassVar[layout.LayoutInfo] = layout_registry.from_name(name)
     languages: ClassVar[dict] = {"computation": "python", "bindings": ["python"]}
     MODULE_GENERATOR_CLASS = py_common.PythonModuleGenerator
 

--- a/src/gt4py/storage/__init__.py
+++ b/src/gt4py/storage/__init__.py
@@ -11,7 +11,7 @@
 from . import cartesian
 from .cartesian import layout
 from .cartesian.interface import empty, from_array, full, ones, zeros
-from .cartesian.layout import from_name, register
+from .cartesian.layout_registry import from_name, register
 
 
 __all__ = [

--- a/src/gt4py/storage/__init__.py
+++ b/src/gt4py/storage/__init__.py
@@ -9,7 +9,7 @@
 """GridTools storages utilities."""
 
 from . import cartesian
-from .cartesian import layout
+from .cartesian import layout, layout_registry
 from .cartesian.interface import empty, from_array, full, ones, zeros
 from .cartesian.layout_registry import from_name, register
 
@@ -21,6 +21,7 @@ __all__ = [
     "from_name",
     "full",
     "layout",
+    "layout_registry",
     "ones",
     "register",
     "zeros",

--- a/src/gt4py/storage/cartesian/interface.py
+++ b/src/gt4py/storage/cartesian/interface.py
@@ -14,7 +14,7 @@ from typing import Optional, Sequence, Union
 import numpy as np
 
 from gt4py.storage import allocators
-from gt4py.storage.cartesian import layout, utils as storage_utils
+from gt4py.storage.cartesian import layout_registry, utils as storage_utils
 
 
 try:
@@ -32,7 +32,7 @@ from numpy.typing import ArrayLike, DTypeLike
 
 # Helper functions
 def _error_on_invalid_preset(backend):
-    if backend not in layout.REGISTRY:
+    if backend not in layout_registry.REGISTRY:
         raise RuntimeError(f"Storage preset '{backend}' is not registered.")
 
 
@@ -79,7 +79,7 @@ def empty(
             If illegal or inconsistent arguments are specified.
     """
     _error_on_invalid_preset(backend)
-    storage_info = layout.from_name(backend)
+    storage_info = layout_registry.from_name(backend)
     assert storage_info is not None
     if storage_info["device"] == "gpu":
         allocate_f = storage_utils.allocate_gpu
@@ -320,7 +320,7 @@ def from_array(
         dimensions=dimensions,
     )
 
-    layout_info = layout.from_name(backend)
+    layout_info = layout_registry.from_name(backend)
     assert layout_info is not None
     storage[...] = storage_utils.asarray(data, device=layout_info["device"])
 

--- a/src/gt4py/storage/cartesian/layout.py
+++ b/src/gt4py/storage/cartesian/layout.py
@@ -6,19 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Final,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    TypedDict,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Literal, Tuple, TypedDict, Union
 
 import numpy as np
 
@@ -35,34 +23,6 @@ class LayoutInfo(TypedDict):
     device: Literal["cpu", "gpu"]
     layout_map: Callable[[Tuple[str, ...]], Tuple[int, ...]]
     is_optimal_layout: Callable[[Any, Tuple[str, ...]], bool]
-
-
-REGISTRY: Dict[str, LayoutInfo] = {}
-
-
-def from_name(name: str) -> Optional[LayoutInfo]:
-    return REGISTRY.get(name, None)
-
-
-def register(name: str, info: Optional[LayoutInfo]) -> None:
-    if info is None:
-        REGISTRY.pop(name, None)
-    else:
-        assert isinstance(name, str)
-        assert isinstance(info, dict)
-
-        REGISTRY[name] = info
-
-
-def check_layout(layout_map, strides):
-    if not (len(strides) == len(layout_map)):
-        return False
-    stride = 0
-    for dim in reversed(np.argsort(layout_map)):
-        if strides[dim] < stride:
-            return False
-        stride = strides[dim]
-    return True
 
 
 def layout_maker_factory(
@@ -97,80 +57,20 @@ def layout_maker_factory(
     return layout_maker
 
 
+def _check_layout(layout_map, strides):
+    if not (len(strides) == len(layout_map)):
+        return False
+    stride = 0
+    for dim in reversed(np.argsort(layout_map)):
+        if strides[dim] < stride:
+            return False
+        stride = strides[dim]
+    return True
+
+
 def layout_checker_factory(layout_maker):
     def layout_checker(field: Union[np.ndarray, "cp.ndarray"], dimensions: Tuple[str, ...]) -> bool:
         layout_map = layout_maker(dimensions)
-        return check_layout(layout_map, field.strides)
+        return _check_layout(layout_map, field.strides)
 
     return layout_checker
-
-
-def _permute_layout_to_dimensions(
-    layout: Sequence[int], dimensions: Tuple[str, ...]
-) -> Tuple[int, ...]:
-    data_dims = [int(d) for d in dimensions if d.isdigit()]
-    canonical_dimensions = [d for d in "IJK" if d in dimensions] + [
-        str(d) for d in sorted(data_dims)
-    ]
-    res_layout = []
-    for d in dimensions:
-        res_layout.append(layout[canonical_dimensions.index(d)])
-    return tuple(res_layout)
-
-
-def make_gtcpu_kfirst_layout_map(dimensions: Tuple[str, ...]) -> Tuple[int, ...]:
-    layout = [i for i in range(len(dimensions))]
-    naxes = sum(dim in dimensions for dim in "IJK")
-    layout = [*layout[-naxes:], *layout[:-naxes]]
-    return _permute_layout_to_dimensions([lt for lt in layout if lt is not None], dimensions)
-
-
-def make_gtcpu_ifirst_layout_map(dimensions: Tuple[str, ...]) -> Tuple[int, ...]:
-    ctr = reversed(range(len(dimensions)))
-    layout = [next(ctr) for dim in "IJK" if dim in dimensions] + list(ctr)
-    if "K" in dimensions and "J" in dimensions:
-        if "I" in dimensions:
-            layout = [layout[0], layout[2], layout[1], *layout[3:]]
-        else:
-            layout = [layout[1], layout[0], *layout[2:]]
-    return _permute_layout_to_dimensions(layout, dimensions)
-
-
-def make_cuda_layout_map(dimensions: Tuple[str, ...]) -> Tuple[int, ...]:
-    layout = tuple(reversed(range(len(dimensions))))
-    return _permute_layout_to_dimensions(layout, dimensions)
-
-
-NaiveCPULayout: Final[LayoutInfo] = {
-    "alignment": 1,
-    "device": "cpu",
-    "layout_map": lambda axes: tuple(i for i in range(len(axes))),
-    "is_optimal_layout": lambda *_: True,
-}
-register("naive_cpu", NaiveCPULayout)
-
-CPUIFirstLayout: Final[LayoutInfo] = {
-    "alignment": 8,
-    "device": "cpu",
-    "layout_map": make_gtcpu_ifirst_layout_map,
-    "is_optimal_layout": layout_checker_factory(make_gtcpu_ifirst_layout_map),
-}
-register("cpu_ifirst", CPUIFirstLayout)
-
-
-CPUKFirstLayout: Final[LayoutInfo] = {
-    "alignment": 1,
-    "device": "cpu",
-    "layout_map": make_gtcpu_kfirst_layout_map,
-    "is_optimal_layout": layout_checker_factory(make_gtcpu_kfirst_layout_map),
-}
-register("cpu_kfirst", CPUKFirstLayout)
-
-
-GPULayout: Final[LayoutInfo] = {
-    "alignment": 32,
-    "device": "gpu",
-    "layout_map": make_cuda_layout_map,
-    "is_optimal_layout": layout_checker_factory(make_cuda_layout_map),
-}
-register("gpu", GPULayout)

--- a/src/gt4py/storage/cartesian/layout.py
+++ b/src/gt4py/storage/cartesian/layout.py
@@ -69,18 +69,26 @@ def layout_maker_factory(
     base_layout: Tuple[int, ...],
 ) -> Callable[[Tuple[str, ...]], Tuple[int, ...]]:
     def layout_maker(dimensions: Tuple[str, ...]) -> Tuple[int, ...]:
+        """Create layout from a given list of dimensions. Cartesian dimensions
+        are given precedence so they follow the requested layout, other dimensions
+        will be appended to it."""
+
+        # Sort cartesian layout
         mask = [dim in dimensions for dim in "IJK"]
-        mask += [True] * (len(dimensions) - sum(mask))
         ranks = []
         for m, bl in zip(mask, base_layout):
             if m:
                 ranks.append(bl)
-        if len(mask) > 3:
-            if base_layout[2] == 2:
-                ranks.extend(3 + c for c in range(len(mask) - 3))
-            else:
-                ranks.extend(-c for c in range(len(mask) - 3))
 
+        # Sort data dimensions
+        # - shift all cartesian layout
+        data_dimensions_size = len(dimensions) - sum(mask)
+        ranks = [data_dimensions_size + r for r in ranks]
+        # - extend ranks with the required amount of data dimensions
+        for ddim in range(data_dimensions_size):
+            ranks.append(ddim)
+
+        # Turn ranks into memory layout
         res_layout = [0] * len(ranks)
         for i, idx in enumerate(np.argsort(ranks)):
             res_layout[idx] = i

--- a/src/gt4py/storage/cartesian/layout_registry.py
+++ b/src/gt4py/storage/cartesian/layout_registry.py
@@ -1,0 +1,113 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+from gt4py.storage.cartesian.layout import LayoutInfo, layout_checker_factory, layout_maker_factory
+
+
+REGISTRY: dict[str, LayoutInfo] = {}
+
+
+def from_name(name: str) -> LayoutInfo:
+    layout_info = REGISTRY.get(name, None)
+    if layout_info is None:
+        raise ValueError(f"Layout '{name} is not registered. Valid options are: {REGISTRY.keys()}.")
+    return layout_info
+
+
+def register(name: str, info: LayoutInfo) -> None:
+    if info is None:
+        REGISTRY.pop(name, None)
+    else:
+        assert isinstance(name, str)
+        assert isinstance(info, dict)
+
+        REGISTRY[name] = info
+
+
+register(
+    "dace:cpu",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((1, 2, 0)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((1, 2, 0))),
+    ),
+)
+register(
+    "dace:cpu_kfirst",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((0, 1, 2)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((0, 1, 2))),
+    ),
+)
+register(
+    "dace:cpu_KJI",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((2, 1, 0)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((2, 1, 0))),
+    ),
+)
+register(
+    "dace:gpu",
+    LayoutInfo(
+        alignment=32,
+        device="gpu",
+        layout_map=layout_maker_factory((2, 1, 0)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((2, 1, 0))),
+    ),
+)
+register(
+    "debug",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((0, 1, 2)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((0, 1, 2))),
+    ),
+)
+register(
+    "gt:cpu_ifirst",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((2, 1, 0)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((2, 1, 0))),
+    ),
+)
+register(
+    "gt:cpu_kfirst",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((0, 1, 2)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((0, 1, 2))),
+    ),
+)
+register(
+    "gt:gpu",
+    LayoutInfo(
+        alignment=32,
+        device="gpu",
+        layout_map=layout_maker_factory((2, 1, 0)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((2, 1, 0))),
+    ),
+)
+register(
+    "numpy",
+    LayoutInfo(
+        alignment=1,
+        device="cpu",
+        layout_map=layout_maker_factory((0, 1, 2)),
+        is_optimal_layout=layout_checker_factory(layout_maker_factory((0, 1, 2))),
+    ),
+)

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -74,3 +74,26 @@ def test_bad_layout_warns(backend):
         "provided allocators in `gt4py.storage`.",
     ):
         stencil(field_a=inp, field_b=outp)
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_data_dimensions_stride_is_always_higher_than_cartesian(backend):
+    xp = get_array_library(backend)
+
+    # Test a 4D array
+    shape = (2, 2, 2, 2)
+    allocated_array = gt_storage.zeros(
+        backend=backend, shape=shape, dtype=xp.float64, aligned_index=(0, 0, 0, 0)
+    )
+
+    assert allocated_array.strides[3] > max(allocated_array.strides[0:3])
+
+    # Test a 5D array
+    shape = (2, 2, 2, 2, 2)
+    allocated_array = gt_storage.zeros(
+        backend=backend, shape=shape, dtype=xp.float64, aligned_index=(0, 0, 0, 0)
+    )
+
+    assert allocated_array.strides[3] > max(
+        allocated_array.strides[0:3]
+    ) and allocated_array.strides[4] > max(allocated_array.strides[0:3])

--- a/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/test_field_layouts.py
@@ -91,7 +91,7 @@ def test_data_dimensions_stride_is_always_higher_than_cartesian(backend):
     # Test a 5D array
     shape = (2, 2, 2, 2, 2)
     allocated_array = gt_storage.zeros(
-        backend=backend, shape=shape, dtype=xp.float64, aligned_index=(0, 0, 0, 0)
+        backend=backend, shape=shape, dtype=xp.float64, aligned_index=(0, 0, 0, 0, 0)
     )
 
     assert allocated_array.strides[3] > max(

--- a/tests/storage_tests/unit_tests/test_interface.py
+++ b/tests/storage_tests/unit_tests/test_interface.py
@@ -23,11 +23,13 @@ from gt4py.storage.cartesian.utils import allocate_cpu, allocate_gpu, normalize_
 
 
 CPU_LAYOUTS = [
-    name for name, info in gt4py.storage.layout.REGISTRY.items() if info["device"] == "cpu"
+    name
+    for name, info in gt4py.storage.cartesian.layout_registry.REGISTRY.items()
+    if info["device"] == "cpu"
 ]
 GPU_LAYOUTS = [
     pytest.param(name, marks=pytest.mark.requires_gpu)
-    for name, info in gt4py.storage.layout.REGISTRY.items()
+    for name, info in gt4py.storage.cartesian.layout_registry.REGISTRY.items()
     if info["device"] == "gpu"
 ]
 

--- a/tests/storage_tests/unit_tests/test_layout.py
+++ b/tests/storage_tests/unit_tests/test_layout.py
@@ -48,90 +48,84 @@ from gt4py.storage.cartesian import layout as gt_layout
         (("I", "J", "K", "1"), (1, 2, 3, 0)),
     ],
 )
-def test_gtcpu_kfirst_layout(dimensions, layout):
-    make_layout_map = gt_layout.CPUKFirstLayout["layout_map"]
-    assert make_layout_map(dimensions) == layout
+def test_IJK_layout(dimensions, layout):
+    layout_maker = gt_layout.layout_maker_factory((0, 1, 2))
+    assert layout_maker(dimensions) == layout
 
 
 @pytest.mark.parametrize(
     ["dimensions", "layout"],
     [
+        # No cartesian dimensions
         ((), ()),
+        (("0",), (0,)),
+        (("1",), (0,)),
+        (("0", "1"), (0, 1)),
+        # One cartesian dimension
         (("I",), (0,)),
+        (("I", "0"), (1, 0)),
+        (("I", "0", "1"), (2, 0, 1)),
         (("J",), (0,)),
-        (("I", "J"), (1, 0)),
+        (("J", "0"), (1, 0)),
+        (("J", "0", "1"), (2, 0, 1)),
         (("K",), (0,)),
+        (("K", "0"), (1, 0)),
+        (("K", "0", "1"), (2, 0, 1)),
+        # Two cartesian dimensions
+        (("I", "J"), (1, 0)),
+        (("I", "J", "0"), (2, 1, 0)),
+        (("I", "J", "0", "1"), (3, 2, 0, 1)),
         (("I", "K"), (1, 0)),
+        (("I", "K", "0"), (2, 1, 0)),
+        (("I", "K", "0", "1"), (3, 2, 0, 1)),
         (("J", "K"), (0, 1)),
-        (("I", "J", "K"), (2, 0, 1)),
-        (("0", "1"), (1, 0)),
-        (("I", "0", "1"), (2, 1, 0)),
-        (("J", "0", "1"), (2, 1, 0)),
-        (("K", "0", "1"), (2, 1, 0)),
-        (("I", "J", "0", "1"), (3, 2, 1, 0)),
-        (("I", "K", "0", "1"), (3, 2, 1, 0)),
-        (("J", "K", "0", "1"), (2, 3, 1, 0)),
-        (("I", "J", "K", "0", "1"), (4, 2, 3, 1, 0)),
-        (("0",), (0,)),
-        (("I", "0"), (1, 0)),
-        (("J", "0"), (1, 0)),
-        (("K", "0"), (1, 0)),
-        (("I", "J", "0"), (2, 1, 0)),
-        (("I", "K", "0"), (2, 1, 0)),
         (("J", "K", "0"), (1, 2, 0)),
+        (("J", "K", "0", "1"), (2, 3, 0, 1)),
+        # Three cartesian dimensions
+        (("I", "J", "K"), (2, 0, 1)),
         (("I", "J", "K", "0"), (3, 1, 2, 0)),
-        (("1",), (0,)),
-        (("I", "1"), (1, 0)),
-        (("J", "1"), (1, 0)),
-        (("K", "1"), (1, 0)),
-        (("I", "J", "1"), (2, 1, 0)),
-        (("I", "K", "1"), (2, 1, 0)),
-        (("J", "K", "1"), (1, 2, 0)),
-        (("I", "J", "K", "1"), (3, 1, 2, 0)),
+        (("I", "J", "K", "0", "1"), (4, 2, 3, 0, 1)),
     ],
 )
-def test_gtcpu_ifirst_layout(dimensions, layout):
-    make_layout_map = gt_layout.CPUIFirstLayout["layout_map"]
-    assert make_layout_map(dimensions) == layout
+def test_JKI_layout(dimensions, layout):
+    layout_maker = gt_layout.layout_maker_factory((2, 0, 1))
+    assert layout_maker(dimensions) == layout
 
 
 @pytest.mark.parametrize(
     ["dimensions", "layout"],
     [
+        # No cartesian dimensions
         ((), ()),
-        (("I",), (0,)),
-        (("J",), (0,)),
-        (("I", "J"), (1, 0)),
-        (("K",), (0,)),
-        (("I", "K"), (1, 0)),
-        (("J", "K"), (1, 0)),
-        (("I", "J", "K"), (2, 1, 0)),
-        (("0", "1"), (1, 0)),
-        (("I", "0", "1"), (2, 1, 0)),
-        (("J", "0", "1"), (2, 1, 0)),
-        (("K", "0", "1"), (2, 1, 0)),
-        (("I", "J", "0", "1"), (3, 2, 1, 0)),
-        (("I", "K", "0", "1"), (3, 2, 1, 0)),
-        (("J", "K", "0", "1"), (3, 2, 1, 0)),
-        (("I", "J", "K", "0", "1"), (4, 3, 2, 1, 0)),
         (("0",), (0,)),
-        (("I", "0"), (1, 0)),
-        (("J", "0"), (1, 0)),
-        (("K", "0"), (1, 0)),
-        (("I", "J", "0"), (2, 1, 0)),
-        (("I", "K", "0"), (2, 1, 0)),
-        (("J", "K", "0"), (2, 1, 0)),
-        (("I", "J", "K", "0"), (3, 2, 1, 0)),
         (("1",), (0,)),
-        (("I", "1"), (1, 0)),
-        (("J", "1"), (1, 0)),
-        (("K", "1"), (1, 0)),
-        (("I", "J", "1"), (2, 1, 0)),
-        (("I", "K", "1"), (2, 1, 0)),
-        (("J", "K", "1"), (2, 1, 0)),
-        (("I", "J", "K", "1"), (3, 2, 1, 0)),
+        (("0", "1"), (0, 1)),
+        # One cartesian dimension
+        (("I",), (0,)),
+        (("I", "0"), (1, 0)),
+        (("I", "0", "1"), (2, 0, 1)),
+        (("J",), (0,)),
+        (("J", "0"), (1, 0)),
+        (("J", "0", "1"), (2, 0, 1)),
+        (("K",), (0,)),
+        (("K", "0"), (1, 0)),
+        (("K", "0", "1"), (2, 0, 1)),
+        # Two cartesian dimensions
+        (("I", "J"), (1, 0)),
+        (("I", "J", "0"), (2, 1, 0)),
+        (("I", "J", "0", "1"), (3, 2, 0, 1)),
+        (("I", "K"), (1, 0)),
+        (("I", "K", "0"), (2, 1, 0)),
+        (("I", "K", "0", "1"), (3, 2, 0, 1)),
+        (("J", "K"), (1, 0)),
+        (("J", "K", "0"), (2, 1, 0)),
+        (("J", "K", "0", "1"), (3, 2, 0, 1)),
+        # Three cartesian dimensions
+        (("I", "J", "K"), (2, 1, 0)),
+        (("I", "J", "K", "0"), (3, 2, 1, 0)),
+        (("I", "J", "K", "0", "1"), (4, 3, 2, 0, 1)),
     ],
 )
-def test_gpu_layout(dimensions, layout):
-    make_layout_map = gt_layout.GPULayout["layout_map"]
-    assert make_layout_map(dimensions) == layout
+def test_KJI_layout(dimensions, layout):
+    layout_maker = gt_layout.layout_maker_factory((2, 1, 0))
+    assert layout_maker(dimensions) == layout


### PR DESCRIPTION
## Description

We change the algorithm to compute strides from dimensions to make sure the cartesian are always given lower strides and data dimensions are pushed after cartesian in stride space. This fix the "kfirst" 4D arrays to actually have K as the smallest stride

e.g.

```
dace:cpu_kfirst:[8, 4, 2, 1]
dace:cpu_KJI:[1, 2, 4, 8]
dace:cpu:[2, 1, 4, 8]
```
becomes
```
dace:cpu_kfirst:[4, 2, 1, 8]
dace:cpu_KJI:[1, 2, 4, 8]
dace:cpu:[2, 1, 4, 8]
```

for a (2, 2, 2, 2) domain.

TODO:
- [x] Unit test that checks the above "cartesian first"

