### PR TITLE
fix[cartesian] Use `utf-8` to encore python module code 

### DIFF
--- a/src/gt4py/cartesian/backend/base.py
+++ b/src/gt4py/cartesian/backend/base.py
@@ -211,7 +211,7 @@ class BaseBackend(Backend):
 
         if not self.builder.options._impl_opts.get("disable-code-generation", False):
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(module_source)
+            file_path.write_text(module_source, encoding="utf-8")
             self.builder.caching.update_cache_info()
 
         module = self._load()
@@ -287,7 +287,7 @@ class BasePyExtBackend(BaseBackend):
                 sources.append(str(src_file_path))
 
             if source is not gt_utils.NOTHING:
-                src_file_path.write_text(source)
+                src_file_path.write_text(source, encoding="utf-8")
 
         pyext_target_file_path = self.builder.pkg_path
         qualified_pyext_name = self.pyext_module_path

--- a/src/gt4py/cartesian/backend/module_generator.py
+++ b/src/gt4py/cartesian/backend/module_generator.py
@@ -121,7 +121,7 @@ class BaseModuleGenerator(abc.ABC):
         self.template = jinja2.Template(
             importlib_resources.files("gt4py.cartesian.backend.templates")
             .joinpath(self.TEMPLATE_RESOURCE)
-            .read_text()
+            .read_text(encoding="utf-8")
         )
 
     def __call__(self, args_data: ModuleData) -> str:

--- a/src/gt4py/cartesian/backend/python_common.py
+++ b/src/gt4py/cartesian/backend/python_common.py
@@ -45,4 +45,4 @@ def recursive_write(root_path: pathlib.Path, tree: dict[str, str | dict]):
             return recursive_write(root_path / key, value)
 
         src_path = root_path / key
-        src_path.write_text(value)
+        src_path.write_text(value, encoding="utf-8")

--- a/src/gt4py/cartesian/caching.py
+++ b/src/gt4py/cartesian/caching.py
@@ -243,7 +243,7 @@ class JITCachingStrategy(CachingStrategy):
                 for k, v in self.builder.backend.extra_cache_info.items()
                 if k in self.builder.backend.extra_cache_validation_keys
             }
-            source = self.builder.module_path.read_text()
+            source = self.builder.module_path.read_text(encoding="utf-8")
             module_shash = gt_utils.shash(source)
 
             if validate_hash:

--- a/src/gt4py/cartesian/gtscript_imports.py
+++ b/src/gt4py/cartesian/gtscript_imports.py
@@ -182,12 +182,12 @@ class GtsLoader(importlib.machinery.SourceFileLoader):
 
         if self.path_stats(self.path) != self.path_stats(str(self.module_file.absolute())):
             assert fullname is not None
-            self.module_file.write_text(self.get_source_code(fullname))
+            self.module_file.write_text(self.get_source_code(fullname), encoding="utf-8")
 
         return str(self.module_file)
 
     def get_source_code(self, fullname: str) -> str:
-        return self.plpath.read_text().replace(GTS_COMMENT, GTS_IMPORT)
+        return self.plpath.read_text(encoding="utf-8").replace(GTS_COMMENT, GTS_IMPORT)
 
     def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
         module = ModuleType(name=spec.name)

