### PR TITLE
refactor[cartesian]: update treeir representation of the vertical loop

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -31,18 +31,8 @@ DEFAULT_STORAGE_TYPE = {
 """Default dace residency types per device type."""
 
 
-def _resolve_loop_schedule(
-    device_type: dtypes.DeviceType, loop_order: common.LoopOrder
-) -> dtypes.ScheduleType:
-    """Optimal kernel schedule type based on syntax and target device.
-
-    Current strategy:
-        - respect OIR syntax: sequential on all non-parallel keyword
-        - maximize local parallel usage per target
-    """
-    if loop_order != common.LoopOrder.PARALLEL:
-        return dtypes.ScheduleType.Sequential
-
+def _resolve_map_schedule(device_type: dtypes.DeviceType) -> dtypes.ScheduleType:
+    """Optimal kernel schedule type based on target device."""
     if device_type == dtypes.DeviceType.GPU:
         return dtypes.ScheduleType.GPU_Device
 
@@ -156,9 +146,7 @@ class OIRToTreeIR(eve.NodeVisitor):
         loop = tir.HorizontalLoop(
             bounds_i=tir.Bounds(start=axis_start_i, end=axis_end_i),
             bounds_j=tir.Bounds(start=axis_start_j, end=axis_end_j),
-            schedule=_resolve_loop_schedule(
-                self._device_type, common.LoopOrder.PARALLEL
-            ),  # Horizontal is always parallel
+            schedule=_resolve_map_schedule(self._device_type),
             children=[],
             parent=ctx.current_scope,
         )
@@ -286,14 +274,23 @@ class OIRToTreeIR(eve.NodeVisitor):
             axis_end=tir.Axis.K.domain_dace_symbol(),
         )
 
-        loop = tir.VerticalLoop(
-            iteration_variable=eve.SymbolRef(f"{tir.Axis.K.iteration_symbol()}_{id(node)}"),
-            loop_order=loop_order,
-            bounds_k=bounds,
-            schedule=_resolve_loop_schedule(self._device_type, loop_order),
-            children=[],
-            parent=ctx.current_scope,
-        )
+        loop: tir.SequentialVerticalLoop | tir.ParallelVerticalLoop
+        if loop_order == common.LoopOrder.PARALLEL:
+            loop = tir.ParallelVerticalLoop(
+                iteration_variable=eve.SymbolRef(f"{tir.Axis.K.iteration_symbol()}_{id(node)}"),
+                bounds_k=bounds,
+                schedule=_resolve_map_schedule(self._device_type),
+                children=[],
+                parent=ctx.current_scope,
+            )
+        else:
+            loop = tir.SequentialVerticalLoop(
+                iteration_variable=eve.SymbolRef(f"{tir.Axis.K.iteration_symbol()}_{id(node)}"),
+                bounds_k=bounds,
+                loop_order=loop_order,
+                children=[],
+                parent=ctx.current_scope,
+            )
 
         with loop.scope(ctx):
             self.visit(node.horizontal_executions, ctx=ctx)

--- a/src/gt4py/cartesian/gtc/dace/treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir.py
@@ -126,16 +126,15 @@ class HorizontalLoop(TreeScope):
     schedule: dtypes.ScheduleType
 
 
-class VerticalLoop(TreeScope):
+class SequentialVerticalLoop(TreeScope):
     iteration_variable: eve.SymbolRef
-    """
-    DaCe 1.x (without CFGs) maps sequential loops to a state machine with the iteration variable
-    on interstate edges. Having unique symbols makes DaCe 1.x happy and allows to rename symbols
-    via search & replace.
-    """
-    loop_order: common.LoopOrder
     bounds_k: Bounds
+    loop_order: common.LoopOrder
 
+
+class ParallelVerticalLoop(TreeScope):
+    iteration_variable: eve.SymbolRef
+    bounds_k: Bounds
     schedule: dtypes.ScheduleType
 
 
@@ -159,7 +158,7 @@ def k_symbol(scope: TreeScope) -> eve.SymbolRef:
     if scope.parent is None:
         raise ValueError("No vertical loop found in (parents of) current scope.")
 
-    if isinstance(scope, VerticalLoop):
+    if isinstance(scope, (SequentialVerticalLoop, ParallelVerticalLoop)):
         return scope.iteration_variable
 
     return k_symbol(scope.parent)

--- a/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
@@ -84,17 +84,13 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
         with ContextPushPop(ctx, map_scope):
             self.visit(node.children, ctx=ctx)
 
-    def visit_VerticalLoop(self, node: tir.VerticalLoop, ctx: Context) -> None:
-        # For serial loops, create a ForScope and add it to the tree
-        if node.loop_order != common.LoopOrder.PARALLEL:
-            for_scope = tn.ForScope(loop=_loop_region_for(node, ctx), children=[])
+    def visit_SequentialVerticalLoop(self, node: tir.SequentialVerticalLoop, ctx: Context) -> None:
+        for_scope = tn.ForScope(loop=_loop_region_for(node, ctx), children=[])
 
-            with ContextPushPop(ctx, for_scope):
-                self.visit(node.children, ctx=ctx)
+        with ContextPushPop(ctx, for_scope):
+            self.visit(node.children, ctx=ctx)
 
