### PR TITLE
fix[cartesian]: actually freeze origin & domain in K-axis

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -95,6 +95,7 @@ def _sdfg_add_arrays_and_edges(
     inputs: set[str] | dict[str, dtypes.typeclass],
     outputs: set[str] | dict[str, dtypes.typeclass],
     origins: dict[str, tuple[int, ...]],
+    domain: tuple[int, ...],
 ) -> None:
     for name, array in inner_sdfg.arrays.items():
         if array.transient:
@@ -129,12 +130,20 @@ def _sdfg_add_arrays_and_edges(
                 if axis not in axes:
                     continue
                 o = origin[index]
-                e = field_info[name].boundary.lower_indices[cartesian_index]
+                lower, upper = field_info[name].boundary[cartesian_index]
                 s = inner_sdfg.arrays[name].shape[index]
-                ranges.append(
-                    # s - 1 because ranges are inclusive
-                    (o - max(0, e), o - max(0, e) + s - 1, 1)
-                )
+                if axis == CartesianSpace.Axis.K.name:
+                    d = domain[cartesian_index]
+                    ranges.append(
+                        # max(0, lower) because ...
+                        # d - 1 because ranges are inclusive
+                        (o - max(0, lower), o + upper + d - 1, 1)
+                    )
+                else:
+                    ranges.append(
+                        # s - 1 because ranges are inclusive
+                        (o - max(0, lower), o - max(0, lower) + s - 1, 1)
+                    )
                 index += 1
 
             # Add data dimensions to the range
@@ -264,7 +273,7 @@ def freeze_origin_domain_sdfg(
     nsdfg = state.add_nested_sdfg(inner_sdfg, inputs, outputs)
 
     _sdfg_add_arrays_and_edges(
-        field_info, wrapper_sdfg, state, inner_sdfg, nsdfg, inputs, outputs, origin
+        field_info, wrapper_sdfg, state, inner_sdfg, nsdfg, inputs, outputs, origin, domain
     )
 
     # in special case of empty domain, remove entire SDFG.


### PR DESCRIPTION
## Description

This fix comes from running GFDL_1M in KJI-layout where - in NDSL - there's no extra point allocated in the vertical (to be able to directly copy the Fortran data).

This commit freezes origin and `domain` (not `shape`) in the K-axis of the stencil. `shape` and `domain` agree most of the time, but can differ if - for example - the stencil is configured on `K_INTERFACE_DIM` and the field of size `K_DIM`. Depending on the combination, this can lead to out of bound reads where we were previously saved by the extra point allocated in the back (but in KJI since we don't have this point, we crash).

I am not touching the horizontal axes in this commit. We probably should, but we haven't seen any crashes (probably due to the fact that we can't currently run dynamics in KJI (i.e. without the extra point)). I'd argue we should tackle this in a follow-up when we also look at the "potential out of bounds" memlet warnings that we get from dace (mainly when running dynamics).


This PR is part of cleaning up our "working branch", i.e. https://github.com/GridTools/gt4py/pull/2595, which accumulated a couple of changes over the last month.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A