### PR TITLE
fix[next-dace]: Ignore `guid` in SDFG fingerprint

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -140,7 +140,7 @@ class CompiledDaceProgram:
 
 @dataclasses.dataclass(frozen=True)
 class DaCeCompilationArtifact:
-    """Result of a DaCe compilation: build folder + library path + SDFG bindings + the SDFG itself.
+    """Result of a DaCe compilation: library path + SDFG bindings + the SDFG itself.
 
     The SDFG is carried inline as JSON because dace's load path
     (``get_program_handle``) needs an SDFG instance to wrap into the

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -148,7 +148,6 @@ class DaCeCompilationArtifact:
     ``program.sdfg(z)`` dump under the upcoming minimal-build-dir mode.
     """
 
-    build_folder: pathlib.Path
     library_path: pathlib.Path
     sdfg_json: str
     binding_source_code: str
@@ -247,7 +246,6 @@ class DaCeCompiler(
 
         assert inp.binding_source is not None
         return DaCeCompilationArtifact(
-            build_folder=sdfg_build_folder,
             library_path=library_path,
             sdfg_json=json.dumps(inp.program_source.source_code),
             binding_source_code=inp.binding_source.source_code,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -474,7 +474,17 @@ class DaCeTranslator(
 
 
 def _drop_element_ids(json_obj: Any) -> Any:
-    """Recursively remove `guid` keys from a serialized SDFG."""
+    """
+    Remove ``guid`` keys from a serialized SDFG with recursion.
+
+    We remove ``guid`` keys because of indeterminism of the ``guid`` values, which
+    would cause two identical programs to result in different compiled SDFGs, since
+    the cache key contains the hash of the serialized SDFG (a JSON string).
+    # FIXME(edopao): remove this workaround once the SDFG lowering is stable.
+
+    Note that this recursive implementation is 2-3x faster than the iterative one,
+    on a large SDFG, and it is also simpler to read.
+    """
     if isinstance(json_obj, dict):
         return {k: _drop_element_ids(v) for k, v in json_obj.items() if k != "guid"}
     if isinstance(json_obj, list):

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -462,11 +462,26 @@ class DaCeTranslator(
             # Set 'hash=True' to compute the SDFG hash and store it in the JSON.
             #   We compute the hash in order to refresh `cfg_list` on the SDFG,
             #   which makes the JSON serialization stable.
-            source_code=sdfg.to_json(hash=True),
+            # `guid` is a per-element identity token: it does not affect code generation, and
+            #   `SDFG.from_json()` assigns fresh ids anyway. Keeping it would make the compile
+            #   cache key depend on element creation order, so two structurally identical
+            #   lowerings of the same program would not share a cached build.
+            source_code=_drop_element_ids(sdfg.to_json(hash=True)),
             library_deps=tuple(),
             code_spec=code_specs.SDFGCodeSpec(),
         )
         return module
+
+
+def _drop_element_ids(json_obj: Any) -> Any:
+    """Recursively remove `guid` keys from a serialized SDFG."""
+    if isinstance(json_obj, dict):
+        return {k: _drop_element_ids(v) for k, v in json_obj.items() if k != "guid"}
+    if isinstance(json_obj, list):
+        return [_drop_element_ids(v) for v in json_obj]
+    if isinstance(json_obj, tuple):
+        return tuple(_drop_element_ids(v) for v in json_obj)
+    return json_obj
 
 
 class DaCeTranslationStepFactory(factory.Factory):

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -70,7 +70,12 @@ def _make_sdfg_with_gpu_map() -> dace.SDFG:
     gpu_map_entry.map.schedule = dace.dtypes.ScheduleType.GPU_Device
     _add_sequential_map(sdfg, state, "seq_map", "a", "b")
     nsdfg, _, _ = _make_nested_sdfg()
-    state.add_nested_sdfg(nsdfg, inputs={"c"}, outputs={"d"})
+    nested_node = state.add_nested_sdfg(nsdfg, inputs={"c"}, outputs={"d"})
+    a_in = state.add_access("a")
+    b_out = state.add_access("b")
+    state.add_edge(a_in, None, nested_node, "c", dace.Memlet("a[0:10]"))
+    state.add_edge(nested_node, "d", b_out, None, dace.Memlet("b[0:10]"))
+    sdfg.validate()
     return sdfg
 
 
@@ -95,11 +100,10 @@ def _run_compiler(
     add_gpu_trace_markers: bool = False,
     cmake_build_type: config.CMakeBuildType = config.CMakeBuildType.RELEASE,
     device_type: core_defs.DeviceType = core_defs.DeviceType.CPU,
-) -> tuple[mock.MagicMock, dace.SDFG]:
+) -> tuple[dace_wf_compilation.DaCeCompilationArtifact, dace.SDFG, mock.MagicMock]:
     """Run `DaCeCompiler` on a GPU SDFG with compilation stubbed out.
 
