### PR TITLE
fix[next-dace]: Avoid referencing subset objects on multiple edges

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -422,8 +422,8 @@ class LambdaToDataflow(eve.NodeVisitor):
         dst_node: dace_nodes.Node,
         dst_conn: Optional[str] = None,
     ) -> None:
-        new_subset = copy.deepcopy(src_subset)  # guarantee unique subset objects
-        edge = MemletInputEdge(self.state, src, new_subset, dst_node, dst_conn)
+        src_subset = copy.deepcopy(src_subset)  # guarantee unique subset objects
+        edge = MemletInputEdge(self.state, src, src_subset, dst_node, dst_conn)
         self.input_edges.append(edge)
 
     def _add_edge(

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -422,7 +422,7 @@ class LambdaToDataflow(eve.NodeVisitor):
         dst_node: dace_nodes.Node,
         dst_conn: Optional[str] = None,
     ) -> None:
-        src_subset = copy.deepcopy(src_subset)  # guarantee unique subset objects
+        src_subset = copy.deepcopy(src_subset)  # avoid referencing a subset used by another edge
         edge = MemletInputEdge(self.state, src, src_subset, dst_node, dst_conn)
         self.input_edges.append(edge)
 

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import abc
+import copy
 import dataclasses
 from typing import (
     Any,
@@ -313,7 +314,7 @@ class DataflowOutputEdge:
         else:
             src_node = write_edge.dst
             src_node_connector = None
-            src_subset = write_edge.data.dst_subset
+            src_subset = copy.deepcopy(write_edge.data.dst_subset)
 
         if map_exit is None:
             self.state.add_edge(
@@ -421,7 +422,8 @@ class LambdaToDataflow(eve.NodeVisitor):
         dst_node: dace_nodes.Node,
         dst_conn: Optional[str] = None,
     ) -> None:
-        edge = MemletInputEdge(self.state, src, src_subset, dst_node, dst_conn)
+        new_subset = copy.deepcopy(src_subset)  # guarantee unique subset objects
+        edge = MemletInputEdge(self.state, src, new_subset, dst_node, dst_conn)
         self.input_edges.append(edge)
 
     def _add_edge(

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_scan.py
@@ -22,6 +22,7 @@ This is likely to change in the future, to enable GTIR optimizations for scan.
 
 from __future__ import annotations
 
+import copy
 from typing import Iterable, Sequence
 
 import dace
@@ -514,7 +515,9 @@ def _lower_lambda_to_nested_sdfg(
             update_state.add_access(scan_result_data),
             update_state.add_access(scan_carry_data),
             dace.Memlet(
-                data=scan_result_data, subset=scan_result_subset, other_subset=scan_result_subset
+                data=scan_result_data,
+                subset=copy.deepcopy(scan_result_subset),
+                other_subset=copy.deepcopy(scan_result_subset),
             ),
         )
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/inline_fuser.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/inline_fuser.py
@@ -451,7 +451,7 @@ def _insert_nested_sdfg(
         dace.Memlet(
             data=outer_output_name,
             subset=edge_to_replace.data.src_subset.offset_new(offset, negative=True),
-            other_subset=edge_to_replace.data.get_dst_subset(edge_to_replace, state),
+            other_subset=copy.deepcopy(edge_to_replace.data.get_dst_subset(edge_to_replace, state)),
         ),
     )
 
@@ -547,7 +547,7 @@ def _populate_nested_sdfg(
                     memlet=dace.Memlet(
                         data=output_name,
                         subset=dace_sbs.Range.from_array(output_desc),
-                        other_subset=oedge.data.get_src_subset(oedge, state),
+                        other_subset=copy.deepcopy(oedge.data.get_src_subset(oedge, state)),
                     ),
                 )
 


### PR DESCRIPTION
This PR ensures that subset objects are not shared by multiple memlets. This is a potential issue since the subsets of a memlet are mutable objects. An additional check in dace validation has been introduced, as part of the new GPU codegen, which caught this issue.