### PR TITLE
fix[next-dace]: Configure TX markers at compile-time

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -72,7 +72,6 @@ def make_dace_backend(
     auto_optimize: bool = True,
     async_sdfg_call: bool = True,
     optimization_args: dict[str, Any] | None = None,
-    add_gpu_trace_markers: bool = config.ADD_GPU_TRACE_MARKERS,
     unstructured_horizontal_has_unit_stride: bool = config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE,
     use_metrics: bool = True,
     use_zero_origin: bool = False,
@@ -88,8 +87,6 @@ def make_dace_backend(
             of GPU kernel execution with the Python driver code.
         optimization_args: A `dict` containing configuration parameters for
             the SDFG auto-optimize pipeline, see `gt_auto_optimize()`.
-        add_gpu_trace_markers: Add trace markers to the generated GPU code to allow
-            profiling with trace visualization tools.
         unstructured_horizontal_has_unit_stride: When the memory layout has unit stride
             in the horizontal dimension, replace the field stride symbol with '1'.
         use_metrics: Add SDFG instrumentation to collect the metric for stencil
@@ -133,7 +130,6 @@ def make_dace_backend(
         otf_workflow__cached_translation=cached,
         otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
         otf_workflow__bare_translation__auto_optimize_args=optimization_args,
-        otf_workflow__bare_translation__add_gpu_trace_markers=add_gpu_trace_markers,
         otf_workflow__bare_translation__unstructured_horizontal_has_unit_stride=unstructured_horizontal_has_unit_stride,
         otf_workflow__bare_translation__use_metrics=use_metrics,
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -72,6 +72,7 @@ def make_dace_backend(
     auto_optimize: bool = True,
     async_sdfg_call: bool = True,
     optimization_args: dict[str, Any] | None = None,
+    add_gpu_trace_markers: bool = config.ADD_GPU_TRACE_MARKERS,
     unstructured_horizontal_has_unit_stride: bool = config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE,
     use_metrics: bool = True,
     use_zero_origin: bool = False,
@@ -87,6 +88,8 @@ def make_dace_backend(
             of GPU kernel execution with the Python driver code.
         optimization_args: A `dict` containing configuration parameters for
             the SDFG auto-optimize pipeline, see `gt_auto_optimize()`.
+        add_gpu_trace_markers: Add trace markers to the generated GPU code to allow
+            profiling with trace visualization tools.
         unstructured_horizontal_has_unit_stride: When the memory layout has unit stride
             in the horizontal dimension, replace the field stride symbol with '1'.
         use_metrics: Add SDFG instrumentation to collect the metric for stencil
@@ -130,6 +133,7 @@ def make_dace_backend(
         otf_workflow__cached_translation=cached,
         otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
         otf_workflow__bare_translation__auto_optimize_args=optimization_args,
+        otf_workflow__bare_translation__add_gpu_trace_markers=add_gpu_trace_markers,
         otf_workflow__bare_translation__unstructured_horizontal_has_unit_stride=unstructured_horizontal_has_unit_stride,
         otf_workflow__bare_translation__use_metrics=use_metrics,
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -131,6 +131,7 @@ class DaCeCompiler(
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
+    add_gpu_trace_markers: bool = config.ADD_GPU_TRACE_MARKERS
     cmake_build_type: config.CMakeBuildType = config.CMakeBuildType.DEBUG
 
     def __call__(
@@ -145,6 +146,16 @@ class DaCeCompiler(
             sdfg_build_folder.mkdir(parents=True, exist_ok=True)
 
             sdfg = dace.SDFG.from_json(inp.program_source.source_code)
+
+            # Add TX markers to the generated GPU code for trace visualization tools.
+            if self.device_type == core_defs.CUPY_DEVICE_TYPE and self.add_gpu_trace_markers:
+                sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+                for node, _ in sdfg.all_nodes_recursive(
+                    # Also adds markers to scopes and maps that are NOT scheduled on GPU
+                    predicate=lambda x, _: isinstance(x, (dace.nodes.MapEntry, dace.sdfg.SDFGState))
+                ):
+                    node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+
             sdfg.build_folder = sdfg_build_folder
             with locking.lock(sdfg_build_folder):
                 sdfg_program = sdfg.compile(validate=False)

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -24,6 +24,21 @@ from gt4py.next.otf.compilation import cache as gtx_cache
 from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 
 
+def _add_tx_markers(sdfg: dace.SDFG) -> None:
+    has_gpu_schedule = any(
+        getattr(node, "schedule", dace.dtypes.ScheduleType.Default) in dace.dtypes.GPU_SCHEDULES
+        for node, _ in sdfg.all_nodes_recursive()
+    )
+
+    if has_gpu_schedule:
+        sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+        for node, _ in sdfg.all_nodes_recursive(
+            # Also adds markers to scopes and maps that are NOT scheduled on GPU
+            predicate=lambda x, _: isinstance(x, (dace.nodes.MapEntry, dace.sdfg.state.SDFGState))
+        ):
+            node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+
+
 class CompiledDaceProgram:
     sdfg_program: dace.CompiledSDFG
 
@@ -148,13 +163,8 @@ class DaCeCompiler(
             sdfg = dace.SDFG.from_json(inp.program_source.source_code)
 
             # Add TX markers to the generated GPU code for trace visualization tools.
-            if self.device_type == core_defs.CUPY_DEVICE_TYPE and self.add_gpu_trace_markers:
-                sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
-                for node, _ in sdfg.all_nodes_recursive(
-                    # Also adds markers to scopes and maps that are NOT scheduled on GPU
-                    predicate=lambda x, _: isinstance(x, (dace.nodes.MapEntry, dace.sdfg.SDFGState))
-                ):
-                    node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+            if self.add_gpu_trace_markers and self.device_type == core_defs.CUPY_DEVICE_TYPE:
+                _add_tx_markers(sdfg)
 
             sdfg.build_folder = sdfg_build_folder
             with locking.lock(sdfg_build_folder):

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -146,8 +146,12 @@ class DaCeCompiler(
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
-    add_gpu_trace_markers: bool = config.ADD_GPU_TRACE_MARKERS
-    cmake_build_type: config.CMakeBuildType = config.CMakeBuildType.DEBUG
+    add_gpu_trace_markers: bool = dataclasses.field(
+        default_factory=lambda: config.ADD_GPU_TRACE_MARKERS
+    )
+    cmake_build_type: config.CMakeBuildType = dataclasses.field(
+        default_factory=lambda: config.CMAKE_BUILD_TYPE
+    )
 
     def __call__(
         self,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -160,7 +160,7 @@ def _make_if_region_for_metrics_collection(
     return if_region, then_state
 
 
-def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
+def add_instrumentation(sdfg: dace.SDFG, gpu: bool, add_gpu_trace_markers: bool = False) -> None:
     """
     Instrument SDFG with measurement of total execution time.
 
@@ -171,6 +171,7 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
     The execution time is measured in seconds and represented as a 'float64' value.
     It is written to the global array 'SDFG_ARG_METRIC_COMPUTE_TIME'.
     """
+    has_gpu_code = gpu and _has_gpu_schedule(sdfg)
     output, _ = sdfg.add_array(gtx_wfdcommon.SDFG_ARG_METRIC_COMPUTE_TIME, [1], dace.float64)
     start_time, _ = sdfg.add_scalar("gt_start_time", dace.int64, transient=True)
     metrics_level = sdfg.add_symbol(gtx_wfdcommon.SDFG_ARG_METRIC_LEVEL, dace.int32)
@@ -179,7 +180,7 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
     # Even when the target device is GPU, it can happen that dace emits code without
     # GPU kernels. In this case, the cuda headers are not imported and the SDFG is
     # compiled as plain C++. Therefore, we also check here the schedule of SDFG maps.
-    if gpu and _has_gpu_schedule(sdfg):
+    if has_gpu_code:
         dace_gpu_backend = dace.Config.get("compiler.cuda.backend")
         assert dace_gpu_backend in ["cuda", "hip"], f"GPU backend '{dace_gpu_backend}' is unknown."
 
@@ -265,7 +266,7 @@ duration = static_cast<double>(run_cpp_end_time - run_cpp_start_time) * 1.e-9;
         dace.Memlet(f"{output}[0]"),
     )
 
-    if gpu and _has_gpu_schedule(sdfg) and config.ADD_GPU_TRACE_MARKERS:
+    if has_gpu_code and add_gpu_trace_markers:
         sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
         for node, _ in sdfg.all_nodes_recursive():
             if isinstance(
@@ -441,7 +442,7 @@ class DaCeTranslator(
             make_sdfg_call_sync(sdfg, on_gpu)
 
         if self.use_metrics:
-            add_instrumentation(sdfg, on_gpu)
+            add_instrumentation(sdfg, on_gpu, self.add_gpu_trace_markers)
 
         return sdfg
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -15,7 +15,7 @@ import dace
 import factory
 
 from gt4py._core import definitions as core_defs
-from gt4py.next import common, config
+from gt4py.next import common
 from gt4py.next.instrumentation import metrics
 from gt4py.next.iterator import ir as itir, transforms as itir_transforms
 from gt4py.next.otf import code_specs, definitions, stages, workflow
@@ -160,7 +160,7 @@ def _make_if_region_for_metrics_collection(
     return if_region, then_state
 
 
-def add_instrumentation(sdfg: dace.SDFG, gpu: bool, add_gpu_trace_markers: bool = False) -> None:
+def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
     """
     Instrument SDFG with measurement of total execution time.
 
@@ -171,7 +171,6 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool, add_gpu_trace_markers: bool 
     The execution time is measured in seconds and represented as a 'float64' value.
     It is written to the global array 'SDFG_ARG_METRIC_COMPUTE_TIME'.
     """
-    has_gpu_code = gpu and _has_gpu_schedule(sdfg)
     output, _ = sdfg.add_array(gtx_wfdcommon.SDFG_ARG_METRIC_COMPUTE_TIME, [1], dace.float64)
     start_time, _ = sdfg.add_scalar("gt_start_time", dace.int64, transient=True)
     metrics_level = sdfg.add_symbol(gtx_wfdcommon.SDFG_ARG_METRIC_LEVEL, dace.int32)
@@ -180,7 +179,7 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool, add_gpu_trace_markers: bool 
     # Even when the target device is GPU, it can happen that dace emits code without
     # GPU kernels. In this case, the cuda headers are not imported and the SDFG is
     # compiled as plain C++. Therefore, we also check here the schedule of SDFG maps.
-    if has_gpu_code:
+    if gpu and _has_gpu_schedule(sdfg):
         dace_gpu_backend = dace.Config.get("compiler.cuda.backend")
         assert dace_gpu_backend in ["cuda", "hip"], f"GPU backend '{dace_gpu_backend}' is unknown."
 
@@ -265,16 +264,6 @@ duration = static_cast<double>(run_cpp_end_time - run_cpp_start_time) * 1.e-9;
         None,
         dace.Memlet(f"{output}[0]"),
     )
-
-    if has_gpu_code and add_gpu_trace_markers:
-        sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
-        for node, _ in sdfg.all_nodes_recursive():
-            if isinstance(
-                node, dace.nodes.MapEntry
-            ):  # Add ranges to scopes and maps that are NOT scheduled to the GPU
-                node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
-            elif isinstance(node, dace.sdfg.state.SDFGState):
-                node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
 
     # Check SDFG validity after applying the above changes.
     # Normally, we do not call `SDFGState.add_tasklet()` directly, instead we call
@@ -442,7 +431,7 @@ class DaCeTranslator(
             make_sdfg_call_sync(sdfg, on_gpu)
 
         if self.use_metrics:
-            add_instrumentation(sdfg, on_gpu, self.add_gpu_trace_markers)
+            add_instrumentation(sdfg, on_gpu)
 
         return sdfg
 


### PR DESCRIPTION
This PR contains two changes:
- A fix: it reads the gt4py configuration inside the constructor of the workflow step, rather than at runtime. This fix is needed for the cached workflow PR.
- A change: the SDFG customization happens now in the compile stage, rather than in the lowering stage. The reason is that this configuration has no impact on the SDFG itself, but only on the generated code. It is possible to cache the lowering and simply generate GPU code with the TX markers in the build stage.