-    Returns the spy wrapping `_add_tx_markers` and the SDFG that was handed to
-    ``SDFG.compile`` (i.e. the SDFG after any marker processing).
+    Returns the compilation artifact, the SDFG which was compiled, and the spy wrapping `_add_tx_markers`.
     """
     inp = _make_extension_source()
 
@@ -116,7 +120,7 @@ def _run_compiler(
             dace_wf_compilation,
             "_add_tx_markers",
             wraps=dace_wf_compilation._add_tx_markers,
-        ) as spy,
+        ) as spy_add_tx_markers,
         mock.patch.object(dace.SDFG, "compile", autospec=True) as compile_mock,
         mock.patch.object(
             dace_wf_compilation.locking, "lock", lambda *args, **kwargs: contextlib.nullcontext()
@@ -128,51 +132,50 @@ def _run_compiler(
         ),
         mock.patch("gt4py.next.otf.compilation.common.get_device_arch", return_value="xyz"),
     ):
-        compiler(inp)
-        compiled_sdfg = compile_mock.call_args.args[0]
+        artifact = compiler(inp)
+        compile_input = compile_mock.call_args.args[0]
 
-    return spy, compiled_sdfg
+    return artifact, compile_input, spy_add_tx_markers
 
 
 def test_compiler_applies_tx_markers_for_gpu():
     """On a CUDA target with the flag on, the compiler applies the markers to the SDFG."""
-    spy, compiled_sdfg = _run_compiler(
+    _, compile_input, spy = _run_compiler(
         add_gpu_trace_markers=True, device_type=core_defs.DeviceType.CUDA
     )
 
     spy.assert_called_once()
     # The SDFG that was marked is the very one passed on to compilation.
-    assert spy.call_args.args[0] is compiled_sdfg
-    assert compiled_sdfg.instrument == _TX
+    assert spy.call_args.args[0] is compile_input
+    assert compile_input.instrument == _TX
     map_entries = [
-        n for n, _ in compiled_sdfg.all_nodes_recursive() if isinstance(n, dace_nodes.MapEntry)
+        n for n, _ in compile_input.all_nodes_recursive() if isinstance(n, dace_nodes.MapEntry)
     ]
     assert map_entries and all(me.instrument == _TX for me in map_entries)
 
 
 def test_compiler_skips_tx_markers_when_flag_disabled():
     """With the flag off the compiler must not touch instrumentation, even on CUDA."""
-    spy, compiled_sdfg = _run_compiler(
+    _, compile_input, spy = _run_compiler(
         add_gpu_trace_markers=False, device_type=core_defs.DeviceType.CUDA
     )
 
     spy.assert_not_called()
-    assert compiled_sdfg.instrument == _NONE
+    assert compile_input.instrument == _NONE
 
 
 def test_compiler_skips_tx_markers_for_non_gpu_device():
     """On a CPU target the markers must not be applied even with the flag on."""
-    spy, compiled_sdfg = _run_compiler(
+    _, compile_input, spy = _run_compiler(
         add_gpu_trace_markers=True, device_type=core_defs.DeviceType.CPU
     )
 
     spy.assert_not_called()
-    assert compiled_sdfg.instrument == _NONE
+    assert compile_input.instrument == _NONE
 
 
 def test_dace_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
     artifact = dace_wf_compilation.DaCeCompilationArtifact(
-        build_folder=tmp_path,
         library_path=tmp_path / "build" / "libprogram.so",
         sdfg_json="{}",
         binding_source_code="def update_sdfg_args(*a, **k): ...",
@@ -204,14 +207,14 @@ def test_compiler_flags_change_build_folder(monkeypatch, device_type, compiler_f
     build cache.
     """
     monkeypatch.delenv(compiler_flags_env, raising=False)
