### PR TITLE
Fix wrong python version selection in some daily CI tasks

### DIFF
--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -8,8 +8,8 @@ on:
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
   # pull_request:
-  #  branches:
-  #    - main
+  #   branches:
+  #     - main
   ## END
 
 jobs:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -75,12 +75,12 @@ jobs:
           # Uncomment to only collect tests without running them (used for debugging CI issues)
           # PYTEST_ADDOPTS: "--collect-only"
         run: |
-          # We run the upgrade commands here explicitly to update the lock
+          # We run explicitly here the commands needed to update the lock
           uv lock --upgrade
           uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
           echo "Running '${{ matrix.gt4py-module }}' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
-          # Add '-l' to debug which session are collected and run by nox
+          # Add '-l' to debug which sessions are collected and run by nox
           ./noxfile.py -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
 
       - name: Notify slack

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -77,8 +77,8 @@ jobs:
           uv lock --upgrade
           uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
-          echo "Running CPU tests for ${{ matrix.gt4py-module }} with ${{ matrix.dependencies-strategy }} resolution strategy"
-          echo "./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'"
+          echo "Running '${{ matrix.gt4py-module }}'' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
+          ./noxfile.py -t 'cpu' -p ${{ matrix.python-version }} -s 'test_${{ matrix.gt4py-module }}'
 
       - name: Notify slack
         if: ${{ failure() && (github.event_name == 'schedule') }}

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #  branches:
+  #    - main
   ## END
 
 jobs:
@@ -81,7 +81,7 @@ jobs:
           # nox will create venvs using uv, which will grab the right options in the env vars
           echo "Running '${{ matrix.gt4py-module }}' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
           # Add '-l' to debug which session are collected and run by nox
-          ./noxfile.py -l -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
+          ./noxfile.py -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
 
       - name: Notify slack
         if: ${{ failure() && (github.event_name == 'schedule') }}

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -72,6 +72,8 @@ jobs:
           # Set uv options through env vars to ensure all commands (including nox) use the same settings
           UV_RESOLUTION: ${{ matrix.dependencies-strategy }}
           UV_PYTHON_PREFERENCE: only-managed
+          # Uncomment to only collect tests without running them (used for debugging CI issues)
+          # PYTEST_ADDOPTS="--collect-only"
         run: |
           # We run the upgrade commands here explicitly to update the lock
           uv lock --upgrade

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -79,8 +79,7 @@ jobs:
           uv lock --upgrade
           uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
-          echo "Running '${{ matrix.gt4py-module }}'' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
-          echo "./noxfile.py -t 'cpu' -p ${{ matrix.python-version }} -s 'test_${{ matrix.gt4py-module }}'"
+          echo "Running '${{ matrix.gt4py-module }}' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
           ./noxfile.py -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
 
       - name: Notify slack

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -77,7 +77,8 @@ jobs:
           uv lock --upgrade
           uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
-          ./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
+          echo "Running CPU tests for ${{ matrix.gt4py-module }} with ${{ matrix.dependencies-strategy }} resolution strategy"
+          echo "./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'"
 
       - name: Notify slack
         if: ${{ failure() && (github.event_name == 'schedule') }}

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -73,7 +73,7 @@ jobs:
           UV_RESOLUTION: ${{ matrix.dependencies-strategy }}
           UV_PYTHON_PREFERENCE: only-managed
           # Uncomment to only collect tests without running them (used for debugging CI issues)
-          # PYTEST_ADDOPTS="--collect-only"
+          PYTEST_ADDOPTS: "--collect-only"
         run: |
           # We run the upgrade commands here explicitly to update the lock
           uv lock --upgrade

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -73,14 +73,15 @@ jobs:
           UV_RESOLUTION: ${{ matrix.dependencies-strategy }}
           UV_PYTHON_PREFERENCE: only-managed
           # Uncomment to only collect tests without running them (used for debugging CI issues)
-          PYTEST_ADDOPTS: "--collect-only"
+          # PYTEST_ADDOPTS: "--collect-only"
         run: |
           # We run the upgrade commands here explicitly to update the lock
           uv lock --upgrade
           uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
           echo "Running '${{ matrix.gt4py-module }}' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
-          ./noxfile.py -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
+          # Add '-l' to debug which session are collected and run by nox
+          ./noxfile.py -l -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
 
       - name: Notify slack
         if: ${{ failure() && (github.event_name == 'schedule') }}

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -7,9 +7,9 @@ on:
 
   ## COMMENTED OUT: only for testing CI action changes.
   ## It only works for PRs to `main` branch from branches in the upstream gt4py repo.
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
   ## END
 
 jobs:
