### PR TITLE
fix[cartesian] : Respect stencil lifetime for arrays when freezing

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -113,6 +113,7 @@ def _sdfg_add_arrays_and_edges(
                 strides=array.strides,
                 shape=shape,
                 storage=array.storage,
+                lifetime=array.lifetime,
             )
 
             # Calculate memlet ranges taking the origin into account
@@ -296,10 +297,6 @@ def freeze_origin_domain_sdfg(
 
     _sdfg_specialize_symbols(wrapper_sdfg, domain)
     _specialize_transient_strides(wrapper_sdfg, layout_info)
-
-    for _, _, array in wrapper_sdfg.arrays_recursive():
-        if array.transient:
-            array.lifetime = dtypes.AllocationLifetime.SDFG
 
     wrapper_sdfg.arg_names = arg_names
 


### PR DESCRIPTION
## Description

When freezing stencil SDFGs as the first step toward orchestration, we flipped all `transient` "arrays" (as in DaCe `arrays_recursive` results, which includes `Scalar`) lifetime to SDFG.

Depending on the layout (IJK vs KIJ) this could lead further down access node flagged as "SDFG" which then `simplify` would remove because of the SDFG inlining.

Thought this points to a bug into the Simplify pass, we already decide of a proper scoping in `oir_to_treeir` (and actually have spotted a memory leak there, per comment). We should keep the freezing operation to it's original intent of freezing the grid. Changes to lifetime should either come upstream from the stencil or downstream during an optimization pass.