### PR TITLE
fix[next]: propagate recursion limit to compilation worker processes

### DIFF
--- a/src/gt4py/next/otf/runners.py
+++ b/src/gt4py/next/otf/runners.py
@@ -17,6 +17,7 @@ import multiprocessing
 import os
 import pathlib
 import pickle
+import sys
 import threading
 import warnings
 from typing import Any, Callable, Protocol, runtime_checkable
@@ -167,8 +168,13 @@ def _run_compilation_task_in_worker(
     executor_blob: bytes,
     compilable: Any,
     config_overrides: dict[str, Any],
+    recursion_limit: int,
 ) -> stages.CompilationArtifact:
     """Worker entry point: deserialize the executor and run it."""
+    # `sys.setrecursionlimit` is per-process: a limit the parent raised for
+    # deeply nested IR would silently reset to the interpreter default in a
+    # `spawn` worker. Adopt the parent's limit, but never lower the worker's.
+    sys.setrecursionlimit(max(recursion_limit, sys.getrecursionlimit()))
     _apply_config_overrides(config_overrides)
     executor = pickle.loads(executor_blob)
     return executor(compilable)
@@ -225,6 +231,7 @@ class ProcessRunner:
             executor_blob=executor_blob,
             compilable=task.construct_compilable(True),
             config_overrides=_config_snapshot(),
+            recursion_limit=sys.getrecursionlimit(),
         )
 
     def shutdown(self, wait: bool = True) -> None:

--- a/tests/next_tests/unit_tests/otf_tests/test_runners.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_runners.py
@@ -12,6 +12,7 @@ import gc
 import multiprocessing
 import os
 import pickle
+import sys
 import unittest.mock as mock
 
 import numpy as np
@@ -51,6 +52,34 @@ def test_process_runner_falls_back_on_unpicklable_executor(process_runner):
 
     assert future.done()
     assert callable(future.result().load())
+
+
+def _recurse(depth: int) -> None:
+    if depth > 0:
+        _recurse(depth - 1)
+
+
+@dataclasses.dataclass(frozen=True)
+class _RecursingExecutor:
+    depth: int
+
+    def __call__(self, compilable):
+        _recurse(self.depth)
+        return _NoOpArtifact()
+
+
+def test_process_runner_propagates_recursion_limit(process_runner):
+    """A raised ``sys.setrecursionlimit`` must reach the worker: it is per-process,
+    and ``spawn`` workers start back at the interpreter default, so deep-IR
+    compiles that succeed in the parent would otherwise fail worker-side."""
+    old_limit = sys.getrecursionlimit()
+    depth = old_limit + 1000
+    sys.setrecursionlimit(depth + 1000)
+    try:
+        future = process_runner.submit(_decomposed_task(executor=_RecursingExecutor(depth)))
+        assert callable(future.result(timeout=120).load())
+    finally:
+        sys.setrecursionlimit(old_limit)
 
 
 def test_process_runner_falls_back_on_non_offloadable_task(process_runner):


### PR DESCRIPTION
## Description

`sys.setrecursionlimit` is per-process: a limit the parent raised for deeply nested IR silently resets to the interpreter default in a `spawn` worker, so compiles that succeed in-process (or under the thread/serial runners) fail with `RecursionError` under the process runner introduced in #2679.

Observed in icon4py CI after bumping to gt4py main (C2SM/icon4py#1350): the large advection stencils set `sys.setrecursionlimit(5500)` at module import, which never reaches the workers; the deep eve traversals then blow past the default 1000 frames worker-side, surfacing as `RecursionError` re-raised from the compilation future.

Fix: capture the parent's recursion limit at submit time and adopt it in the worker entry point, never lowering the worker's own limit. Captured per task (not at pool creation) because user code may raise the limit after the pool exists.

The unit test reproduces the failure signature exactly before the fix (recursion succeeding in the parent, `RecursionError` from the worker future).

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. (No new design decision: restores the "compile behaves identically in a worker" contract of ADR 0024.)