--- a/src/gt4py/cartesian/stencil_builder.py
+++ b/src/gt4py/cartesian/stencil_builder.py
@@ -290,7 +290,7 @@ class StencilBuilder:
         """
         if not self.module_path.exists():
             return ""
-        return self.module_path.read_text()
+        return self.module_path.read_text(encoding="utf-8")
 
     @property
     def class_name(self) -> str:

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_gtcpp_compilation.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_gtcpp_compilation.py
@@ -33,7 +33,7 @@ from .utils import match
 
 def build_gridtools_test(tmp_path: Path, code: str):
     tmp_src = tmp_path / "test.cpp"
-    tmp_src.write_text(code)
+    tmp_src.write_text(code, encoding="utf-8")
 
     extra_compile_args = ["-std=c++17"]
     ext_module = setuptools.Extension(

--- a/tests/cartesian_tests/unit_tests/test_gtc/test_npir_codegen.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/test_npir_codegen.py
@@ -317,7 +317,7 @@ def test_full_computation_valid(tmp_path) -> None:
     result = NpirCodegen().visit(computation)
     print(result)
     mod_path = tmp_path / "npir_codegen_1.py"
-    mod_path.write_text(result)
+    mod_path.write_text(result, encoding="utf-8")
 
     sys.path.append(str(tmp_path))
     import npir_codegen_1 as mod
@@ -350,7 +350,7 @@ def test_variable_read_outside_bounds(tmp_path) -> None:
     result = NpirCodegen().visit(computation)
     print(result)
     mod_path = tmp_path / "npir_codegen_2.py"
-    mod_path.write_text(result)
+    mod_path.write_text(result, encoding="utf-8")
 
     sys.path.append(str(tmp_path))
     import npir_codegen_2 as mod

--- a/tests/cartesian_tests/unit_tests/test_gtscript_imports.py
+++ b/tests/cartesian_tests/unit_tests/test_gtscript_imports.py
@@ -56,7 +56,8 @@ def make_single_file(tmp_path, extension, reset_importsys):
                 "\n"
                 "\n"
                 "SENTINEL = 5\n"
-            )
+            ),
+            encoding="utf-8",
         )
         return gts_file
 
@@ -101,7 +102,8 @@ def make_two_files(tmp_path, extension, reset_importsys):
                 "def a_square_b(a: FT, b: FT):\n"
                 "    with computation(PARALLEL), interval(...):\n"
                 "        a = square(b)\n"
-            )
+            ),
+            encoding="utf-8",
         )
 
         module_two.write_text(
@@ -122,7 +124,8 @@ def make_two_files(tmp_path, extension, reset_importsys):
                 "@function\n"
                 "def square(field):\n"
                 "    return field * field\n"
-            )
+            ),
+            encoding="utf-8",
         )
         return module_one, module_two
 
@@ -177,14 +180,16 @@ def make_package(tmp_path, extension, reset_importsys):
                 "    with computation(PARALLEL), interval(...):\n"
                 "        b = mf(a, const=C)\n"
                 "        a = sf1(b)\n"
-            )
+            ),
+            encoding="utf-8",
         )
         lib_init.write_text(
             (
                 f"from . import {prefix}_sub2\n"
                 f"from .{prefix}_sub1 import sf1\n"
                 f"from .{prefix}_sub2 import CONST, sss\n"
-            )
+            ),
+            encoding="utf-8",
         )
         sub_1_path.write_text(
             (
@@ -194,7 +199,8 @@ def make_package(tmp_path, extension, reset_importsys):
                 "def sf1(b):\n"
                 "    return b + SS_SENT\n\n\n"
                 "SENTINEL = 2\n"
-            )
+            ),
+            encoding="utf-8",
         )
         sub_2_init.write_text(
             (
@@ -203,7 +209,8 @@ def make_package(tmp_path, extension, reset_importsys):
                 f"from . import {prefix}_sub_sub\n"
                 f"from .{prefix}_sub_sub import sss\n\n\n"
                 "CONST = 3.14\n"
-            )
+            ),
+            encoding="utf-8",
         )
         sub_sub_path.write_text(
             (
@@ -213,7 +220,8 @@ def make_package(tmp_path, extension, reset_importsys):
                 "    with computation(PARALLEL), interval(...):\n"
                 "        a = 0\n\n\n"
                 "SENTINEL = 3\n"
-            )
+            ),
+            encoding="utf-8",
         )
         return module_file
 


### PR DESCRIPTION
## Description

An (odd) bug manifested for the first time on the HPC on a GPU build: Using non-ascii characters in docstrings (here a `²`), crashed writing the generated code.

The issue was tracked down the following: In GT4Py, if stencils have docstrings, that docstring is copied over into the generated source code. On the HPC, the default encoding is ascii (for whatever reason). Now when the generated code (including the non-ascii characters in the description) was written down to disk, writing failed because the non-ascii characters could not be represented.

The PR proposes to write and read all code in `utf-8` to alleviate the issue.

<!-- original
The module code of the stencils copies into the generate code for the bindings the `docstring` if it exists on any particular source stencil. If the docstrings have a non-ascii character 
Use `utf-8` to allow non ascii code in docstrings for generated code (here a `²`) the writing of the module would fail.

We propose to write all code in `utf-8` to alleviate the issue and cover comon UTF.
-->

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.