### PR TITLE
test: mark dace backend with `requires_dace`

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1765,10 +1765,11 @@ def test_reset_mask_2d(backend: str) -> None:
     "backend",
     [
         "debug",
-        "dace:cpu",
+        pytest.param("dace:cpu", marks=[pytest.mark.requires_dace]),
         pytest.param(
             "dace:gpu",
             marks=[
+                pytest.mark.requires_dace,
                 pytest.mark.requires_gpu,
                 pytest.mark.xfail(
                     raises=SystemExit,


### PR DESCRIPTION
## Description

Follow-up from PR https://github.com/GridTools/gt4py/pull/2628 in which we added a new test, but forgot to mark the dace-backends with `pytest.mark.requires_dace`.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A