### PR TITLE
test[next]: Fix fvm_nabla_setup for daily CI

### DIFF
--- a/tests/next_tests/integration_tests/multi_feature_tests/fvm_nabla_setup.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/fvm_nabla_setup.py
@@ -203,7 +203,7 @@ class nabla_setup:
         m_pp = self.fs_nodes.create_field(name="m_pp", levels=1, dtype=np.float64)
         rzs = np.array(m_pp, copy=False)
 
-        rcoords_deg = np.array(self.mesh.nodes.field("lonlat"))
+        rcoords_deg = np.array(self.mesh.nodes.field("lonlat"), copy=False)
 
         for jnode in range(0, self.nodes_size):
             for i in range(0, 2):

--- a/tests/next_tests/integration_tests/multi_feature_tests/fvm_nabla_setup.py
+++ b/tests/next_tests/integration_tests/multi_feature_tests/fvm_nabla_setup.py
@@ -99,7 +99,7 @@ class nabla_setup:
 
     @property
     def is_pole_edge_field(self) -> gtx.Field:
-        edge_flags = np.array(self.mesh.edges.flags())
+        edge_flags = np.array(self.mesh.edges.flags(), copy=False)
 
         pole_edge_field = np.zeros((self.edges_size,), dtype=bool)
         for e in range(self.edges_size):
@@ -109,7 +109,7 @@ class nabla_setup:
     @property
     def sign_field(self) -> gtx.Field:
         node2edge_sign = np.zeros((self.nodes_size, self.edges_per_node))
-        edge_flags = np.array(self.mesh.edges.flags())
+        edge_flags = np.array(self.mesh.edges.flags(), copy=False)
 
         for jnode in range(0, self.nodes_size):
             node_edge_con = self.mesh.nodes.edge_connectivity


### PR DESCRIPTION
Add missing `copy=False` to `np.array()` in `fvm_nabla_setup`. This is needed for compatibility with latest numpy.

This fix addresses errors in daily CI with `UV_RESOLUTION=highest`.