### PR TITLE
fix[next]: correct domain inference for never-selected concat_where branches

### DIFF
--- a/src/gt4py/next/iterator/transforms/infer_domain.py
+++ b/src/gt4py/next/iterator/transforms/infer_domain.py
@@ -97,7 +97,10 @@ def _domain_union(
     filtered_domains: list[domain_utils.SymbolicDomain] = [
         d  # type: ignore[misc]  # domain can never be unknown as these cases are filtered above
         for d in domains
+        # Drop empty (and `NEVER`) domains: the union is a convex hull, so keeping them
+        # over-approximates, e.g. `[10, 10[` and `[11, 11[` would become `[10, 11[` (#2205).
         if d != DomainAccessDescriptor.NEVER
+        and not (isinstance(d, domain_utils.SymbolicDomain) and d.empty())
     ]
     if len(filtered_domains) == 0:
         return DomainAccessDescriptor.NEVER
@@ -219,9 +222,21 @@ def _infer_as_fieldop(
             raise ValueError(f"Unsupported expression of type '{type(in_field)}'.")
         input_ids.append(id_)
 
-    inputs_accessed_domains: dict[str, NonTupleDomainAccess] = _extract_accessed_domains(
-        stencil, input_ids, target_domain, offset_provider, symbolic_domain_sizes
+    # Over an empty domain an `as_fieldop` accesses no input. Translating the empty domain by the
+    # stencil's shifts would over-approximate (see `_domain_union`) or, for unstructured shifts,
+    # fail. The empty domain stays on the node so `prune_empty_concat_where` can drop the branch.
+    target_is_empty = isinstance(target_domain, domain_utils.SymbolicDomain) and bool(
+        target_domain.empty()
     )
+    inputs_accessed_domains: dict[str, NonTupleDomainAccess]
+    if target_is_empty:
+        inputs_accessed_domains = {
+            in_field_id: DomainAccessDescriptor.NEVER for in_field_id in input_ids
+        }
+    else:
+        inputs_accessed_domains = _extract_accessed_domains(
+            stencil, input_ids, target_domain, offset_provider, symbolic_domain_sizes
+        )
 
     # Recursively infer domain of inputs and update domain arg of nested `as_fieldop`s
     accessed_domains: AccessedDomains = {}
@@ -232,7 +247,8 @@ def _infer_as_fieldop(
             inputs_accessed_domains[in_field_id],
             offset_provider=offset_provider,
             symbolic_domain_sizes=symbolic_domain_sizes,
-            allow_uninferred=allow_uninferred,
+            # never-accessed nested `as_fieldop`s are pruned later; don't raise on their `NEVER`.
+            allow_uninferred=allow_uninferred or target_is_empty,
             keep_existing_domains=keep_existing_domains,
         )
         transformed_inputs.append(transformed_input)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_domain_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_domain_inference.py
@@ -1331,6 +1331,118 @@ def test_nested_concat_where_two_dimensions():
     assert expected_domains == constant_fold_accessed_domains(actual_domains)
 
 
+def test_concat_where_shift_in_never_selected_branch():
+    # Regression test for https://github.com/GridTools/gt4py/issues/2205.
+    # A `concat_where` accessed on `KDim: [0, 10)` selects the difference `a[K] - a[K+1]` for
+    # `K < 9` and `K >= 10`, and `a[K]` for `K == 9`. The `K >= 10` branch does not overlap the
+    # accessed domain, i.e. it is never selected. Its (empty) domain must not contribute the
+    # shifted access `a[K+1]`, which would otherwise over-extend `a` to `KDim: [0, 11)`.
+    domain = im.domain(common.GridType.CARTESIAN, {KDim: (0, 10)})
+    cond_lt = im.domain(common.GridType.CARTESIAN, {KDim: (itir.InfinityLiteral.NEGATIVE, 9)})
+    cond_ge = im.domain(common.GridType.CARTESIAN, {KDim: (10, itir.InfinityLiteral.POSITIVE)})
+    diff = im.lambda_("t")(im.minus(im.deref("t"), im.deref(im.shift(Koff, 1)("t"))))
+
+    domain_lt = im.domain(common.GridType.CARTESIAN, {KDim: (0, 9)})
+    domain_never = im.domain(common.GridType.CARTESIAN, {KDim: (10, 10)})  # empty
+    domain_eq = im.domain(common.GridType.CARTESIAN, {KDim: (9, 10)})
+
+    testee = im.concat_where(
+        cond_lt,
+        im.as_fieldop(diff)("a"),
+        im.concat_where(cond_ge, im.as_fieldop(diff)("a"), im.as_fieldop("deref")("a")),
+    )
+    expected = im.concat_where(
+        cond_lt,
+        im.as_fieldop(diff, domain_lt)("a"),
+        im.concat_where(
+            cond_ge,
+            im.as_fieldop(diff, domain_never)("a"),
+            im.as_fieldop("deref", domain_eq)("a"),
+        ),
+    )
+    expected_domains = {"a": domain}  # `[0, 10)`, not the over-extended `[0, 11)`
+
+    actual_call, actual_domains = infer_domain.infer_expr(
+        testee, domain_utils.SymbolicDomain.from_expr(domain), offset_provider={}
+    )
+
+    folded_call = constant_fold_domain_exprs(actual_call)
+    assert expected == folded_call
+    assert expected_domains == constant_fold_accessed_domains(actual_domains)
+
+
+def test_concat_where_shift_in_never_selected_branch_shared():
+    # Regression test for https://github.com/GridTools/gt4py/issues/2205, exercising the form
+    # produced by `canonicalize_domain_argument`: the shifted value is bound in a `let` and
+    # referenced from both the selected (`K < 9`) and the never-selected (`K >= 10`) branch. The
+    # never-selected branch contributes an empty domain `[10, 10)` for the let-variable, which
+    # must be dropped from the union instead of being convex-hulled into `[0, 10)` (which would
+    # over-extend `a` to `[0, 11)`).
+    domain = im.domain(common.GridType.CARTESIAN, {KDim: (0, 10)})
+    cond_lt = im.domain(common.GridType.CARTESIAN, {KDim: (itir.InfinityLiteral.NEGATIVE, 9)})
+    cond_ge = im.domain(common.GridType.CARTESIAN, {KDim: (10, itir.InfinityLiteral.POSITIVE)})
+    diff = im.lambda_("t")(im.minus(im.deref("t"), im.deref(im.shift(Koff, 1)("t"))))
+
+    domain_diff = im.domain(common.GridType.CARTESIAN, {KDim: (0, 9)})
+    domain_eq = im.domain(common.GridType.CARTESIAN, {KDim: (9, 10)})
+
+    testee = im.let("diff", im.as_fieldop(diff)("a"))(
+        im.concat_where(
+            cond_lt,
+            "diff",
+            im.concat_where(cond_ge, "diff", im.as_fieldop("deref")("a")),
+        )
+    )
+    expected = im.let("diff", im.as_fieldop(diff, domain_diff)("a"))(
+        im.concat_where(
+            cond_lt,
+            "diff",
+            im.concat_where(cond_ge, "diff", im.as_fieldop("deref", domain_eq)("a")),
+        )
+    )
+    expected_domains = {"a": domain}  # `[0, 10)`, not the over-extended `[0, 11)`
+
+    actual_call, actual_domains = infer_domain.infer_expr(
+        testee, domain_utils.SymbolicDomain.from_expr(domain), offset_provider={}
+    )
+
+    folded_call = constant_fold_domain_exprs(actual_call)
+    assert expected == folded_call
+    assert expected_domains == constant_fold_accessed_domains(actual_domains)
+
+
+def test_concat_where_unstructured_shift_in_never_selected_branch(unstructured_offset_provider):
+    # Regression test for https://github.com/GridTools/gt4py/issues/2205: a never-selected branch
+    # that shifts along the (empty) dimension of an unstructured connectivity must not be
+    # translated at all. Translating the empty `Edge: [1, 1)` range would reduce over an empty
+    # connectivity slice and raise; instead the branch contributes `NEVER`.
+    domain = im.domain(common.GridType.UNSTRUCTURED, {Edge: (0, 1)})
+    cond = im.domain(common.GridType.UNSTRUCTURED, {Edge: (1, itir.InfinityLiteral.POSITIVE)})
+    e2v = im.lambda_("it")(im.deref(im.shift("E2V", 0)("it")))
+
+    domain_never = im.domain(common.GridType.UNSTRUCTURED, {Edge: (1, 1)})  # empty
+    domain_false = im.domain(common.GridType.UNSTRUCTURED, {Edge: (0, 1)})
+
+    testee = im.concat_where(cond, im.as_fieldop(e2v)("a"), im.as_fieldop("deref")("b"))
+    expected = im.concat_where(
+        cond, im.as_fieldop(e2v, domain_never)("a"), im.as_fieldop("deref", domain_false)("b")
+    )
+    expected_domains = {
+        "a": infer_domain.DomainAccessDescriptor.NEVER,
+        "b": domain_false,
+    }
+
+    actual_call, actual_domains = infer_domain.infer_expr(
+        testee,
+        domain_utils.SymbolicDomain.from_expr(domain),
+        offset_provider=unstructured_offset_provider,
+    )
+
+    folded_call = constant_fold_domain_exprs(actual_call)
+    assert expected == folded_call
+    assert expected_domains == constant_fold_accessed_domains(actual_domains)
+
+
 def test_broadcast():
     testee = im.call("broadcast")("in_field", im.make_tuple(itir.AxisLiteral(value="IDim")))
     domain = im.domain(common.GridType.CARTESIAN, {IDim: (0, 10)})


### PR DESCRIPTION
- A `concat_where` branch whose selection region does not overlap the accessed domain is never evaluated, so it accesses none of its inputs. Domain inference instead propagated the branch's empty domain through the stencil's shifts.
- Because `_domain_union` is a convex hull, shifted empty ranges (e.g. `[10, 10[` and `[11, 11[`) merged into a spurious `[10, 11[`, over-extending inferred input/temporary domains by one level at boundaries (#2205). Unstructured shifts instead failed (reducing over an empty connectivity slice or unioning over inconsistent dimensions).
- Fix: treat an empty domain as `NEVER` (no access) where domains are derived and combined — `_infer_as_fieldop` (yields `NEVER` for all inputs, recurses with `allow_uninferred`) and `_domain_union` (empty is the identity element, dropped).
- Adds regression tests: cartesian `KDim`, `let`-bound shared branch, and unstructured `E2V`.

Fixes #2205.
