### PR TITLE
refactor[cartesian]: remove unused get_stencil_id on Frontend

### DIFF
--- a/src/gt4py/cartesian/frontend/base.py
+++ b/src/gt4py/cartesian/frontend/base.py
@@ -12,7 +12,7 @@ import abc
 from typing import Any
 
 from gt4py.cartesian import utils as gt_utils
-from gt4py.cartesian.definitions import BuildOptions, StencilID
+from gt4py.cartesian.definitions import BuildOptions
 from gt4py.cartesian.gtc import gtir
 from gt4py.cartesian.type_hints import AnnotatedStencilFunc, AnyStencilFunc
 
@@ -20,37 +20,6 @@ from gt4py.cartesian.type_hints import AnnotatedStencilFunc, AnyStencilFunc
 class Frontend(abc.ABC):
     name: str
     """Frontend name."""
-
-    @classmethod
-    @abc.abstractmethod
-    def get_stencil_id(
-        cls,
-        qualified_name: str,
-        definition: AnyStencilFunc,
-        externals: dict[str, Any],
-        options_id: str,
-    ) -> StencilID:
-        """
-        Create a StencilID object that contains a unique hash for the stencil.
-
-        Notes
-        -----
-        This method seems to no longer be used through StencilBuilder.
-
-        Returns
-        -------
-        StencilID:
-            An object that contains the qualified name and unique hash.
-
-        Raises
-        ------
-        GTSyntaxError
-            If there is a parsing error.
-
-        TypeError
-            If there is a error resolving external types.
-        """
-        pass
 
     @classmethod
     @abc.abstractmethod

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2554,25 +2554,6 @@ class GTScriptFrontend(Frontend):
     name = "gtscript"
 
     @classmethod
-    def get_stencil_id(cls, qualified_name, definition, externals, options_id):
-        cls.prepare_stencil_definition(definition, externals or {})
-        fingerprint = {
-            "__main__": definition._gtscript_["canonical_ast"],
-            "docstring": inspect.getdoc(definition),
-            "api_annotations": f"[{', '.join(str(item) for item in definition._gtscript_['api_annotations'])}]",
-        }
-        for name, value in definition._gtscript_["externals"].items():
-            fingerprint[name] = (
-                value._gtscript_["canonical_ast"] if hasattr(value, "_gtscript_") else value
-            )
-
-        definition_id = gt_utils.shashed_id(fingerprint)
-        version = gt_utils.shashed_id(definition_id, options_id)
-        stencil_id = gt_definitions.StencilID(qualified_name, version)
-
-        return stencil_id
-
-    @classmethod
     def prepare_stencil_definition(
         cls,
         definition: Callable,


### PR DESCRIPTION
## Description

Deletes dead code from the frontend base class (and an associated implementation in the gtscript frontend). This code - backed up by the note in the base class - has been unused for a long time. No need to keep this around.

Found while debugging [the caching issue](https://github.com/GridTools/gt4py/pull/2588).

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A