### PR TITLE
fix[cartesian] No OpenMP on device compile

### DIFF
--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -158,18 +158,9 @@ def get_gt_pyext_build_opts(
             extra_link_args=extra_link_args,
         )
 
-    if gt_config.build_settings["openmp"]["use_openmp"]:
+    if gt_config.build_settings["openmp"]["use_openmp"] and not uses_cuda:
         cpp_flags = gt_config.build_settings["openmp"]["cppflags"]
-        if uses_cuda:
-            cuda_flags = []
-            for cpp_flag in cpp_flags:
-                if is_rocm_gpu:
-                    cuda_flags.extend([cpp_flag])
-                else:
-                    cuda_flags.extend(["--compiler-options", cpp_flag])
-            build_opts["extra_compile_args"]["cuda"].extend(cuda_flags)
-        elif cpp_flags:
-            build_opts["extra_compile_args"].extend(cpp_flags)
+        build_opts["extra_compile_args"].extend(cpp_flags)
 
         ld_flags = gt_config.build_settings["openmp"]["ldflags"]
         if ld_flags:


### PR DESCRIPTION
## Description

Do not apply `open_mp` flags on device compilers - we don't do multithreading host code for GPU backends (and device is plain wrong).

This flag usage was discovered in the case of an `icx/nvcc` where the `-qopenmp` intel flag bled into the command line of `nvcc`.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.

