### PR TITLE
fix[next-dace]: Set cmake argument for local cuda architecture

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -72,10 +72,11 @@ def set_dace_config(
     dace.Config.set("cache", value="single")
 
     # Disable auto-detection of the CUDA architecture, and instead use the one provided by GT4Py.
-    dace.Config.set(
-        "compiler.extra_cmake_args",
-        value=f"-DLOCAL_CUDA_ARCHITECTURES={gtx_cmake.get_device_arch()}",
-    )
+    if device_type == core_defs.CUPY_DEVICE_TYPE:
+        dace.Config.set(
+            "compiler.extra_cmake_args",
+            value=f"-DLOCAL_CUDA_ARCHITECTURES={gtx_cmake.get_device_arch()}",
+        )
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by
     #  `gt4py.next.program_processors.runners.dace.transfromations.gpu_utils.gt_gpu_transform_non_standard_memlet()`.

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -14,6 +14,7 @@ import dace
 
 from gt4py._core import definitions as core_defs
 from gt4py.next import config as gtx_config
+from gt4py.next.otf.compilation.build_systems import cmake as gtx_cmake
 
 
 SDFG_ARG_METRIC_LEVEL: Final[str] = "gt_metrics_level"
@@ -69,6 +70,12 @@ def set_dace_config(
     #   cache the generated code and binary objects for the program SDFG, without
     #   creating any further sub-folder to compile the SDFG.
     dace.Config.set("cache", value="single")
+
+    # Disable auto-detection of the CUDA architecture, and instead use the one provided by GT4Py.
+    dace.Config.set(
+        "compiler.cmake_extra_args",
+        value=f"-DLOCAL_CUDA_ARCHITECTURES={gtx_cmake.get_device_arch()}",
+    )
 
     # Prevents the implicit change of Memlets to Maps. Instead they should be handled by
     #  `gt4py.next.program_processors.runners.dace.transfromations.gpu_utils.gt_gpu_transform_non_standard_memlet()`.

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -73,7 +73,7 @@ def set_dace_config(
 
     # Disable auto-detection of the CUDA architecture, and instead use the one provided by GT4Py.
     dace.Config.set(
-        "compiler.cmake_extra_args",
+        "compiler.extra_cmake_args",
         value=f"-DLOCAL_CUDA_ARCHITECTURES={gtx_cmake.get_device_arch()}",
     )
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -71,7 +71,9 @@ def set_dace_config(
     #   creating any further sub-folder to compile the SDFG.
     dace.Config.set("cache", value="single")
 
-    # Disable auto-detection of the CUDA architecture, and instead use the one provided by GT4Py.
+    # Workaround to disable detection of the CUDA architecture in DaCe, and instead use the one provided by GT4Py.
+    # TODO(edopao): revisit this workaround once it is possible to disable GPU detection in DaCe.
+    # (see https://github.com/spcl/dace/pull/2424)
     if core_defs.CUPY_DEVICE_TYPE is not None:
         dace.Config.set(
             "compiler.extra_cmake_args",

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -72,7 +72,7 @@ def set_dace_config(
     dace.Config.set("cache", value="single")
 
     # Disable auto-detection of the CUDA architecture, and instead use the one provided by GT4Py.
-    if device_type == core_defs.CUPY_DEVICE_TYPE:
+    if core_defs.CUPY_DEVICE_TYPE is not None:
         dace.Config.set(
             "compiler.extra_cmake_args",
             value=f"-DLOCAL_CUDA_ARCHITECTURES={gtx_cmake.get_device_arch()}",

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -121,6 +121,9 @@ def _run_compiler(
         mock.patch.object(
             dace_wf_compilation.core_defs, "CUPY_DEVICE_TYPE", core_defs.DeviceType.CUDA
         ),
+        mock.patch(
+            "gt4py.next.otf.compilation.build_systems.cmake.get_device_arch", return_value="xyz"
+        ),
     ):
         compiler(inp)
         compiled_sdfg = compile_mock.call_args.args[0]


### PR DESCRIPTION
Skip auto-discovery of cuda device architecture, by default enabled in the dace cmake configuration, and rely on the device architecture provided by GT4Py. 