### PR TITLE
fix[cartesian]: Fix format of extra flags for device compiler 

### DIFF
--- a/src/gt4py/cartesian/utils/compiler.py
+++ b/src/gt4py/cartesian/utils/compiler.py
@@ -83,7 +83,7 @@ def cxx_compiler_defaults(optimization_level: str) -> CxxCompilerDefaults:
     # Defaults
     name = CxxCompilerName.DEFAULT
     open_mp_flags = "-fopenmp"
-    cxx_flags = []
+    cxx_flags: list[str] = []
     enable_openmp = True
 
     # FMA is deactivated by default when running -O0
@@ -169,15 +169,13 @@ def gpu_configuration(optimization_level: str) -> GPUConfiguration:
         library_path = os.path.join(cuda_root, "lib64")
 
     # Default arguments for GPU source code
-    gpu_compile_flags_default = ""
+    gpu_compile_flags: list[str] = []
     if optimization_level == "0":
         # When running -O0 we deactivate FMA
-        gpu_compile_flags_default = "-fmad=false"
+        gpu_compile_flags.append("-fmad=false")
 
-    extra_cuda_compile_args = os.environ.get(
-        "GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS", gpu_compile_flags_default
-    )
-    gpu_compile_flags = extra_cuda_compile_args.split(" ") if extra_cuda_compile_args else []
+    extra_cuda_compile_args = os.environ.get("GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS", "")
+    gpu_compile_flags.extend(extra_cuda_compile_args.split(" "))
 
     return GPUConfiguration(
         name=name,

--- a/src/gt4py/cartesian/utils/compiler.py
+++ b/src/gt4py/cartesian/utils/compiler.py
@@ -137,7 +137,7 @@ class GPUCompilerName(enum.Enum):
 class GPUConfiguration:
     name: GPUCompilerName
     """Name identifier of the compiler"""
-    gpu_compile_flags: list[str]
+    gpu_compile_flags: str
     """Compile flags for device code"""
     binary_path: str
     """Path to binaries for GPU compiler & tools"""
@@ -179,7 +179,7 @@ def gpu_configuration(optimization_level: str) -> GPUConfiguration:
 
     return GPUConfiguration(
         name=name,
-        gpu_compile_flags=gpu_compile_flags,
+        gpu_compile_flags=" ".join(gpu_compile_flags).strip(),
         binary_path=os.path.join(cuda_root, "bin"),
         include_path=os.path.join(cuda_root, "include"),
         library_path=library_path,

--- a/src/gt4py/cartesian/utils/compiler.py
+++ b/src/gt4py/cartesian/utils/compiler.py
@@ -137,7 +137,7 @@ class GPUCompilerName(enum.Enum):
 class GPUConfiguration:
     name: GPUCompilerName
     """Name identifier of the compiler"""
-    gpu_compile_flags: str
+    gpu_compile_flags: list[str]
     """Compile flags for device code"""
     binary_path: str
     """Path to binaries for GPU compiler & tools"""
@@ -181,7 +181,7 @@ def gpu_configuration(optimization_level: str) -> GPUConfiguration:
 
     return GPUConfiguration(
         name=name,
-        gpu_compile_flags=" ".join(gpu_compile_flags).strip(),
+        gpu_compile_flags=gpu_compile_flags,
         binary_path=os.path.join(cuda_root, "bin"),
         include_path=os.path.join(cuda_root, "include"),
         library_path=library_path,

--- a/src/gt4py/cartesian/utils/compiler.py
+++ b/src/gt4py/cartesian/utils/compiler.py
@@ -137,7 +137,7 @@ class GPUCompilerName(enum.Enum):
 class GPUConfiguration:
     name: GPUCompilerName
     """Name identifier of the compiler"""
-    gpu_compile_flags: str
+    gpu_compile_flags: list[str]
     """Compile flags for device code"""
     binary_path: str
     """Path to binaries for GPU compiler & tools"""
@@ -179,7 +179,8 @@ def gpu_configuration(optimization_level: str) -> GPUConfiguration:
 
     return GPUConfiguration(
         name=name,
-        gpu_compile_flags=" ".join(gpu_compile_flags).strip(),
+        # strip any leading/trailing whitespace and filter empty flags
+        gpu_compile_flags=[flag.strip() for flag in gpu_compile_flags if len(flag.strip()) > 0],
         binary_path=os.path.join(cuda_root, "bin"),
         include_path=os.path.join(cuda_root, "include"),
         library_path=library_path,

--- a/tests/cartesian_tests/unit_tests/test_compiler.py
+++ b/tests/cartesian_tests/unit_tests/test_compiler.py
@@ -41,6 +41,8 @@ def extra_cuda_args(request) -> Generator[Any, None, None]:
 def test_gpu_configuration(optimization_level: str) -> None:
     config = gpu_configuration(optimization_level)
 
+    assert isinstance(config.gpu_compile_flags, str)
+
     if optimization_level == "0":
         assert "-fmad=false" in config.gpu_compile_flags
 

--- a/tests/cartesian_tests/unit_tests/test_compiler.py
+++ b/tests/cartesian_tests/unit_tests/test_compiler.py
@@ -41,11 +41,15 @@ def extra_cuda_args(request) -> Generator[Any, None, None]:
 def test_gpu_configuration(optimization_level: str) -> None:
     config = gpu_configuration(optimization_level)
 
-    assert isinstance(config.gpu_compile_flags, str)
+    assert isinstance(config.gpu_compile_flags, list)
+    for flag in config.gpu_compile_flags:
+        assert len(flag) > 0
+        assert flag.strip() == flag
 
     if optimization_level == "0":
         assert "-fmad=false" in config.gpu_compile_flags
 
     extra_args = os.environ.get("GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS", "").split(" ")
     for arg in extra_args:
-        assert arg in config.gpu_compile_flags
+        if len(arg.strip()) > 0:
+            assert arg in config.gpu_compile_flags

--- a/tests/cartesian_tests/unit_tests/test_compiler.py
+++ b/tests/cartesian_tests/unit_tests/test_compiler.py
@@ -1,0 +1,49 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Generator, Any
+
+import pytest
+import os
+
+from gt4py.cartesian.utils.compiler import gpu_configuration
+
+
+@pytest.fixture(
+    scope="function",
+    autouse=True,
+    params=[
+        pytest.param("", id="no-extra-args"),
+        pytest.param("arg1 arg2", id="extra-args"),
+    ],
+)
+def extra_cuda_args(request) -> Generator[Any, None, None]:
+    # keep a snapshot of old state
+    old_extra_args = os.environ.get("GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS", "")
+
+    # run test with extra args
+    os.environ["GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS"] = request.param
+    yield
+
+    # reset old state
+    if old_extra_args:
+        os.environ["GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS"] = old_extra_args
+    else:
+        del os.environ["GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS"]
+
+
+@pytest.mark.parametrize("optimization_level", ["0", "1", "2", "3", "s"])
+def test_gpu_configuration(optimization_level: str) -> None:
+    config = gpu_configuration(optimization_level)
+
+    if optimization_level == "0":
+        assert "-fmad=false" in config.gpu_compile_flags
+
+    extra_args = os.environ.get("GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS", "").split(" ")
+    for arg in extra_args:
+        assert arg in config.gpu_compile_flags


### PR DESCRIPTION
## Description

CFlags for device code is a list, as expected later by GT stencil compiler.

Cherry-picked from https://github.com/romanc/gt4py/tree/romanc/fix-log10-precision.

- [x] Comes with a unit tests with `GT4PY_CARTESIAN_EXTRA_CUDA_COMPILE_ARGS`