### PR TITLE
refactor[next]: Replace apply_to_primitive_constituents with tree_map_type

### DIFF
--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -871,10 +871,9 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
 
         new_type = new_type_constructor.type.definition.returns
 
-        return_type = type_info.apply_to_primitive_constituents(
-            lambda primitive_type: with_altered_scalar_kind(primitive_type, new_type.kind),
-            value.type,
-        )
+        return_type = type_info.tree_map_type(
+            lambda primitive_type: with_altered_scalar_kind(primitive_type, new_type.kind)
+        )(value.type)
         assert isinstance(return_type, (ts.TupleType, ts.ScalarType, ts.FieldType))
 
         return foast.Call(
@@ -962,7 +961,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             return_type = ts.FieldType(dims=return_dims, dtype=t_dtype)
             return return_type
 
-        return deduce_return_type(true_branch, false_branch)  # type: ignore[return-value]
+        return deduce_return_type(true_branch, false_branch)
 
     def _visit_where(self, node: foast.Call, **kwargs: Any) -> foast.Call:
         mask_type, true_branch_type, false_branch_type = (arg.type for arg in node.args)

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -18,7 +18,6 @@ from gt4py.next.ffront import (
     dialect_ast_enums,
     experimental,
     fbuiltins,
-    type_info as ti_ffront,
     type_specifications as ts_ffront,
 )
 from gt4py.next.ffront.foast_passes import utils as foast_utils
@@ -933,7 +932,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
 
         # replace all primitive constituents by the same type, `ts.DeferredType()` for convenience,
         # to capture the structure of the two branches
-        extract_structure = ti_ffront.tree_map_type(lambda x: ts.DeferredType(constraint=None))
+        extract_structure = type_info.tree_map_type(lambda x: ts.DeferredType(constraint=None))
         tb_structure = extract_structure(true_branch)
         fb_structure = extract_structure(false_branch)
 
@@ -947,7 +946,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 ),
             )
 
-        @ti_ffront.tree_map_type
+        @type_info.tree_map_type
         def deduce_return_type(
             tb: ts.FieldType | ts.ScalarType, fb: ts.FieldType | ts.ScalarType
         ) -> ts.FieldType:

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -157,7 +157,7 @@ def _tree_map_type_constructor_drop_python_type(
     value: ts.CollectionTypeSpecT,
     elems: Iterable[ts.DataType],
 ) -> ts.CollectionTypeSpecT:
-    result = type_info._tree_map_type_constructor(value, elems)
+    result = type_info.tree_map_type_constructor(value, elems)
     if isinstance(value, ts.NamedCollectionType):
         result = datamodels.evolve(result, original_python_type=ts.ANY_PYTHON_TYPE_NAME)
     return result

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -7,20 +7,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import functools
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, Iterator, Sequence, cast
 
 import gt4py.next.ffront.type_specifications as ts_ffront
 import gt4py.next.type_system.type_specifications as ts
 from gt4py.eve import datamodels
-from gt4py.eve.extended_typing import NestedTuple
 from gt4py.next import common, utils
 from gt4py.next.ffront.type_specifications import ProgramType
 from gt4py.next.type_system import type_info
 
