### PR TITLE
feat[cartesian] Use default CXX all the time + Intel traceback for debug

### DIFF
--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -28,10 +28,10 @@ _gpu_compiler_configuration = gpu_configuration(GT4PY_COMPILE_OPT_LEVEL)
 GT4PY_EXTRA_COMPILE_OPT_FLAGS = os.environ.get("GT4PY_EXTRA_COMPILE_OPT_FLAGS", "")
 
 # Settings dict
-GT4PY_EXTRA_COMPILE_ARGS = os.environ.get(
-    "GT4PY_EXTRA_COMPILE_ARGS", _cxx_compiler_infos.cxx_compile_flags
-)
-_extra_compile_args = GT4PY_EXTRA_COMPILE_ARGS.split(" ") if GT4PY_EXTRA_COMPILE_ARGS else []
+GT4PY_EXTRA_COMPILE_ARGS = os.environ.get("GT4PY_EXTRA_COMPILE_ARGS", "")
+_extra_compile_args = []
+_extra_compile_args.extend(GT4PY_EXTRA_COMPILE_ARGS.split(" "))
+_extra_compile_args.extend(_cxx_compiler_infos.cxx_compile_flags.split(" "))
 
 GT4PY_EXTRA_LINK_ARGS = os.environ.get("GT4PY_EXTRA_LINK_ARGS", "")
 extra_link_args = GT4PY_EXTRA_LINK_ARGS.split(" ") if GT4PY_EXTRA_LINK_ARGS else []

--- a/src/gt4py/cartesian/config.py
+++ b/src/gt4py/cartesian/config.py
@@ -32,6 +32,8 @@ GT4PY_EXTRA_COMPILE_ARGS = os.environ.get("GT4PY_EXTRA_COMPILE_ARGS", "")
 _extra_compile_args = []
 _extra_compile_args.extend(GT4PY_EXTRA_COMPILE_ARGS.split(" "))
 _extra_compile_args.extend(_cxx_compiler_infos.cxx_compile_flags.split(" "))
+# Clean up for empty flags (GCC special)
+_extra_compile_args = [flag for flag in _extra_compile_args if flag.strip()]
 
 GT4PY_EXTRA_LINK_ARGS = os.environ.get("GT4PY_EXTRA_LINK_ARGS", "")
 extra_link_args = GT4PY_EXTRA_LINK_ARGS.split(" ") if GT4PY_EXTRA_LINK_ARGS else []

--- a/src/gt4py/cartesian/utils/compiler.py
+++ b/src/gt4py/cartesian/utils/compiler.py
@@ -39,6 +39,24 @@ class CxxCompilerDefaults:
     """Cxx compile flags"""
 
 
+def _intel_cxx_flags(optimization_level: str) -> list[str]:
+    flags = []
+    if optimization_level == "0":
+        flags.append("-g")
+        flags.append("-traceback")  # make sure to have a good stack
+        flags.append("-fp-model=strict")  # strict model for FP opts
+
+    return flags
+
+
+def _gnu_cxx_flags(optimization_level: str) -> list[str]:
+    flags = []
+    if optimization_level == "0":
+        flags.append("-g")
+
+    return flags
+
+
 def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
     """Return a set of defaults for the compiler flags"""
 
@@ -49,12 +67,12 @@ def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
     # Defaults
     name = CxxCompilerName.DEFAULT
     open_mp_flags = "-fopenmp"
-    cxx_flags = ""
+    cxx_flags = []
     enable_openmp = True
 
     # FMA is deactivated by default when running -O0
     if optimization_level == "0":
-        cxx_flags += "-ffp-contract=off"
+        cxx_flags.append("-ffp-contract=off")
 
     # Query the compiler version string
     try:
@@ -65,8 +83,14 @@ def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
         version_name_on_cli = "default"
     if "gcc" in version_name_on_cli.lower():
         name = CxxCompilerName.GNU
-    elif "icx" in version_name_on_cli.lower() or "icpx" in version_name_on_cli.lower():
+        cxx_flags.extend(_gnu_cxx_flags(optimization_level))
+    elif (
+        "icx" in version_name_on_cli.lower()
+        or "icpx" in version_name_on_cli.lower()
+        or "intel" in version_name_on_cli.lower()
+    ):
         name = CxxCompilerName.INTEL
+        cxx_flags.extend(_intel_cxx_flags(optimization_level))
         open_mp_flags = "-qopenmp"
     elif "apple clang" in version_name_on_cli.lower():
         # By default Apple Clang doesn't have OpenMP installed,
@@ -81,7 +105,7 @@ def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
         name,
         open_mp_flags,
         enable_openmp,
-        cxx_flags.strip(),  # be overly cautious for old GCC bad behavior
+        " ".join(cxx_flags).strip(),  # be overly cautious for old GCC bad behavior
     )
 
 

--- a/src/gt4py/cartesian/utils/compiler.py
+++ b/src/gt4py/cartesian/utils/compiler.py
@@ -57,6 +57,22 @@ def _gnu_cxx_flags(optimization_level: str) -> list[str]:
     return flags
 
 
+def _apple_clang_cxx_flags(optimization_level: str) -> list[str]:
+    flags = []
+    if optimization_level == "0":
+        flags.append("-g")
+
+    return flags
+
+
+def _llvm_clang_cxx_flags(optimization_level: str) -> list[str]:
+    flags = []
+    if optimization_level == "0":
+        flags.append("-g")
+
+    return flags
+
+
 def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
     """Return a set of defaults for the compiler flags"""
 
@@ -97,9 +113,11 @@ def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
         # so we remove the flag and disallow OpenMP altogether
         name = CxxCompilerName.APPLE_CLANG
         open_mp_flags = ""
+        cxx_flags.extend(_apple_clang_cxx_flags(optimization_level))
         enable_openmp = False
     elif "clang" in version_name_on_cli.lower():
         name = CxxCompilerName.CLANG
+        cxx_flags.extend(_llvm_clang_cxx_flags(optimization_level))
 
     return CxxCompilerDefaults(
         name,


### PR DESCRIPTION
## Description

The original design of the `cxx_compile_flags` was to feed it in the `GT4PY_EXTRA_COMPILE_ARGS`. This means we can have user override the internal decision.
We propose to swap this strategy - we control flags.

On this PR we also had `-traceback` and `-g` to debug compile in order to gather a better stack on crash or FPE trap.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
