### PR TITLE
fix[next]: Fix SyntaxWarnings from \. in regexes

### DIFF
--- a/src/gt4py/next/config.py
+++ b/src/gt4py/next/config.py
@@ -151,9 +151,9 @@ if SKIP_DACE_WARNINGS:
     # NOTE: Ideally we would suppress the warnings using context managers directly in
     #   the backend. However, because this is not thread safe in Python versions before
     #   3.14, we have to do it here.
-    warnings.filterwarnings(action="ignore", module="^dace(\..+)?")
+    warnings.filterwarnings(action="ignore", module=r"^dace(\..+)?")
     warnings.filterwarnings(
-        action="ignore", module="^gt4py.next.program_processors.runners.dace.transformations(\..+)?"
+        action="ignore", module=r"^gt4py.next.program_processors.runners.dace.transformations(\..+)?"
     )
 
 

--- a/src/gt4py/next/config.py
+++ b/src/gt4py/next/config.py
@@ -154,7 +154,7 @@ if SKIP_DACE_WARNINGS:
     warnings.filterwarnings(action="ignore", module=r"^dace(\..+)?")
     warnings.filterwarnings(
         action="ignore",
-        module=r"^gt4py.next.program_processors.runners.dace.transformations(\..+)?"
+        module=r"^gt4py.next.program_processors.runners.dace.transformations(\..+)?",
     )
 
 

--- a/src/gt4py/next/config.py
+++ b/src/gt4py/next/config.py
@@ -153,7 +153,8 @@ if SKIP_DACE_WARNINGS:
     #   3.14, we have to do it here.
     warnings.filterwarnings(action="ignore", module=r"^dace(\..+)?")
     warnings.filterwarnings(
-        action="ignore", module=r"^gt4py.next.program_processors.runners.dace.transformations(\..+)?"
+        action="ignore",
+        module=r"^gt4py.next.program_processors.runners.dace.transformations(\..+)?"
     )
 
 


### PR DESCRIPTION
## Description

The `\.` in a literal string produces `SyntaxWarning: invalid escape sequence '\.'`. The regexes should be raw strings. This PR changes them to raw strings.

I have not checked if there are other instances of this. I've fixed the ones that are triggered when running icon4py standalone driver.