### PR TITLE
refactor[cartesian]: Avoid dummy DebugInfo in favor of configuration

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -14,7 +14,7 @@ import pathlib
 import re
 from typing import TYPE_CHECKING, ClassVar
 
-from dace import SDFG, DebugInfo, Memlet, SDFGState, config, data, dtypes, nodes, subsets, symbolic
+from dace import SDFG, Memlet, SDFGState, config, data, dtypes, nodes, subsets, symbolic
 from dace.codegen import codeobject
 from dace.sdfg.analysis.schedule_tree import treenodes as tn
 from dace.sdfg.utils import inline_sdfgs
@@ -146,10 +146,7 @@ def _sdfg_add_arrays_and_edges(
 
             if name in inputs:
                 state.add_edge(
-                    state.add_read(
-                        name,
-                        DebugInfo(123456),  # fake DebugInfo to avoid calls to `inspect`
-                    ),
+                    state.add_read(name),
                     None,
                     nsdfg,
                     name,
@@ -159,10 +156,7 @@ def _sdfg_add_arrays_and_edges(
                 state.add_edge(
                     nsdfg,
                     name,
-                    state.add_write(
-                        name,
-                        DebugInfo(123456),  # fake DebugInfo to avoid calls to `inspect`
-                    ),
+                    state.add_write(name),
                     None,
                     Memlet(name, subset=subsets.Range(ranges)),
                 )
@@ -175,10 +169,7 @@ def _sdfg_add_arrays_and_edges(
             )
             if name in inputs:
                 state.add_edge(
-                    state.add_read(
-                        name,
-                        DebugInfo(123456),  # fake DebugInfo to avoid calls to `inspect`
-                    ),
+                    state.add_read(name),
                     None,
                     nsdfg,
                     name,
@@ -188,10 +179,7 @@ def _sdfg_add_arrays_and_edges(
                 state.add_edge(
                     nsdfg,
                     name,
-                    state.add_write(
-                        name,
-                        DebugInfo(123456),  # fake DebugInfo to avoid calls to `inspect`
-                    ),
+                    state.add_write(name),
                     None,
                     Memlet(name),
                 )
@@ -273,8 +261,7 @@ def freeze_origin_domain_sdfg(
     inputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, inputs))
     outputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, outputs))
 
-    # fake DebugInfo to avoid calls to `inspect`
-    nsdfg = state.add_nested_sdfg(inner_sdfg, inputs, outputs, debuginfo=DebugInfo(123456))
+    nsdfg = state.add_nested_sdfg(inner_sdfg, inputs, outputs)
 
     _sdfg_add_arrays_and_edges(
         field_info, wrapper_sdfg, state, inner_sdfg, nsdfg, inputs, outputs, origin
@@ -608,6 +595,11 @@ auto ${name}(const std::array<gt::uint_t, 3>& domain) {
                 value=gt_config.DACE_DEFAULT_BLOCK_SIZE,
             )
             config.Config.set("compiler", "cpu", "openmp_sections", value=False)
+            # The default, "inspect", will inspect the python stack for every object that's added
+            # to the SDFG, which doesn't provide a DebugInfo object. Those calls add up over time
+            # and - in our case - end up with line information pointing to the GT4Py-DaCe bridge.
+            # We thus decided to turn off lineinfo in the DaCe config.
+            config.Config.set("compiler", "lineinfo", value="none")
             code_objects = sdfg.generate_code()
         is_gpu = "CUDA" in {co.title for co in code_objects}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1210,7 +1210,7 @@ wheels = [
 [[package]]
 name = "dace"
 version = "1.0.0"
-source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-v2#0d9f3b4ede7a87aa3c86913481740390431e2b21" }
+source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-v2#43811b298769a626085d8917e5d9516060af8ec5" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
@@ -1789,7 +1789,7 @@ build = [
     { name = "wheel" },
 ]
 dace-cartesian = [
-    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-v2#0d9f3b4ede7a87aa3c86913481740390431e2b21" } },
+    { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-v2#43811b298769a626085d8917e5d9516060af8ec5" } },
 ]
 dace-next = [
     { name = "dace", version = "43!2026.4.20", source = { registry = "https://gridtools.github.io/pypi/" } },


### PR DESCRIPTION
## Description

DaCe now comes with a configuration option whether or not to inspect the python stack in case debug information (e.g. line number) is missing. We previously used a fake `DebugInfo` object to prevent the call to `inspect()`. With the new configuration option, we can remove those fake objects again and just configure the desired behavior.

A word of caution: until https://github.com/spcl/dace/pull/2344 or something similar is merged, DaCe will output a ton of deprecation warnings caused by the addition of the new config option.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