-            return
-
-        # For parallel loops, create a map and add it to the tree
+    def visit_ParallelVerticalLoop(self, node: tir.ParallelVerticalLoop, ctx: Context) -> None:
         dace_map = nodes.Map(
             label=f"{ctx.tree.name}__v_map_{id(node)}",
             params=[node.iteration_variable],
@@ -140,9 +136,9 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
         return ctx.tree
 
 
-def _loop_region_for(node: tir.VerticalLoop, ctx: Context) -> LoopRegion:
+def _loop_region_for(node: tir.SequentialVerticalLoop, ctx: Context) -> LoopRegion:
     """
-    Translates a vertical loop into a Dace LoopRegion to be used in `tn.ForScope`.
+    Translates a sequential vertical loop into a Dace LoopRegion to be used in `tn.ForScope`.
 
     :param node: Vertical loop to translate
     :return: DaCe LoopRegion to use in `tn.ForScope`

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -49,7 +49,7 @@ rng = np.random.default_rng(1337)
 
 @pytest.mark.parametrize("name", stencil_definitions)
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_generation(name, backend):
+def test_generation(name, backend) -> None:
     stencil_definition = stencil_definitions[name]
     externals = externals_registry[name]
     stencil = gtscript.stencil(backend, stencil_definition, externals=externals)
@@ -70,17 +70,17 @@ def test_generation(name, backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_lazy_stencil(backend):
+def test_lazy_stencil(backend) -> None:
     @gtscript.lazy_stencil(backend=backend)
-    def definition(field_a: Field[np.float64], field_b: Field[np.float64]):  # type: ignore
+    def definition(field_a: Field[np.float64], field_b: Field[np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             field_a[0, 0, 0] = field_b
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_temporary_field_declared_in_if(backend):
+def test_temporary_field_declared_in_if(backend) -> None:
     @gtscript.stencil(backend=backend)
-    def definition(field_a: Field[np.float64]):  # type: ignore
+    def definition(field_a: Field[np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             if field_a < 0:
                 field_b = -field_a
@@ -90,21 +90,21 @@ def test_temporary_field_declared_in_if(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_stage_without_effect(backend):
+def test_stage_without_effect(backend) -> None:
     @gtscript.stencil(backend=backend)
-    def definition(field_a: Field[np.float64]):  # type: ignore
+    def definition(field_a: Field[np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             field_c = 0.0  # noqa: F841
 
 
-def test_ignore_np_errstate():
-    def setup_and_run(backend, **kwargs):
+def test_ignore_np_errstate() -> None:
+    def setup_and_run(backend, **kwargs) -> None:
         field_a = gt_storage.zeros(
             dtype=np.float64, backend=backend, shape=(3, 3, 1), aligned_index=(0, 0, 0)
         )
 
         @gtscript.stencil(backend=backend, **kwargs)
-        def divide_by_zero(field_a: Field[np.float64]):  # type: ignore
+        def divide_by_zero(field_a: Field[np.float64]) -> None:  # type: ignore
             with computation(PARALLEL), interval(...):
                 field_a = 1.0 / field_a
 
@@ -118,12 +118,12 @@ def test_ignore_np_errstate():
 
 
 @pytest.mark.parametrize("backend", CPU_BACKENDS)
-def test_stencil_without_effect(backend):
-    def definition1(field_in: Field[np.float64]):  # type: ignore
+def test_stencil_without_effect(backend) -> None:
+    def definition1(field_in: Field[np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             tmp = 0.0  # noqa: F841
 
-    def definition2(f_in: Field[np.float64]):  # type: ignore
+    def definition2(f_in: Field[np.float64]) -> None:  # type: ignore
         from __externals__ import flag  # type: ignore
 
         with computation(PARALLEL), interval(...):
@@ -146,7 +146,7 @@ def test_stencil_without_effect(backend):
 
 
 @pytest.mark.parametrize("backend", CPU_BACKENDS)
-def test_stage_merger_induced_interval_block_reordering(backend):
+def test_stage_merger_induced_interval_block_reordering(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(23, 23, 23), aligned_index=(0, 0, 0)
     )
@@ -155,7 +155,7 @@ def test_stage_merger_induced_interval_block_reordering(backend):
     )
 
     @gtscript.stencil(backend=backend)
-    def stencil(field_in: Field[np.float64], field_out: Field[np.float64]):  # type: ignore
+    def stencil(field_in: Field[np.float64], field_out: Field[np.float64]) -> None:  # type: ignore
         with computation(BACKWARD):
             with interval(-2, -1):  # block 1
                 field_out = field_in
@@ -174,13 +174,13 @@ def test_stage_merger_induced_interval_block_reordering(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_lower_dimensional_inputs(backend):
+def test_lower_dimensional_inputs(backend) -> None:
     @gtscript.stencil(backend=backend)
     def stencil(
         field_3d: Field[gtscript.IJK, np.float64],  # type: ignore
         field_2d: Field[gtscript.IJ, np.float64],  # type: ignore
         field_1d: Field[gtscript.K, np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL):
             with interval(0, -1):
                 tmp = field_2d + field_1d[1]
@@ -228,13 +228,13 @@ def test_lower_dimensional_inputs(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_lower_dimensional_masked(backend):
+def test_lower_dimensional_masked(backend) -> None:
     @gtscript.stencil(backend=backend)
     def copy_2to3(
         cond: Field[gtscript.IJK, np.float64],  # type: ignore
         inp: Field[gtscript.IJ, np.float64],  # type: ignore
         outp: Field[gtscript.IJK, np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             if cond > 0.0:
                 outp[0, 0, 0] = inp
@@ -259,13 +259,13 @@ def test_lower_dimensional_masked(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_lower_dimensional_masked_2dcond(backend):
+def test_lower_dimensional_masked_2dcond(backend) -> None:
     @gtscript.stencil(backend=backend)
     def copy_2to3(
         cond: Field[gtscript.IJK, np.float64],  # type: ignore
         inp: Field[gtscript.IJ, np.float64],  # type: ignore
         outp: Field[gtscript.IJK, np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(FORWARD), interval(...):
             if cond > 0.0:
                 outp[0, 0, 0] = inp
@@ -290,12 +290,12 @@ def test_lower_dimensional_masked_2dcond(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_lower_dimensional_inputs_2d_to_3d_forward(backend):
+def test_lower_dimensional_inputs_2d_to_3d_forward(backend) -> None:
     @gtscript.stencil(backend=backend)
     def copy_2to3(
         inp: Field[gtscript.IJ, np.float64],  # type: ignore
         outp: Field[gtscript.IJK, np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(FORWARD), interval(...):
             outp[0, 0, 0] = inp
 
@@ -312,7 +312,7 @@ def test_lower_dimensional_inputs_2d_to_3d_forward(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_higher_dimensional_fields(backend):
+def test_higher_dimensional_fields(backend) -> None:
     FLOAT64_VEC2 = (np.float64, (2,))
     FLOAT64_MAT22 = (np.float64, (2, 2))
 
@@ -321,7 +321,7 @@ def test_higher_dimensional_fields(backend):
         field: Field[np.float64],  # type: ignore
         vec_field: Field[FLOAT64_VEC2],  # type: ignore
         mat_field: Field[FLOAT64_MAT22],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             tmp = vec_field[0, 0, 0][0] + vec_field[0, 0, 0][1]  # noqa: F841
 
@@ -367,13 +367,13 @@ def test_higher_dimensional_fields(backend):
 
 
 @pytest.mark.parametrize("backend", CPU_BACKENDS)
-def test_input_order(backend):
+def test_input_order(backend) -> None:
     @gtscript.stencil(backend=backend)
     def stencil(
         in_field: Field[np.float64],  # type: ignore
         parameter: np.float64,
         out_field: Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = in_field * parameter
 
@@ -390,13 +390,13 @@ def test_input_order(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_variable_offsets(backend):
+def test_variable_offsets(backend) -> None:
     @gtscript.stencil(backend=backend)
     def stencil_ij(
         in_field: Field[np.float64],  # type: ignore
         out_field: Field[np.float64],  # type: ignore
         index_field: Field[gtscript.IJ, int],  # type: ignore
-    ):
+    ) -> None:
         with computation(FORWARD), interval(...):
             out_field[0, 0, 0] = in_field[0, 0, 1] + in_field[0, 0, index_field + 1]
             index_field = index_field + 1
@@ -406,13 +406,13 @@ def test_variable_offsets(backend):
         in_field: Field[np.float64],  # type: ignore
         out_field: Field[np.float64],  # type: ignore
         index_field: Field[int],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = in_field[0, 0, 1] + in_field[0, 0, index_field + 1]
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_variable_offsets_and_while_loop(backend):
+def test_variable_offsets_and_while_loop(backend) -> None:
     @gtscript.stencil(backend=backend)
     def stencil(
         pe1: Field[np.float64],  # type: ignore
@@ -420,7 +420,7 @@ def test_variable_offsets_and_while_loop(backend):
         qin: Field[np.float64],  # type: ignore
         qout: Field[np.float64],  # type: ignore
         lev: Field[gtscript.IJ, np.int_],  # type: ignore
-    ):
+    ) -> None:
         with computation(FORWARD), interval(0, -1):
             if pe2[0, 0, 1] <= pe1[0, 0, lev]:
                 qout = qin[0, 0, 1]
@@ -433,7 +433,7 @@ def test_variable_offsets_and_while_loop(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_nested_while_loop(backend):
+def test_nested_while_loop(backend) -> None:
     @gtscript.stencil(backend=backend)
     def stencil(field_a: Field[np.float64], field_b: Field[np.int_]):  # type: ignore
         with computation(PARALLEL), interval(...):
@@ -445,9 +445,9 @@ def test_nested_while_loop(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_mask_with_offset_written_in_conditional(backend):
+def test_mask_with_offset_written_in_conditional(backend) -> None:
     @gtscript.stencil(backend)
-    def stencil(outp: Field[np.float64]):  # type: ignore
+    def stencil(outp: Field[np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             cond = True
             if cond[0, -1, 0] or cond[0, 0, 0]:
@@ -466,14 +466,14 @@ def test_mask_with_offset_written_in_conditional(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_write_data_dim_indirect_addressing(backend):
+def test_write_data_dim_indirect_addressing(backend) -> None:
     INT32_VEC2 = (np.int32, (2,))
 
     def stencil(
         input_field: Field[gtscript.IJK, np.int32],  # type: ignore
         output_field: Field[gtscript.IJK, INT32_VEC2],  # type: ignore
         index: int,
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             output_field[0, 0, 0][index] = input_field
 
@@ -491,14 +491,14 @@ def test_write_data_dim_indirect_addressing(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_read_data_dim_indirect_addressing(backend):
+def test_read_data_dim_indirect_addressing(backend) -> None:
     INT32_VEC2 = (np.int32, (2,))
 
     def stencil(
         input_field: Field[gtscript.IJK, INT32_VEC2],  # type: ignore
         output_field: Field[gtscript.IJK, np.int32],  # type: ignore
         index: int,
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             output_field[0, 0, 0] = input_field[0, 0, 0][index]
 
@@ -517,12 +517,12 @@ def test_read_data_dim_indirect_addressing(backend):
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 class TestNegativeOrigin:
-    def test_negative_origin_i(self, backend):
+    def test_negative_origin_i(self, backend) -> None:
         @gtscript.stencil(backend=backend)
         def stencil_i(
             input_field: Field[gtscript.IJK, np.int32],  # type: ignore
             output_field: Field[gtscript.IJK, np.int32],  # type: ignore
-        ):
+        ) -> None:
             with computation(PARALLEL), interval(...):
                 output_field[0, 0, 0] = input_field[1, 0, 0]
 
@@ -536,12 +536,12 @@ class TestNegativeOrigin:
         stencil_i(input_field, output_field, origin={"input_field": (-1, 0, 0)})
         assert output_field[0, 0, 0] == 1
 
-    def test_negative_origin_k(self, backend):
+    def test_negative_origin_k(self, backend) -> None:
         @gtscript.stencil(backend=backend)
         def stencil_k(
             input_field: Field[gtscript.IJK, np.int32],  # type: ignore
             output_field: Field[gtscript.IJK, np.int32],  # type: ignore
-        ):
+        ) -> None:
             with computation(PARALLEL), interval(...):
                 output_field[0, 0, 0] = input_field[0, 0, 1]
 
@@ -557,9 +557,9 @@ class TestNegativeOrigin:
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_origin_k_fields(backend):
+def test_origin_k_fields(backend) -> None:
     @gtscript.stencil(backend=backend, rebuild=True)
-    def k_to_ijk(outp: Field[np.float64], inp: Field[gtscript.K, np.float64]):  # type: ignore
+    def k_to_ijk(outp: Field[np.float64], inp: Field[gtscript.K, np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             outp[0, 0, 0] = inp
 
@@ -585,7 +585,7 @@ def test_origin_k_fields(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_tmp_stencil(backend):
+def test_tmp_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(6, 6, 6), aligned_index=(0, 0, 0)
     )
@@ -594,7 +594,10 @@ def test_tmp_stencil(backend):
     )
 
     @gtscript.stencil(backend=backend)
-    def stencil(field_in: gtscript.Field[np.float64], field_out: gtscript.Field[np.float64]):  # type: ignore
+    def stencil(
+        field_in: gtscript.Field[np.float64],  # type: ignore
+        field_out: gtscript.Field[np.float64],  # type: ignore
+    ) -> None:
         with computation(PARALLEL):
             with interval(...):
                 tmp = field_in + 1
@@ -615,7 +618,7 @@ def test_tmp_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_backward_stencil(backend):
+def test_backward_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -624,7 +627,10 @@ def test_backward_stencil(backend):
     )
 
     @gtscript.stencil(backend=backend)
-    def stencil(field_in: gtscript.Field[np.float64], field_out: gtscript.Field[np.float64]):  # type: ignore
+    def stencil(
+        field_in: gtscript.Field[np.float64],  # type: ignore
+        field_out: gtscript.Field[np.float64],  # type: ignore
+    ) -> None:
         with computation(BACKWARD):
             with interval(-1, None):
                 field_in = 2
@@ -643,7 +649,7 @@ def test_backward_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_while_stencil(backend):
+def test_while_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(6, 6, 6), aligned_index=(0, 0, 0)
     )
@@ -652,7 +658,10 @@ def test_while_stencil(backend):
     )
 
     @gtscript.stencil(backend=backend)
-    def stencil(field_in: gtscript.Field[np.float64], field_out: gtscript.Field[np.float64]):  # type: ignore
+    def stencil(
+        field_in: gtscript.Field[np.float64],  # type: ignore
+        field_out: gtscript.Field[np.float64],  # type: ignore
+    ) -> None:
         with computation(PARALLEL):
             with interval(...):
                 while field_in < 10:
@@ -667,7 +676,7 @@ def test_while_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_higher_dim_literal_stencil(backend):
+def test_higher_dim_literal_stencil(backend) -> None:
     FLOAT64_NDDIM = (np.float64, (4,))
 
     field_in = gt_storage.ones(
@@ -682,7 +691,7 @@ def test_higher_dim_literal_stencil(backend):
     def stencil(
         vec_field: gtscript.Field[FLOAT64_NDDIM],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = vec_field[0, 0, 0][2]
 
@@ -694,7 +703,7 @@ def test_higher_dim_literal_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_higher_dim_scalar_stencil(backend):
+def test_higher_dim_scalar_stencil(backend) -> None:
     FLOAT64_NDDIM = (np.float64, (4,))
 
     field_in = gt_storage.ones(
@@ -710,7 +719,7 @@ def test_higher_dim_scalar_stencil(backend):
         vec_field: gtscript.Field[FLOAT64_NDDIM],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
         scalar_argument: int,
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = vec_field[0, 0, 0][scalar_argument]
 
@@ -722,7 +731,7 @@ def test_higher_dim_scalar_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_native_function_call_stencil(backend):
+def test_native_function_call_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -734,7 +743,7 @@ def test_native_function_call_stencil(backend):
     def test_stencil(
         in_field: gtscript.Field[np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = in_field[0, 0, 0] + sin(0.848062)
 
@@ -744,7 +753,7 @@ def test_native_function_call_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_unary_operator_stencil(backend):
+def test_unary_operator_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -756,7 +765,7 @@ def test_unary_operator_stencil(backend):
     def test_stencil(
         in_field: gtscript.Field[np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = -in_field[0, 0, 0]
 
@@ -766,7 +775,7 @@ def test_unary_operator_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_ternary_operator_stencil(backend):
+def test_ternary_operator_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -779,7 +788,7 @@ def test_ternary_operator_stencil(backend):
     def test_stencil(
         in_field: gtscript.Field[np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = in_field[0, 0, 0] if in_field > 10 else in_field[0, 0, 0] + 1
 
@@ -791,7 +800,7 @@ def test_ternary_operator_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_mask_stencil(backend):
+def test_mask_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -804,7 +813,7 @@ def test_mask_stencil(backend):
     def test_stencil(
         in_field: gtscript.Field[np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             if in_field[0, 0, 0] > 0:
                 out_field[0, 0, 0] = in_field
@@ -818,7 +827,7 @@ def test_mask_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_k_offset_stencil(backend):
+def test_k_offset_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -833,7 +842,7 @@ def test_k_offset_stencil(backend):
         in_field: gtscript.Field[np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
         scalar_value: int,
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(1, None):
             out_field[0, 0, 0] = in_field[0, 0, scalar_value]
 
@@ -844,7 +853,7 @@ def test_k_offset_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_k_offset_field_stencil(backend):
+def test_k_offset_field_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)
     )
@@ -860,7 +869,7 @@ def test_k_offset_field_stencil(backend):
         in_field: gtscript.Field[np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
         idx_field: gtscript.Field[gtscript.IJ, np.int64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(1, None):
             out_field[0, 0, 0] = in_field[0, 0, idx_field + 1]
 
@@ -871,7 +880,7 @@ def test_k_offset_field_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_k_only_access_stencil(backend):
+def test_k_only_access_stencil(backend) -> None:
     field_in = gt_storage.from_array(
         np.array([2, 3, 4, 5]), dtype=np.float64, backend=backend, aligned_index=(0,)
     )
@@ -883,7 +892,7 @@ def test_k_only_access_stencil(backend):
     def test_stencil(
         in_field: gtscript.Field[gtscript.K, np.float64],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL):
             with interval(0, 1):
                 out_field[0, 0, 0] = in_field[1]
@@ -897,7 +906,7 @@ def test_k_only_access_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_table_access_stencil(backend):
+def test_table_access_stencil(backend) -> None:
     table_view = gt_storage.from_array(
         np.array([2, 3, 4, 5]), dtype=np.float64, backend=backend, aligned_index=(0,)
     )
@@ -909,7 +918,7 @@ def test_table_access_stencil(backend):
     def test_stencil(
         table_view: gtscript.GlobalTable[(np.float64, (4))],  # type: ignore
         out_field: gtscript.Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL):
             with interval(0, 1):
                 out_field[0, 0, 0] = table_view.A[1]
@@ -923,9 +932,9 @@ def test_table_access_stencil(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_pruned_args_match(backend):
+def test_pruned_args_match(backend) -> None:
     @gtscript.stencil(backend=backend)
-    def test(out: Field[np.float64], inp: Field[np.float64]):  # type: ignore
+    def test(out: Field[np.float64], inp: Field[np.float64]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             out = 0.0
             with horizontal(region[I[0] - 1, J[0] - 1]):
@@ -950,7 +959,7 @@ def test_K_offset_write_simple(backend: str) -> None:
     # A is untouched
     # B is written in K+1 and should have K_values, except for the first element (FORWARD)
     @gtscript.stencil(backend=backend)
-    def simple(A: Field[np.float64], B: Field[np.float64]):  # type: ignore
+    def simple(A: Field[np.float64], B: Field[np.float64]) -> None:  # type: ignore
         with computation(FORWARD), interval(...):
             B[0, 0, 1] = A
 
@@ -978,7 +987,7 @@ def test_K_offset_write_forward(backend: str) -> None:
     # means while A is update B will have non-updated values of A
     # Because of the interval, value of B[0] is 0
     @gtscript.stencil(backend=backend)
-    def forward(A: Field[np.float64], B: Field[np.float64], scalar: np.float64):  # type: ignore
+    def forward(A: Field[np.float64], B: Field[np.float64], scalar: np.float64) -> None:  # type: ignore
         with computation(FORWARD), interval(1, None):
             A[0, 0, -1] = scalar
             B[0, 0, 0] = A
@@ -1009,7 +1018,7 @@ def test_K_offset_write_backward(backend: str) -> None:
     # means A is update B will get the updated values of A
     # Because of the interval, B[0] is never written
     @gtscript.stencil(backend=backend)
-    def backward(A: Field[np.float64], B: Field[np.float64], scalar: np.float64):  # type: ignore
+    def backward(A: Field[np.float64], B: Field[np.float64], scalar: np.float64) -> None:  # type: ignore
         with computation(BACKWARD), interval(-1, None):
             A = scalar
 
@@ -1033,13 +1042,17 @@ def test_K_offset_write_backward(backend: str) -> None:
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_K_offset_write_conditional(backend):
+def test_K_offset_write_conditional(backend) -> None:
     arraylib = get_array_library(backend)
     array_shape = (1, 1, 4)
     K_values = arraylib.arange(start=40, stop=44)
 
     @gtscript.stencil(backend=backend)
-    def column_physics_conditional(A: Field[np.float64], B: Field[np.float64], scalar: np.float64):  # type: ignore
+    def column_physics_conditional(
+        A: Field[np.float64],  # type: ignore
+        B: Field[np.float64],  # type: ignore
+        scalar: np.float64,
+    ) -> None:
         with computation(BACKWARD), interval(1, -1):
             if A > 0 and B > 0:
                 A[0, 0, -1] = scalar
@@ -1099,11 +1112,11 @@ def test_K_offset_write_conditional(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_direct_datadims_index(backend):
+def test_direct_datadims_index(backend) -> None:
     F64_VEC4 = (np.float64, (2, 2, 2, 2))
 
     @gtscript.stencil(backend=backend)
-    def test(out: Field[np.float64], inp: GlobalTable[F64_VEC4]):  # type: ignore
+    def test(out: Field[np.float64], inp: GlobalTable[F64_VEC4]) -> None:  # type: ignore
         with computation(PARALLEL), interval(...):
             out[0, 0, 0] = inp.A[1, 0, 1, 0]
 
@@ -1115,7 +1128,7 @@ def test_direct_datadims_index(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_function_inline_in_while(backend):
+def test_function_inline_in_while(backend) -> None:
     @gtscript.function
     def add_42(v):
         return v + 42
@@ -1124,7 +1137,7 @@ def test_function_inline_in_while(backend):
     def test(
         in_field: Field[np.float64],  # type: ignore
         out_field: Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         with computation(PARALLEL), interval(...):
             count = 1
             while count < 10:
@@ -1140,21 +1153,21 @@ def test_function_inline_in_while(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_cast_in_index(backend):
+def test_cast_in_index(backend) -> None:
     @gtscript.stencil(backend)
     def cast_in_index(
         in_field: Field[np.float64],  # type: ignore
         i32: np.int32,
         i64: np.int64,
         out_field: Field[np.float64],  # type: ignore
-    ):
+    ) -> None:
         """Simple copy stencil with forced cast in index calculation."""
         with computation(PARALLEL), interval(...):
             out_field[0, 0, 0] = in_field[0, 0, i32 - i64]
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_read_after_write_stencil(backend):
+def test_read_after_write_stencil(backend) -> None:
     """Stencil with multiple read after write access patterns."""
 
     @gtscript.stencil(backend=backend)
@@ -1168,7 +1181,7 @@ def test_read_after_write_stencil(backend):
         q4_4: Field[np.float64],  # type: ignore
         dp1: Field[np.float64],  # type: ignore
         lev: Field[gtscript.IJ, np.int64],  # type: ignore
-    ):
+    ) -> None:
         """
         Args:
             q (out):
@@ -1228,9 +1241,9 @@ def test_read_after_write_stencil(backend):
         for backend in ["gt:cpu_ifirst", "numpy"]
     ],
 )