@@ -74,8 +74,8 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
         run: |
           # We run the upgrade commands here explicitly to update the lock
-          uv python upgrade ${{ matrix.python-version }}
           uv lock --upgrade
+          uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
           ./noxfile.py -s 'test_${{ matrix.gt4py-module }}-${{ matrix.python-version }}' -t 'cpu'
 

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -79,7 +79,7 @@ jobs:
           # nox will create venvs using uv, which will grab the right options in the env vars
           echo "Running '${{ matrix.gt4py-module }}'' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
           echo "./noxfile.py -t 'cpu' -p ${{ matrix.python-version }} -s 'test_${{ matrix.gt4py-module }}'"
-          ./noxfile.py -t 'cpu' -p ${{ matrix.python-version }} -s 'test_${{ matrix.gt4py-module }}'
+          ./noxfile.py -p ${{ matrix.python-version }} -k 'test_${{ matrix.gt4py-module }} and cpu' 
 
       - name: Notify slack
         if: ${{ failure() && (github.event_name == 'schedule') }}

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -78,6 +78,7 @@ jobs:
           uv python upgrade ${{ matrix.python-version }}
           # nox will create venvs using uv, which will grab the right options in the env vars
           echo "Running '${{ matrix.gt4py-module }}'' CPU tests for python ${{ matrix.python-version }} with '${{ matrix.dependencies-strategy }}' resolution strategy"
+          echo "./noxfile.py -t 'cpu' -p ${{ matrix.python-version }} -s 'test_${{ matrix.gt4py-module }}'"
           ./noxfile.py -t 'cpu' -p ${{ matrix.python-version }} -s 'test_${{ matrix.gt4py-module }}'
 
       - name: Notify slack

