### PR TITLE
feat[next]: Friendly error messages

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -93,6 +93,8 @@ raise TypeError(f"Wrong argument type: 'int' expected, got '{type(arg)}'")
 
 The terseness vs. helpfulness tradeoff should be more in favor of terseness for internal error messages and more in favor of helpfulness for `DSLError` and it's subclassses, where additional sentences are encouraged if they point out likely hidden sources of the problem or common fixes.
 
+For `gt4py.next` user-facing DSL diagnostics (`DSLError` and subclasses), see [`docs/development/next/error-messages.md`](docs/development/next/error-messages.md): it covers structured diagnostics (source spans, notes, hints), the unsupported-construct catalogue, and the regression-test requirement.
+
 ### Docstrings
 
 We generate the API documentation automatically from the docstrings using [Sphinx] and some extensions such as [Sphinx-autodoc] and [Sphinx-napoleon]. These follow the Google Python Style Guide docstring conventions to automatically format the generated documentation. A complete overview can be found here: [Example Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).

--- a/docs/development/next/error-messages.md
+++ b/docs/development/next/error-messages.md
@@ -1,0 +1,214 @@
+# GT4Py DSL Error Messages — Authoring Guide
+
+How to write user-facing DSL diagnostics (`DSLError` and its subclasses) in
+`gt4py.next`. For the base error-message style (sentences, single-quoted code
+objects, terseness) see
+[`CODING_GUIDELINES.md`](../../../CODING_GUIDELINES.md#error-messages); this
+guide covers the structured-diagnostic layer on top.
+
+## Internal error vs. DSL diagnostic — pick the right tool
+
+- **Internal / library error** (a precondition an end user can't reach, a bug,
+  a misuse of an internal API) → raise a builtin (`ValueError`, `TypeError`,
+  …).
+- **DSL diagnostic** (the user wrote a field operator / program that GT4Py
+  rejects) → raise `DSLError` or a subclass with a `SourceLocation` and, where
+  you have it, structured payload (label, related spans, notes, hints). The
+  user is learning the DSL's rules, not debugging GT4Py.
+
+A `DSLError` without a usable `location` is a smell — the user gets a message
+with no pointer into their code. Thread a `SourceLocation` through.
+
+## What a good diagnostic does
+
+1. **Carries structured data, not strings.** Put the message, primary span,
+   caret label, related spans, notes, and hints in their `DSLError` fields and
+   let the renderer lay them out; don't bake spans or hints into the message
+   string. Rendering is a single-owner concern (see
+   [Architecture reference](#architecture-reference)).
+2. **Points at the smallest offending span.** Put the caret under the part
+   that is wrong; describe other contributing code (e.g. the other operand of
+   a type mismatch) as a `related` span, not in the headline.
+3. **Says what to do, not only what is wrong.** Give a `Hint:` that names the
+   supported alternative (`where(...)`, `astype(...)`, `scan_operator`,
+   `&` / `|`).
+4. **Keeps compiler internals out of the headline.** Say `'while' loop`, not
+   `ast.While`; raw internal names are only the last-resort fallback for
+   constructs that are not catalogued yet.
+5. **Uses the familiar Python header.** The renderer keeps the
+   `File "...", line N` line that terminals and IDEs linkify and adds a
+   line-number gutter and carets beneath it — don't invent a new header.
+6. **Is pinned by a test.** Every diagnostic has a bad program plus an
+   assertion on its rendered text in
+   `tests/next_tests/unit_tests/ffront_tests/test_diagnostic_messages.py`. An
+   unpinned diagnostic rots.
+
+## The `DSLError` data model
+
+`DSLError` (in `gt4py.next.errors.exceptions`) is the single user-facing error
+type — both the exception that flows through `raise` and the structured
+diagnostic the renderer consumes. `DSLError(location, message)` still works;
+the structured fields are all optional keyword arguments:
+
+| field      | kind              | purpose                                                             |
+| ---------- | ----------------- | ------------------------------------------------------------------- |
+| `location` | `SourceLocation`  | primary span; where the carets go                                   |
+| `message`  | `str`             | the headline sentence (`super().__init__(message)`)                 |
+| `label`    | `str`             | short fragment printed right after the carets ("this has type '…'") |
+| `related`  | `(loc, str)` list | secondary labeled spans (e.g. the *other* operand of a mismatch)    |
+| `notes`    | `str` list        | `Note:` — facts, *why* it's an error                                |
+| `hints`    | `str` list        | `Hint:` — commands, *what to do instead*                            |
+| `code`     | `ClassVar[str]`   | stable category slug (`"undefined-symbol"`), set per subclass       |
+
+Keep `notes` and `hints` distinct: a note states a fact ("GT4Py does not
+implicitly convert between datatypes."), a hint gives an action ("Convert one
+operand explicitly, e.g. 'astype(<expr>, float64)'."). Set `code` on the
+subclass, not per call site — the category belongs to the error class and
+gives tooling and documentation a stable handle.
+
+Build the message in the subclass so call sites pass meaning, not prose:
+`UndefinedSymbolError(loc, name, candidates=...)` computes its own
+"Did you mean …?" hint (via `difflib.get_close_matches`); the caller only
+supplies the candidate set it has at hand.
+
+## How to add or improve a diagnostic
+
+Pick the row that matches what you're doing.
+
+### 1. A newly rejected Python construct
+
+Add one entry to `_UNSUPPORTED_FEATURE_HINTS` in `ffront/dialect_parser.py`,
+keyed by the `ast` node type:
+
+```python
+ast.Match: ("'match' statement", ("Use 'if'/'elif' chains or 'where' instead.",)),
+```
+
+Name the construct as the *user* spells it (`"'match' statement"`, not
+`ast.Match`) and give one actionable hint naming the closest supported
+alternative. `DialectParser.generic_visit` consults the table and falls back
+to the qualified `ast` class name for unlisted nodes, so the table grows
+incrementally and nothing regresses when CPython adds node types. Every entry
+also gets the uniform note "Only a subset of Python is valid inside GT4Py
+functions." Adding a construct is one dict entry plus one test — no renderer or
+exception changes.
+
+### 2. A richer message at an existing `raise errors.DSLError(...)`
+
+Add `label=`, `related=`, `notes=`, `hints=` keyword arguments. Do **not**
+encode that information into the message string — the renderer places each
+field deliberately (label after the carets, related spans as their own
+underline rows, notes/hints as wrapped trailing lines).
+
+### 3. A new error category
+
+Subclass `DSLError`, set `code`, and build the message and hints in
+`__init__` from semantic arguments (as `UndefinedSymbolError` does). Export it
+from `errors/__init__.py`.
+
+### 4. Late context from a later toolchain stage
+
+Attach context to an in-flight error without rewriting its message, using the
+standard `add_note` API (PEP 678):
+
+```python
+try:
+    foast_node = FieldOperatorTypeDeduction.apply(untyped_foast_node)
+except errors.DSLError as err:
+    err.add_note(f"While processing the definition of '{name}'.")
+    raise
+```
+
+`DSLError.add_note` overrides `BaseException.add_note` to route the note into
+the structured `notes` field instead of `__notes__`: the traceback machinery
+(and therefore pytest and IPython/Jupyter) prints the exception via
+`str(err)`, which already renders the structured notes, so writing `__notes__`
+as well would duplicate them. The seam is wired at `func_to_foast`
+(`ffront/func_to_foast.py`); add it at later stages as they gain useful
+context.
+
+### 5. Always: a test
+
+Add a bad program plus an assertion on the rendered text in
+`test_diagnostic_messages.py`. The test is the spec; it is what keeps message
+quality from regressing.
+
+## Style
+
+Beyond the base style in
+[`CODING_GUIDELINES.md`](../../../CODING_GUIDELINES.md#error-messages):
+
+- **Labels are sentence fragments** — they continue the caret line, so no
+  trailing period ("not defined at this point", "this has type 'bool'").
+  Messages, notes, and hints stay full sentences.
+- Keep the headline to one sentence; push the *why* into a `Note:` and the
+  *fix* into a `Hint:` rather than growing the headline.
+
+## Examples
+
+Rendered output (`str(err)`). Diagnostics raised through `@field_operator`
+also carry the `While processing the definition of '<name>'.` note from the
+toolchain seam, omitted here for brevity.
+
+**Undefined symbol** (`UndefinedSymbolError` with a candidate set):
+
+```
+Undeclared symbol 'tmp_feild'.
+  File "/tmp/demo.py", line 11
+    11 |         return tmp_feild
+       |                ^^^^^^^^^ not defined at this point
+  Hint: Did you mean 'tmp_field'?
+```
+
+**Unsupported construct** (a catalogue entry):
+
+```
+Unsupported Python syntax: 'while' loop.
+  File "/tmp/demo.py", line 21
+    21 |         while True:
+       |         ^^^^^^^^^^^
+  Note: Only a subset of Python is valid inside GT4Py functions.
+  Hint: GT4Py functions describe operations on whole fields without explicit loops. For
+    sequential dependencies along a dimension, use a 'scan_operator'.
+```
+
+**Arithmetic with a boolean mask** (`label` on the bad operand, `related` on
+the other, plus a `hint`):
+
+```
+Unsupported operand type(s) for +: 'Field[[IDim], float64]' and 'Field[[IDim], bool]'.
+  File "/tmp/demo.py", line 44
+    44 |         return a + mask
+       |                    ^^^^ '+' expects arithmetic operands, but this has type 'Field[[IDim], bool]'
+       |                - the other operand has type 'Field[[IDim], float64]'
+  Hint: To select values based on a boolean mask, use 'where(mask, a, b)'. To compute
+    with a boolean field, convert it explicitly, e.g. 'astype(mask, int32)'.
+```
+
+## Architecture reference
+
+- **Rendering has one owner:** `format_diagnostic_parts` in
+  `errors/formatting.py`, to which both `DSLError.__str__` and the excepthook
+  delegate. It draws the line-number gutter and carets, merges a same-line
+  `related` span into the primary snippet as a `-` underline row, caps
+  multi-line spans at three source lines, wraps notes/hints at 88 columns, and
+  falls back to the bare `File "...", line N` header when source text is
+  unavailable (REPL, garbage-collected notebook cell) — never crashing, never
+  showing a wrong snippet. New presentation behavior belongs here, not at call
+  sites.
+- **The unsupported-subset catalogue** is `_UNSUPPORTED_FEATURE_HINTS` in
+  `ffront/dialect_parser.py` (see recipe step 1).
+
+## Python-version caveat
+
+The supported floor is Python 3.10, so the diagnostics code carries a few
+forward-compat shims; respect them:
+
+- Import `Self` from `gt4py.eve.extended_typing`, not `typing` (3.11+ only).
+- `DSLError.add_note` works on every Python because `DSLError` defines it;
+  don't rely on `add_note` for *other* `GT4PyError`s — it is a builtin only on
+  3.11+.
+- The catalogue must not reference `ast` nodes added after 3.10 (e.g.
+  `ast.TryStar`) unconditionally — that breaks import on 3.10.
+
+These spots are flagged with `TODO(havogt)`.

--- a/src/gt4py/next/AGENTS.md
+++ b/src/gt4py/next/AGENTS.md
@@ -35,7 +35,11 @@ field operators / programs (ffront)
   `dace` (DaCe SDFG), `roundtrip` / `double_roundtrip` (pure Python).
 - `type_system/` — `next` type specifications and the type inference the
   frontend runs.
-- `errors/` — user-facing DSL error formatting.
+- `errors/` — user-facing DSL error formatting. When raising or improving a
+  `DSLError`, follow
+  [`docs/development/next/error-messages.md`](../../../docs/development/next/error-messages.md)
+  (structured diagnostics: spans, notes, hints, the unsupported-construct
+  catalogue, and the UI-test requirement).
 
 ## Conventions specific to next
 

--- a/src/gt4py/next/errors/excepthook.py
+++ b/src/gt4py/next/errors/excepthook.py
@@ -24,12 +24,17 @@ from gt4py.next.errors import exceptions, formatting
 
 
 def _format_uncaught_error(err: exceptions.DSLError, verbose_exceptions: bool) -> list[str]:
-    if verbose_exceptions:
-        return formatting.format_compilation_error(
-            type(err), err.message, err.location, err.__traceback__, err.__cause__
-        )
-    else:
-        return formatting.format_compilation_error(type(err), err.message, err.location)
+    return formatting.format_compilation_error(
+        type(err),
+        err.message,
+        err.location,
+        err.__traceback__ if verbose_exceptions else None,
+        err.__cause__ if verbose_exceptions else None,
+        label=err.label,
+        related=err.related,
+        notes=err.notes,
+        hints=err.hints,
+    )
 
 
 def compilation_error_hook(

--- a/src/gt4py/next/errors/excepthook.py
+++ b/src/gt4py/next/errors/excepthook.py
@@ -50,6 +50,9 @@ def compilation_error_hook(
     # in hard crashes of the interpreter, the `exceptions` module might be partially unloaded
     if exceptions.DSLError is not None and isinstance(value, exceptions.DSLError):
         exc_strs = _format_uncaught_error(value, config.VERBOSE_EXCEPTIONS)
+        # Our hook replaces the default, so we render PEP 678 '__notes__'
+        # ('add_note' breadcrumbs) ourselves instead of the traceback machinery.
+        exc_strs += [f"\n{note}" for note in getattr(value, "__notes__", [])]
         print("".join(exc_strs), file=sys.stderr)
     else:
         fallback(type_, value, tb)

--- a/src/gt4py/next/errors/exceptions.py
+++ b/src/gt4py/next/errors/exceptions.py
@@ -20,6 +20,7 @@ in that submodule as opposed to being in this file.
 from __future__ import annotations
 
 import difflib
+import sys
 from typing import Any, ClassVar, Iterable, Optional, Sequence
 
 from gt4py.eve import SourceLocation
@@ -94,26 +95,18 @@ class DSLError(GT4PyError):
         self.location = location
         return self
 
-    # TODO(havogt): on Python >=3.11 this shadows 'BaseException.add_note' (PEP 678);
-    #  on 3.10 it is a plain new method, so 'add_note' on GT4Py exceptions that are
-    #  not 'DSLError's raises 'AttributeError' on 3.10 but silently goes to
-    #  '__notes__' on 3.11+. Remove this caveat once the Python floor is >=3.12.
-    def add_note(self, note: str) -> None:
-        """
-        Add a note to the diagnostic, using the standard 'BaseException.add_note' API.
+    # TODO(havogt): drop this shim and the matching '__notes__' fold-in in
+    #  '__str__' once the Python floor is >=3.11, where 'BaseException.add_note'
+    #  (PEP 678) and its automatic '__notes__' traceback rendering are built in.
+    if sys.version_info < (3, 11):
 
-        Toolchain stages use this to attach context to an in-flight error
-        ("While processing ...") without touching the message.
-
-        The note is routed into the structured 'notes' field instead of
-        '__notes__': the traceback machinery (and IPython/pytest) renders this
-        exception through 'str()', which already includes the structured notes,
-        so storing them in '__notes__' as well would print them twice.
-        """
-        self.notes.append(note)
+        def add_note(self, note: str) -> None:
+            if not hasattr(self, "__notes__"):
+                self.__notes__ = []
+            self.__notes__.append(note)
 
     def __str__(self) -> str:
-        return formatting.format_diagnostic_parts(
+        body = formatting.format_diagnostic_parts(
             self.message,
             self.location,
             label=self.label,
@@ -121,6 +114,12 @@ class DSLError(GT4PyError):
             notes=self.notes,
             hints=self.hints,
         )
+        if sys.version_info < (3, 11):
+            # On 3.10 the traceback machinery doesn't render '__notes__'; fold
+            # them in so they surface through 'str()' (pytest, IPython, logging)
+            # the way the >=3.11 machinery does automatically.
+            body += "".join(f"\n{note}" for note in getattr(self, "__notes__", []))
+        return body
 
 
 class UnsupportedPythonFeatureError(DSLError):

--- a/src/gt4py/next/errors/exceptions.py
+++ b/src/gt4py/next/errors/exceptions.py
@@ -19,10 +19,13 @@ in that submodule as opposed to being in this file.
 
 from __future__ import annotations
 
-import textwrap
-from typing import Any, Optional
+import difflib
+from typing import Any, ClassVar, Iterable, Optional, Sequence
 
 from gt4py.eve import SourceLocation
+
+# TODO(havogt): import 'Self' from 'typing' directly once the Python floor is >=3.12.
+from gt4py.eve.extended_typing import Self
 from gt4py.next.errors import formatting
 
 
@@ -32,37 +35,130 @@ class GT4PyError(Exception):
         return self.args[0]
 
 
-class DSLError(GT4PyError):
-    location: Optional[SourceLocation]
+def _did_you_mean(name: str, candidates: Iterable[str]) -> list[str]:
+    """Produce a 'Did you mean ...?' hint if `name` closely matches any candidate."""
+    # Never suggest the name the user already wrote (it can appear among the
+    # candidates as a same-named symbol from another SSA generation).
+    matches = difflib.get_close_matches(name, [c for c in candidates if c != name], n=3, cutoff=0.6)
+    if not matches:
+        return []
+    return [f"Did you mean {' or '.join(f'{m!r}' for m in matches)}?"]
 
-    def __init__(self, location: Optional[SourceLocation], message: str) -> None:
+
+class DSLError(GT4PyError):
+    """
+    Error in user code of one of the GT4Py-embedded DSLs.
+
+    Besides the message and the primary source location, a diagnostic can carry
+    optional structured payload that the formatter renders for the user:
+
+    - ``label``: short text printed right after the carets, qualifying the
+      marked code (e.g. "this has type 'bool'").
+    - ``related``: further (location, message) pairs that contribute to the
+      error (e.g. the other operand of a type mismatch).
+    - ``notes``: factual background ("Note: ..."), explaining *why* this is an
+      error.
+    - ``hints``: actionable advice ("Hint: ..."), telling the user what to do
+      instead.
+    - ``code``: a stable, machine-readable identifier of the error category,
+      set per subclass; intended for searching documentation and for tooling.
+    """
+
+    code: ClassVar[Optional[str]] = None
+
+    location: Optional[SourceLocation]
+    label: Optional[str]
+    related: list[tuple[SourceLocation, str]]
+    notes: list[str]
+    hints: list[str]
+
+    def __init__(
+        self,
+        location: Optional[SourceLocation],
+        message: str,
+        *,
+        label: Optional[str] = None,
+        related: Sequence[tuple[SourceLocation, str]] = (),
+        notes: Sequence[str] = (),
+        hints: Sequence[str] = (),
+    ) -> None:
         self.location = location
+        self.label = label
+        self.related = list(related)
+        self.notes = list(notes)
+        self.hints = list(hints)
         super().__init__(message)
 
-    def with_location(self, location: Optional[SourceLocation]) -> DSLError:
+    def with_location(self, location: Optional[SourceLocation]) -> Self:
         self.location = location
         return self
 
+    # TODO(havogt): on Python >=3.11 this shadows 'BaseException.add_note' (PEP 678);
+    #  on 3.10 it is a plain new method, so 'add_note' on GT4Py exceptions that are
+    #  not 'DSLError's raises 'AttributeError' on 3.10 but silently goes to
+    #  '__notes__' on 3.11+. Remove this caveat once the Python floor is >=3.12.
+    def add_note(self, note: str) -> None:
+        """
+        Add a note to the diagnostic, using the standard 'BaseException.add_note' API.
+
+        Toolchain stages use this to attach context to an in-flight error
+        ("While processing ...") without touching the message.
+
+        The note is routed into the structured 'notes' field instead of
+        '__notes__': the traceback machinery (and IPython/pytest) renders this
+        exception through 'str()', which already includes the structured notes,
+        so storing them in '__notes__' as well would print them twice.
+        """
+        self.notes.append(note)
+
     def __str__(self) -> str:
-        if self.location:
-            loc_str = formatting.format_location(self.location, show_caret=True)
-            return f"{self.message}\n{textwrap.indent(loc_str, '  ')}"
-        return self.message
+        return formatting.format_diagnostic_parts(
+            self.message,
+            self.location,
+            label=self.label,
+            related=self.related,
+            notes=self.notes,
+            hints=self.hints,
+        )
 
 
 class UnsupportedPythonFeatureError(DSLError):
+    code = "unsupported-syntax"
+
     feature: str
 
-    def __init__(self, location: Optional[SourceLocation], feature: str) -> None:
-        super().__init__(location, f"Unsupported Python syntax: '{feature}'.")
+    def __init__(
+        self,
+        location: Optional[SourceLocation],
+        feature: str,
+        *,
+        notes: Sequence[str] = (),
+        hints: Sequence[str] = (),
+    ) -> None:
+        super().__init__(
+            location, f"Unsupported Python syntax: {feature}.", notes=notes, hints=hints
+        )
         self.feature = feature
 
 
 class UndefinedSymbolError(DSLError):
+    code = "undefined-symbol"
+
     sym_name: str
 
-    def __init__(self, location: Optional[SourceLocation], name: str) -> None:
-        super().__init__(location, f"Name '{name}' is not defined.")
+    def __init__(
+        self,
+        location: Optional[SourceLocation],
+        name: str,
+        *,
+        candidates: Iterable[str] = (),
+    ) -> None:
+        super().__init__(
+            location,
+            f"Undeclared symbol '{name}'.",
+            label="not defined at this point",
+            hints=_did_you_mean(name, candidates),
+        )
         self.sym_name = name
 
 

--- a/src/gt4py/next/errors/exceptions.py
+++ b/src/gt4py/next/errors/exceptions.py
@@ -50,18 +50,19 @@ class DSLError(GT4PyError):
     Error in user code of one of the GT4Py-embedded DSLs.
 
     Besides the message and the primary source location, a diagnostic can carry
-    optional structured payload that the formatter renders for the user:
+    optional structured payload that the formatter renders for the user.
 
-    - ``label``: short text printed right after the carets, qualifying the
-      marked code (e.g. "this has type 'bool'").
-    - ``related``: further (location, message) pairs that contribute to the
-      error (e.g. the other operand of a type mismatch).
-    - ``notes``: factual background ("Note: ..."), explaining *why* this is an
-      error.
-    - ``hints``: actionable advice ("Hint: ..."), telling the user what to do
-      instead.
-    - ``code``: a stable, machine-readable identifier of the error category,
-      set per subclass; intended for searching documentation and for tooling.
+    Attributes:
+        label: Short text printed right after the carets, qualifying the marked
+            code (e.g. "this has type 'bool'").
+        related: Further (location, message) pairs that contribute to the error
+            (e.g. the other operand of a type mismatch).
+        notes: Factual background ("Note: ..."), explaining why this is an
+            error.
+        hints: Actionable advice ("Hint: ..."), telling the user what to do
+            instead.
+        code: A stable, machine-readable identifier of the error category, set
+            per subclass; intended for searching documentation and for tooling.
     """
 
     code: ClassVar[Optional[str]] = None

--- a/src/gt4py/next/errors/exceptions.py
+++ b/src/gt4py/next/errors/exceptions.py
@@ -124,7 +124,7 @@ class DSLError(GT4PyError):
 
 
 class UnsupportedPythonFeatureError(DSLError):
-    code = "unsupported-syntax"
+    code: ClassVar[str] = "unsupported-syntax"
 
     feature: str
 
@@ -143,7 +143,7 @@ class UnsupportedPythonFeatureError(DSLError):
 
 
 class UndefinedSymbolError(DSLError):
-    code = "undefined-symbol"
+    code: ClassVar[str] = "undefined-symbol"
 
     sym_name: str
 

--- a/src/gt4py/next/errors/formatting.py
+++ b/src/gt4py/next/errors/formatting.py
@@ -14,7 +14,7 @@ import linecache
 import textwrap
 import traceback
 import types
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING, Final, Optional, Sequence, TypeAlias
 
 from gt4py.eve import SourceLocation
 
@@ -23,11 +23,11 @@ if TYPE_CHECKING:
     from gt4py.next.errors import exceptions
 
 #: Maximum number of source lines rendered for a multi-line location.
-_MAX_SNIPPET_LINES = 3
+_MAX_SNIPPET_LINES: Final = 3
 
 
 #: An underline row below the first snippet line: (column, end_column, label).
-_UnderlineRow = tuple[int, Optional[int], str]
+_UnderlineRow: TypeAlias = tuple[int, Optional[int], str]
 
 
 def _gutter(width: int, body: str, lineno: Optional[int] = None) -> str:

--- a/src/gt4py/next/errors/formatting.py
+++ b/src/gt4py/next/errors/formatting.py
@@ -14,7 +14,7 @@ import linecache
 import textwrap
 import traceback
 import types
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Sequence
 
 from gt4py.eve import SourceLocation
 
@@ -22,44 +22,198 @@ from gt4py.eve import SourceLocation
 if TYPE_CHECKING:
     from gt4py.next.errors import exceptions
 
-
-def get_source_from_location(location: SourceLocation) -> str:
-    if not location.filename:
-        raise FileNotFoundError()
-    source_lines = linecache.getlines(location.filename)
-    if not source_lines:
-        raise FileNotFoundError()
-    start_line = location.line
-    end_line = location.end_line + 1 if location.end_line is not None else start_line + 1
-    relevant_lines = source_lines[(start_line - 1) : (end_line - 1)]
-    return "\n".join(relevant_lines)
+#: Maximum number of source lines rendered for a multi-line location.
+_MAX_SNIPPET_LINES = 3
 
 
-def format_location(loc: SourceLocation, show_caret: bool = False) -> str:
+#: An underline row below the first snippet line: (column, end_column, label).
+_UnderlineRow = tuple[int, Optional[int], str]
+
+
+def _gutter(width: int, body: str, lineno: Optional[int] = None) -> str:
+    """A gutter row: ``"11 | <body>"`` with a right-aligned line number, or blank."""
+    head = f"{lineno:>{width}}" if lineno is not None else " " * width
+    return f"{head} | {body}"
+
+
+def _caret_span(location: SourceLocation, first_line: str) -> tuple[int, int]:
+    """Start column (0-based) and width of the caret run on the first line of ``location``."""
+    start = location.column - 1
+    if location.end_line == location.line and location.end_column is not None:
+        width = max(location.end_column - location.column, 1)
+    else:
+        width = max(len(first_line) - start, 1)
+    return start, width
+
+
+def _format_snippet_lines(
+    location: SourceLocation,
+    *,
+    label: Optional[str] = None,
+    secondary: Sequence[_UnderlineRow] = (),
+) -> Optional[list[str]]:
     """
-    Format the source file location.
+    Render the source lines of ``location`` with a line-number gutter and carets.
+
+    The caret row carries ``label`` (if any); ``secondary`` spans (which must lie
+    on the first line of ``location``) are underlined with ``-`` markers below it.
+
+    Returns ``None`` if the source is not available (e.g. code defined in a REPL).
+
+    Example output (as a list of lines)::
+
+        11 |     return tmp_feild
+           |            ^^^^^^^^^ not defined at this point
+    """
+    if not location.filename:
+        return None
+    source_lines = linecache.getlines(location.filename)
+    if not source_lines or location.line > len(source_lines):
+        return None
+
+    start_line = location.line
+    end_line = location.end_line if location.end_line is not None else location.line
+    snippet_lines = [line.rstrip("\n") for line in source_lines[(start_line - 1) : end_line]]
+    if not snippet_lines:
+        return None
+
+    truncated = len(snippet_lines) > _MAX_SNIPPET_LINES
+    snippet_lines = snippet_lines[:_MAX_SNIPPET_LINES]
+
+    width = len(str(start_line + len(snippet_lines) - 1))
+    result: list[str] = []
+    for i, line in enumerate(snippet_lines):
+        result.append(_gutter(width, line, lineno=start_line + i))
+        if i == 0:
+            # Carets, the label, and secondary underlines all sit under the first line.
+            caret_start, caret_width = _caret_span(location, line)
+            carets = " " * caret_start + "^" * caret_width
+            result.append(_gutter(width, f"{carets} {label}" if label else carets))
+            for column, end_column, sec_label in sorted(secondary, key=lambda s: s[0]):
+                sec_width = max(end_column - column, 1) if end_column is not None else 1
+                underline = " " * (column - 1) + "-" * sec_width
+                result.append(_gutter(width, f"{underline} {sec_label}"))
+    if truncated:
+        result.append(_gutter(width, "..."))
+    return result
+
+
+def format_location(
+    loc: SourceLocation,
+    show_caret: bool = False,
+    label: Optional[str] = None,
+    secondary: Sequence[_UnderlineRow] = (),
+) -> str:
+    """
+    Format the source file location, optionally with a code snippet.
 
     Args:
-        show_caret (bool): Indicate the position within the source line by placing carets underneath.
+        loc: The location to format.
+        show_caret: Indicate the position within the source line by placing carets
+            underneath, together with a line-number gutter.
+        label: Short text appended after the carets explaining the marked code.
+        secondary: Further labeled spans on the first line of ``loc``, underlined
+            with ``-`` markers.
+
+    Example output::
+
+        File "model/diffusion.py", line 11
+          11 |     return tmp_feild
+             |            ^^^^^^^^^ undeclared name
     """
     filename = loc.filename or "<unknown>"
-    lineno = loc.line
-    loc_str = f'File "{filename}", line {lineno}'
+    loc_str = f'File "{filename}", line {loc.line}'
 
-    if show_caret and loc.column is not None:
-        offset = loc.column - 1
-        width = loc.end_column - loc.column if loc.end_column is not None else 1
-        caret_str = "".join([" "] * offset + ["^"] * width)
-    else:
-        caret_str = None
-
-    try:
-        snippet_str = get_source_from_location(loc)
-        if caret_str:
-            snippet_str = f"{snippet_str}{caret_str}"
-        return f"{loc_str}\n{textwrap.indent(snippet_str, '  ')}"
-    except (FileNotFoundError, IndexError):
+    if not show_caret:
         return loc_str
+
+    snippet_lines = _format_snippet_lines(loc, label=label, secondary=secondary)
+    if snippet_lines is None:
+        return loc_str
+    snippet_str = "\n".join(snippet_lines)
+    return f"{loc_str}\n{textwrap.indent(snippet_str, '  ')}"
+
+
+def _split_related(
+    location: Optional[SourceLocation],
+    related: Sequence[tuple[SourceLocation, str]],
+) -> tuple[list[_UnderlineRow], list[tuple[SourceLocation, str]]]:
+    """
+    Partition related locations into those on the primary location's first line and the rest.
+
+    Same-line spans are rendered inside the primary snippet; the rest get their
+    own ``Related:`` snippet block.
+    """
+    same_line: list[_UnderlineRow] = []
+    remote: list[tuple[SourceLocation, str]] = []
+    for rel_location, rel_message in related:
+        if (
+            location is not None
+            and rel_location.filename == location.filename
+            and rel_location.line == location.line
+            and (rel_location.end_line is None or rel_location.end_line == rel_location.line)
+        ):
+            same_line.append((rel_location.column, rel_location.end_column, rel_message))
+        else:
+            remote.append((rel_location, rel_message))
+    return same_line, remote
+
+
+#: Wrapping width of notes and hints; source snippet lines are never wrapped.
+_TEXT_WIDTH = 88
+
+
+def _format_extras(
+    related: Sequence[tuple[SourceLocation, str]],
+    notes: Sequence[str],
+    hints: Sequence[str],
+) -> list[str]:
+    """Render the secondary parts of a diagnostic: related locations, notes and hints."""
+    bits: list[str] = []
+    for rel_location, rel_message in related:
+        rel_str = format_location(rel_location, show_caret=True)
+        bits.append(f"  Related: {rel_message}\n{textwrap.indent(rel_str, '    ')}")
+    for prefix, items in (("Note", notes), ("Hint", hints)):
+        for item in items:
+            bits.append(
+                textwrap.fill(
+                    f"{prefix}: {item}",
+                    width=_TEXT_WIDTH,
+                    initial_indent="  ",
+                    subsequent_indent="    ",
+                )
+            )
+    return bits
+
+
+def format_diagnostic_parts(
+    message: str,
+    location: Optional[SourceLocation],
+    *,
+    label: Optional[str] = None,
+    related: Sequence[tuple[SourceLocation, str]] = (),
+    notes: Sequence[str] = (),
+    hints: Sequence[str] = (),
+) -> str:
+    """
+    Render the full body of a diagnostic: message, source snippet, related locations, notes and hints.
+
+    This is the single place defining the on-screen shape of GT4Py diagnostics;
+    both ``DSLError.__str__`` and the excepthook go through it.
+    """
+    same_line_related, remote_related = _split_related(location, related)
+    bits: list[str] = [message]
+    if location is not None:
+        bits.append(
+            textwrap.indent(
+                format_location(
+                    location, show_caret=True, label=label, secondary=same_line_related
+                ),
+                "  ",
+            )
+        )
+    bits.extend(_format_extras(remote_related, notes, hints))
+    return "\n".join(bits)
 
 
 def _format_cause(cause: BaseException) -> list[str]:
@@ -82,17 +236,27 @@ def format_compilation_error(
     location: Optional[SourceLocation],
     tb: Optional[types.TracebackType] = None,
     cause: Optional[BaseException] = None,
+    *,
+    label: Optional[str] = None,
+    related: Sequence[tuple[SourceLocation, str]] = (),
+    notes: Sequence[str] = (),
+    hints: Sequence[str] = (),
 ) -> list[str]:
     bits: list[str] = []
 
+    same_line_related, remote_related = _split_related(location, related)
     if cause is not None:
         bits = [*bits, *_format_cause(cause)]
     if tb is not None:
         bits = [*bits, *_format_traceback(tb)]
     if location is not None:
-        loc_str = format_location(location, show_caret=True)
+        loc_str = format_location(
+            location, show_caret=True, label=label, secondary=same_line_related
+        )
         loc_str_all = f"Source location:\n{textwrap.indent(loc_str, '  ')}\n"
         bits = [*bits, loc_str_all]
     msg_str = f"{type_.__module__}.{type_.__name__}: {message}"
     bits = [*bits, msg_str]
+    if extras := _format_extras(remote_related, notes, hints):
+        bits = [*bits, "\n" + "\n".join(extras)]
     return bits

--- a/src/gt4py/next/errors/formatting.py
+++ b/src/gt4py/next/errors/formatting.py
@@ -198,8 +198,9 @@ def format_diagnostic_parts(
     """
     Render the full body of a diagnostic: message, source snippet, related locations, notes and hints.
 
-    This is the single place defining the on-screen shape of GT4Py diagnostics;
-    both ``DSLError.__str__`` and the excepthook go through it.
+    This is the single renderer for the on-screen shape of GT4Py diagnostics:
+    ``DSLError.__str__`` calls it directly, and ``format_compilation_error``
+    (the verbose excepthook) prepends the traceback and qualified type name.
     """
     same_line_related, remote_related = _split_related(location, related)
     bits: list[str] = [message]
@@ -243,20 +244,14 @@ def format_compilation_error(
     hints: Sequence[str] = (),
 ) -> list[str]:
     bits: list[str] = []
-
-    same_line_related, remote_related = _split_related(location, related)
     if cause is not None:
-        bits = [*bits, *_format_cause(cause)]
+        bits += _format_cause(cause)
     if tb is not None:
-        bits = [*bits, *_format_traceback(tb)]
-    if location is not None:
-        loc_str = format_location(
-            location, show_caret=True, label=label, secondary=same_line_related
+        bits += _format_traceback(tb)
+    qualified_message = f"{type_.__module__}.{type_.__name__}: {message}"
+    bits.append(
+        format_diagnostic_parts(
+            qualified_message, location, label=label, related=related, notes=notes, hints=hints
         )
-        loc_str_all = f"Source location:\n{textwrap.indent(loc_str, '  ')}\n"
-        bits = [*bits, loc_str_all]
-    msg_str = f"{type_.__module__}.{type_.__name__}: {message}"
-    bits = [*bits, msg_str]
-    if extras := _format_extras(remote_related, notes, hints):
-        bits = [*bits, "\n" + "\n".join(extras)]
+    )
     return bits

--- a/src/gt4py/next/ffront/ast_passes/single_static_assign.py
+++ b/src/gt4py/next/ffront/ast_passes/single_static_assign.py
@@ -31,6 +31,11 @@ def unique_name(name: str, num_assignments: int) -> str:
     return name
 
 
+def original_name(name: str) -> str:
+    """Return the variable name as written by the user, stripping the versioning of 'unique_name'."""
+    return name.split(_UNIQUE_NAME_SEPARATOR, 1)[0]
+
+
 def _make_assign(target: str, source: str, location_node: ast.AST) -> ast.Assign:
     result = ast.Assign(
         targets=[ast.Name(ctx=ast.Store(), id=target)], value=ast.Name(ctx=ast.Load(), id=source)

--- a/src/gt4py/next/ffront/dialect_parser.py
+++ b/src/gt4py/next/ffront/dialect_parser.py
@@ -23,6 +23,59 @@ from gt4py.next.ffront.source_utils import SourceDefinition, get_closure_vars_fr
 DialectRootT = TypeVar("DialectRootT")
 
 
+#: Friendly diagnostics for Python constructs that are not part of the DSL subset:
+#: maps the offending `ast` node type to a user-facing construct name and hints on
+#: what to use instead. Constructs not listed here get a generic message naming
+#: the `ast` class. Keep the hints actionable: name the closest supported
+#: alternative, not just the restriction.
+# TODO(havogt): add 'ast.TryStar' ('try*' statement, Python >=3.11) once the
+#  Python floor is >=3.12; referencing it unconditionally breaks import on 3.10.
+_UNSUPPORTED_FEATURE_HINTS: dict[type[ast.AST], tuple[str, tuple[str, ...]]] = {
+    ast.For: (
+        "'for' loop",
+        (
+            "GT4Py functions describe operations on whole fields without explicit loops. "
+            "Use field expressions or built-ins like 'neighbor_sum' instead; for sequential "
+            "dependencies along a dimension, use a 'scan_operator'.",
+        ),
+    ),
+    ast.While: (
+        "'while' loop",
+        (
+            "GT4Py functions describe operations on whole fields without explicit loops. "
+            "For sequential dependencies along a dimension, use a 'scan_operator'.",
+        ),
+    ),
+    ast.ListComp: (
+        "list comprehension",
+        ("Operations apply to whole fields at once; use field expressions instead.",),
+    ),
+    ast.SetComp: ("set comprehension", ()),
+    ast.DictComp: ("dictionary comprehension", ()),
+    ast.GeneratorExp: ("generator expression", ()),
+    ast.Lambda: (
+        "'lambda' expression",
+        ("Define a separate function decorated with '@field_operator' instead.",),
+    ),
+    ast.Try: ("'try' statement", ("Exception handling is not available inside GT4Py functions.",)),
+    ast.Raise: (
+        "'raise' statement",
+        ("Exception handling is not available inside GT4Py functions.",),
+    ),
+    ast.With: ("'with' statement", ()),
+    ast.Assert: ("'assert' statement", ()),
+    ast.ClassDef: ("class definition", ()),
+    ast.JoinedStr: ("f-string", ("Strings cannot be computed inside GT4Py functions.",)),
+    ast.Match: ("'match' statement", ("Use 'if'/'elif' chains or 'where' instead.",)),
+}
+
+
+def _describe_unsupported_feature(node: ast.AST) -> tuple[str, tuple[str, ...]]:
+    if (entry := _UNSUPPORTED_FEATURE_HINTS.get(type(node))) is not None:
+        return entry
+    return f"'{type(node).__module__}.{type(node).__qualname__}'", ()
+
+
 def parse_source_definition(source_definition: SourceDefinition) -> ast.AST:
     try:
         return ast.parse(textwrap.dedent(source_definition.source)).body[0]
@@ -98,8 +151,13 @@ class DialectParser(ast.NodeVisitor, Generic[DialectRootT]):
 
     def generic_visit(self, node: ast.AST) -> None:
         loc = self.get_location(node)
-        feature = f"{type(node).__module__}.{type(node).__qualname__}"
-        raise errors.UnsupportedPythonFeatureError(loc, feature)
+        feature, hints = _describe_unsupported_feature(node)
+        raise errors.UnsupportedPythonFeatureError(
+            loc,
+            feature,
+            notes=("Only a subset of Python is valid inside GT4Py functions.",),
+            hints=hints,
+        )
 
     def _check_not_a_reserved_name(self, name: str, location: SourceLocation) -> None:
         if name in self.reserved_names:

--- a/src/gt4py/next/ffront/foast_passes/type_deduction.py
+++ b/src/gt4py/next/ffront/foast_passes/type_deduction.py
@@ -20,6 +20,7 @@ from gt4py.next.ffront import (
     fbuiltins,
     type_specifications as ts_ffront,
 )
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.ffront.foast_passes import utils as foast_utils
 from gt4py.next.iterator import builtins
 from gt4py.next.type_system import type_info, type_specifications as ts, type_translation
@@ -143,6 +144,21 @@ class FieldOperatorTypeDeductionCompletnessValidator(NodeVisitor):
 
         if hasattr(node, "type") and not type_info.is_concrete(node.type):
             incomplete_nodes.append(node)
+
+
+def _no_implicit_conversion_diagnostic(left: foast.Expr, right: foast.Expr) -> dict[str, Any]:
+    """Shared 'related'/'notes'/'hints' payload for the no-implicit-conversion errors."""
+    return {
+        "related": [
+            (left.location, f"this operand has type '{left.type}'"),
+            (right.location, f"this operand has type '{right.type}'"),
+        ],
+        "notes": ["GT4Py does not implicitly convert between datatypes."],
+        "hints": [
+            "Convert one operand explicitly, e.g. 'astype(<expr>, float64)', "
+            "or make the datatypes of the inputs match."
+        ],
+    }
 
 
 class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTranslator):
@@ -282,7 +298,12 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
     def visit_Name(self, node: foast.Name, **kwargs: Any) -> foast.Name:
         symtable = kwargs["symtable"]
         if node.id not in symtable or symtable[node.id].type is None:
-            raise errors.DSLError(node.location, f"Undeclared symbol '{node.id}'.")
+            defined_names = {
+                ssa.original_name(name) for name, sym in symtable.items() if sym.type is not None
+            }
+            raise errors.UndefinedSymbolError(
+                node.location, ssa.original_name(node.id), candidates=defined_names
+            )
 
         symbol = symtable[node.id]
         return foast.Name(id=node.id, type=symbol.type, location=node.location)
@@ -612,9 +633,23 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             is_compatible = (
                 type_info.is_logical if node.op in logical_ops else type_info.is_arithmetic
             )
-            for arg in (left, right):
+            requirement = "logical" if node.op in logical_ops else "arithmetic"
+            for arg, other in ((left, right), (right, left)):
                 if not is_compatible(arg.type):
-                    raise errors.DSLError(arg.location, err_msg)
+                    hints = []
+                    if node.op not in logical_ops and type_info.is_logical(arg.type):
+                        hints = [
+                            "To select values based on a boolean mask, use 'where(mask, a, b)'. "
+                            "To compute with a boolean field, convert it explicitly, "
+                            "e.g. 'astype(mask, int32)'."
+                        ]
+                    raise errors.DSLError(
+                        arg.location,
+                        err_msg,
+                        label=f"'{node.op}' expects {requirement} operands, but this has type '{arg.type}'",
+                        related=[(other.location, f"the other operand has type '{other.type}'")],
+                        hints=hints,
+                    )
 
             if node.op == dialect_ast_enums.BinaryOperator.POW:
                 return left.type
@@ -623,7 +658,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                 right.type
             ):
                 raise errors.DSLError(
-                    arg.location,
+                    right.location,
                     f"Type '{right.type}' can not be used in operator '{node.op}', it only accepts 'int'.",
                 )
 
@@ -634,6 +669,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
                     node.location,
                     f"Could not promote '{left.type}' and '{right.type}' to common type"
                     f" in call to '{node.op}'.",
+                    **_no_implicit_conversion_diagnostic(left, right),
                 ) from ex
         elif isinstance(left.type, ts.DomainType) and isinstance(right.type, ts.DomainType):
             if node.op not in logical_ops:
@@ -654,6 +690,7 @@ class FieldOperatorTypeDeduction(traits.VisitorWithSymbolTableTrait, NodeTransla
             raise errors.DSLError(
                 node.location,
                 f"Incompatible datatypes in operator '{node.op}': '{left.type}' and '{right.type}'.",
+                **_no_implicit_conversion_diagnostic(left, right),
             )
 
     def visit_UnaryOp(self, node: foast.UnaryOp, **kwargs: Any) -> foast.UnaryOp:

--- a/src/gt4py/next/ffront/func_to_foast.py
+++ b/src/gt4py/next/ffront/func_to_foast.py
@@ -72,19 +72,23 @@ def func_to_foast(inp: DSLFieldOperatorDef) -> FOASTOperatorDef:
     source_def = source_utils.SourceDefinition.from_function(inp.definition)
     closure_vars = source_utils.get_closure_vars_from_function(inp.definition)
     annotations = typing.get_type_hints(inp.definition)
-    foast_definition_node = FieldOperatorParser.apply(source_def, closure_vars, annotations)
-    loc = foast_definition_node.location
-    operator_attribute_nodes = {
-        key: foast.Constant(value=value, type=type_translation.from_value(value), location=loc)
-        for key, value in inp.attributes.items()
-    }
-    untyped_foast_node = inp.node_class(
-        id=foast_definition_node.id,
-        definition=foast_definition_node,
-        location=loc,
-        **operator_attribute_nodes,
-    )
-    foast_node = FieldOperatorTypeDeduction.apply(untyped_foast_node)
+    try:
+        foast_definition_node = FieldOperatorParser.apply(source_def, closure_vars, annotations)
+        loc = foast_definition_node.location
+        operator_attribute_nodes = {
+            key: foast.Constant(value=value, type=type_translation.from_value(value), location=loc)
+            for key, value in inp.attributes.items()
+        }
+        untyped_foast_node = inp.node_class(
+            id=foast_definition_node.id,
+            definition=foast_definition_node,
+            location=loc,
+            **operator_attribute_nodes,
+        )
+        foast_node = FieldOperatorTypeDeduction.apply(untyped_foast_node)
+    except errors.DSLError as err:
+        err.add_note(f"While processing the definition of '{inp.definition.__name__}'.")
+        raise
     return ffront_stages.FOASTOperatorDef(
         foast_node=foast_node,
         closure_vars=closure_vars,
@@ -407,7 +411,13 @@ class FieldOperatorParser(DialectParser[foast.FunctionDefinition]):
 
     def visit_BoolOp(self, node: ast.BoolOp, **kwargs: Any) -> None:
         raise errors.UnsupportedPythonFeatureError(
-            self.get_location(node), "logical operators `and`, `or`"
+            self.get_location(node),
+            "logical operators `and`, `or`",
+            notes=[
+                "`and` and `or` operate on whole truth values, but fields contain "
+                "one boolean per grid point."
+            ],
+            hints=["Use the element-wise operators '&' and '|' instead."],
         )
 
     def visit_IfExp(self, node: ast.IfExp, **kwargs: Any) -> foast.TernaryExpr:

--- a/tests/next_tests/unit_tests/errors_tests/test_excepthook.py
+++ b/tests/next_tests/unit_tests/errors_tests/test_excepthook.py
@@ -17,12 +17,12 @@ def test_format_uncaught_error():
         raise exceptions.DSLError(loc, msg) from ValueError("value error msg")
     except exceptions.DSLError as err:
         str_devmode = "".join(excepthook._format_uncaught_error(err, True))
-        assert str_devmode.find("Source location") >= 0
+        assert str_devmode.find('File "/src/file.py"') >= 0
         assert str_devmode.find("Traceback") >= 0
         assert str_devmode.find("cause") >= 0
         assert str_devmode.find("ValueError") >= 0
         str_usermode = "".join(excepthook._format_uncaught_error(err, False))
-        assert str_usermode.find("Source location") >= 0
+        assert str_usermode.find('File "/src/file.py"') >= 0
         assert str_usermode.find("Traceback") < 0
         assert str_usermode.find("cause") < 0
         assert str_usermode.find("ValueError") < 0

--- a/tests/next_tests/unit_tests/errors_tests/test_exceptions.py
+++ b/tests/next_tests/unit_tests/errors_tests/test_exceptions.py
@@ -46,6 +46,13 @@ def test_with_location(loc_plain, message):
     assert errors.DSLError(None, message).with_location(loc_plain).location == loc_plain
 
 
+def test_did_you_mean_does_not_suggest_the_looked_up_name(loc_plain):
+    # A same-named symbol in the candidate set (e.g. a later SSA version) must not
+    # produce "Did you mean 'result'?" — the user already wrote that.
+    err = errors.UndefinedSymbolError(loc_plain, "result", candidates={"result"})
+    assert err.hints == []
+
+
 def test_str(loc_plain, message):
     pattern = f'{message}\\n  File ".*", line.*'
     s = str(errors.DSLError(loc_plain, message))
@@ -57,8 +64,8 @@ def test_str_snippet(loc_snippet, message):
         [
             f"{message}",
             '  File ".*", line.*',
-            "        # This very line of comment should be shown in the snippet.",
-            r"                  \^\^\^\^\^\^\^\^\^\^\^\^\^\^",
+            r"\s+\d+ \|     # This very line of comment should be shown in the snippet\.",
+            r"\s+\| {15}\^{14}",
         ]
     )
     s = str(errors.DSLError(loc_snippet, message))

--- a/tests/next_tests/unit_tests/errors_tests/test_formatting.py
+++ b/tests/next_tests/unit_tests/errors_tests/test_formatting.py
@@ -51,10 +51,11 @@ def test_format(type_, qualname, message):
 
 
 def test_format_loc(type_, qualname, message, location):
-    loc_pattern = "Source location.*"
-    file_pattern = '  File "/source.*".*'
+    # The qualified message comes first, the source location follows (same body
+    # as str(err), only with the type name prepended).
     cls_pattern = f"{qualname}: {message}"
-    pattern = r"\n".join([loc_pattern, file_pattern, cls_pattern])
+    file_pattern = '  File "/source.*".*'
+    pattern = r"\n".join([cls_pattern, file_pattern])
     s = "".join(format_compilation_error(type_, message, location, None, None))
     assert re.match(pattern, s)
 

--- a/tests/next_tests/unit_tests/errors_tests/test_formatting.py
+++ b/tests/next_tests/unit_tests/errors_tests/test_formatting.py
@@ -6,13 +6,14 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
 import re
 
 import pytest
 
 from gt4py.eve import SourceLocation
 from gt4py.next import errors
-from gt4py.next.errors.formatting import format_compilation_error
+from gt4py.next.errors.formatting import format_compilation_error, format_diagnostic_parts
 
 
 @pytest.fixture
@@ -66,6 +67,53 @@ def test_format_traceback(type_, qualname, message, tb):
     pattern = r"\n".join([tb_pattern, file_pattern, line_pattern, cls_pattern])
     s = "".join(format_compilation_error(type_, message, None, tb, None))
     assert re.match(pattern, s)
+
+
+@pytest.fixture
+def loc_here():
+    # location spanning the body of this fixture function, in this file
+    frameinfo = inspect.getframeinfo(inspect.currentframe())
+    return SourceLocation(
+        frameinfo.filename,
+        frameinfo.lineno - 1,
+        1,
+        end_line=frameinfo.lineno + 10,
+        end_column=2,
+    )
+
+
+def test_snippet_multiline_is_truncated(message, loc_here):
+    s = format_diagnostic_parts(message, loc_here)
+    lines = s.splitlines()
+    snippet_lines = [line for line in lines if re.match(r"\s+(\d+ )?\|", line)]
+    assert snippet_lines[-1].strip().endswith("...")
+    # gutter-prefixed source lines are capped, +1 caret row, +1 truncation row
+    assert len(snippet_lines) <= 5
+
+
+def test_notes_and_hints_are_rendered_and_wrapped(message):
+    s = format_diagnostic_parts(
+        message, None, notes=["A short note."], hints=["A very long hint. " * 10]
+    )
+    assert "  Note: A short note." in s
+    assert "  Hint: A very long hint." in s
+    assert all(len(line) <= 88 for line in s.splitlines())
+
+
+def test_same_line_related_merges_into_snippet(message, loc_here):
+    related_loc = SourceLocation(
+        loc_here.filename, loc_here.line, 5, end_line=loc_here.line, end_column=14
+    )
+    s = format_diagnostic_parts(message, loc_here, related=[(related_loc, "relevant")])
+    assert "Related:" not in s
+    assert re.search(r"\| {5}-{9} relevant", s), s
+
+
+def test_remote_related_gets_own_block(message, loc_here):
+    related_loc = SourceLocation(loc_here.filename, 1, 1, end_line=1, end_column=2)
+    s = format_diagnostic_parts(message, loc_here, related=[(related_loc, "relevant")])
+    assert "  Related: relevant" in s
+    assert re.search(r'    File ".*", line 1', s), s
 
 
 def test_format_cause(type_, qualname, message):

--- a/tests/next_tests/unit_tests/ffront_tests/test_diagnostic_messages.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_diagnostic_messages.py
@@ -16,6 +16,7 @@ regress. When changing a message, update the expectation here alongside.
 """
 
 import re
+import sys
 
 import pytest
 
@@ -126,15 +127,26 @@ def test_bool_op_suggests_bitwise_operators():
     assert any("'&' and '|'" in hint for hint in err.hints)
 
 
-def test_add_note_renders_once_via_str():
-    # 'add_note' (PEP 678) routes into the structured diagnostic instead of
-    # '__notes__', so the note is rendered exactly once (through 'str()').
+def test_add_note_uses_pep678_notes():
+    # 'add_note' uses the standard PEP 678 mechanism ('__notes__'); the
+    # structured 'notes' field is reserved for content authored at the raise
+    # site, so the breadcrumb must not leak into it.
     err = errors.DSLError(None, "A message.")
     err.add_note("Extra context.")
 
-    assert err.notes == ["Extra context."]
-    assert "Note: Extra context." in str(err)
-    assert "__notes__" not in err.__dict__
+    assert err.__notes__ == ["Extra context."]
+    assert err.notes == []
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="On >=3.11 the traceback machinery renders '__notes__'; 'str()' does not.",
+)
+def test_add_note_folded_into_str_on_py310():
+    err = errors.DSLError(None, "A message.")
+    err.add_note("Extra context.")
+
+    assert "Extra context." in str(err)
 
 
 def test_toolchain_step_attaches_definition_context():
@@ -148,7 +160,7 @@ def test_toolchain_step_attaches_definition_context():
     with pytest.raises(errors.DSLError) as exc_info:
         func_to_foast(ffront_stages.DSLFieldOperatorDef(definition=misspelled))
 
-    assert "While processing the definition of 'misspelled'." in exc_info.value.notes
+    assert "While processing the definition of 'misspelled'." in exc_info.value.__notes__
 
 
 def test_diagnostic_codes_are_stable():

--- a/tests/next_tests/unit_tests/ffront_tests/test_diagnostic_messages.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_diagnostic_messages.py
@@ -1,0 +1,157 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Tests pinning the rendered text of user-facing diagnostics.
+
+These are deliberately end-to-end on the message level (in the spirit of
+rustc's UI tests): they parse intentionally wrong programs and assert on the
+rendered diagnostic, so that the quality of error messages cannot silently
+regress. When changing a message, update the expectation here alongside.
+"""
+
+import re
+
+import pytest
+
+import gt4py.next as gtx
+from gt4py.next import errors, float32, float64
+from gt4py.next.ffront.func_to_foast import FieldOperatorParser
+
+
+IDim = gtx.Dimension("IDim")
+
+
+def parse_error(func) -> errors.DSLError:
+    with pytest.raises(errors.DSLError) as exc_info:
+        FieldOperatorParser.apply_to_function(func)
+    return exc_info.value
+
+
+def test_undeclared_symbol_suggests_close_match():
+    def misspelled(temperature: gtx.Field[[IDim], float64]) -> gtx.Field[[IDim], float64]:
+        tmp_field = temperature * 2.0
+        return tmp_feild  # noqa: F821 [undefined-name]
+
+    err = parse_error(misspelled)
+
+    assert isinstance(err, errors.UndefinedSymbolError)
+    assert err.message == "Undeclared symbol 'tmp_feild'."
+    assert err.hints == ["Did you mean 'tmp_field'?"]
+    rendered = str(err)
+    assert "return tmp_feild" in rendered
+    assert re.search(r"\| +\^{9}", rendered), rendered
+    assert "Hint: Did you mean 'tmp_field'?" in rendered
+
+
+def test_undeclared_symbol_without_close_match_has_no_hint():
+    def misspelled(a: gtx.Field[[IDim], float64]) -> gtx.Field[[IDim], float64]:
+        return completely_unrelated  # noqa: F821 [undefined-name]
+
+    err = parse_error(misspelled)
+
+    assert isinstance(err, errors.UndefinedSymbolError)
+    assert err.hints == []
+
+
+def test_while_loop_names_construct_and_alternative():
+    def with_while(a: gtx.Field[[IDim], float64]) -> gtx.Field[[IDim], float64]:
+        while True:
+            a = a + 1.0
+        return a
+
+    err = parse_error(with_while)
+
+    assert isinstance(err, errors.UnsupportedPythonFeatureError)
+    assert err.message == "Unsupported Python syntax: 'while' loop."
+    assert any("scan_operator" in hint for hint in err.hints)
+    rendered = str(err)
+    assert "while True:" in rendered
+    assert "Note: Only a subset of Python is valid inside GT4Py functions." in rendered
+
+
+def test_unlisted_construct_falls_back_to_ast_name():
+    def with_string(a: gtx.Field[[IDim], float64]) -> gtx.Field[[IDim], float64]:
+        f"{a}"
+        return a
+
+    err = parse_error(with_string)
+
+    assert isinstance(err, errors.UnsupportedPythonFeatureError)
+    assert "f-string" in err.message
+
+
+def test_bool_field_arithmetic_suggests_where():
+    def bool_arithmetic(
+        a: gtx.Field[[IDim], float64], mask: gtx.Field[[IDim], bool]
+    ) -> gtx.Field[[IDim], float64]:
+        return a + mask
+
+    err = parse_error(bool_arithmetic)
+
+    assert err.label is not None and "'Field[[IDim], bool]'" in err.label
+    assert err.related and "Field[[IDim], float64]" in err.related[0][1]
+    assert any("where(mask, a, b)" in hint for hint in err.hints)
+    rendered = str(err)
+    # both operand labels are rendered into a single snippet of the offending line
+    assert rendered.count("return a + mask") == 1
+    assert re.search(r"\| +- the other operand has type", rendered), rendered
+
+
+def test_dtype_mismatch_explains_promotion():
+    def mixed_precision(
+        a: gtx.Field[[IDim], float32], b: gtx.Field[[IDim], float64]
+    ) -> gtx.Field[[IDim], float64]:
+        return a + b
+
+    err = parse_error(mixed_precision)
+
+    assert err.notes == ["GT4Py does not implicitly convert between datatypes."]
+    assert any("astype" in hint for hint in err.hints)
+    assert len(err.related) == 2
+
+
+def test_bool_op_suggests_bitwise_operators():
+    def with_and(a: gtx.Field[[IDim], bool], b: gtx.Field[[IDim], bool]) -> gtx.Field[[IDim], bool]:
+        return a and b
+
+    err = parse_error(with_and)
+
+    assert isinstance(err, errors.UnsupportedPythonFeatureError)
+    assert any("'&' and '|'" in hint for hint in err.hints)
+
+
+def test_add_note_renders_once_via_str():
+    # 'add_note' (PEP 678) routes into the structured diagnostic instead of
+    # '__notes__', so the note is rendered exactly once (through 'str()').
+    err = errors.DSLError(None, "A message.")
+    err.add_note("Extra context.")
+
+    assert err.notes == ["Extra context."]
+    assert "Note: Extra context." in str(err)
+    assert "__notes__" not in err.__dict__
+
+
+def test_toolchain_step_attaches_definition_context():
+    from gt4py.next.ffront import stages as ffront_stages
+    from gt4py.next.ffront.func_to_foast import func_to_foast
+
+    def misspelled(temperature: gtx.Field[[IDim], float64]) -> gtx.Field[[IDim], float64]:
+        tmp_field = temperature * 2.0
+        return tmp_feild  # noqa: F821 [undefined-name]
+
+    with pytest.raises(errors.DSLError) as exc_info:
+        func_to_foast(ffront_stages.DSLFieldOperatorDef(definition=misspelled))
+
+    assert "While processing the definition of 'misspelled'." in exc_info.value.notes
+
+
+def test_diagnostic_codes_are_stable():
+    assert errors.UndefinedSymbolError.code == "undefined-symbol"
+    assert errors.UnsupportedPythonFeatureError.code == "unsupported-syntax"
+    assert errors.DSLError.code is None


### PR DESCRIPTION
Makes gt4py.next DSL errors user-friendly: structured diagnostics that point at the offending source and suggest a fix, instead of plain message strings.

- Extends DSLError in place with optional structured fields (label, related spans, notes, hints, per-subclass code).
- A single renderer owns the on-screen shape: line-number gutter, carets, same-line related-span merge, multi-line capping, note/hint wrapping, and a graceful fallback when source text is unavailable.
- Adds a catalogue of unsupported Python constructs, mapping each to a user-facing name and an actionable hint, with a fallback for uncatalogued nodes.
- Upgrades the highest-frequency frontend errors: undefined symbol with "did you mean", boolean and mixed-precision operand mismatches, and and/or on fields.
- Attaches toolchain context ("While processing the definition of ...") via PEP 678 add_note.
- Adds an authoring guide at docs/development/next/error-messages.md, linked from CODING_GUIDELINES.md and src/gt4py/next/AGENTS.md.
- Regression tests pin the rendered diagnostic text.