### PR TITLE
fix[next]: cache dir construction and translation_cache lifetime

### DIFF
--- a/src/gt4py/_core/filecache.py
+++ b/src/gt4py/_core/filecache.py
@@ -25,7 +25,6 @@ class FileCache:
 
     def __init__(self, path: str | os.PathLike):
         self.path = pathlib.Path(path).resolve()
-        self.path.mkdir(parents=True, exist_ok=True)
 
     def _get_path(self, key: Hashable) -> pathlib.Path:
         """Return the path where an item with `key` is stored."""
@@ -41,6 +40,7 @@ class FileCache:
                 return pickle.load(f)
 
     def __setitem__(self, key: Hashable, value: Any) -> None:
+        self.path.mkdir(parents=True, exist_ok=True)
         with locking.lock(path := self._get_path(key)):
             with open(path, "wb") as f:
                 pickle.dump(value, f, protocol=5)

--- a/src/gt4py/next/otf/compilation/cache.py
+++ b/src/gt4py/next/otf/compilation/cache.py
@@ -49,6 +49,17 @@ def _cache_folder_name(source: stages.ProgramSource) -> str:
     return source.entry_point.name + "_" + fingerprint_hex_str
 
 
+def get_cache_base_path(lifetime: config.BuildCacheLifetime) -> pathlib.Path:
+    """Return the base directory for cached artifacts with the given lifetime."""
+    match lifetime:
+        case config.BuildCacheLifetime.SESSION:
+            return _session_cache_dir_path
+        case config.BuildCacheLifetime.PERSISTENT:
+            return config.BUILD_CACHE_DIR
+        case _:
+            raise ValueError("Unsupported caching lifetime.")
+
+
 def get_cache_folder(
     compilable_source: stages.CompilableProject, lifetime: config.BuildCacheLifetime
 ) -> pathlib.Path:
@@ -60,14 +71,7 @@ def get_cache_folder(
     # TODO(ricoh): make dependent on binding source too or add alternative that depends on bindings
     folder_name = _cache_folder_name(compilable_source.program_source)
 
-    match lifetime:
-        case config.BuildCacheLifetime.SESSION:
-            base_path = _session_cache_dir_path
-        case config.BuildCacheLifetime.PERSISTENT:
-            base_path = config.BUILD_CACHE_DIR
-        case _:
-            raise ValueError("Unsupported caching lifetime.")
-
+    base_path = get_cache_base_path(lifetime)
     base_path.mkdir(exist_ok=True)
 
     complete_path = base_path / folder_name

--- a/src/gt4py/next/program_processors/runners/dace/workflow/factory.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/factory.py
@@ -16,6 +16,7 @@ import factory
 from gt4py._core import definitions as core_defs, filecache
 from gt4py.next import config
 from gt4py.next.otf import recipes, stages, workflow
+from gt4py.next.otf.compilation import cache
 from gt4py.next.program_processors.runners.dace.workflow import (
     bindings as bindings_step,
     decoration as decoration_step,
@@ -47,7 +48,12 @@ class DaCeWorkflowFactory(factory.Factory):
                 lambda o: workflow.CachedStep(
                     o.bare_translation,
                     hash_function=stages.fingerprint_compilable_program,
-                    cache=filecache.FileCache(str(config.BUILD_CACHE_DIR / "translation_cache")),
+                    cache=filecache.FileCache(
+                        str(
+                            cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME)
+                            / "translation_cache"
+                        )
+                    ),
                 )
             ),
         )

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -20,7 +20,7 @@ from gt4py.next.embedded import nd_array_field
 from gt4py.next.instrumentation import metrics
 from gt4py.next.otf import recipes, stages, workflow
 from gt4py.next.otf.binding import nanobind
-from gt4py.next.otf.compilation import compiler
+from gt4py.next.otf.compilation import cache, compiler
 from gt4py.next.otf.compilation.build_systems import compiledb
 from gt4py.next.program_processors.codegens.gtfn import gtfn_module
 
@@ -124,7 +124,9 @@ class GTFNCompileWorkflowFactory(factory.Factory):
                 lambda o: workflow.CachedStep(
                     o.bare_translation,
                     hash_function=stages.fingerprint_compilable_program,
-                    cache=filecache.FileCache(str(config.BUILD_CACHE_DIR / "gtfn_cache")),
+                    cache=filecache.FileCache(
+                        str(cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME) / "gtfn_cache")
+                    ),
                 )
             ),
         )

--- a/tests/next_tests/unit_tests/otf_tests/compilation_tests/build_systems_tests/test_compiledb.py
+++ b/tests/next_tests/unit_tests/otf_tests/compilation_tests/build_systems_tests/test_compiledb.py
@@ -45,7 +45,7 @@ def test_compiledb_project_is_relocatable(compilable_source_example, clean_examp
 
     builder.build()
 
-    with tempfile.TemporaryDirectory(dir=config.BUILD_CACHE_DIR) as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         # copy the project to a new location
         relocated_dir = pathlib.Path(tmpdir) / "relocated"
         shutil.copytree(


### PR DESCRIPTION
- Before the .gt4py_cache dir is constructed on import time of gt4py. Now the directory is created on first write.
- Respect BUILD_CACHE_LIFETIME for the `translation_cache`.