### PR TITLE
fix[cartesian]: Consider full stencil when hashing stencil code for caching purposes

### DIFF
--- a/src/gt4py/cartesian/caching.py
+++ b/src/gt4py/cartesian/caching.py
@@ -322,7 +322,7 @@ class JITCachingStrategy(CachingStrategy):
         if self.builder.backend.name == "dace:gpu":
             fingerprint["default_block_size"] = gt_config.DACE_DEFAULT_BLOCK_SIZE
 
-        # typeignore because attrclass StencilID has generated constructor
+        # ignore type because attrclass StencilID has generated constructor
         return StencilID(  # type: ignore
             self.builder.options.qualified_name,
             gt_utils.shashed_id(fingerprint, self.options_id),

--- a/src/gt4py/cartesian/caching.py
+++ b/src/gt4py/cartesian/caching.py
@@ -266,9 +266,7 @@ class JITCachingStrategy(CachingStrategy):
 
     @property
     def cache_info(self) -> Dict[str, Any]:
-        if not self.cache_info_path:
-            return {}
-        if not self.cache_info_path.exists():
+        if not self.cache_info_path or not self.cache_info_path.exists():
             return {}
         return self._unpickle_cache_info_file(self.cache_info_path)
 

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -13,7 +13,7 @@ import copy
 import inspect
 import operator
 import textwrap
-from typing import Callable, Dict, Final, List, Tuple, Type
+from typing import Callable, Final
 
 
 def get_closure(func, *, include_globals=True, included_nonlocals=True, include_builtins=True):
@@ -52,7 +52,7 @@ def get_source(func):
     return source
 
 
-def get_ast(func_or_source_or_ast, *, feature_version: Tuple[int, int]):
+def get_ast(func_or_source_or_ast, *, feature_version: tuple[int, int]):
     if callable(func_or_source_or_ast):
         func_or_source_or_ast = get_source(func_or_source_or_ast)
     if isinstance(func_or_source_or_ast, str):
@@ -216,7 +216,7 @@ class ASTTransformPass(ASTPass):
 
 
 class ASTEvaluator(ASTPass):
-    AST_OP_TO_OP: Final[Dict[Type, Callable]] = {
+    AST_OP_TO_OP: Final[dict[type, Callable]] = {
         # Arithmetic operations
         ast.UAdd: operator.pos,
         ast.USub: operator.neg,
@@ -387,7 +387,7 @@ class QualifiedNameCollector(ASTPass):
             self.name_nodes[node.id].append(node)
 
     def _get_name_components(self, node: ast.AST):
-        components: List
+        components: list
         if isinstance(node, ast.Name):
             components = [node.id]
             valid = self.prefixes is None or node.id in self.prefixes

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -66,25 +66,10 @@ def get_ast(func_or_source_or_ast, *, feature_version: Tuple[int, int]):
     return ast_root
 
 
-def ast_dump(
-    definition,
-    *,
-    skip_decorators: bool = True,
-    feature_version: Tuple[int, int],
-) -> str:
-    def _dump(node: ast.AST, excluded_names):
+def ast_dump(definition, *, feature_version: tuple[int, int]) -> str:
+    def _dump(node: ast.AST) -> str:
         if isinstance(node, ast.AST):
-            if excluded_names:
-                fields = [
-                    (name, _dump(value, excluded_names))
-                    for name, value in sorted(ast.iter_fields(node))
-                    if name not in excluded_names
-                ]
-            else:
-                fields = [
-                    (name, _dump(value, excluded_names))
-                    for name, value in sorted(ast.iter_fields(node))
-                ]
+            fields = [(name, _dump(value)) for name, value in sorted(ast.iter_fields(node))]
 
             return "".join(
                 [
@@ -95,18 +80,13 @@ def ast_dump(
                 ]
             )
 
-        elif isinstance(node, list):
-            lines = ["[", *[_dump(i, excluded_names) + "," for i in node], "]"]
+        if isinstance(node, list):
+            lines = ["[", *[_dump(i) + "," for i in node], "]"]
             return "\n".join(lines)
 
-        else:
-            return repr(node)
+        return repr(node)
 
-    skip_node_names = set()
-    if skip_decorators:
-        skip_node_names.add("decorator_list")
-
-    dumped_ast = _dump(get_ast(definition, feature_version=feature_version), skip_node_names)
+    dumped_ast = _dump(get_ast(definition, feature_version=feature_version))
 
     return dumped_ast
 

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -15,8 +15,6 @@ import operator
 import textwrap
 from typing import Callable, Dict, Final, List, Tuple, Type
 
-from gt4py.cartesian.utils.base import shashed_id
-
 
 def get_closure(func, *, include_globals=True, included_nonlocals=True, include_builtins=True):
     closure_vars = inspect.getclosurevars(func)
@@ -71,7 +69,6 @@ def get_ast(func_or_source_or_ast, *, feature_version: Tuple[int, int]):
 def ast_dump(
     definition,
     *,
-    skip_annotations: bool = True,
     skip_decorators: bool = True,
     feature_version: Tuple[int, int],
 ) -> str:
@@ -108,16 +105,10 @@ def ast_dump(
     skip_node_names = set()
     if skip_decorators:
         skip_node_names.add("decorator_list")
-    if skip_annotations:
-        skip_node_names.add("annotation")
 
     dumped_ast = _dump(get_ast(definition, feature_version=feature_version), skip_node_names)
 
     return dumped_ast
-
-
-def ast_shash(ast_node, *, skip_decorators=True):
-    return shashed_id(ast_dump(ast_node, skip_decorators=skip_decorators))
 
 
 def collect_decorators(func_or_source_or_ast):

--- a/tests/cartesian_tests/unit_tests/test_caching.py
+++ b/tests/cartesian_tests/unit_tests/test_caching.py
@@ -6,10 +6,12 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from pathlib import Path
+
 import pytest
 
 from gt4py import cartesian as gt4pyc
-from gt4py.cartesian.gtscript import PARALLEL, Field, computation, interval
+from gt4py.cartesian.gtscript import FORWARD, IJ, IJK, PARALLEL, Field, computation, interval
 from gt4py.cartesian.stencil_builder import StencilBuilder
 
 
@@ -18,23 +20,23 @@ from gt4py.cartesian.stencil_builder import StencilBuilder
 
 
 def simple_stencil(field: Field[float]):  # type: ignore
-    with computation(PARALLEL), interval(...):  # type: ignore
-        field += 1  # type: ignore
+    with computation(PARALLEL), interval(...):
+        field += 1
 
 
 def simple_stencil_same(field: Field[float]):  # type: ignore
-    with computation(PARALLEL), interval(...):  # type: ignore
-        field += 1  # type: ignore
+    with computation(PARALLEL), interval(...):
+        field += 1
 
 
 def simple_stencil_with_doc(field: Field[float]):  # type: ignore
     """Increment the in/out field by one."""
-    with computation(PARALLEL), interval(...):  # type: ignore
-        field += 1  # type: ignore
+    with computation(PARALLEL), interval(...):
+        field += 1
 
 
 @pytest.fixture
-def builder():
+def builder() -> StencilBuilder:
     """Preconfigure builder so everything but definition has defaults."""
 
     def make_builder(definition, backend_name="numpy", module=None):
@@ -48,7 +50,7 @@ def builder():
     return make_builder
 
 
-def test_jit_properties(builder):
+def test_jit_properties(builder: StencilBuilder) -> None:
     builder = builder(simple_stencil).with_caching("jit")
     jit_caching = builder.caching
 
@@ -65,17 +67,17 @@ def test_jit_properties(builder):
     assert stencil_id.version in jit_caching.class_name
 
 
-def stencil_fingerprints_are_equal(builder_a, builder_b):
+def stencil_fingerprints_are_equal(builder_a: StencilBuilder, builder_b: StencilBuilder) -> None:
     return builder_a.caching.stencil_id.version == builder_b.caching.stencil_id.version
 
 
-def could_load_stencil_from_cache(builder, catch_exceptions=False):
+def could_load_stencil_from_cache(builder: StencilBuilder, catch_exceptions: bool = False) -> None:
     return builder.caching.is_cache_info_available_and_consistent(
         validate_hash=True, catch_exceptions=catch_exceptions
     )
 
 
-def test_jit_version(builder):
+def test_jit_version(builder: StencilBuilder) -> None:
     simple_stencil_same.__name__ = "simple_stencil"
 
     # create builders with jit caching strategy
@@ -108,7 +110,7 @@ def test_jit_version(builder):
     assert not duplicate.caching.cache_info
 
 
-def test_jit_extrainfo(builder):
+def test_jit_extrainfo(builder: StencilBuilder) -> None:
     builder = builder(simple_stencil, "gt:cpu_kfirst").with_caching("jit")
     builder.backend.generate()
 
@@ -116,7 +118,7 @@ def test_jit_extrainfo(builder):
     assert "pyext_md5" in builder.caching.cache_info
 
 
-def test_nocaching_paths(builder, tmp_path):
+def test_nocaching_paths(builder: StencilBuilder, tmp_path: Path) -> None:
     builder = builder(simple_stencil).with_caching("nocaching", output_path=tmp_path)
     no_caching = builder.caching
 
@@ -126,7 +128,9 @@ def test_nocaching_paths(builder, tmp_path):
     assert no_caching.cache_info_path is None
 
 
-def assert_nocaching_gtcpp_source_file_tree_conforms_to_expectations(root_path, stencil_name):
+def assert_nocaching_gtcpp_source_file_tree_conforms_to_expectations(
+    root_path: Path, stencil_name: str
+) -> None:
     stencil_path = root_path / stencil_name
     build_path = stencil_path / f"{stencil_name}_pyext_BUILD"
 
@@ -139,7 +143,7 @@ def assert_nocaching_gtcpp_source_file_tree_conforms_to_expectations(root_path, 
     assert comp_bindings_path.exists()
 
 
-def test_nocaching_generate(builder, tmp_path):
+def test_nocaching_generate(builder: StencilBuilder, tmp_path: Path) -> None:
     # generate pure python stencil and ensure the module is in the right place
     builder_d = builder(simple_stencil, backend_name="numpy", module="foo_d").with_caching(
         "nocaching", output_path=tmp_path
@@ -156,7 +160,7 @@ def test_nocaching_generate(builder, tmp_path):
     assert_nocaching_gtcpp_source_file_tree_conforms_to_expectations(tmp_path / "foo_g", "foo")
 
 
-def test_compiler_optimizations(builder):
+def test_compiler_optimizations(builder: StencilBuilder) -> None:
     builder_1 = builder(simple_stencil, backend_name="gt:cpu_kfirst")
     builder_2 = builder(simple_stencil, backend_name="gt:cpu_kfirst").with_changed_options(
         backend_opts={
@@ -171,7 +175,7 @@ def test_compiler_optimizations(builder):
     assert not stencil_fingerprints_are_equal(builder_1, builder_2)
 
 
-def test_different_opt_levels(builder):
+def test_different_opt_levels(builder: StencilBuilder) -> None:
     builder_1 = builder(simple_stencil, backend_name="gt:cpu_kfirst").with_changed_options(
         backend_opts={"opt_level": "0"}
     )
@@ -185,7 +189,7 @@ def test_different_opt_levels(builder):
     assert not stencil_fingerprints_are_equal(builder_1, builder_2)
 
 
-def test_different_extra_opt_flags(builder):
+def test_different_extra_opt_flags(builder: StencilBuilder) -> None:
     builder_1 = builder(simple_stencil, backend_name="gt:cpu_kfirst").with_changed_options(
         backend_opts={"opt_level": "0"}
     )
@@ -199,7 +203,7 @@ def test_different_extra_opt_flags(builder):
     assert not stencil_fingerprints_are_equal(builder_1, builder_2)
 
 
-def test_debug_mode(builder):
+def test_debug_mode(builder: StencilBuilder) -> None:
     builder_1 = builder(simple_stencil, backend_name="gt:cpu_kfirst").with_changed_options(
         backend_opts={"debug_mode": True, "opt_level": "0"}
     )
@@ -211,3 +215,54 @@ def test_debug_mode(builder):
     builder_2.backend.generate()
 
     assert not stencil_fingerprints_are_equal(builder_1, builder_2)
+
+
+def stencil_tmp_IJ(in_field: Field[float], out_field: Field[float]):  # type: ignore
+    with computation(FORWARD), interval(0, 1):
+        tmp: Field[IJ, float] = 0  # type: ignore
+
+    with computation(FORWARD), interval(...):
+        tmp = in_field + tmp
+
+    with computation(PARALLEL), interval(...):
+        out_field = tmp * 2
+
+
+def stencil_tmp_modified(in_field: Field[float], out_field: Field[float]):  # type: ignore
+    with computation(FORWARD), interval(0, 1):
+        tmp: Field[IJK, float] = 0  # type: ignore
+
+    with computation(FORWARD), interval(...):
+        tmp = in_field + tmp
+
+    with computation(PARALLEL), interval(...):
+        out_field = tmp * 2
+
+
+def test_temporaries_annotation(builder: StencilBuilder) -> None:
+    """
+    The scenario in this test is that users place an annotation for temporaries
+    inside the stencil (e.g. 2d temporaries). The user is then assumed to
+    change/remove that annotation, which should invalidate the cache.
+    """
+    # setup "initial stencil"
+    initial_stencil = builder(stencil_tmp_IJ)
+    # trigger writing cache info to disk
+    initial_stencil.backend.generate()
+
+    assert initial_stencil.caching.cache_info
+    assert could_load_stencil_from_cache(initial_stencil)
+
+    # setup "modified stencil"
+    modified_stencil = builder(stencil_tmp_modified)
+
+    # access .definition to trigger stencil annotation
+    modified_stencil.definition
+    assert hasattr(stencil_tmp_modified, "_gtscript_")
+
+    # patch stencil s.t. the only change are inside the stencil
+    stencil_tmp_modified._gtscript_["canonical_ast"] = stencil_tmp_modified._gtscript_[
+        "canonical_ast"
+    ].replace("stencil_tmp_modified", "stencil_tmp_IJ")
+
+    assert not could_load_stencil_from_cache(modified_stencil, catch_exceptions=True)


### PR DESCRIPTION
## Description

Issue https://github.com/NOAA-GFDL/NDSL/issues/445 suggests that there might be a problem with caching in `gt4py.cartesian`. Indeed, caching would not hash the full stencil code, but skip certain nodes, in particular annotations. Those annotation became important with [2d temporaries](https://github.com/GridTools/gt4py/blob/main/docs/development/ADRs/cartesian/experimental/2d-temporaries.md).

The PR suggests to just dump thus hash the full stencil code to work around the issue. The added test is a bit cumbersome. If anyone known something simpler - I'm happy to go with that.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
