### PR TITLE
test[next]: Fix value type in symbol_mapping (flacky issue in dace tests)

### DIFF
--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_fuse_horizontal_conditionblocks.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_fuse_horizontal_conditionblocks.py
@@ -95,6 +95,9 @@ def _make_if_block_with_tasklet(
         inputs={b1_name, b2_name, cond_name},
         outputs={output_name},
     )
+    # TODO(edoapo): The typecast to sympy is needed because the constructor of the `symbol_mapping`
+    # dict property converts the values to symbolic expressions, but the assignment of entries
+    # in the dict does not. Update this line when dace provides better type conversion.
     nested_sdfg.symbol_mapping["multiplier"] = sympy.Number(2.0)
     return nested_sdfg
 

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_fuse_horizontal_conditionblocks.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_fuse_horizontal_conditionblocks.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
+import sympy
 
 dace = pytest.importorskip("dace")
 from dace.sdfg import nodes as dace_nodes
@@ -94,7 +95,7 @@ def _make_if_block_with_tasklet(
         inputs={b1_name, b2_name, cond_name},
         outputs={output_name},
     )
-    nested_sdfg.symbol_mapping["multiplier"] = 2.0
+    nested_sdfg.symbol_mapping["multiplier"] = sympy.Number(2.0)
     return nested_sdfg
 
 


### PR DESCRIPTION
The value assignment to `symbol_mapping` did not respect the type signature of the dictionary.
```
   symbol_mapping = DictProperty(key_type=str,
                                  value_type=sp.Basic,
                                  desc="Mapping between internal symbols and their values, expressed as "
                                  "symbolic expressions")
```

This fix addresses a flacky test failure, which is related to the usage of `lru_cache` without typed keys (see dace [PR#2404](https://github.com/spcl/dace/pull/2404)).