### PR TITLE
fix[next]: empty range is absorbing for domain intersection

### DIFF
--- a/src/gt4py/next/iterator/ir_utils/domain_utils.py
+++ b/src/gt4py/next/iterator/ir_utils/domain_utils.py
@@ -244,34 +244,44 @@ def _reduce_ranges(
     start_reduce_op: Callable[[itir.Expr, itir.Expr], itir.Expr],
     stop_reduce_op: Callable[[itir.Expr, itir.Expr], itir.Expr],
 ) -> SymbolicRange:
-    """
-    Uses start_op and stop_op to fold the start and stop of a list of ranges.
-
-    This function only computes the correct value if the (non-empty) ranges are either
-    overlapping / adjacent or empty, as calculation is by means of the convex hull. Non-static
-    ranges may not be empty for now.
-    """
-    non_empty_ranges = [range_ for range_ in ranges if not range_.empty()]
-    if len(non_empty_ranges) == 0:
-        return ranges[0]  # all empty -> empty
-    elif len(non_empty_ranges) == 1:
-        # the reduction of a single range is the range itself
-        return non_empty_ranges[0]
-    else:
-        start = functools.reduce(start_reduce_op, [range_.start for range_ in non_empty_ranges])
-        stop = functools.reduce(stop_reduce_op, [range_.stop for range_ in non_empty_ranges])
+    """Uses start_op and stop_op to fold the start and stop of a list of ranges."""
+    start = functools.reduce(start_reduce_op, [range_.start for range_ in ranges])
+    stop = functools.reduce(stop_reduce_op, [range_.stop for range_ in ranges])
     # constant fold to keep the tree small and so translated bounds (e.g. `0 + 1`) collapse to a
     # literal (we deliberately do not fold in `translate`)
     start, stop = ConstantFolding.apply(start), ConstantFolding.apply(stop)  # type: ignore[assignment]  # always an itir.Expr
     return SymbolicRange(start, stop)
 
 
