### PR TITLE
fix[next-dace]: Fixed Memlet Expansion

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -70,6 +70,9 @@ def gt_gpu_transformation(
             that you should set `try_removing_trivial_maps` to `False`.
         - The function assumes that the iteration order has been set correctly before
             it is called.
+        - To work around a bug in DaCe this function has to reconstruct the SDFG.
+            While this is done inplace, i.e. the passed object `sdfg` is reused, this
+            will invalidate all references to graph objects.
 
     Todo:
         - Currently only one block size for all maps is given, add more options.
@@ -79,6 +82,26 @@ def gt_gpu_transformation(
     assert len(kwargs) == 0, (
         f"gt_gpu_transformation(): found unknown arguments: {', '.join(arg for arg in kwargs.keys())}"
     )
+
+    # NOTE: This is a hack that avoids some issues that are caused by DaCe
+    #   [PR#2366](github.com/spcl/dace/pull/2366). That PR made symbol serialization
+    #   type safe, but it had some strange side effect. In the GPU transformations
+    #   we expand Memlets that can not be represented as a `cudaMemcpy()` call. This
+    #   is also done in the `preprocess()` function of DaCe's GPU codegen, but there
+    #   the iteration order is such that it will lead to launch errors. The issue
+    #   now is that GT4Py decides to _not_ expand certain Memlets, but in the
+    #   codegen DaCe want's to expand them, leading to an error, since we suppress
+    #   this behaviour. At some time it was found out that serializing and deserializing
+    #   the SDFG fixes this behaviour. However, the net effect is, that now _all_
+    #   Memlets are expanded.
+    #   The reason for restoration of the SDFG inplace is because this function has
+    #   modified the SDFG inplace and this behaviour should not be changed.
+    #   However, this also has a side effect, while the `sdfg` object, in some sense
+    #   the root, stains the same, all graph objects, such as `Map`, `MapEntry`,
+    #   `SDFGState` and so on, are equivalent but different objects. Thus, all
+    #   references to graph members are invalidated.
+    json_dump = sdfg.to_json()
+    _load_sdfg_from_json_inplace(sdfg, json_dump)
 
     # Turn all global arrays (which we identify as input) into GPU memory.
     #  This way the GPU transformation will not create this copying stuff.
@@ -1064,3 +1087,58 @@ def gt_gpu_apply_mempool(sdfg: dace.SDFG) -> None:
             and desc.transient
         ):
             desc.pool = True
+
+
+def _load_sdfg_from_json_inplace(sdfg: dace.SDFG, json_obj: dict[str, Any]) -> dace.SDFG:
+    """Reconstruct the JSON dump `json` into `sdfg`.
+
+    This function is a hack and you should not use it.
+    """
+
+    # This function is based on `SDFG.from_json()`.
+
+    context = {"sdfg": None}
+    _type = json_obj["type"]
+    if _type != "SDFG":
+        raise TypeError("Class type mismatch")
+
+    attrs = dict(json_obj["attributes"])
+    json_obj = dict(json_obj)
+    json_obj["attributes"] = attrs
+    nodes = json_obj["nodes"]
+    edges = json_obj["edges"]
+
+    if "constants_prop" in attrs:
+        constants_prop = dace.serialize.loads(dace.serialize.dumps(attrs["constants_prop"]))
+    else:
+        constants_prop = None
+
+    sdfg.__dict__.clear()
+    sdfg.__init__(name=attrs["name"], constants=constants_prop, parent=context["sdfg"])
+
+    dace.serialize.set_properties_from_json(
+        sdfg, json_obj, ignore_properties={"constants_prop", "name", "hash"}
+    )
+
+    nodelist = []
+    for n in nodes:
+        nci = copy.copy(context)
+        nci["sdfg"] = sdfg
+
+        block = dace.serialize.from_json(n, context=nci)
+        sdfg.add_node(block)
+        nodelist.append(block)
+
+    for e in edges:
+        e = dace.serialize.from_json(e)
+        sdfg.add_edge(nodelist[int(e.src)], nodelist[int(e.dst)], e.data)
+
+    if "start_block" in json_obj:
+        sdfg._start_block = json_obj["start_block"]
+
+    if (
+        "source_files" in json_obj
+    ):  # This will only happen on the root SDFG, once deserialization is complete
+        sdfg.rematerialize_debuginfo_files(json_obj["source_files"])
+
+    return sdfg

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
@@ -208,7 +208,7 @@ def test_set_gpu_properties(method: int):
     for node in sdfg.states()[0].nodes():
         if isinstance(node, dace_nodes.MapEntry):
             map_entries[int(node.label[4])] = node.map
-    map1, map2, map3, map4 = (map_entries[d].map for d in [1, 2, 3, 4])
+    map1, map2, map3, map4 = (map_entries[d] for d in [1, 2, 3, 4])
 
     # It takes the normal block size and does not regulate anything.
     assert len(map1.params) == 1

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
@@ -204,11 +204,11 @@ def test_set_gpu_properties(method: int):
         raise ValueError(f"Unknown method {method}")
 
     # Because of the inplace reconstruction all references to graph objects are destroyed.
-    map_entries: dict[int, dace_nodes.Map] = {}
+    map_entries: dict[int, dace_nodes.MapEntry] = {}
     for node in sdfg.states()[0].nodes():
         if isinstance(node, dace_nodes.MapEntry):
-            map_entries[int(node.label[4])] = node.map
-    map1, map2, map3, map4 = (map_entries[d] for d in [1, 2, 3, 4])
+            map_entries[int(node.label[4])] = node
+    map1, map2, map3, map4 = (map_entries[d].map for d in [1, 2, 3, 4])
 
     # It takes the normal block size and does not regulate anything.
     assert len(map1.params) == 1

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_gpu_utils.py
@@ -159,7 +159,6 @@ def test_set_gpu_properties(method: int):
     sdfg = dace.SDFG(gtx_transformations_utils.unique_name("gpu_properties_test"))
     state = sdfg.add_state(is_start_block=True)
 
-    map_entries: dict[int, dace_nodes.MapEntry] = {}
     for dim in [1, 2, 3, 4]:
         shape = (10,) * dim
         sdfg.add_array(
@@ -168,7 +167,7 @@ def test_set_gpu_properties(method: int):
         sdfg.add_array(
             f"B_{dim}", shape=shape, dtype=dace.float64, storage=dace.StorageType.GPU_Global
         )
-        _, me, _ = state.add_mapped_tasklet(
+        state.add_mapped_tasklet(
             f"map_{dim}",
             map_ranges={f"__i{i}": f"0:{s}" for i, s in enumerate(shape)},
             inputs={"__in": dace.Memlet(f"A_{dim}[{','.join(f'__i{i}' for i in range(dim))}]")},
@@ -176,7 +175,7 @@ def test_set_gpu_properties(method: int):
             outputs={"__out": dace.Memlet(f"B_{dim}[{','.join(f'__i{i}' for i in range(dim))}]")},
             external_edges=True,
         )
-        map_entries[dim] = me
+    del state
     sdfg.validate()
 
     if method == 0:
@@ -204,6 +203,11 @@ def test_set_gpu_properties(method: int):
     else:
         raise ValueError(f"Unknown method {method}")
 
+    # Because of the inplace reconstruction all references to graph objects are destroyed.
+    map_entries: dict[int, dace_nodes.Map] = {}
+    for node in sdfg.states()[0].nodes():
+        if isinstance(node, dace_nodes.MapEntry):
+            map_entries[int(node.label[4])] = node.map
     map1, map2, map3, map4 = (map_entries[d].map for d in [1, 2, 3, 4])
 
     # It takes the normal block size and does not regulate anything.
@@ -259,6 +263,7 @@ def test_set_gpu_properties_1D():
         map_entries[dim] = me
     sdfg.validate()
 
+    # `get_set_gpu_blocksize()` is non destructive, so `map_entries` are still pointing into the SDFG.
     sdfg.apply_gpu_transformations()
     gtx_dace_fieldview_gpu_utils.gt_set_gpu_blocksize(
         sdfg=sdfg,
@@ -323,6 +328,7 @@ def test_set_gpu_properties_2D_3D():
         map_entries[dim] = me
     sdfg.validate()
 
+    # `get_set_gpu_blocksize()` is non destructive, so `map_entries` are still pointing into the SDFG.
     sdfg.apply_gpu_transformations()
     gtx_dace_fieldview_gpu_utils.gt_set_gpu_blocksize(
         sdfg=sdfg,


### PR DESCRIPTION
This PR "fixes" an issue that was caused by [DaCe PR#2366](github.com/spcl/dace/pull/2366). This PR made symbol serialization "type safe", but it had some strange side effect.
In the GT4Py GPU transformations we expand Memlets, that can not be represented as a `cudaMemcpy()` call. This is also done in the `preprocess()` function of DaCe's GPU codegen. But there the iteration order is such that it will lead to launch errors. To avoid this GT4Py does the same expansion first and sets the iteration order correctly.

The issue is that GT4Py decides to _not_ expand certain Memlets (this is actually the correct behaviour as the Memlet can be expressed as `cudaMemcpy()`). But in the codegen DaCe wants to expand them, leading to an error, since we suppress this behaviour.
It was then found that serializing and deserializing the SDFG fixes this behaviour. However, now the behaviour is that this Memlet, which can be expressed as `cudaMemcpy()`, is expanded.