-
-_tree_map_type_constructor = type_info._tree_map_type_constructor
-tree_map_type = type_info.tree_map_type
 
 named_collections_to_tuple_types = cast(
     Callable[..., ts.TupleType],
@@ -65,7 +61,7 @@ def promote_zero_dims(
                     raise ValueError(f"'{arg_el}' is not compatible with '{param_el}'.")
             return arg_el
 
-        res = tree_map_type(_as_field, with_path_arg=True)(arg)
+        res = type_info.tree_map_type(_as_field, with_path_arg=True)(arg)
         assert isinstance(res, ts.TypeSpec)
         return res
 
@@ -159,9 +155,9 @@ def function_signature_incompatibilities_fieldop(
 
 def _tree_map_type_constructor_drop_python_type(
     value: ts.CollectionTypeSpecT,
-    elems: NestedTuple[ts.DataType],
+    elems: Iterable[ts.DataType],
 ) -> ts.CollectionTypeSpecT:
-    result = _tree_map_type_constructor(value, elems)
+    result = type_info._tree_map_type_constructor(value, elems)
     if isinstance(value, ts.NamedCollectionType):
         result = datamodels.evolve(result, original_python_type=ts.ANY_PYTHON_TYPE_NAME)
     return result
@@ -208,7 +204,7 @@ def _scan_param_promotion(
     # the original python type in NamedCollections as we want to be able to express compatibility
     # between named collections of scalars and their structurally equivalent collection of fields.
     # Once we support generic named collections, this special case will disappear.
-    res = tree_map_type(
+    res = type_info.tree_map_type(
         _as_field,
         result_collection_constructor=_tree_map_type_constructor_drop_python_type,
         with_path_arg=True,
@@ -330,7 +326,9 @@ def return_type_scanop(
     )
     return cast(
         ts.TypeSpec,
-        tree_map_type(lambda arg: ts.FieldType(dims=promoted_dims, dtype=arg))(carry_dtype),
+        type_info.tree_map_type(lambda arg: ts.FieldType(dims=promoted_dims, dtype=arg))(
+            carry_dtype
+        ),
     )
 
 
@@ -367,7 +365,7 @@ def type_in_program_context(callable_type: ts.CallableType) -> ProgramType | ts.
             )
         )
     elif isinstance(callable_type, ts_ffront.ScanOperatorType):
-        as_deferred_type_with_same_structure = tree_map_type(
+        as_deferred_type_with_same_structure = type_info.tree_map_type(
             lambda _: ts.DeferredType(constraint=None)
         )
         scan_pass_type = callable_type.definition

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -155,7 +155,7 @@ def function_signature_incompatibilities_fieldop(
 
 def _tree_map_type_constructor_drop_python_type(
     value: ts.CollectionTypeSpecT,
-    elems: Iterable[ts.DataType],
+    elems: Iterable[ts.DataType | ts.DimensionType | ts.DeferredType],
 ) -> ts.CollectionTypeSpecT:
     result = type_info.tree_map_type_constructor(value, elems)
     if isinstance(value, ts.NamedCollectionType):

--- a/src/gt4py/next/ffront/type_info.py
+++ b/src/gt4py/next/ffront/type_info.py
@@ -19,26 +19,8 @@ from gt4py.next.ffront.type_specifications import ProgramType
 from gt4py.next.type_system import type_info
 
 
-def _tree_map_type_constructor(
-    value: ts.CollectionTypeSpecT,
-    elems: NestedTuple[ts.DataType],
-) -> ts.CollectionTypeSpecT:
-    return (
-        ts.NamedCollectionType(
-            keys=value.keys, original_python_type=value.original_python_type, types=list(elems)
-        )
-        if isinstance(value, ts.NamedCollectionType)
-        else ts.TupleType(types=list(elems))  # type: ignore[return-value]
-    )
-
-
-# TODO: Replace all occurrences of `apply_to_primitive_constituents` with this function,
-#   which also works with NamedCollections.
-tree_map_type = functools.partial(
-    utils.tree_map,
-    collection_type=ts.COLLECTION_TYPE_SPECS,
-    result_collection_constructor=_tree_map_type_constructor,
-)
+_tree_map_type_constructor = type_info._tree_map_type_constructor
+tree_map_type = type_info.tree_map_type
 
 named_collections_to_tuple_types = cast(
     Callable[..., ts.TupleType],

--- a/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
+++ b/src/gt4py/next/iterator/transforms/fuse_as_fieldop.py
@@ -164,7 +164,7 @@ def fuse_as_fieldop(
                 assert isinstance(arg.type, ts.TypeSpec)
 
                 assert not isinstance(
-                    type_info.apply_to_primitive_constituents(type_info.extract_dtype, arg.type),
+                    type_info.tree_map_type(type_info.extract_dtype)(arg.type),
                     ts.ListType,
                 )
             new_args = _merge_arguments(new_args, {stencil_param.id: arg})
@@ -215,7 +215,7 @@ def _arg_inline_predicate(node: itir.Expr, shifts: set[tuple[itir.OffsetLiteral,
         # applied fieldop with list return type must always be inlined as no backend supports this
         type_inference.reinfer(node)
         assert isinstance(node.type, ts.TypeSpec)
-        dtype = type_info.apply_to_primitive_constituents(type_info.extract_dtype, node.type)
+        dtype = type_info.tree_map_type(type_info.extract_dtype)(node.type)
         if isinstance(dtype, ts.ListType):
             return True
         # only accessed at the center location

--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -169,7 +169,7 @@ def _transform_by_pattern(
     if extracted_fields:
         tmp_stmts: list[itir.Stmt] = []
 
-        into_tuple = lambda _, elts: tuple(elts)  # noqa: E731
+        as_tuple = lambda _, elts: tuple(elts)  # noqa: E731
 
         # for each extracted expression generate:
         #  - one or more `Temporary` declarations (depending on whether the expression is a field
@@ -179,13 +179,13 @@ def _transform_by_pattern(
             assert isinstance(tmp_expr.type, ts.TypeSpec)
             tmp_names: str | tuple[str | tuple, ...] = type_info.tree_map_type(
                 lambda x: next(uids["__tmp"]),
-                result_collection_constructor=into_tuple,
+                result_collection_constructor=as_tuple,
             )(tmp_expr.type)
             tmp_dtypes: (
                 ts.ScalarType | ts.ListType | tuple[ts.ScalarType | ts.ListType | tuple, ...]
             ) = type_info.tree_map_type(
                 type_info.extract_dtype,
-                result_collection_constructor=into_tuple,
+                result_collection_constructor=as_tuple,
             )(tmp_expr.type)
 
             tmp_domains: SymbolicDomain | tuple[SymbolicDomain | tuple, ...] = tmp_expr.annex.domain
@@ -216,7 +216,7 @@ def _transform_by_pattern(
             # `tmp_domains` might not have this structure because domain inference was not able to infer the tuple structure.
             tmp_domains = type_info.tree_map_type(
                 get_domain,
-                result_collection_constructor=into_tuple,
+                result_collection_constructor=as_tuple,
                 with_path_arg=True,
             )(tmp_expr.type)
 

--- a/src/gt4py/next/iterator/transforms/global_tmps.py
+++ b/src/gt4py/next/iterator/transforms/global_tmps.py
@@ -169,24 +169,24 @@ def _transform_by_pattern(
     if extracted_fields:
         tmp_stmts: list[itir.Stmt] = []
 
+        into_tuple = lambda _, elts: tuple(elts)  # noqa: E731
+
         # for each extracted expression generate:
         #  - one or more `Temporary` declarations (depending on whether the expression is a field
         #    or a tuple thereof)
         #  - one `SetAt` statement that materializes the expression into the temporary
         for tmp_sym, tmp_expr in extracted_fields.items():
             assert isinstance(tmp_expr.type, ts.TypeSpec)
-            tmp_names: str | tuple[str | tuple, ...] = type_info.apply_to_primitive_constituents(
+            tmp_names: str | tuple[str | tuple, ...] = type_info.tree_map_type(
                 lambda x: next(uids["__tmp"]),
-                tmp_expr.type,
-                tuple_constructor=lambda *elements: tuple(elements),
-            )
+                result_collection_constructor=into_tuple,
+            )(tmp_expr.type)
             tmp_dtypes: (
                 ts.ScalarType | ts.ListType | tuple[ts.ScalarType | ts.ListType | tuple, ...]
-            ) = type_info.apply_to_primitive_constituents(
+            ) = type_info.tree_map_type(
                 type_info.extract_dtype,
-                tmp_expr.type,
-                tuple_constructor=lambda *elements: elements,
-            )
+                result_collection_constructor=into_tuple,
+            )(tmp_expr.type)
 
             tmp_domains: SymbolicDomain | tuple[SymbolicDomain | tuple, ...] = tmp_expr.annex.domain
 
@@ -214,12 +214,11 @@ def _transform_by_pattern(
 
             # The following propagates the domains to the tuple structure of `tmp_expr.type`.
             # `tmp_domains` might not have this structure because domain inference was not able to infer the tuple structure.
-            tmp_domains = type_info.apply_to_primitive_constituents(
+            tmp_domains = type_info.tree_map_type(
                 get_domain,
-                tmp_expr.type,
+                result_collection_constructor=into_tuple,
                 with_path_arg=True,
-                tuple_constructor=lambda *elements: tuple(elements),
-            )
+            )(tmp_expr.type)
 
             declarations.extend(
                 itir.Temporary(id=tmp_name, domain=domain.as_expr(), dtype=dtype)

--- a/src/gt4py/next/iterator/type_system/inference.py
+++ b/src/gt4py/next/iterator/type_system/inference.py
@@ -424,10 +424,11 @@ class ITIRTypeInference(eve.NodeTranslator):
         assert isinstance(domain, ts.DomainType)
         assert domain.dims != "unknown"
         assert node.dtype
-        return type_info.apply_to_primitive_constituents(
-            lambda dtype: ts.FieldType(dims=domain.dims, dtype=dtype),
-            node.dtype,
+        result = type_info.tree_map_type(lambda dtype: ts.FieldType(dims=domain.dims, dtype=dtype))(
+            node.dtype
         )
+        assert isinstance(result, (ts.FieldType, ts.TupleType))
+        return result
 
     def visit_IfStmt(self, node: itir.IfStmt, *, ctx) -> None:
         cond = self.visit(node.cond, ctx=ctx)

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -382,9 +382,7 @@ def _convert_as_fieldop_input_to_iterator(
     Convert a field operation input into an iterator type, preserving its dimensions and data type.
     """
     input_dims = _collect_and_check_dimensions(input_)
-    element_type: ts.DataType = type_info.apply_to_primitive_constituents(
-        type_info.extract_dtype, input_
-    )
+    element_type: ts.DataType = type_info.tree_map_type(type_info.extract_dtype)(input_)
 
     return it_ts.IteratorType(
         position_dims=domain.dims, defined_dims=input_dims, element_type=element_type
@@ -436,9 +434,7 @@ def _canonicalize_nb_fields(
             )
         case ts.FieldType():
             input_dims = _collect_and_check_dimensions(input_)
-            element_type: ts.DataType = type_info.apply_to_primitive_constituents(
-                type_info.extract_dtype, input_
-            )
+            element_type: ts.DataType = type_info.tree_map_type(type_info.extract_dtype)(input_)
             defined_dims = []
             neighbor_dim = None
             for dim in input_dims:
@@ -535,7 +531,7 @@ def as_fieldop(
         # For each stencil parameter all locations it is `deref`ed on
         #  see :func:`gt4py.next.iterator.transforms.trace_stencil`.
         shift_sequences_per_param: list[set[tuple[itir.OffsetLiteral, ...]]] | None,
-    ) -> ts.FieldType | ts.DeferredType:
+    ) -> ts.FieldType | ts.TupleType | ts.DeferredType:
         if any(
             isinstance(el, ts.DeferredType)
             for f in fields
@@ -578,13 +574,11 @@ def as_fieldop(
 
         assert isinstance(stencil_return, ts.DataType)
 
-        return type_info.apply_to_primitive_constituents(
-            lambda el_type: ts.FieldType(
-                dims=domain.dims,
-                dtype=el_type,
-            ),
-            stencil_return,
-        )
+        result = type_info.tree_map_type(
+            lambda el_type: ts.FieldType(dims=domain.dims, dtype=el_type)
+        )(stencil_return)
+        assert isinstance(result, (ts.FieldType, ts.TupleType))
+        return result
 
     return applied_as_fieldop
 

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -33,7 +33,7 @@ from gt4py.next.ffront import (
 )
 from gt4py.next.instrumentation import hook_machinery, metrics
 from gt4py.next.otf import arguments, stages
-from gt4py.next.type_system import type_specifications as ts
+from gt4py.next.type_system import type_info, type_specifications as ts
 from gt4py.next.utils import tree_map
 
 
@@ -209,7 +209,7 @@ def _make_param_context_from_func_type(
     """
     params = func_type.pos_or_kw_args | func_type.kw_only_args
     return {
-        param: ffront_type_info.tree_map_type(
+        param: type_info.tree_map_type(
             # note(tehrengruber): Mapping all collections to tuples is and must be the same as in
             #  :ref:`arguments.extract`.
             type_map,

--- a/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
@@ -235,7 +235,7 @@ def _process_elements(
     obj: Expr,
     type_: ts.TypeSpec,
     *,
-    tuple_constructor: Callable[..., Expr] = lambda _, *elements: FunCall(
+    tuple_constructor: Callable[..., Expr] = lambda _, elements: FunCall(
         fun=SymRef(id="make_tuple"), args=list(elements)
     ),
 ) -> Expr:
@@ -264,13 +264,11 @@ def _process_elements(
         )
         return process_func(el, el_type)
 
-    result = type_info.apply_to_primitive_constituents(
+    return type_info.tree_map_type(
         _gen_constituent_expr,
-        type_,
+        result_collection_constructor=tuple_constructor,
         with_path_arg=True,
-        tuple_constructor=tuple_constructor,
-    )
-    return result
+    )(type_)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -523,7 +521,7 @@ class GTFN_lowering(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
             check_el_type,
             lowered_output,
             node.type,
-            tuple_constructor=lambda *elements: SidComposite(values=list(elements)),
+            tuple_constructor=lambda _, elements: SidComposite(values=list(elements)),
         )
 
         assert isinstance(lowered_output_as_sid, (SidComposite, SymRef))
@@ -615,7 +613,7 @@ class GTFN_lowering(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
                 convert_el_to_sid,
                 lowered_input,
                 input_.type,
-                tuple_constructor=lambda *elements: SidComposite(values=list(elements)),
+                tuple_constructor=lambda _, elements: SidComposite(values=list(elements)),
             )
 
             lowered_inputs.append(lowered_input_as_sid)

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -9,23 +9,12 @@
 import functools
 import types
 from collections.abc import Callable, Iterator
-from typing import (
-    Any,
-    Generic,
-    Literal,
-    Protocol,
-    Sequence,
-    Type,
-    TypeGuard,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import Any, Literal, Sequence, Type, TypeGuard, TypeVar, cast, overload
 
 import numpy as np
 
 from gt4py.eve import extended_typing as xtyping, utils
-from gt4py.next import common
+from gt4py.next import common, utils as next_utils
 from gt4py.next.iterator.type_system import type_specifications as it_ts
 from gt4py.next.type_system import type_specifications as ts
 
@@ -143,63 +132,53 @@ def primitive_constituents(
     return utils.xiter(constituents_yielder(symbol_type, ()))  # type: ignore[return-value] # why resolved to XIterable[object]?
 
 
-_R = TypeVar("_R", covariant=True)
 _T = TypeVar("_T")
+_C = TypeVar("_C")
 
 
-class TupleConstructorType(Protocol, Generic[_R]):
-    def __call__(self, *args: Any) -> _R: ...
-
-
-def apply_to_primitive_constituents(
-    fun: Callable[..., _T],
-    *symbol_types: ts.TypeSpec,
-    with_path_arg: bool = False,
-    tuple_constructor: TupleConstructorType[_R] = lambda *elements: ts.TupleType(types=[*elements]),  # type: ignore[assignment] # probably related to https://github.com/python/mypy/issues/10854
-    _path: tuple[int, ...] = (),
-) -> _T | _R:
-    """
-    Apply function to all primitive constituents of a type.
-
-    >>> int_type = ts.ScalarType(kind=ts.ScalarKind.INT64)
-    >>> tuple_type = ts.TupleType(types=[int_type, int_type])
-    >>> print(
-    ...     apply_to_primitive_constituents(
-    ...         lambda primitive_type: ts.FieldType(dims=[], dtype=primitive_type),
-    ...         tuple_type,
-    ...     )
-    ... )
-    tuple[Field[[], int64], Field[[], int64]]
-
-    >>> apply_to_primitive_constituents(
-    ...     lambda primitive_type, path: (path, primitive_type),
-    ...     tuple_type,
-    ...     with_path_arg=True,
-    ...     tuple_constructor=lambda *elements: dict(elements),
-    ... )
-    {(0,): ScalarType(kind=<ScalarKind.INT64: 8>, shape=None), (1,): ScalarType(kind=<ScalarKind.INT64: 8>, shape=None)}
-    """
-    if isinstance(symbol_types[0], ts.TupleType):
-        assert all(isinstance(symbol_type, ts.TupleType) for symbol_type in symbol_types)
-
-        return tuple_constructor(
-            *[
-                apply_to_primitive_constituents(
-                    fun,
-                    *el_types,
-                    _path=(*_path, i),
-                    with_path_arg=with_path_arg,
-                    tuple_constructor=tuple_constructor,
-                )
-                for i, el_types in enumerate(
-                    zip(*(symbol_type.types for symbol_type in symbol_types))  # type: ignore[attr-defined]  # ensured by assert above
-                )
-            ]
+def _tree_map_type_constructor(
+    value: ts.CollectionTypeSpecT,
+    elems: xtyping.NestedTuple[ts.DataType],
+) -> ts.CollectionTypeSpecT:
+    return (
+        ts.NamedCollectionType(
+            keys=value.keys, original_python_type=value.original_python_type, types=list(elems)
         )
-    if with_path_arg:
-        return fun(*symbol_types, path=_path)
-    else:
-        return fun(*symbol_types)
+        if isinstance(value, ts.NamedCollectionType)
+        else ts.TupleType(types=list(elems))  # type: ignore[return-value]
+    )
+
+
+@overload
+def tree_map_type(
+    fun: Callable[..., _T], *, with_path_arg: bool = ..., unpack: bool = ...
+) -> Callable[..., _T | ts.CollectionTypeSpec]: ...
+
+
+@overload
+def tree_map_type(
+    fun: Callable[..., _T],
+    *,
+    result_collection_constructor: Callable[..., _C],
+    with_path_arg: bool = ...,
+    unpack: bool = ...,
+) -> Callable[..., _T | _C]: ...
+
+
+def tree_map_type(
+    fun: Callable[..., _T],
+    *,
+    result_collection_constructor: Callable[..., Any] = _tree_map_type_constructor,
+    with_path_arg: bool = False,
+    unpack: bool = False,
+) -> Callable[..., Any]:
+    return next_utils.tree_map(
+        fun,
+        collection_type=ts.COLLECTION_TYPE_SPECS,
+        result_collection_constructor=result_collection_constructor,
+        with_path_arg=with_path_arg,
+        unpack=unpack,
+    )
 
 
 def extract_dtype(symbol_type: ts.TypeSpec) -> ts.ScalarType | ts.ListType:

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -138,7 +138,7 @@ _C = TypeVar("_C")
 
 def tree_map_type_constructor(
     value: ts.CollectionTypeSpecT,
-    elems: Iterable[ts.DataType],
+    elems: Iterable[ts.DataType | ts.DimensionType | ts.DeferredType],
 ) -> ts.CollectionTypeSpecT:
     return (
         ts.NamedCollectionType(

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -136,7 +136,7 @@ _T = TypeVar("_T")
 _C = TypeVar("_C")
 
 
-def _tree_map_type_constructor(
+def tree_map_type_constructor(
     value: ts.CollectionTypeSpecT,
     elems: Iterable[ts.DataType],
 ) -> ts.CollectionTypeSpecT:
@@ -168,7 +168,7 @@ def tree_map_type(
 def tree_map_type(
     fun: Callable[..., _T],
     *,
-    result_collection_constructor: Callable[..., Any] = _tree_map_type_constructor,
+    result_collection_constructor: Callable[..., Any] = tree_map_type_constructor,
     with_path_arg: bool = False,
     unpack: bool = False,
 ) -> Callable[..., Any]:

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -8,7 +8,7 @@
 
 import functools
 import types
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any, Literal, Sequence, Type, TypeGuard, TypeVar, cast, overload
 
 import numpy as np
@@ -138,7 +138,7 @@ _C = TypeVar("_C")
 
 def _tree_map_type_constructor(
     value: ts.CollectionTypeSpecT,
-    elems: xtyping.NestedTuple[ts.DataType],
+    elems: Iterable[ts.DataType],
 ) -> ts.CollectionTypeSpecT:
     return (
         ts.NamedCollectionType(


### PR DESCRIPTION
Closes #1570

## Description

Removes `type_info.apply_to_primitive_constituents` and migrates all call sites to `tree_map_type`, completing the long-standing TODO in `ffront/type_info.py`.

- The canonical `tree_map_type` / `_tree_map_type_constructor` are moved from `ffront.type_info` down to the low-level `type_system.type_info`, so iterator- and codegen-layer call sites can use them without an upward dependency on `ffront`. All call sites (including the ones in `ffront`) reference `type_system.type_info` directly — there is no re-export.
- Unlike `apply_to_primitive_constituents` (which recursed only on `ts.TupleType` and treated `ts.NamedCollectionType` as a leaf), `tree_map_type` recurses over `COLLECTION_TYPE_SPECS` and preserves named-collection structure. This changes behavior only for `NamedCollectionType` inputs, which are lowered to plain tuples (`named_collections_to_tuple_types`) before any iterator-/codegen-stage call site — so the migrated sites are unaffected.
- `tree_map_type` is overloaded so its result type reflects the constructor's return (`_T | ts.CollectionTypeSpec` for the default, `_T | _C` for a custom `result_collection_constructor`) instead of `tree_map`'s intentionally weak return type, avoiding casts at the call sites.

Pure refactoring, no behavior change at any call site.

## Requirements

- [x] All fixes and/or new features come with corresponding tests. — behavior-preserving refactor, covered by existing suites (type system, iterator type inference, `global_tmps`, gtfn codegen, ffront type deduction).
- [ ] Important design decisions have been documented in the appropriate ADR — N/A, no user-facing design change.