-_range_union = functools.partial(
-    _reduce_ranges, start_reduce_op=im.minimum, stop_reduce_op=im.maximum
-)
-_range_intersection = functools.partial(
-    _reduce_ranges, start_reduce_op=im.maximum, stop_reduce_op=im.minimum
-)
+def _range_union(*ranges: SymbolicRange) -> SymbolicRange:
+    """
+    Return the union of a list of ranges, computed as the convex hull.
+
+    This only computes the correct value if the non-empty ranges are overlapping or adjacent.
+    An empty range is the identity element of the union, so empty ranges are dropped rather than
+    fed into the convex hull, which would otherwise over-approximate (e.g. `[10, 10[ | [11, 11[`
+    is empty, but its convex hull is `[10, 11[`). Emptiness is only decidable for static ranges;
+    non-static ranges may not be empty for now.
+    """
+    non_empty_ranges = [range_ for range_ in ranges if not range_.empty()]
+    if not non_empty_ranges:
+        return ranges[0]  # all empty -> empty
+    return _reduce_ranges(*non_empty_ranges, start_reduce_op=im.minimum, stop_reduce_op=im.maximum)
+
+
+def _range_intersection(*ranges: SymbolicRange) -> SymbolicRange:
+    """
+    Return the intersection of a list of ranges.
+
+    An empty range is the absorbing element of the intersection, so it is returned directly.
+    Folding it into `max`/`min` instead would give a wrong (possibly non-empty, possibly
+    unbounded) result, e.g. `[1, 1[ & [0, inf[` would yield `[1, inf[`. Emptiness is only
+    decidable for static ranges; non-static ranges may not be empty for now.
+    """
+    for range_ in ranges:
+        if range_.empty():
+            return range_
+    return _reduce_ranges(*ranges, start_reduce_op=im.maximum, stop_reduce_op=im.minimum)
 
 
 def _reduce_domains(

--- a/tests/next_tests/unit_tests/iterator_tests/ir_utils_tests/test_domain_utils.py
+++ b/tests/next_tests/unit_tests/iterator_tests/ir_utils_tests/test_domain_utils.py
@@ -129,6 +129,29 @@ def test_domain_intersection():
     assert result.as_expr() == expected
 
 
+def test_domain_intersection_with_empty_stays_empty():
+    # Empty domains are the intersection's absorbing element. Dropping them (as the union does)
+    # would yield a non-empty result.
+    non_empty = _make_domain({I: (0, 10)})
+    empty = _make_domain({I: (1, 1)})
+
+    assert domain_utils.domain_intersection(empty, non_empty).empty()
+    assert domain_utils.domain_intersection(non_empty, empty).empty()
+
+
+def test_domain_intersection_empty_with_infinite_range():
+    # An empty range intersected with a half-infinite one must stay empty. Dropping the empty
+    # range would leak the `InfinityLiteral` bound into the result.
+    empty = _make_domain({I: (1, 1)})
+    half_infinite = domain_utils.SymbolicDomain(
+        grid_type=common.GridType.CARTESIAN, ranges={I: right_infinity_range}
+    )
+
+    result = domain_utils.domain_intersection(empty, half_infinite)
+    assert result.empty()
+    assert result.ranges[I].stop != itir.InfinityLiteral.POSITIVE
+
+
 def test_domain_union_then_intersection():
     # Cross-operation case: the union result flows into the intersection.
     domain0 = _make_domain({I: (0, 10), J: (0, 10)})


### PR DESCRIPTION
## Problem

`_reduce_ranges` in `domain_utils.py` is shared by `domain_union` and `domain_intersection`:

```python
_range_union        = functools.partial(_reduce_ranges, start_reduce_op=im.minimum, stop_reduce_op=im.maximum)
_range_intersection = functools.partial(_reduce_ranges, start_reduce_op=im.maximum, stop_reduce_op=im.minimum)
```

#2677 taught it to drop statically empty ranges before folding. That is correct for the **union**, where an empty range is the identity element, but wrong for the **intersection**, where an empty range is the *absorbing* element.

Dropping the empty range from an intersection returns the remaining range instead of staying empty:

```
[1, 1[  &  [0, 10[   ->  [0, 10[     # should be empty
[1, 1[  &  [0, inf[  ->  [0, inf[    # should be empty
```

The second form is reached in practice: `promote_domain` fills non-condition dimensions with `[-inf, inf[`, and `_infer_concat_where` intersects that with the target domain. If the target range is statically empty, the half-infinite range survives verbatim and an `InfinityLiteral` leaks into the inferred domain.

## Symptoms

Both show up in ICON4Py with `concat_where` over a statically-known-empty vertical range (a Rayleigh damping layer of zero thickness, where the layer bound is bound as a compile-time static arg):

- **gtfn** — the leaked `InfinityLiteral` reaches `itir_to_gtfn_ir._make_domain`:

  ```
  TypeError: 'BinaryExpr.lhs' must be <class '...gtfn_ir_common.Expr'>
  (got 'InfinityLiteral.POSITIVE' which is a <class '...iterator.ir.InfinityLiteral'>).
  ```

- **dace** — `gtir_to_sdfg_concat_where` calls `domain_intersection(source_domain, output_domain)` directly at lowering time, with finite bounds. No infinity, no crash: a scalar `concat_where` branch whose range is empty (`[1, 1[`) is widened to the full output domain (`[1, 10[`), so the constant branch is broadcast over the whole domain and silently overwrites the real values.

The dace case is a silent wrong-results bug, so it is worth backporting alongside the crash.

## Fix

Split the two operations. The union keeps dropping empty ranges; the intersection returns the empty range directly. Emptiness remains decidable only for static ranges — non-static ranges may not be empty, as before.

Also restores the constant folding that #2677 skipped in the single-surviving-range case.

## Testing

- Two regression tests in `test_domain_utils.py` covering the finite and the half-infinite case. Both fail on `main`.
- `tests/next_tests/unit_tests/` A/B'd with and without the change: no new failures.
- Verified against ICON4Py (C2SM/icon4py#1350): the gtfn `TypeError` and the dace `diff_multfac_n2w` mismatch both disappear, and the previously-failing GAUSS3D driver integration test passes.

Follow-up on #2677, related to #2205. The symbolic (non-static) case is still left to #2673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
