### PR TITLE
fix[next]: Better error when scan state and return don't agree.

### DIFF
--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -249,15 +249,15 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         new_definition = self.visit(node.definition, **kwargs)
         new_def_type = new_definition.type
-        carry_type = next(iter(new_def_type.pos_or_kw_args.values()))
-        if new_init.type != new_def_type.returns:
+        carry_arg_name = next(iter(new_def_type.pos_or_kw_args.keys()))
+        carry_type = new_def_type.pos_or_kw_args[carry_arg_name]
+        if carry_type != new_def_type.returns:
             raise errors.DSLError(
                 node.location,
-                f"Argument 'init' to scan operator '{node.id}' must have same type as its return: "
-                f"expected '{new_def_type.returns}', got '{new_init.type}'.",
+                f"Argument '{carry_arg_name}' to scan operator '{node.id}' must have same type as its return: "
+                f"expected '{new_def_type.returns}', got '{carry_type}'.",
             )
         elif new_init.type != carry_type:
-            carry_arg_name = next(iter(new_def_type.pos_or_kw_args.keys()))
             raise errors.DSLError(
                 node.location,
                 f"Argument 'init' to scan operator '{node.id}' must have same type as '{carry_arg_name}' argument: "

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -249,6 +249,11 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             )
         new_definition = self.visit(node.definition, **kwargs)
         new_def_type = new_definition.type
+        if not new_def_type.pos_or_kw_args:
+            raise errors.DSLError(
+                node.location,
+                f"Scan operator '{node.id}' must have at least one argument (the carry).",
+            )
         carry_arg_name = next(iter(new_def_type.pos_or_kw_args.keys()))
         carry_type = new_def_type.pos_or_kw_args[carry_arg_name]
         if carry_type != new_def_type.returns:

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -242,6 +242,18 @@ def test_scan_wrong_init_type(cartesian_case):
             testee_scan(qc, param_1, param_2, scalar, out=(qc, param_1, param_2))
 
 
+@pytest.mark.uses_scan
+def test_scan_without_carry(cartesian_case):
+    with pytest.raises(
+        errors.DSLError,
+        match=r"Scan operator 'testee_scan' must have at least one argument",
+    ):
+
+        @scan_operator(axis=KDim, forward=True, init=0)
+        def testee_scan() -> float:
+            return 1.0
+
+
 @pytest.fixture
 def bound_args_testee():
     @field_operator

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_arg_call_interface.py
@@ -210,7 +210,9 @@ def test_call_scan_operator_from_program(cartesian_case):
 def test_scan_wrong_return_type(cartesian_case):
     with pytest.raises(
         errors.DSLError,
-        match=(r"Argument 'init' to scan operator 'testee_scan' must have same type as its return"),
+        match=(
+            r"Argument 'state' to scan operator 'testee_scan' must have same type as its return"
+        ),
     ):
 
         @scan_operator(axis=KDim, forward=True, init=0)
@@ -223,7 +225,7 @@ def test_scan_wrong_return_type(cartesian_case):
 
 
 @pytest.mark.uses_scan
-def test_scan_wrong_state_type(cartesian_case):
+def test_scan_wrong_init_type(cartesian_case):
     with pytest.raises(
         errors.DSLError,
         match=(
@@ -232,8 +234,8 @@ def test_scan_wrong_state_type(cartesian_case):
     ):
 
         @scan_operator(axis=KDim, forward=True, init=0)
-        def testee_scan(state: float) -> int32:
-            return 1
+        def testee_scan(state: float) -> float:
+            return 1.0
 
         @program
         def testee(qc: cases.IKFloatField, param_1: int32, param_2: float, scalar: float):


### PR DESCRIPTION
Closes #932.

Scan operators raise at the FOAST level when the carry argument type and the return type disagree, pointing at the carry argument instead of (misleadingly) blaming `init`. The `init`-vs-carry mismatch keeps its own message.