--- a/noxfile.py
+++ b/noxfile.py
@@ -135,7 +135,7 @@ def install_session_venv(
         # uv does not yet combine explicit python version requests with the
         # `requires-python` range in `pyproject.toml`, so we do it manually.
         # See: https://github.com/astral-sh/uv/issues/16654
-        f"{REQUIRES_PYTHON}, >={session.python!s}.0",
+        f"{REQUIRES_PYTHON}, ~={session.python!s}.0",
         "--no-dev",
         *(f"--extra={e}" for e in extras),
         *(f"--group={g}" for g in groups),

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S uv run -q --script --python 3.11
+#! /usr/bin/env -S uv run -q --script --python 3.12
 #
 # GT4Py - GridTools Framework
 #

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 from collections.abc import Sequence
 from typing import Final, Literal, TypeAlias
@@ -113,6 +114,8 @@ CodeGenNextTestSettings = CodeGenTestSettings | {
 
 
 # -- Utilities --
+os.environ["UV_VENV_CLEAR"] = "1"  # See: https://github.com/astral-sh/uv/issues/17899
+
 def install_session_venv(
     session: nox.Session,
     *args: str | Sequence[str],

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env -S uv run -q --script --python 3.12
+#!/usr/bin/env -S uv run -q --frozen --isolated --python 3.12 --group scripts
 #
 # GT4Py - GridTools Framework
 #
@@ -8,14 +8,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Note:
-#   The explicit '--python 3.11' in the shebang is only needed due
-#   to the existence of the .python-versions file, which overrides
-#   the PEP 723 'requires-python' metadata.
-# /// script
-# requires-python = ">=3.11"
-# dependencies = ["nox>=2025.02.09", "uv>=0.6.10"]
-# ///
 
 from __future__ import annotations
 
@@ -27,6 +19,10 @@ from typing import Final, Literal, TypeAlias
 import nox
 import tomllib
 
+
+# This is needed because uv now fails to create an env when it already exists.
+# See: https://github.com/astral-sh/uv/issues/17899
+os.environ["UV_VENV_CLEAR"] = "1"
 
 # This should just be `pytest.ExitCode.NO_TESTS_COLLECTED` but `pytest`
 # is not guaranteed to be available in the venv where `nox` is running.
@@ -114,9 +110,6 @@ CodeGenNextTestSettings = CodeGenTestSettings | {
 
 
 # -- Utilities --
-os.environ["UV_VENV_CLEAR"] = "1"  # See: https://github.com/astral-sh/uv/issues/17899
-
-
 def install_session_venv(
     session: nox.Session,
     *args: str | Sequence[str],

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,13 +181,13 @@ def test_cartesian(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"])
 
     session.run(
-        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "cartesian_tests"),
         *session.posargs,
     )
     session.run(
-        *"pytest --collect-only --doctest-modules --doctest-ignore-import-errors -sv".split(),
+        *"pytest --doctest-modules --doctest-ignore-import-errors -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "cartesian"),
     )
 
@@ -199,12 +199,12 @@ def test_eve(session: nox.Session) -> None:
     install_session_venv(session, groups=["test"])
 
     session.run(
-        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
         str(pathlib.Path("tests") / "eve_tests"),
         *session.posargs,
     )
     session.run(
-        *"pytest --collect-only --doctest-modules -sv".split(),
+        *"pytest --doctest-modules -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "eve"),
     )
 
@@ -226,7 +226,7 @@ def test_examples(session: nox.Session) -> None:
         ("examples", (None)),
     ]:
         session.run(
-            *f"pytest --collect-only --nbmake {notebook} -sv -n 1 --benchmark-disable".split(),
+            *f"pytest --nbmake {notebook} -sv -n 1 --benchmark-disable".split(),
             *(extra_args or []),
         )
 
@@ -272,14 +272,14 @@ def test_next(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"] + mesh_markers)
 
     session.run(
-        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "next_tests"),
         *session.posargs,
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )
     session.run(
-        *"pytest --collect-only --doctest-modules --doctest-ignore-import-errors -sv".split(),
+        *"pytest --doctest-modules --doctest-ignore-import-errors -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "next"),
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )
@@ -292,14 +292,14 @@ def test_package(session: nox.Session) -> None:
     install_session_venv(session, groups=["test"])
 
     session.run(
-        *"pytest --collect-only --cache-clear -sv".split(),
+        *"pytest --cache-clear -sv".split(),
         str(pathlib.Path("tests") / "package_tests"),
         *session.posargs,
     )
 
     modules = [str(path) for path in (pathlib.Path("src") / "gt4py").glob("*.py")]
     session.run(
-        *"pytest --collect-only --doctest-modules --doctest-ignore-import-errors -sv".split(),
+        *"pytest --doctest-modules --doctest-ignore-import-errors -sv".split(),
         *modules,
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )
@@ -322,13 +322,13 @@ def test_storage(
     markers = " and ".join(device_settings["markers"])
 
     session.run(
-        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "storage_tests"),
         *session.posargs,
     )
     session.run(
-        *"pytest --collect-only --doctest-modules -sv".split(),
+        *"pytest --doctest-modules -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "storage"),
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -116,6 +116,7 @@ CodeGenNextTestSettings = CodeGenTestSettings | {
 # -- Utilities --
 os.environ["UV_VENV_CLEAR"] = "1"  # See: https://github.com/astral-sh/uv/issues/17899
 
+
 def install_session_venv(
     session: nox.Session,
     *args: str | Sequence[str],
@@ -180,13 +181,13 @@ def test_cartesian(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"])
 
     session.run(
-        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "cartesian_tests"),
         *session.posargs,
     )
     session.run(
-        *"pytest --doctest-modules --doctest-ignore-import-errors -sv".split(),
+        *"pytest --collect-only --doctest-modules --doctest-ignore-import-errors -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "cartesian"),
     )
 
@@ -198,12 +199,12 @@ def test_eve(session: nox.Session) -> None:
     install_session_venv(session, groups=["test"])
 
     session.run(
-        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
         str(pathlib.Path("tests") / "eve_tests"),
         *session.posargs,
     )
     session.run(
-        *"pytest --doctest-modules -sv".split(),
+        *"pytest --collect-only --doctest-modules -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "eve"),
     )
 
@@ -225,7 +226,7 @@ def test_examples(session: nox.Session) -> None:
         ("examples", (None)),
     ]:
         session.run(
-            *f"pytest --nbmake {notebook} -sv -n 1 --benchmark-disable".split(),
+            *f"pytest --collect-only --nbmake {notebook} -sv -n 1 --benchmark-disable".split(),
             *(extra_args or []),
         )
 
@@ -271,14 +272,14 @@ def test_next(
     markers = " and ".join(codegen_settings["markers"] + device_settings["markers"] + mesh_markers)
 
     session.run(
-        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "next_tests"),
         *session.posargs,
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )
     session.run(
-        *"pytest --doctest-modules --doctest-ignore-import-errors -sv".split(),
+        *"pytest --collect-only --doctest-modules --doctest-ignore-import-errors -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "next"),
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )
@@ -291,14 +292,14 @@ def test_package(session: nox.Session) -> None:
     install_session_venv(session, groups=["test"])
 
     session.run(
-        *"pytest --cache-clear -sv".split(),
+        *"pytest --collect-only --cache-clear -sv".split(),
         str(pathlib.Path("tests") / "package_tests"),
         *session.posargs,
     )
 
     modules = [str(path) for path in (pathlib.Path("src") / "gt4py").glob("*.py")]
     session.run(
-        *"pytest --doctest-modules --doctest-ignore-import-errors -sv".split(),
+        *"pytest --collect-only --doctest-modules --doctest-ignore-import-errors -sv".split(),
         *modules,
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )
@@ -321,13 +322,13 @@ def test_storage(
     markers = " and ".join(device_settings["markers"])
 
     session.run(
-        *"pytest --cache-clear -sv -n auto --dist loadgroup".split(),
+        *"pytest --collect-only --cache-clear -sv -n auto --dist loadgroup".split(),
         *("-m", f"{markers}"),
         str(pathlib.Path("tests") / "storage_tests"),
         *session.posargs,
     )
     session.run(
-        *"pytest --doctest-modules -sv".split(),
+        *"pytest --collect-only --doctest-modules -sv".split(),
         str(pathlib.Path("src") / "gt4py" / "storage"),
         success_codes=[0, NO_TESTS_COLLECTED_EXIT_CODE],
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run -q --frozen --isolated --python 3.12 --group scripts
+#!/usr/bin/env -S uv run -q --script --python 3.12
 #
 # GT4Py - GridTools Framework
 #
@@ -8,6 +8,14 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 #
+# Note:
+#   The explicit '--python 3.11' in the shebang is only needed due
+#   to the existence of the .python-versions file, which overrides
+#   the PEP 723 'requires-python' metadata.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["nox>=2025.02.09", "uv>=0.6.10"]
+# ///
 
 from __future__ import annotations
 

--- a/uv.lock
+++ b/uv.lock
@@ -3482,7 +3482,7 @@ wheels = [
 
 [[package]]
 name = "nox"
-version = "2026.2.9"
+version = "2026.4.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -3494,9 +3494,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-5-gt4py-cuda12' and extra == 'extra-5-gt4py-jax-cuda13') or (extra == 'extra-5-gt4py-cuda12' and extra == 'extra-5-gt4py-rocm6') or (extra == 'extra-5-gt4py-cuda12' and extra == 'extra-5-gt4py-rocm7') or (extra == 'extra-5-gt4py-jax-cuda13' and extra == 'extra-5-gt4py-rocm6') or (extra == 'extra-5-gt4py-jax-cuda13' and extra == 'extra-5-gt4py-rocm7') or (extra == 'extra-5-gt4py-rocm6' and extra == 'extra-5-gt4py-rocm7') or (extra == 'group-5-gt4py-dace-cartesian' and extra == 'group-5-gt4py-dace-next')" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/8e/55a9679b31f1efc48facedd2448eb53c7f1e647fb592aa1403c9dd7a4590/nox-2026.2.9.tar.gz", hash = "sha256:1bc8a202ee8cd69be7aaada63b2a7019126899a06fc930a7aee75585bf8ee41b", size = 4031165, upload-time = "2026-02-10T04:38:58.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/6b/e672c862a43cfca704d32359221fa3780226daa1e5db5dfc401bcc8be9c9/nox-2026.4.10.tar.gz", hash = "sha256:2d0af5374f3f37a295428c927d1b04a8182aa01762897d172446dda2f1ce9692", size = 4034839, upload-time = "2026-04-10T17:42:42.209Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/58/0d5e5a044f1868bdc45f38afdc2d90ff9867ce398b4e8fa9e666bfc9bfba/nox-2026.2.9-py3-none-any.whl", hash = "sha256:1b7143bc8ecdf25f2353201326152c5303ae4ae56ca097b1fb6179ad75164c47", size = 74615, upload-time = "2026-02-10T04:38:57.266Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/95/4df134a100b5a9a12378d5301b934366686ef6fbdaffcd21211d5654970e/nox-2026.4.10-py3-none-any.whl", hash = "sha256:082c117627590d9b90aa21f86df89b310b07c5842539524203bcb3c719f116c1", size = 75536, upload-time = "2026-04-10T17:42:40.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix a bug in the way `nox` was called to run some specific sessions which made every CI matrix entry run more tests than needed:  `-t` (tag filter) and `-s` (session filter) options do not interact together as an intersection, but `-t` completely replaces `-s`.

Additionally, fix some other minor issues and add comments on how to debug CI issues for this workflow without running all tests.  