### PR TITLE
build[next]: Fixed Discovery of `nanobind`

### DIFF
--- a/src/gt4py/next/otf/compilation/build_systems/cmake_lists.py
+++ b/src/gt4py/next/otf/compilation/build_systems/cmake_lists.py
@@ -91,7 +91,7 @@ class CMakeListsGenerator(eve.codegen.TemplatedGenerator):
 
                 find_package(Python COMPONENTS Interpreter Development REQUIRED)
                 """
-                nb = f"find_package(nanobind CONFIG REQUIRED PATHS {nanobind.cmake_dir()} NO_DEFAULT_PATHS)"
+                nb = f'find_package(nanobind CONFIG REQUIRED HINTS "{nanobind.cmake_dir()}" NO_DEFAULT_PATH)'
                 return py + "\n" + nb
             case "gridtools_cpu" | "gridtools_gpu":
                 import gridtools_cpp


### PR DESCRIPTION
If `nanobind` is installed on the system it might not be found correctly.

While the Python package is picked up correctly, the `nanobind-config.cmake` is not. Instead of the one that ships with the Python package the one of the system is found, which is in a cmake directory. However, then the headers are not found.

The solution is to move the path from the Python package up in the search hierarchy as `PATHS` are searched after `HINTS`, see [`cmake` documentation](https://cmake.org/cmake/help/latest/command/find_package.html#id21), `HINTS` are processed in step 4, while `PATHS` are processed in step 9.