-    _, sdfg_default = _run_compiler(device_type=device_type)
+    artifact_default, _, _ = _run_compiler(device_type=device_type)
 
     monkeypatch.setenv(compiler_flags_env, "-O0 -some-custom-flag")
-    _, sdfg_custom = _run_compiler(device_type=device_type)
+    artifact_custom, _, _ = _run_compiler(device_type=device_type)
 
     # The differing `dace_config_nondefaults` make the two compilers fingerprint differently,
     # so `get_cache_folder` names two distinct build folders.
-    assert sdfg_default.build_folder != sdfg_custom.build_folder
+    assert artifact_default.library_path != artifact_custom.library_path
 
 
 def test_cmake_build_type_changes_build_folder():
@@ -223,7 +226,7 @@ def test_cmake_build_type_changes_build_folder():
     changing the build type lands the SDFG build in a different folder of the
     build cache.
     """
-    _, sdfg_release = _run_compiler(cmake_build_type=config.CMakeBuildType.RELEASE)
-    _, sdfg_debug = _run_compiler(cmake_build_type=config.CMakeBuildType.DEBUG)
+    artifact_release, _, _ = _run_compiler(cmake_build_type=config.CMakeBuildType.RELEASE)
+    artifact_debug, _, _ = _run_compiler(cmake_build_type=config.CMakeBuildType.DEBUG)
 
-    assert sdfg_release.build_folder != sdfg_debug.build_folder
+    assert artifact_release.library_path != artifact_debug.library_path

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -11,7 +11,9 @@
 import pytest
 
 import re
+import uuid
 from typing import Callable
+from unittest import mock
 
 dace = pytest.importorskip("dace")
 
@@ -19,6 +21,8 @@ from gt4py._core import definitions as core_defs
 from gt4py.next import common as gtx_common
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.otf import arguments as otf_arguments, toolchain as otf_toolchain
+from gt4py.next.program_processors.runners.dace import lowering as gtx_dace_lowering
 from gt4py.next.program_processors.runners.dace.workflow import (
     translation as dace_wf_translation,
     common as dace_wf_common,
@@ -419,3 +423,97 @@ def test_generate_sdfg_async_call_multi_state(
     else:
         # There is no dependency between the states, so no sync.
         assert not _are_streams_synchronized(sdfg)
+
+
+def _make_simple_field_operator_compilable_program() -> otf_toolchain.ConcreteArtifact:
+    """Return a compilable program wrapping a minimal GTIR field operator."""
+    ir = itir.Program(
+        id="simple_field_operator",
+        declarations=[],
+        function_definitions=[],
+        params=[
+            itir.Sym(id="x", type=IFTYPE),
+            itir.Sym(id="y", type=IFTYPE),
+        ],
+        body=[
+            itir.SetAt(
+                expr=im.op_as_fieldop("plus")("x", 1.0),
+                domain=im.get_field_domain(gtx_common.GridType.CARTESIAN, "y", IFTYPE.dims),
+                target=itir.SymRef(id="y"),
+            ),
+        ],
+    )
+    return otf_toolchain.ConcreteArtifact(
+        data=ir,
+        args=otf_arguments.CompileTimeArgs(
+            args=tuple(param.type for param in ir.params),
+            kwargs={},
+            offset_provider={},
+            column_axis=None,
+            argument_descriptor_contexts={},
+        ),
+    )
+
+
+def _increment_sdfg_guids(sdfg: dace.SDFG) -> None:
+    """Increment the `guid` value of every SDFG element by one."""
+    if hasattr(sdfg, "guid"):
+        guid = uuid.UUID(str(sdfg.guid))
+        sdfg.guid = str(uuid.UUID(int=guid.int + 1))
+    for state in sdfg.states():
+        if hasattr(state, "guid"):
+            guid = uuid.UUID(str(state.guid))
+            state.guid = str(uuid.UUID(int=guid.int + 1))
+        for node in state.nodes():
+            if hasattr(node, "guid"):
+                guid = uuid.UUID(str(node.guid))
+                node.guid = str(uuid.UUID(int=guid.int + 1))
+
+
+def test_translation_source_code_invariant_under_guid_change():
+    """SDFG `guid` changes must not alter the translation cache key.
+
+    `DaCeTranslator.__call__` drops `guid` values via `_drop_element_ids`
+    before storing the SDFG JSON in `ProgramSource.source_code`. This test
+    mocks `build_sdfg_from_gtir` so that the second lowering returns the same
+    SDFG with all `guid` values incremented by one, and verifies that the
+    resulting `source_code` is byte-for-byte identical.
+    """
+    compilable_program = _make_simple_field_operator_compilable_program()
+
+    translator = dace_wf_translation.DaCeTranslator(
+        device_type=core_defs.DeviceType.CPU,
+        auto_optimize=False,
+        auto_optimize_args=None,
+        async_sdfg_call=False,
+        unstructured_horizontal_has_unit_stride=False,
+        use_metrics=False,
+    )
+
+    # Keep a reference to the real implementation so the mock can return the base
+    # SDFG from the real implementation on the first call, then a guid-shifted clone.
+    real_build_sdfg = dace_wf_translation.gtx_dace_lowering.build_sdfg_from_gtir
+    base_sdfg: dace.SDFG | None = None
+    call_count = 0
+
+    def _build_sdfg_from_gtir_with_guid_change(*args: object, **kwargs: object) -> dace.SDFG:
+        nonlocal base_sdfg, call_count
+        call_count += 1
+        if call_count == 1:
+            base_sdfg = real_build_sdfg(*args, **kwargs)
+            return base_sdfg
+        assert base_sdfg is not None
+        modified_sdfg = dace.SDFG.from_json(base_sdfg.to_json())
+        _increment_sdfg_guids(modified_sdfg)
+        assert modified_sdfg.to_json() != base_sdfg.to_json()
+        return modified_sdfg
+
+    with mock.patch.object(
+        dace_wf_translation.gtx_dace_lowering,
+        "build_sdfg_from_gtir",
+        side_effect=_build_sdfg_from_gtir_with_guid_change,
+    ):
+        first_source = translator(compilable_program)
+        second_source = translator(compilable_program)
+
+    assert first_source.source_code == second_source.source_code

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -477,7 +477,7 @@ def test_translation_source_code_invariant_under_guid_change():
     before storing the SDFG JSON in `ProgramSource.source_code`. This test
     mocks `build_sdfg_from_gtir` so that the second lowering returns the same
     SDFG with all `guid` values incremented by one, and verifies that the
-    resulting `source_code` is byte-for-byte identical.
+    resulting `source_code` strings are identical.
     """
     compilable_program = _make_simple_field_operator_compilable_program()
 


### PR DESCRIPTION
The source code generated by the translation stage should be byte identical, for the same input IR program. In case of lowered SDFGs, the JSON representation produced by the translation stage contains `guid`s which are not deterministic. These IDs should be excluded from the string containing the JSON source code, in order not to influence the DaCe compilation cache key.
The random `guid`s could be a problem in multi-rank deployment: multiple ranks could try compiling the same gt4py program. This PR allows the ranks to produce exactly the same compilable program, thus using the same cache key and compilation artifact.

Additional change: remove `build_folder` from `DaCeCompilationArtifact`, because not used.

Co-authored-by: Hannes Vogt