### PR TITLE
fix[next-dace]: Remove Unused Data Descriptor

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg.py
@@ -677,7 +677,62 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
             if output is not None and (dataname := output.dc_node.data) not in data_args
         }
 
+        connectivity_arrays = {
+            gtx_dace_args.connectivity_identifier(offset)
+            for offset in gtx_dace_args.filter_connectivity_types(self.offset_provider_type)
+        }
+
+        inner_ctx_globals = [
+            dataname
+            for dataname, datadesc in inner_ctx.sdfg.arrays.items()
+            if not datadesc.transient
+        ]
+
+        input_memlets = {}
+        for dataname in inner_ctx_globals:
+            if dataname in data_args:
+                # The global data refers to an argument. However, it might not be used.
+                # If it is used, i.e. `data_args[dataname]` is not `None` then we will
+                # fully map it into the nested SDFG. Otherwise we will remove bellow.
+                if (arg_node := data_args[dataname]) is not None:
+                    input_memlets[dataname] = outer_ctx.sdfg.make_array_memlet(
+                        arg_node.dc_node.data
+                    )
+            else:
+                # Always capture connectivity arrays from parent scope.
+                # For other GTIR-symbols (scalars, arrays), check if it is allowed.
+                assert dataname in outer_ctx.sdfg.arrays
+                assert dataname in connectivity_arrays or capture_outer_data
+                # We check whether this global data can be removed. Besides reducing
+                # the number of input connectors, this check is necessary for tuple
+                # arguments, for which domain inference has detected that one or more
+                # of the nested fields is not used. In such cases, the corresponding
+                # argument in the top-level lambda is expected to be None to setup an
+                # input edge.
+                # Note that we call `remove_data()` with `validate=True` to ensure
+                # that the data is not used by any access node.
+                try:
+                    inner_ctx.sdfg.remove_data(dataname, validate=True)
+                except ValueError:
+                    # It is accessed in the lambda SDFG, so we need to setup an input edge.
+                    outer_ctx.sdfg.arrays[dataname].transient = False
+                    input_memlets[dataname] = outer_ctx.sdfg.make_array_memlet(dataname)
+
+        # We have to remove the uninitialized and unused data from the SDFG. This is
+        # needed because otherwise the transients (that are not used) are picked up
+        # by `free_symbols`.
+        for data_name, data_node in data_args.items():
+            if data_node is None:
+                # NOTE: We only delete the data descriptor and not the symbols that
+                #   are used for its shape/strides, i.e. they are still in
+                #   `inner_ctx.sdfg.symbols`. We will keep them there, because to
+                #   delete them we would need to make sure that the symbol is not
+                #   used by anything else.
+                inner_ctx.sdfg.remove_data(data_name, validate=gtx_config.DEBUG)
+
         # Map free symbols to parent SDFG
+        # NOTE: This must happen after we cleaned up the SDFG to make sure that the
+        #   "dead data" is not added to the free symbols.
         nsdfg_symbols_mapping = {}
         for dc_symbol in inner_ctx.sdfg.free_symbols:
             if dc_symbol in data_args:
@@ -694,48 +749,6 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         for gt_symbol, arg in data_args.items():
             if arg is not None:
                 nsdfg_symbols_mapping |= arg.get_symbol_mapping(gt_symbol, outer_ctx.sdfg)
-
-        connectivity_arrays = {
-            gtx_dace_args.connectivity_identifier(offset)
-            for offset in gtx_dace_args.filter_connectivity_types(self.offset_provider_type)
-        }
-
-        inner_ctx_globals = [
-            dataname
-            for dataname, datadesc in inner_ctx.sdfg.arrays.items()
-            if not datadesc.transient
-        ]
-
-        input_memlets = {}
-        for dataname in inner_ctx_globals:
-            if dataname in data_args:
-                # Uninitialized arguments should not be used inside the nested SDFG.
-                if (arg_node := data_args[dataname]) is None:
-                    inner_ctx.sdfg.remove_data(dataname, validate=gtx_config.DEBUG)
-                else:
-                    input_memlets[dataname] = outer_ctx.sdfg.make_array_memlet(
-                        arg_node.dc_node.data
-                    )
-            else:
-                # Always capture connectivity arrays from parent scope.
-                # For other GTIR-symbols (scalars, arrays), check if it is allowed.
-                assert dataname in outer_ctx.sdfg.arrays
-                assert dataname in connectivity_arrays or capture_outer_data
-                # We check whether this global data can be removed. Besides reducing
-                # the number of input connectors, this check is necessary for tuple
-                # arguments, for which domain inference has detected that one or more
-                # of the nested fields is not used. In such cases, the corresponding
-                # argument in the top-level lambda is expected to be None (see how
-                # this case is handled in the if-branch above) and it is not possible
-                # to setup an input edge.
-                # Note that we call `remove_data()` with `validate=True` to ensure
-                # that the data is not used by any access node.
-                try:
-                    inner_ctx.sdfg.remove_data(dataname, validate=True)
-                except ValueError:
-                    # It is accessed in the lambda SDFG, so we need to setup an input edge.
-                    outer_ctx.sdfg.arrays[dataname].transient = False
-                    input_memlets[dataname] = outer_ctx.sdfg.make_array_memlet(dataname)
 
         nsdfg_node = outer_ctx.state.add_nested_sdfg(
             inner_ctx.sdfg,

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg.py
@@ -691,9 +691,10 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
         input_memlets = {}
         for dataname in inner_ctx_globals:
             if dataname in data_args:
-                # The global data refers to an argument. However, it might not be used.
-                # If it is used, i.e. `data_args[dataname]` is not `None` then we will
-                # fully map it into the nested SDFG. Otherwise we will remove bellow.
+                # The global data refers to an argument. If the argument is initialized,
+                # i.e. `data_args[dataname]` is not `None`, the argument is used by
+                # the lambda and we fully map it into the nested SDFG. Otherwise, we
+                # remove the data descriptor from the nested SDFG (see the next for-loop).
                 if (arg_node := data_args[dataname]) is not None:
                     input_memlets[dataname] = outer_ctx.sdfg.make_array_memlet(
                         arg_node.dc_node.data
@@ -707,8 +708,8 @@ class GTIRToSDFG(eve.NodeVisitor, SDFGBuilder):
                 # the number of input connectors, this check is necessary for tuple
                 # arguments, for which domain inference has detected that one or more
                 # of the nested fields is not used. In such cases, the corresponding
-                # argument in the top-level lambda is expected to be None to setup an
-                # input edge.
+                # argument in the top-level lambda is expected to be `None` and it
+                # is not possible to setup an input edge.
                 # Note that we call `remove_data()` with `validate=True` to ensure
                 # that the data is not used by any access node.
                 try:


### PR DESCRIPTION
In certain cases the lowering generates SDFGs that contains data descriptors that are not used anywhere. There was a recent change in DaCe which slightly changed how free symbols are computed. The effect was that the symbols of these unused data descriptors (i.e. the shape and size of arrays) must now be provided.
This PR changes the lowering in such a way that these transients are removed.

For more information see [DaCe issue#2382](https://github.com/spcl/dace/issues/2382). 