### PR TITLE
fix[next]: Fix syntax warnings

### DIFF
--- a/src/gt4py/next/config.py
+++ b/src/gt4py/next/config.py
@@ -134,9 +134,10 @@ if SKIP_DACE_WARNINGS:
     # NOTE: Ideally we would suppress the warnings using context managers directly in
     #   the backend. However, because this is not thread safe in Python versions before
     #   3.14, we have to do it here.
-    warnings.filterwarnings(action="ignore", module="^dace(\..+)?")
+    warnings.filterwarnings(action="ignore", module=r"^dace(\..+)?")
     warnings.filterwarnings(
-        action="ignore", module="^gt4py.next.program_processors.runners.dace.transformations(\..+)?"
+        action="ignore",
+        module=r"^gt4py.next.program_processors.runners.dace.transformations(\..+)?",
     )
 
 


### PR DESCRIPTION
Fix the following warnings:
```
/capstor/scratch/cscs/ioannmag/beverin/cycl35/icon4py-JW/.venv/lib/python3.12/site-packages/gt4py/next/config.py:137: SyntaxWarning: invalid escape sequence '.'
warnings.filterwarnings(action="ignore", module="^dace(..+)?")
/capstor/scratch/cscs/ioannmag/beverin/cycl35/icon4py-JW/.venv/lib/python3.12/site-packages/gt4py/next/config.py:139: SyntaxWarning: invalid escape sequence '.'
action="ignore", module="^gt4py.next.program_processors.runners.dace.transformations(..+)?"
```