### PR TITLE
fix[eve]: use identity check for None in infer_type

### DIFF
--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -776,7 +776,9 @@ def infer_type(
     if isinstance(value, (StdGenericAliasType, _TypingSpecialFormType)):
         return value
 
-    if value in (None, type(None)):
+    # note: identity check instead of `in`, which would use `__eq__` and fail
+    # for values with non-boolean equality (e.g. NumPy arrays)
+    if value is None or value is type(None):
         return type(None) if none_as_type else None
 
     if isinstance(value, type):


### PR DESCRIPTION
- infer_type used `value in (None, type(None))`, which invokes `__eq__` and raises for values with non-boolean equality such as NumPy arrays ("The truth value of an array ... is ambiguous").
- Switch to an identity check (`value is None or value is type(None)`).