-def test_absolute_K_index_raise(backend):
+def test_absolute_K_index_raise(backend) -> None:
     @gtscript.stencil(backend=backend)
-    def test_absolute_k_index(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
+    def test_absolute_k_index(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:  # type:ignore
         with computation(PARALLEL), interval(...):
             out_field = in_field.at(K=2)
 
@@ -1243,7 +1256,7 @@ def test_absolute_K_index_raise(backend):
         pytest.param("dace:gpu", marks=[pytest.mark.requires_dace, pytest.mark.requires_gpu]),
     ],
 )
-def test_absolute_K_index(backend):
+def test_absolute_K_index(backend) -> None:
     domain = (5, 5, 5)
 
     in_arr = gt_storage.ones(backend=backend, shape=domain, dtype=np.float64)
@@ -1253,7 +1266,7 @@ def test_absolute_K_index(backend):
     out_arr = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
 
     @gtscript.stencil(backend=backend)
-    def test_literal_access(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
+    def test_literal_access(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:  # type:ignore
         with computation(PARALLEL), interval(...):
             out_field = in_field.at(K=2)
 
@@ -1265,7 +1278,9 @@ def test_absolute_K_index(backend):
 
     @gtscript.stencil(backend=backend)
     def test_parameter_access(
-        in_field: Field[np.float64], out_field: Field[np.float64], idx: int
+        in_field: Field[np.float64],  # type:ignore
+        out_field: Field[np.float64],  # type:ignore
+        idx: int,
     ) -> None:
         with computation(PARALLEL), interval(...):
             out_field = in_field.at(K=idx)
@@ -1277,9 +1292,9 @@ def test_absolute_K_index(backend):
     assert (out_arr[:, :, :] == 42.42).all()
 
     @gtscript.stencil(backend=backend, externals={"K4": 4})
-    def test_external_access(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
+    def test_external_access(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:  # type:ignore
         with computation(PARALLEL), interval(...):
-            from __externals__ import K4
+            from __externals__ import K4  # type:ignore
 
             out_field = in_field.at(K=K4)
 
@@ -1291,7 +1306,9 @@ def test_absolute_K_index(backend):
 
     @gtscript.stencil(backend=backend)
     def test_field_access(
-        in_field: Field[np.float64], index_field: Field[IJ, np.int64], out_field: Field[np.float64]
+        in_field: Field[np.float64],  # type:ignore
+        index_field: Field[IJ, np.int64],  # type:ignore
+        out_field: Field[np.float64],  # type:ignore
     ) -> None:
         with computation(PARALLEL), interval(...):
             out_field = in_field.at(K=index_field)
@@ -1305,7 +1322,9 @@ def test_absolute_K_index(backend):
 
     @gtscript.stencil(backend=backend)
     def test_field_access_computation(
-        in_field: Field[np.float64], index_field: Field[IJ, np.int32], out_field: Field[np.float64]
+        in_field: Field[np.float64],  # type:ignore
+        index_field: Field[IJ, np.int32],  # type:ignore
+        out_field: Field[np.float64],  # type:ignore
     ) -> None:
         with computation(PARALLEL), interval(...):
             out_field = in_field.at(K=index_field - 1)
@@ -1319,8 +1338,8 @@ def test_absolute_K_index(backend):
 
     @gtscript.stencil(backend=backend)
     def test_lower_dim_field(
-        k_field: Field[K, np.float64],
-        out_field: Field[np.float64],
+        k_field: Field[K, np.float64],  # type:ignore
+        out_field: Field[np.float64],  # type:ignore
     ) -> None:
         with computation(PARALLEL), interval(...):
             out_field = k_field.at(K=2)
@@ -1333,8 +1352,8 @@ def test_absolute_K_index(backend):
 
     @gtscript.stencil(backend=backend)
     def test_conditional_absolute(
-        in_field: Field[np.float64],
-        out_field: Field[np.float64],
+        in_field: Field[np.float64],  # type:ignore
+        out_field: Field[np.float64],  # type:ignore
     ) -> None:
         with computation(PARALLEL), interval(...):
             k_level = 0
@@ -1362,7 +1381,9 @@ def test_iterator_access(backend: str) -> None:
 
     @gtscript.stencil(backend=backend)
     def test_all_valid_usage(
-        field_A: Field[np.float64], field_B: Field[np.float64], offsets: Field[K, np.int32]
+        field_A: Field[np.float64],  # type:ignore
+        field_B: Field[np.float64],  # type:ignore
+        offsets: Field[K, np.int32],  # type:ignore
     ) -> None:
         with computation(PARALLEL), interval(...):
             if K == 2:
@@ -1395,7 +1416,7 @@ def test_iterator_access_raises_in_unsupported_backends(backend: str) -> None:
     field_B = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
 
     @gtscript.stencil(backend=backend)
-    def test_all_valid_usage(field_A: Field[np.float64], field_B: Field[np.float64]) -> None:
+    def test_all_valid_usage(field_A: Field[np.float64], field_B: Field[np.float64]) -> None:  # type:ignore
         with computation(PARALLEL), interval(...):
             if K == 2:
                 field_A = 20.20
@@ -1404,7 +1425,7 @@ def test_iterator_access_raises_in_unsupported_backends(backend: str) -> None:
     test_all_valid_usage(field_A, field_B)
 
 
-def test_runtime_interval_bounds():
+def test_runtime_interval_bounds() -> None:
     backend = "debug"
     domain = (5, 5, 10)
     in_arr = gt_storage.ones(backend=backend, shape=domain, dtype=np.float64)
@@ -1509,14 +1530,14 @@ def test_runtime_interval_bounds():
         ),
     ],
 )
-def test_runtime_interval_raises(backend):
+def test_runtime_interval_raises(backend) -> None:
     @gtscript.stencil(backend=backend)
     def test_stencil(
         out_field: Field[np.float64],  # type: ignore
         input_data: Field[np.float64],  # type: ignore
         index_data: Field[gtscript.IJ, np.int64],  # type: ignore
         scalar_arg: int,
-    ):
+    ) -> None:
         with computation(FORWARD), interval(0, 1):
             temporary: Field[IJ, np.float64] = 7  # type: ignore
 
