### PR TITLE
fix[next]: scalar dtype in math builtins + implement embedded gamma (#2277)

### DIFF
--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -56,18 +56,12 @@ def _get_nd_array_class(*fields: common.Field | core_defs.Scalar) -> type[NdArra
 
 
 def _make_builtin(
-    builtin_name: str,
-    array_builtin_name: str | Callable[[ModuleType], Callable],
-    reverse: bool = False,
+    builtin_name: str, array_builtin_name: str, reverse: bool = False
 ) -> Callable[..., NdArrayField]:
     def _builtin_op(*fields: common.Field | core_defs.Scalar) -> NdArrayField:
         cls_ = _get_nd_array_class(*fields)
         xp = cls_.array_ns
-        op = (
-            array_builtin_name(xp)
-            if callable(array_builtin_name)
-            else getattr(xp, array_builtin_name)
-        )
+        op = _get_builtin(xp, array_builtin_name)
 
         domain_intersection = embedded_common.domain_intersection(
             *[f.domain for f in fields if isinstance(f, common.Field)]
@@ -104,18 +98,24 @@ except ImportError:
         return np.vectorize(math.gamma, otypes=[a.dtype])(a)
 
 
-def _gamma_op(xp: ModuleType) -> Callable:
-    if xp is np:
-        return _np_gamma
-    if cp is not None and xp is cp:
-        import cupyx.scipy.special
+def _get_builtin(xp: ModuleType, name: str) -> Callable:
+    match name:
+        case "gamma":
+            if xp is np:
+                return _np_gamma
+            if cp is not None and xp is cp:
+                import cupyx.scipy.special
 
-        return cupyx.scipy.special.gamma
-    if jnp is not None and xp is jnp:
-        import jax.scipy.special
+                return cupyx.scipy.special.gamma
+            if jnp is not None and xp is jnp:
+                import jax.scipy.special
 
-        return jax.scipy.special.gamma
-    raise NotImplementedError(f"'gamma' is not implemented for array namespace '{xp.__name__}'.")
+                return jax.scipy.special.gamma
+            raise NotImplementedError(
+                f"'gamma' is not implemented for array namespace '{xp.__name__}'."
+            )
+        case _:
+            return getattr(xp, name)
 
 
 _Value: TypeAlias = common.Field | core_defs.ScalarT
@@ -759,14 +759,13 @@ NdArrayField.register_builtin_func(
     fbuiltins.power,
     NdArrayField.__pow__,
 )
-NdArrayField.register_builtin_func(fbuiltins.gamma, _make_builtin("gamma", _gamma_op))
 
 for name in (
     fbuiltins.UNARY_MATH_FP_BUILTIN_NAMES
     + fbuiltins.UNARY_MATH_FP_PREDICATE_BUILTIN_NAMES
     + fbuiltins.UNARY_MATH_NUMBER_BUILTIN_NAMES
 ):
-    if name in ["abs", "power", "gamma"]:
+    if name in ["abs", "power"]:
         continue
     NdArrayField.register_builtin_func(getattr(fbuiltins, name), _make_builtin(name, name))
 

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -103,11 +103,11 @@ def _get_builtin(xp: ModuleType, name: str) -> Callable:
         case "gamma":
             if xp is np:
                 return _np_gamma
-            if cp is not None and xp is cp:
+            if xp is cp:
                 import cupyx.scipy.special
 
                 return cupyx.scipy.special.gamma
-            if jnp is not None and xp is jnp:
+            if xp is jnp:
                 import jax.scipy.special
 
                 return jax.scipy.special.gamma

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -12,6 +12,7 @@ import collections
 import dataclasses
 import functools
 import itertools
+import math
 from collections.abc import Callable, Sequence
 from types import ModuleType
 
@@ -55,12 +56,18 @@ def _get_nd_array_class(*fields: common.Field | core_defs.Scalar) -> type[NdArra
 
 
 def _make_builtin(
-    builtin_name: str, array_builtin_name: str, reverse: bool = False
+    builtin_name: str,
+    array_builtin_name: str | Callable[[ModuleType], Callable],
+    reverse: bool = False,
 ) -> Callable[..., NdArrayField]:
     def _builtin_op(*fields: common.Field | core_defs.Scalar) -> NdArrayField:
         cls_ = _get_nd_array_class(*fields)
         xp = cls_.array_ns
-        op = getattr(xp, array_builtin_name)
+        op = (
+            array_builtin_name(xp)
+            if callable(array_builtin_name)
+            else getattr(xp, array_builtin_name)
+        )
 
         domain_intersection = embedded_common.domain_intersection(
             *[f.domain for f in fields if isinstance(f, common.Field)]
@@ -87,6 +94,28 @@ def _make_builtin(
 
     _builtin_op.__name__ = builtin_name
     return _builtin_op
+
+
+try:
+    from scipy.special import gamma as _np_gamma
+except ImportError:
+
+    def _np_gamma(a: core_defs.NDArrayObject) -> core_defs.NDArrayObject:
+        return np.vectorize(math.gamma, otypes=[a.dtype])(a)
+
+
+def _gamma_op(xp: ModuleType) -> Callable:
+    if xp is np:
+        return _np_gamma
+    if cp is not None and xp is cp:
+        import cupyx.scipy.special
+
+        return cupyx.scipy.special.gamma
+    if jnp is not None and xp is jnp:
+        import jax.scipy.special
+
+        return jax.scipy.special.gamma
+    raise NotImplementedError(f"'gamma' is not implemented for array namespace '{xp.__name__}'.")
 
 
 _Value: TypeAlias = common.Field | core_defs.ScalarT
@@ -730,7 +759,7 @@ NdArrayField.register_builtin_func(
     fbuiltins.power,
     NdArrayField.__pow__,
 )
-# TODO gamma
+NdArrayField.register_builtin_func(fbuiltins.gamma, _make_builtin("gamma", _gamma_op))
 
 for name in (
     fbuiltins.UNARY_MATH_FP_BUILTIN_NAMES

--- a/src/gt4py/next/ffront/fbuiltins.py
+++ b/src/gt4py/next/ffront/fbuiltins.py
@@ -313,34 +313,44 @@ def astype(
 _UNARY_MATH_NUMBER_BUILTIN_IMPL: Final = {"abs": abs, "neg": operator.neg}
 UNARY_MATH_NUMBER_BUILTIN_NAMES: Final = [*_UNARY_MATH_NUMBER_BUILTIN_IMPL.keys()]
 
+
+try:
+    from scipy.special import gamma as _gamma  # dtype-preserving ufunc
+except ImportError:
+
+    def _gamma(value: core_defs.ScalarT) -> core_defs.ScalarT:
+        # restore the input scalar type, which `math.gamma` widens to `float`
+        return cast(core_defs.ScalarT, type(value)(math.gamma(value)))
+
+
 _UNARY_MATH_FP_BUILTIN_IMPL: Final = {
-    "sin": math.sin,
-    "cos": math.cos,
-    "tan": math.tan,
-    "arcsin": math.asin,
-    "arccos": math.acos,
-    "arctan": math.atan,
-    "sinh": math.sinh,
-    "cosh": math.cosh,
-    "tanh": math.tanh,
-    "arcsinh": math.asinh,
-    "arccosh": math.acosh,
-    "arctanh": math.atanh,
-    "sqrt": math.sqrt,
-    "exp": math.exp,
-    "log": math.log,
-    "gamma": math.gamma,
-    "cbrt": math.cbrt if hasattr(math, "cbrt") else np.cbrt,  # match.cbrt() only added in 3.11
-    "floor": math.floor,
-    "ceil": math.ceil,
-    "trunc": math.trunc,
+    "sin": np.sin,
+    "cos": np.cos,
+    "tan": np.tan,
+    "arcsin": np.arcsin,
+    "arccos": np.arccos,
+    "arctan": np.arctan,
+    "sinh": np.sinh,
+    "cosh": np.cosh,
+    "tanh": np.tanh,
+    "arcsinh": np.arcsinh,
+    "arccosh": np.arccosh,
+    "arctanh": np.arctanh,
+    "sqrt": np.sqrt,
+    "exp": np.exp,
+    "log": np.log,
+    "gamma": _gamma,
+    "cbrt": np.cbrt,
+    "floor": np.floor,
+    "ceil": np.ceil,
+    "trunc": np.trunc,
 }
 UNARY_MATH_FP_BUILTIN_NAMES: Final = [*_UNARY_MATH_FP_BUILTIN_IMPL.keys()]
 
 _UNARY_MATH_FP_PREDICATE_BUILTIN_IMPL: Final = {
-    "isfinite": math.isfinite,
-    "isinf": math.isinf,
-    "isnan": math.isnan,
+    "isfinite": np.isfinite,
+    "isinf": np.isinf,
+    "isnan": np.isnan,
 }
 UNARY_MATH_FP_PREDICATE_BUILTIN_NAMES: Final = [*_UNARY_MATH_FP_PREDICATE_BUILTIN_IMPL.keys()]
 
@@ -358,7 +368,7 @@ def _make_unary_math_builtin(name: str) -> BuiltInFunction:
             value
         )  # default implementation for scalars, Fields are handled via dispatch
 
-        return cast(common.Field | core_defs.ScalarT, _math_builtin(value))  # type: ignore[operator, arg-type] # calling a function of unknown type; trunc not supported for all types
+        return cast(common.Field | core_defs.ScalarT, _math_builtin(value))
 
     impl.__name__ = name
     return BuiltInFunction(impl)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_math_unary_builtins.py
@@ -6,6 +6,8 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import math
+
 import numpy as np
 import pytest
 
@@ -19,6 +21,7 @@ from gt4py.next import (
     exp,
     float64,
     floor,
+    gamma,
     int32,
     isfinite,
     isinf,
@@ -208,6 +211,16 @@ def test_exp_log(cartesian_case):
 
     cases.verify_with_default_data(
         cartesian_case, exp_log_fieldop, ref=lambda inp1, inp2: np.log(inp1) - np.exp(inp2)
+    )
+
+
+def test_gamma(cartesian_case):
+    @gtx.field_operator
+    def gamma_fieldop(inp1: cases.IFloatField) -> cases.IFloatField:
+        return gamma(inp1)
+
+    cases.verify_with_default_data(
+        cartesian_case, gamma_fieldop, ref=lambda inp1: np.vectorize(math.gamma)(inp1)
     )
 
 

--- a/tests/next_tests/unit_tests/ffront_tests/test_fbuiltins.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_fbuiltins.py
@@ -1,0 +1,31 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import pytest
+
+from gt4py.next.ffront import fbuiltins
+
+
+# values inside the domain of every unary math builtin (0.5 is invalid for `arccosh`)
+_SAFE_INPUT = {"arccosh": 2.0}
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize(
+    "name", fbuiltins.UNARY_MATH_NUMBER_BUILTIN_NAMES + fbuiltins.UNARY_MATH_FP_BUILTIN_NAMES
+)
+def test_unary_math_builtin_scalar_preserves_dtype(name, dtype):
+    value = dtype(_SAFE_INPUT.get(name, 0.5))
+    assert type(getattr(fbuiltins, name)(value)) is dtype
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("name", fbuiltins.UNARY_MATH_FP_PREDICATE_BUILTIN_NAMES)
+def test_unary_math_predicate_builtin_scalar_returns_bool(name, dtype):
+    assert isinstance(getattr(fbuiltins, name)(dtype(0.5)), (bool, np.bool_))


### PR DESCRIPTION
Two related changes to gt4py.next math builtins, both centered on gamma and scalar dtype.

1. Preserve scalar dtype in unary math builtins (fixes #2277)

Unary math builtins on scalars (gtx.sqrt, gtx.sin, ...) returned a Python float/int/bool instead of preserving the input scalar type, e.g. type(gtx.sqrt(gtx.float32(4))) was float instead of numpy.float32. The scalar fallback in ffront/fbuiltins.py used Python's math module, which widens to a Python scalar. It now uses the numpy equivalents, which keep the input dtype, matching the field path (nd_array_field.py) and the iterator-embedded path (iterator/embedded.py). gamma has no numpy equivalent, so it uses scipy.special.gamma when available (as in gt4py.cartesian), falling back to math.gamma with a cast back to the input scalar type.

2. Implement gamma for embedded fields (numpy/cupy/jax)

gtx.gamma on an embedded field previously raised AssertionError on every backend: the field path had a '# TODO gamma' and skipped registration because numpy has no gamma ufunc. It is now registered via a per-namespace resolver: scipy.special.gamma (numpy), cupyx.scipy.special.gamma (cupy), jax.scipy.special.gamma (jax), with a np.vectorize(math.gamma) fallback when scipy is absent. _make_builtin was extended to accept a namespace-to-op resolver.

No new dependencies: scipy is already pulled in by gt4py[next] via the standard extra; cupyx.scipy and jax.scipy ship with cupy and jax.

Tests
- New backend-free unit test for scalar dtype preservation across all unary math builtins (float32/float64) and bool for the predicates.
- New gamma field-operator test exercising the full backend matrix; verified locally green on embedded numpy, embedded cupy (GPU), embedded jax, gtfn (cpu+gpu), dace (cpu+gpu), and roundtrip.

Fixes #2277.