### PR TITLE
refactor[cartesian]: descriptive loop names in dace backend

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
@@ -68,7 +68,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
 
     def visit_HorizontalLoop(self, node: tir.HorizontalLoop, ctx: Context) -> None:
         dace_map = nodes.Map(
-            label=f"horizontal_loop_{id(node)}",
+            label=f"{ctx.tree.name}__h_map_{id(node)}",
             params=[tir.Axis.J.iteration_symbol(), tir.Axis.I.iteration_symbol()],
             ndrange=subsets.Range(
                 [
@@ -87,7 +87,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
     def visit_VerticalLoop(self, node: tir.VerticalLoop, ctx: Context) -> None:
         # For serial loops, create a ForScope and add it to the tree
         if node.loop_order != common.LoopOrder.PARALLEL:
-            for_scope = tn.ForScope(loop=_loop_region_for(node), children=[])
+            for_scope = tn.ForScope(loop=_loop_region_for(node, ctx), children=[])
 
             with ContextPushPop(ctx, for_scope):
                 self.visit(node.children, ctx=ctx)
@@ -96,7 +96,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
 
         # For parallel loops, create a map and add it to the tree
         dace_map = nodes.Map(
-            label=f"vertical_loop_{id(node)}",
+            label=f"{ctx.tree.name}__v_map_{id(node)}",
             params=[node.iteration_variable],
             ndrange=subsets.Range(
                 # -1 because range bounds are inclusive
@@ -140,7 +140,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
         return ctx.tree
 
 
-def _loop_region_for(node: tir.VerticalLoop) -> LoopRegion:
+def _loop_region_for(node: tir.VerticalLoop, ctx: Context) -> LoopRegion:
     """
     Translates a vertical loop into a Dace LoopRegion to be used in `tn.ForScope`.
 
@@ -152,7 +152,7 @@ def _loop_region_for(node: tir.VerticalLoop) -> LoopRegion:
     iteration_var = node.iteration_variable
 
     return LoopRegion(
-        label=f"vertical_loop_{id(node)}",
+        label=f"{ctx.tree.name}__v_loop_{id(node)}",
         loop_var=iteration_var,
         initialize_expr=CodeBlock(f"{iteration_var} = {node.bounds_k.start}"),
         condition_expr=CodeBlock(f"{iteration_var} {comparison} {node.bounds_k.end}"),

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_dace_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_dace_backend.py
@@ -6,7 +6,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from gt4py.eve import SymbolRef
 import os
 import pytest
 
@@ -15,7 +14,6 @@ pytest.importorskip("dace")
 
 
 from dace import nodes
-from dace import sdfg as dace_sdfg
 from dace.sdfg.state import LoopRegion
 import dace.sdfg.analysis.schedule_tree.treenodes as tn
 


### PR DESCRIPTION
## Description

The pipeline of representations (truncated) for the cartesian dace backend is as follows:

```none
... > oir -> treeir (gt4py) -> schedule tree (dace) -> SDFG (dace)
```

In this PR, we change the names of map/loop in the schedule tree representation. The map/loop names in that representation are just names (that can more or less be anything). We had a rather general description and replace it with a more descriptive one, which includes the name of the stencil where the horizontal/vertical loop (sections) come from. This allows easier debugging and profiling. Nothing (except names) changes in the generated code. Thus no tests have been added.

This PR contains an unrelated commit removing unused imports from dace backend tests.


This PR is part of cleaning up our "working branch", i.e. https://github.com/GridTools/gt4py/pull/2595, which accumulated a couple of changes over the last month.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A