@@ -1539,16 +1560,16 @@ def test_runtime_interval_raises(backend):
         pytest.param("dace:gpu", marks=[pytest.mark.requires_dace, pytest.mark.requires_gpu]),
     ],
 )
-def test_2d_temporaries(backend):
+def test_2d_temporaries(backend) -> None:
     domain = (5, 5, 3)
 
     in_arr = gt_storage.ones(backend=backend, shape=domain, dtype=np.float64)
     out_arr = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
 
     @gtscript.stencil(backend=backend)
-    def test_with_plain_gt4py(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
+    def test_with_plain_gt4py(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:  # type:ignore
         with computation(FORWARD), interval(0, 1):
-            tmp_2D: Field[IJ, np.float64] = 0
+            tmp_2D: Field[IJ, np.float64] = 0  # type:ignore
 
         with computation(FORWARD), interval(...):
             tmp_2D = tmp_2D + in_field
@@ -1562,9 +1583,9 @@ def test_2d_temporaries(backend):
     assert (out_arr[:, :, :] == domain[2]).all()
 
     @gtscript.stencil(backend=backend, dtypes={"MyFancySymbol": Field[IJ, np.float64]})
-    def test_with_user_dtype(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
+    def test_with_user_dtype(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:  # type:ignore
         with computation(FORWARD), interval(0, 1):
-            tmp_2D: MyFancySymbol = 0
+            tmp_2D: MyFancySymbol = 0  # type:ignore
 
         with computation(FORWARD), interval(...):
             out_field = tmp_2D
@@ -1575,10 +1596,11 @@ def test_2d_temporaries(backend):
 
         @gtscript.stencil(backend=backend)
         def test_failing_on_non_IJ(
-            in_field: Field[np.float64], out_field: Field[np.float64]
+            in_field: Field[np.float64],  # type:ignore
+            out_field: Field[np.float64],  # type:ignore
         ) -> None:
             with computation(FORWARD), interval(0, 1):
-                tmp_2D: Field[K, np.float64] = 0
+                tmp_2D: Field[K, np.float64] = 0  # type:ignore
 
             with computation(FORWARD), interval(...):
                 out_field = tmp_2D
@@ -1596,11 +1618,11 @@ def test_2d_temporaries(backend):
         for backend in ["gt:cpu_ifirst", "gt:cpu_kfirst", "gt:gpu"]
     ],
 )
-def test_2d_temporaries_raises(backend):
+def test_2d_temporaries_raises(backend) -> None:
     @gtscript.stencil(backend=backend)
-    def test_with_user_dtypes(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:
+    def test_with_user_dtypes(in_field: Field[np.float64], out_field: Field[np.float64]) -> None:  # type:ignore
         with computation(FORWARD), interval(0, 1):
-            tmp_2D: Field[IJ, np.float64] = 0
+            tmp_2D: Field[IJ, np.float64] = 0  # type:ignore
 
         with computation(FORWARD), interval(...):
             out_field = tmp_2D
@@ -1616,7 +1638,9 @@ def test_upcasting_both_sides_of_assignment(backend: str) -> None:
 
     @gtscript.stencil(backend=backend)
     def test_upcasting_stencil(
-        in_field: Field[np.float64], index_field: Field[IJ, np.int32], out_field: Field[np.float64]
+        in_field: Field[np.float64],  # type:ignore
+        index_field: Field[IJ, np.int32],  # type:ignore
+        out_field: Field[np.float64],  # type:ignore
     ) -> None:
         with computation(FORWARD), interval(...):
             out_field[0, 0, index_field - 1] = in_field
@@ -1625,7 +1649,7 @@ def test_upcasting_both_sides_of_assignment(backend: str) -> None:
     assert (input == output).all()
 
 
-@pytest.mark.parametrize("backend", ("debug",))  # ALL_BACKENDS)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_upcasting_leave_integer_power_arguments_alone(backend: str) -> None:
     domain = (5, 5, 5)
 
@@ -1637,7 +1661,9 @@ def test_upcasting_leave_integer_power_arguments_alone(backend: str) -> None:
 
     @gtscript.stencil(backend=backend)
     def test_upcasting_stencil(
-        in_field: Field[np.float32], squared: Field[IJ, np.int32], out_field: Field[np.float32]
+        in_field: Field[np.float32],  # type:ignore
+        squared: Field[IJ, np.int32],  # type:ignore
+        out_field: Field[np.float32],  # type:ignore
     ) -> None:
         with computation(FORWARD), interval(...):
             out_field = in_field**squared
@@ -1649,14 +1675,14 @@ def test_no_write_and_read_with_horizontal_offset() -> None:
     with pytest.raises(ValueError, match="Self-assignment with offset in I or J is illegal."):
 
         @gtscript.stencil(backend="debug")
-        def self_assign_offset(field: Field[np.float64]) -> None:
+        def self_assign_offset(field: Field[np.float64]) -> None:  # type:ignore
             with computation(PARALLEL), interval(...):
                 field = (field[I - 1] + field[I + 1]) / 2
 
     with pytest.raises(ValueError, match="Illegal write and read with horizontal offset"):
 
         @gtscript.stencil(backend="debug")
-        def self_assign_offset(field: Field[np.float64]) -> None:
+        def self_assign_offset(field: Field[np.float64]) -> None:  # type:ignore
             with computation(PARALLEL), interval(...):
                 tmp = (field[J - 1] + field[J + 1]) / 2
                 field = tmp * 2
@@ -1666,14 +1692,14 @@ def test_k_offsets_in_parallel_loops() -> None:
     with pytest.raises(ValueError, match="write and read with k-offsets in PARALLEL"):
 
         @gtscript.stencil(backend="debug")
-        def self_assign_offset_parallel(field: Field[np.int32]) -> None:
+        def self_assign_offset_parallel(field: Field[np.int32]) -> None:  # type:ignore
             with computation(PARALLEL), interval(1, None):
                 field = field[K - 1] * 2
 
     with pytest.raises(ValueError, match="write and read with k-offsets in PARALLEL"):
 
         @gtscript.stencil(backend="debug")
-        def self_assign_offset_parallel_temp(field: Field[np.int32]) -> None:
+        def self_assign_offset_parallel_temp(field: Field[np.int32]) -> None:  # type:ignore
             with computation(PARALLEL), interval(1, None):
                 tmp = field[K - 1]
                 field = tmp * 2
@@ -1683,7 +1709,7 @@ def test_k_offsets_in_parallel_loops() -> None:
     ):
 
         @gtscript.stencil(backend="debug")
-        def mixed_read_write(field: Field[np.int32]):
+        def mixed_read_write(field: Field[np.int32]) -> None:  # type:ignore
             with computation(PARALLEL), interval(...):
                 level = field.at(K=1)
                 field = 2 * level
@@ -1693,31 +1719,31 @@ def test_k_offsets_in_parallel_loops() -> None:
     ):
 
         @gtscript.stencil(backend="debug")
-        def mixed_read_write(field: Field[np.int32], offset: int = -1):
+        def mixed_read_write(field: Field[np.int32], offset: int = -1) -> None:  # type:ignore
             with computation(PARALLEL), interval(1, None):
                 bottom = field[0, 0, offset]
                 field = field + 2 * bottom
 
     # center reads and writes are allowed
     @gtscript.stencil(backend="debug")
-    def self_assignment_center_read_parallel(field: Field[np.int32]) -> None:
+    def self_assignment_center_read_parallel(field: Field[np.int32]) -> None:  # type:ignore
         with computation(PARALLEL), interval(...):
             field = field[0, 0, 0] * 2
 
     @gtscript.stencil(backend="debug")
-    def self_assignment_center_write_parallel(field: Field[np.int32]) -> None:
+    def self_assignment_center_write_parallel(field: Field[np.int32]) -> None:  # type:ignore
         with computation(PARALLEL), interval(...):
             field[0, 0, 0] = field * 2
 
     # not mixing reads and writes are allowed (e.g. index fields)
     @gtscript.stencil(backend="debug")
-    def self_assignment_center_parallel(field: Field[np.float32], index: Field[np.int32]) -> None:
+    def self_assignment_center_parallel(field: Field[np.float32], index: Field[np.int32]) -> None:  # type:ignore
         with computation(PARALLEL), interval(1, None):
             field = index + index[K - 1] * 2
 
     # parallel intervals of static size 1 are allowed
     @gtscript.stencil(backend="debug")
-    def the_stencil(field: Field[np.bool_]) -> None:
+    def the_stencil(field: Field[np.bool_]) -> None:  # type:ignore
         with computation(PARALLEL):
             with interval(0, 1):
                 field = field[K + 1]
@@ -1728,12 +1754,12 @@ def test_k_offsets_in_parallel_loops() -> None:
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_self_assignment_in_forward(backend: str) -> None:
     @gtscript.stencil(backend=backend)
-    def self_assignment_parallel(field: Field[np.int32]) -> None:
+    def self_assignment_parallel(field: Field[np.int32]) -> None:  # type:ignore
         with computation(FORWARD), interval(1, None):
             field = field[K - 1] * 2
 
     @gtscript.stencil(backend=backend)
-    def self_assignment_2_parallel(field: Field[np.int32]) -> None:
+    def self_assignment_2_parallel(field: Field[np.int32]) -> None:  # type:ignore
         with computation(FORWARD), interval(1, None):
             tmp = field[K - 1]
             field = tmp * 2
@@ -1749,7 +1775,9 @@ def test_reset_mask_2d(backend: str) -> None:
 
     @gtscript.stencil(backend=backend)
     def test_set_2d_mask(
-        dp1: Field[np.float64], pe1: Field[np.float64], lev: Field[IJ, np.int32]
+        dp1: Field[np.float64],  # type:ignore
+        pe1: Field[np.float64],  # type:ignore
+        lev: Field[IJ, np.int32],  # type:ignore
     ) -> None:
         with computation(PARALLEL), interval(0, -1):
             dp1 = pe1[0, 0, 1] - pe1
@@ -1780,7 +1808,7 @@ def test_reset_mask_2d(backend: str) -> None:
         pytest.param("gt:gpu", marks=[pytest.mark.requires_gpu]),
     ],
 )
-def test_offset_j_in_temporaries(backend: str):
+def test_offset_j_in_temporaries(backend: str) -> None:
     @gtscript.function
     def a_gtscript_function(b):
         return sqrt(abs(b[0, 1, 0]))


### PR DESCRIPTION
## Description

Change the representation of vertical loop sections in the treeir of the dace backend. This doesn't change anything - just makes the tree ir look nicer (see issue for motivation).

This PR contains unrelated cleanup in `test_code_generation.py`.

Related issue: https://github.com/GridTools/gt4py/issues/2681

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A