### PR TITLE
refactor[cartesian]: remove unused function argument

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -350,7 +350,6 @@ class OIRToTreeIR(eve.NodeVisitor):
                         param,
                         field_without_mask_extents[param.name],
                         k_bound,
-                        symbols,
                     ),
                     strides=get_dace_strides(param, symbols),
                     storage=DEFAULT_STORAGE_TYPE[self._device_type],
@@ -374,7 +373,7 @@ class OIRToTreeIR(eve.NodeVisitor):
             # than persistent will yield issues with memory leaks.
             containers[field.name] = data.Array(
                 dtype=utils.data_type_to_dace_typeclass(field.dtype),
-                shape=get_dace_shape(field, field_extent, k_bound, symbols),
+                shape=get_dace_shape(field, field_extent, k_bound),
                 strides=get_dace_strides(field, symbols),
                 transient=True,
                 lifetime=dtypes.AllocationLifetime.Persistent,
@@ -532,7 +531,6 @@ def get_dace_shape(
     field: oir.FieldDecl,
     extent: definitions.Extent,
     k_bound: tuple[int, int],
-    symbols: tir.SymbolDict,
 ) -> list[symbolic.symbol]:
     shape = []
     for index, axis in enumerate(tir.Axis.dims_3d()):

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_suites.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_suites.py
@@ -800,10 +800,7 @@ class TestVariableKAndReadOutside(gt_testing.StencilTestSuite):
 
     def definition(field_in, field_out, index):
         with computation(PARALLEL), interval(1, None):
-            field_out[0, 0, 0] = (
-                field_in[0, 0, index]  # noqa: F841 [unused-variable]
-                + field_in[0, 0, -2]
-            )
+            field_out[0, 0, 0] = field_in[0, 0, index] + field_in[0, 0, -2]
 
     def validation(field_in, field_out, index, *, domain, origin):
         idx = 1 + (np.arange(domain[-1]) + index)[1:]


### PR DESCRIPTION
## Description

Small cleanup to remove an unused function argument in `get_dace_shape()` of `oir_to_treeir.py`.

Pulled out from https://github.com/GridTools/gt4py/pull/2595.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing tests.