### PR TITLE
feat[cartesian]: Make `dace` gpu backend unit-aligned

### DIFF
--- a/src/gt4py/storage/cartesian/layout_registry.py
+++ b/src/gt4py/storage/cartesian/layout_registry.py
@@ -60,7 +60,7 @@ register(
 register(
     "dace:gpu",
     LayoutInfo(
-        alignment=32,
+        alignment=1,
         device="gpu",
         layout_map=layout_maker_factory((2, 1, 0)),
         is_optimal_layout=layout_checker_factory(layout_maker_factory((2, 1, 0))),
@@ -69,7 +69,7 @@ register(
 register(
     "dace:gpu_IJK",
     LayoutInfo(
-        alignment=32,
+        alignment=1,
         device="gpu",
         layout_map=layout_maker_factory((0, 1, 2)),
         is_optimal_layout=layout_checker_factory(layout_maker_factory((0, 1, 2))),


### PR DESCRIPTION
## Description

Previous decision was to make the GPU backend 32-bit aligned to help with auto-vectorization. With more modern hardware it's not as crucial _and_ it gets in the way of mapping to Fortran-style memory allocation.

We propose to make `dace:gpu` and `dace:gpu_IJK` unit aligned to allow memory mapping but also have a small reduction on memory impact.

Current tests should cover this.