### PR TITLE
refactor[cartesian]: use f-strings instead of `.format()`

### DIFF
--- a/src/gt4py/cartesian/backend/gtc_common.py
+++ b/src/gt4py/cartesian/backend/gtc_common.py
@@ -149,7 +149,7 @@ class PyExtModuleGenerator(BaseModuleGenerator):
         for decl in ir.params:
             args.append(decl.name)
             if isinstance(decl, gtir.FieldDecl):
-                args.append("list(_origin_['{}'])".format(decl.name))
+                args.append(f"list(_origin_['{decl.name}'])")
 
         # only generate implementation if any multi_stages are present. e.g. if no statement in the
         # stencil has any effect on the API fields, this may not be the case since they could be

--- a/src/gt4py/cartesian/backend/gtcpp_backend.py
+++ b/src/gt4py/cartesian/backend/gtcpp_backend.py
@@ -101,9 +101,9 @@ class GTCppBindingsCodegen(codegen.TemplatedGenerator):
     def visit_GlobalParamDecl(self, node: gtcpp.GlobalParamDecl, **kwargs):
         if "external_arg" in kwargs:
             if kwargs["external_arg"]:
-                return "{dtype} {name}".format(name=node.name, dtype=self.visit(node.dtype))
-            else:
-                return "gridtools::stencil::global_parameter({name})".format(name=node.name)
+                return f"{self.visit(node.dtype)} {node.name}"
+
+            return f"gridtools::stencil::global_parameter({node.name})"
 
     def visit_Program(self, node: gtcpp.Program, **kwargs):
         assert "module_name" in kwargs

--- a/src/gt4py/cartesian/backend/module_generator.py
+++ b/src/gt4py/cartesian/backend/module_generator.py
@@ -266,14 +266,12 @@ class BaseModuleGenerator(abc.ABC):
         for arg in self.builder.gtir.api_signature:
             if arg.is_keyword:
                 if arg.default:
-                    keyword_args.append(
-                        "{name}={default}".format(name=arg.name, default=arg.default)
-                    )
+                    keyword_args.append(f"{arg.name}={arg.default}")
                 else:
                     keyword_args.append(arg.name)
             else:
                 if arg.default:
-                    args.append("{name}={default}".format(name=arg.name, default=arg.default))
+                    args.append(f"{arg.name}={arg.default}")
                 else:
                     args.append(arg.name)
 

--- a/src/gt4py/cartesian/backend/pyext_builder.py
+++ b/src/gt4py/cartesian/backend/pyext_builder.py
@@ -84,32 +84,32 @@ def get_gt_pyext_build_opts(
     extra_compile_args = dict(
         cxx=[
             "-std=c++17",
-            "-ftemplate-depth={}".format(gt_config.build_settings["cpp_template_depth"]),
+            f"-ftemplate-depth={gt_config.build_settings['cpp_template_depth']}",
             "-fvisibility=hidden",
             "-fPIC",
             # A compiler is allowed to choose if `char` is signed or unsigned. We force the signed behavior
             # because `char` is used to represent the `int8` type in GT4Py programs.
             "-fsigned-char",
-            "-isystem{}".format(gt_include_path),
+            f"-isystem{gt_include_path}",
             *extra_compile_args_from_config["cxx"],
         ]
     )
     extra_compile_args["cuda"] = [
         "-std=c++17",
-        "-ftemplate-depth={}".format(gt_config.build_settings["cpp_template_depth"]),
+        f"-ftemplate-depth={gt_config.build_settings['cpp_template_depth']}",
         *extra_compile_args_from_config["cuda"],
     ]
     if is_rocm_gpu:
         extra_compile_args["cuda"] += [
-            "-isystem{}".format(gt_include_path),
+            f"-isystem{gt_include_path}",
             "-fvisibility=hidden",
             "-fPIC",
             *([f"--offload-arch={cuda_arch}"] if cuda_arch else []),
         ]
     else:
         extra_compile_args["cuda"] += [
-            "-isystem={}".format(gt_include_path),
-            "-arch=sm_{}".format(cuda_arch),
+            f"-isystem={gt_include_path}",
+            f"-arch=sm_{cuda_arch}",
             "--expt-relaxed-constexpr",
             "--compiler-options",
             "-fvisibility=hidden",
@@ -127,16 +127,14 @@ def get_gt_pyext_build_opts(
     extra_link_args.extend(mode_flags)
 
     if dace_path := get_dace_module_path():
-        extra_compile_args["cxx"].append(
-            "-isystem{}".format(os.path.join(dace_path, "runtime/include"))
-        )
+        extra_compile_args["cxx"].append(f"-isystem{os.path.join(dace_path, 'runtime/include')}")
         if is_rocm_gpu:
             extra_compile_args["cuda"].append(
-                "-isystem{}".format(os.path.join(dace_path, "runtime/include"))
+                f"-isystem{os.path.join(dace_path, 'runtime/include')}"
             )
         else:
             extra_compile_args["cuda"].append(
-                "-isystem={}".format(os.path.join(dace_path, "runtime/include"))
+                f"-isystem={os.path.join(dace_path, 'runtime/include')}"
             )
 
     if add_profile_info:
@@ -233,8 +231,8 @@ def build_pybind_ext(
         ext_modules=[py_extension],
         script_args=[
             "build_ext",
-            "--build-temp={}".format(build_path),
-            "--build-lib={}".format(build_path),
+            f"--build-temp={build_path}",
+            f"--build-lib={build_path}",
             "--force",
         ],
     )

--- a/src/gt4py/cartesian/caching.py
+++ b/src/gt4py/cartesian/caching.py
@@ -197,9 +197,8 @@ class JITCachingStrategy(CachingStrategy):
 
     @property
     def backend_root_path(self) -> pathlib.Path:
-        cpython_id = "py{version.major}{version.minor}_{api_version}".format(
-            version=sys.version_info, api_version=sys.api_version
-        )
+        version = sys.version_info
+        cpython_id = f"py{version.major}{version.minor}_{sys.api_version}"
         backend_root = self.root_path / cpython_id / gt_utils.slugify(self.builder.backend.name)
         if not backend_root.exists():
             if not backend_root.parent.exists():

--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -70,13 +70,7 @@ class FieldInfo:
     dtype: numpy.dtype
 
     def __repr__(self):
-        return "FieldInfo(access=AccessKind.{access}, boundary={boundary}, axes={axes}, data_dims={data_dims}, dtype={dtype})".format(
-            access=self.access.name,
-            boundary=repr(self.boundary),
-            axes=repr(self.axes),
-            data_dims=repr(self.data_dims),
-            dtype=repr(self.dtype),
-        )
+        return f"FieldInfo(access=AccessKind.{self.access.name}, boundary={self.boundary!r}, axes={self.axes!r}, data_dims={self.data_dims!r}, dtype={self.dtype!r})"
 
     @functools.cached_property
     def domain_mask(self):
@@ -101,9 +95,7 @@ class ParameterInfo:
     dtype: numpy.dtype
 
     def __repr__(self):
-        return "ParameterInfo(access=AccessKind.{access}, dtype={dtype})".format(
-            access=self.access.name, dtype=repr(self.dtype)
-        )
+        return f"ParameterInfo(access=AccessKind.{self.access.name}, dtype={self.dtype!r})"
 
 
 @attribkwclass

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1460,7 +1460,7 @@ class IRMaker(ast.NodeVisitor):
         op = self.visit(node.op)
         arg = self.visit(node.operand)
         if isinstance(arg, numbers.Number):
-            return eval("{op}{arg}".format(op=op.python_symbol, arg=arg))
+            return eval(f"{op.python_symbol}{arg}")
 
         return nodes.UnaryOpExpr(
             op=op,
@@ -2090,7 +2090,7 @@ class GTScriptParser(ast.NodeVisitor):
 
     def __str__(self) -> str:
         result = "<GT4Py.GTScriptParser> {\n"
-        result += "\n".join("\t{}: {}".format(name, getattr(self, name)) for name in vars(self))
+        result += "\n".join(f"\t{name}: {getattr(self, name)}" for name in vars(self))
         result += "\n}"
         return result
 
@@ -2120,7 +2120,7 @@ class GTScriptParser(ast.NodeVisitor):
         api_signature = []
         api_annotations = []
 
-        qualified_name = "{}.{}".format(definition.__module__, definition.__name__)
+        qualified_name = f"{definition.__module__}.{definition.__name__}"
         sig = inspect.signature(definition)
         for param in sig.parameters.values():
             if param.kind == inspect.Parameter.VAR_POSITIONAL:
@@ -2274,7 +2274,7 @@ class GTScriptParser(ast.NodeVisitor):
                     wrong_imports.append(key)
 
         if wrong_imports:
-            raise GTScriptSyntaxError("Invalid 'import' statements ({})".format(wrong_imports))
+            raise GTScriptSyntaxError(f"Invalid 'import' statements ({wrong_imports})")
 
         context, unbound = gt_meta.get_closure(
             definition, included_nonlocals=True, include_builtins=False
@@ -2329,7 +2329,7 @@ class GTScriptParser(ast.NodeVisitor):
             raise GTScriptDefinitionError(
                 name=name,
                 value="<unknown>",
-                message="Missing or invalid value for external symbol {name}".format(name=name),
+                message=f"Missing or invalid value for external symbol {name}",
                 loc=loc,
             ) from e
         return value
@@ -2380,7 +2380,7 @@ class GTScriptParser(ast.NodeVisitor):
                 if hasattr(value, "_gtscript_") and exhaustive:
                     assert callable(value)
                     nested_inlined_values = {
-                        "{}.{}".format(value._gtscript_["qualified_name"], item_name): item_value
+                        f"{value._gtscript_['qualified_name']}.{item_name}": item_value
                         for item_name, item_value in value._gtscript_["nonlocals"].items()
                     }
                     resolved_values_list.extend(nested_inlined_values.items())

--- a/src/gt4py/cartesian/gtc/common.py
+++ b/src/gt4py/cartesian/gtc/common.py
@@ -279,7 +279,9 @@ class Stmt(LocNode):
 
 def verify_condition_is_boolean(parent_node_cls: datamodels.DataModel, cond: Expr) -> None:
     if cond.dtype and cond.dtype is not DataType.BOOL:
-        raise ValueError("Condition in `{}` must be boolean.".format(type(parent_node_cls)))
+        raise ValueError(
+            f"Condition in `{type(parent_node_cls)}` must be boolean, got {cond.dtype} instead. Condition: {cond}."
+        )
 
 
 def verify_and_get_common_dtype(
@@ -648,7 +650,7 @@ def validate_dtype_is_set() -> datamodels.RootValidator:
                 nodes_without_dtype.append(node)
 
         if len(nodes_without_dtype) > 0:
-            raise ValueError("Nodes without dtype detected {}".format(nodes_without_dtype))
+            raise ValueError(f"Nodes without dtype detected: {nodes_without_dtype}.")
 
     return _make_root_validator(_impl)
 
@@ -684,7 +686,7 @@ class _LvalueDimsValidator(eve.VisitorWithSymbolTableTrait):
     ) -> None:
         decl = symtable.get(node.left.name, None)
         if decl is None:
-            raise ValueError("Symbol {} not found.".format(node.left.name))
+            raise ValueError(f"Symbol {node.left.name} not found.")
         if not isinstance(decl, self.decl_type):
             return None
 

--- a/src/gt4py/cartesian/gtc/definitions.py
+++ b/src/gt4py/cartesian/gtc/definitions.py
@@ -47,7 +47,7 @@ class NumericTuple(tuple):
         if isinstance(ndims, numbers.Integral):
             ndims = tuple([ndims] * 2)
         elif not isinstance(ndims, tuple) or len(ndims) != 2:
-            raise ValueError("Invalid 'ndims' definition ({})".format(ndims))
+            raise ValueError(f"Invalid 'ndims' definition ({ndims})")
 
         try:
             cls._check_value(value, ndims)
@@ -90,12 +90,12 @@ class NumericTuple(tuple):
         elif isinstance(ndims, int):
             ndims = tuple([ndims] * 2)
         elif not isinstance(ndims, tuple) or len(ndims) != 2:
-            raise ValueError("Invalid 'ndims' definition ({})".format(ndims))
+            raise ValueError(f"Invalid 'ndims' definition ({ndims})")
 
         try:
             cls._check_value(sizes, ndims=ndims)
         except Exception as e:
-            raise TypeError("Invalid {} definition".format(cls.__name__)) from e
+            raise TypeError(f"Invalid {cls.__name__} definition") from e
         else:
             return super().__new__(cls, sizes)
 
@@ -104,7 +104,7 @@ class NumericTuple(tuple):
             value = self[CartesianSpace.Axis.symbols.index(name)]
         except (IndexError, ValueError) as e:
             raise AttributeError(
-                "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
             ) from e
         else:
             return value
@@ -179,9 +179,7 @@ class NumericTuple(tuple):
         )
 
     def __repr__(self):
-        return "{cls_name}({value})".format(
-            cls_name=type(self).__name__, value=tuple.__repr__(self)
-        )
+        return f"{type(self).__name__}({tuple.__repr__(self)})"
 
     def __hash__(self):
         return tuple.__hash__(self)
@@ -210,7 +208,7 @@ class NumericTuple(tuple):
 
     def _apply(self, other, func):
         if not isinstance(other, type(self)) or len(self) != len(other):
-            raise ValueError("Incompatible instance '{obj}'".format(obj=other))
+            raise ValueError(f"Incompatible instance '{other}'")
 
         return type(self)([func(a, b) for a, b in zip(self, other)])
 
@@ -224,7 +222,7 @@ class NumericTuple(tuple):
 
     def _compare(self, other, op, reduction_op):
         if len(self) != len(other):  # or not isinstance(other, type(self))
-            raise ValueError("Incompatible instance '{obj}'".format(obj=other))
+            raise ValueError(f"Incompatible instance '{other}'")
 
         return reduction_op(op(a, b) for a, b in zip(self, other))
 
@@ -277,7 +275,7 @@ class FrameTuple(tuple):
         if isinstance(ndims, int):
             ndims = tuple([ndims] * 2)
         elif not isinstance(ndims, tuple) or len(ndims) != 2:
-            raise ValueError("Invalid 'ndims' definition ({})".format(ndims))
+            raise ValueError(f"Invalid 'ndims' definition ({ndims})")
 
         try:
             cls._check_value(value, ndims)
@@ -321,7 +319,7 @@ class FrameTuple(tuple):
             value = self[CartesianSpace.Axis.symbols.index(name)]
         except (IndexError, ValueError) as e:
             raise AttributeError(
-                "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
             ) from e
         else:
             return value
@@ -372,9 +370,7 @@ class FrameTuple(tuple):
         return self._compare(self._broadcast(other), operator.ge)
 
     def __repr__(self):
-        return "{cls_name}({value})".format(
-            cls_name=self.__class__.__name__, value=tuple.__repr__(self)
-        )
+        return f"{self.__class__.__name__}({tuple.__repr__(self)})"
 
     def __hash__(self):
         return tuple.__hash__(self)
@@ -428,7 +424,7 @@ class FrameTuple(tuple):
 
     def _apply(self, other, left_func, right_func=None):
         if not isinstance(other, FrameTuple) or len(self) != len(other):
-            raise ValueError("Incompatible instance '{obj}'".format(obj=other))
+            raise ValueError(f"Incompatible instance '{other}'")
 
         right_func = right_func or left_func
         return type(self)(
@@ -440,7 +436,7 @@ class FrameTuple(tuple):
 
     def _compare(self, other, left_op, right_op=None):
         if len(self) != len(other):  # or not isinstance(other, Frame)
-            raise ValueError("Incompatible instance '{obj}'".format(obj=other))
+            raise ValueError(f"Incompatible instance '{other}'")
 
         right_op = right_op or left_op
         return all(left_op(a[0], b[0]) and right_op(a[1], b[1]) for a, b in zip(self, other))
@@ -479,7 +475,7 @@ class Boundary(FrameTuple):
     @classmethod
     def from_offset(cls, offset):
         if not Index.is_valid(offset):
-            raise ValueError("Invalid offset value ({})".format(offset))
+            raise ValueError(f"Invalid offset value ({offset})")
         return cls([(-1 * min(0, i), max(0, i)) for i in offset])
 
     @property
@@ -524,7 +520,7 @@ class Extent(FrameTuple):
     @classmethod
     def from_offset(cls, offset):
         if not Index.is_valid(offset):
-            raise ValueError("Invalid offset value ({})".format(offset))
+            raise ValueError(f"Invalid offset value ({offset})")
         return cls([(i, i) for i in offset])
 
     def __and__(self, other):
@@ -571,7 +567,7 @@ class Extent(FrameTuple):
 
     def _apply(self, other, left_func, right_func=None):
         if not isinstance(other, FrameTuple) or len(self) != len(other):
-            raise ValueError("Incompatible instance '{obj}'".format(obj=other))
+            raise ValueError(f"Incompatible instance '{other}'")
 
         right_func = right_func or left_func
         result = [None] * len(self)
@@ -622,7 +618,7 @@ class CenteredExtent(Extent):
     @classmethod
     def from_offset(cls, offset):
         if not Index.is_valid(offset):
-            raise ValueError("Invalid offset value ({})".format(offset))
+            raise ValueError(f"Invalid offset value ({offset})")
         return cls([(min(i, 0), max(i, 0)) for i in offset])
 
     def to_boundary(self):

--- a/src/gt4py/cartesian/loader.py
+++ b/src/gt4py/cartesian/loader.py
@@ -58,7 +58,7 @@ def gtscript_loader(
     dtypes: dict[type, type],
 ) -> StencilObject:
     if not isinstance(definition_func, types.FunctionType):
-        raise ValueError("Invalid stencil definition object ({obj})".format(obj=definition_func))
+        raise ValueError(f"Invalid stencil definition object ({definition_func})")
 
     if not build_options.name:
         build_options.name = f"{definition_func.__name__}"

--- a/src/gt4py/cartesian/stencil_object.py
+++ b/src/gt4py/cartesian/stencil_object.py
@@ -207,26 +207,15 @@ class StencilObject(abc.ABC):
         return type(self) is type(other)
 
     def __str__(self) -> str:
-        result = """
-<StencilObject: {name}> [backend="{backend}"]
-    - I/O fields: {fields}
-    - Parameters: {params}
-    - Constants: {constants}
-    - Version: {version}
-    - Definition ({func}):
-{source}
-        """.format(
-            name=self.options["module"] + "." + self.options["name"],
-            version=self._gt_id_,
-            backend=self.backend,
-            fields=self.field_info,
-            params=self.parameter_info,
-            constants=self.constants,
-            func=self.definition_func,
-            source=self.source,
-        )
-
-        return result
+        return f"""
+<StencilObject: {self.options["module"] + "." + self.options["name"]}> [backend="{self.backend}"]
+    - I/O fields: {self.field_info}
+    - Parameters: {self.parameter_info}
+    - Constants: {self.constants}
+    - Version: {self._gt_id_}
+    - Definition ({self.definition_func}):
+{self.source}
+        """
 
     def __hash__(self) -> int:
         return int.from_bytes(type(self)._gt_id_.encode(), byteorder="little")
@@ -293,7 +282,7 @@ class StencilObject(abc.ABC):
         except Exception:
             pass
 
-        raise ValueError("Invalid 'origin' value ({})".format(origin))
+        raise ValueError(f"Invalid 'origin' value ({origin})")
 
     @staticmethod
     def _get_max_domain(
@@ -370,7 +359,7 @@ class StencilObject(abc.ABC):
         try:
             domain = Shape(domain)
         except Exception as ex:
-            raise ValueError("Invalid 'domain' value ({})".format(domain)) from ex
+            raise ValueError(f"Invalid 'domain' value ({domain})") from ex
 
         if not domain > Shape.zeros(domain_ndim):
             raise ValueError(f"Compute domain contains zero sizes '{domain}')")

--- a/src/gt4py/cartesian/testing/suites.py
+++ b/src/gt4py/cartesian/testing/suites.py
@@ -208,9 +208,7 @@ class SuiteMeta(type):
             if test["suite"] == cls_name:
                 name = test["backend"]
                 name += "".join(f"_{key}_{value}" for key, value in test["constants"].items())
-                name += "".join(
-                    "_{}_{}".format(key, value.name) for key, value in test["dtypes"].items()
-                )
+                name += "".join(f"_{key}_{value.name}" for key, value in test["dtypes"].items())
 
                 marks = test["marks"].copy()
                 if gt_backend.from_name(test["backend"]).storage_info["device"] == "gpu":
@@ -242,9 +240,7 @@ class SuiteMeta(type):
             if test["suite"] == cls_name:
                 name = test["backend"]
                 name += "".join(f"_{key}_{value}" for key, value in test["constants"].items())
-                name += "".join(
-                    "_{}_{}".format(key, value.name) for key, value in test["dtypes"].items()
-                )
+                name += "".join(f"_{key}_{value.name}" for key, value in test["dtypes"].items())
 
                 marks = test["marks"].copy()
                 if gt_backend.from_name(test["backend"]).storage_info["device"] == "gpu":
@@ -273,9 +269,7 @@ class SuiteMeta(type):
         missing_members = cls.required_members - cls_dict.keys()
         if len(missing_members) > 0:
             raise TypeError(
-                "Missing {missing} required members in '{name}' definition".format(
-                    missing=missing_members, name=cls_name
-                )
+                f"Missing {missing_members} required members in '{cls_name}' definition"
             )
         # Check class dict
         domain_range = cls_dict["domain_range"]
@@ -309,7 +303,7 @@ class SuiteMeta(type):
         backends = [pytest.param(b) if isinstance(b, str) else b for b in backends]
         for b in backends:
             if b.values[0] not in gt_backend.REGISTRY.names:
-                raise ValueError("backend '{backend}' not supported".format(backend=b))
+                raise ValueError(f"Backend '{b}' not supported")
 
         # Check definition and validation functions
         if not isinstance(cls_dict["definition"], types.FunctionType):
@@ -370,8 +364,8 @@ class SuiteMeta(type):
 
         assert set(input_names + parameter_names) == set(
             cls_dict["implementation_strategy_factories"].keys()
-        ), "Missing or invalid keys in 'symbols' mapping (generated: {})".format(
-            cls_dict["implementation_strategy_factories"].keys()
+        ), (
+            f"Missing or invalid keys in 'symbols' mapping (generated: {cls_dict['implementation_strategy_factories'].keys()})"
         )
 
         cls.parametrize_generation_tests(cls_name, cls_dict)
@@ -602,7 +596,7 @@ class StencilTestSuite(metaclass=SuiteMeta):
                     rtol=RTOL,
                     atol=ATOL,
                     equal_nan=EQUAL_NAN,
-                    err_msg="Wrong data in output field '{name}'".format(name=name),
+                    err_msg=f"Wrong data in output field '{name}'",
                 )
 
     @classmethod

--- a/src/gt4py/cartesian/utils/attrib.py
+++ b/src/gt4py/cartesian/utils/attrib.py
@@ -27,8 +27,8 @@ class _TypeDescriptor:
                 arg_names.append(a.__name__)
             elif isinstance(a, _TypeDescriptor):
                 arg_names.append(repr(a))
-        args = "[{}]".format(", ".join(arg_names)) if len(arg_names) > 0 else ""
-        return "{}{}".format(self.name, args)
+        args = f"[{', '.join(arg_names)}]" if len(arg_names) > 0 else ""
+        return f"{self.name}{args}"
 
     @property
     def validator(self):
@@ -92,9 +92,7 @@ def _make_sequence_validator(type_list, container_types=(list, tuple)):
             assert isinstance([item_validator(instance, attribute, v) for v in value], list)
         except Exception as ex:
             raise ValueError(
-                "Expr ({value}) does not match the '{name}' specification".format(
-                    value=value, name=attribute.name
-                )
+                f"Expr ({value}) does not match the '{attribute.name}' specification"
             ) from ex
 
     return _is_sequence_of_validator
@@ -121,9 +119,7 @@ def _make_dict_validator(type_list):
             )
         except Exception as ex:
             raise ValueError(
-                "Expr ({value}) does not match the '{name}' specification".format(
-                    value=value, name=attribute.name
-                )
+                f"Expr ({value}) does not match the '{attribute.name}' specification"
             ) from ex
 
     return _is_dict_of_validator
@@ -146,9 +142,7 @@ def _make_tuple_validator(type_list):
             )
         except Exception as ex:
             raise ValueError(
-                "Expr ({value}) does not match the '{name}' specification".format(
-                    value=value, name=attribute.name
-                )
+                f"Expr ({value}) does not match the '{attribute.name}' specification"
             ) from ex
 
     return _is_tuple_of_validator
@@ -171,11 +165,7 @@ def _make_union_validator(type_list):
             passed = False
 
         if not passed:
-            raise ValueError(
-                "Expr ({value}) does not match the '{name}' specification".format(
-                    value=value, name=attribute.name
-                )
-            )
+            raise ValueError(f"Expr ({value}) does not match the '{attribute.name}' specification")
 
     return _is_union_of_validator
 
@@ -215,14 +205,12 @@ def attribute(of, optional=False, **kwargs):
     if isinstance(of, _TypeDescriptor):
         attr_validator = of.validator
         attr_type_hint = of.type_hint
-
     elif isinstance(of, type):
         # assert of in (bool, float, str, int, enum.Enum) # noqa: ERA001 [commented-out-code]
         attr_validator = attr.validators.instance_of(of)
         attr_type_hint = of
-
     else:
-        raise ValueError("Invalid attribute type '{}'".format(of))
+        raise ValueError(f"Invalid attribute type '{of}'")
 
     if optional:
         attr_validator = attr.validators.optional(attr_validator)
@@ -263,9 +251,7 @@ def attribclass(cls_or_none=None, **kwargs):
         for name, member in extra_members.items():
             if name in cls.__dict__.keys():
                 raise ValueError(
-                    "Name clashing with a existing '{name}' member of the decorated class ".format(
-                        name=name
-                    )
+                    f"Name clashing with a existing '{name}' member of the decorated class"
                 )
             setattr(cls, name, member)
 

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -62,7 +62,7 @@ def get_ast(func_or_source_or_ast, *, feature_version: tuple[int, int]):
     if isinstance(func_or_source_or_ast, (ast.AST, list)):
         ast_root = func_or_source_or_ast
     else:
-        raise ValueError("Invalid function definition ({})".format(func_or_source_or_ast))
+        raise ValueError(f"Invalid function definition ({func_or_source_or_ast})")
     return ast_root
 
 
@@ -74,9 +74,7 @@ def ast_dump(definition, *, feature_version: tuple[int, int]) -> str:
             return "".join(
                 [
                     node.__class__.__name__,
-                    "({content})".format(
-                        content=", ".join("{}={}".format(name, value) for name, value in fields)
-                    ),
+                    f"({', '.join('{}={}'.format(name, value) for name, value in fields)})",
                 ]
             )
 
@@ -301,7 +299,7 @@ class ASTEvaluator(ASTPass):
         return all(comparisons)
 
     def generic_visit(self, node):
-        raise ValueError("Invalid AST node for evaluation: {}".format(repr(node)))
+        raise ValueError(f"Invalid AST node for evaluation: {node!r}")
 
 
 ast_eval = ASTEvaluator.apply

--- a/src/gt4py/cartesian/utils/meta.py
+++ b/src/gt4py/cartesian/utils/meta.py
@@ -74,7 +74,7 @@ def ast_dump(definition, *, feature_version: tuple[int, int]) -> str:
             return "".join(
                 [
                     node.__class__.__name__,
-                    f"({', '.join('{}={}'.format(name, value) for name, value in fields)})",
+                    f"({', '.join(f'{name}={value}' for name, value in fields)})",
                 ]
             )
 

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -149,7 +149,7 @@ def normalize_storage_spec(
         aligned_index = tuple(aligned_index)
 
         if any(i < 0 for i in aligned_index):
-            raise ValueError("aligned_index ({}) contains negative value.".format(aligned_index))
+            raise ValueError(f"aligned_index ({aligned_index}) contains negative value.")
     else:
         raise TypeError("aligned_index must be an iterable of ints.")
 

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1835,3 +1835,12 @@ def test_offset_j_in_temporaries(backend: str) -> None:
                 if isnan(sqrt_res)
                 else 0.0
             )
+
+
+def test_if_statement_non_boolean_condition():
+
+    @gtscript.stencil(backend="debug")
+    def stencil(field: gtscript.Field[float]):  # type: ignore
+        with computation(PARALLEL), interval(...):
+            if field:
+                field[0, 0, 0] = 42

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1835,12 +1835,3 @@ def test_offset_j_in_temporaries(backend: str) -> None:
                 if isnan(sqrt_res)
                 else 0.0
             )
-
-
-def test_if_statement_non_boolean_condition():
-
-    @gtscript.stencil(backend="debug")
-    def stencil(field: gtscript.Field[float]):  # type: ignore
-        with computation(PARALLEL), interval(...):
-            if field:
-                field[0, 0, 0] = 42


### PR DESCRIPTION
## Description

Use f-strings instead of `.format()` for simple text concatenation where e.g. the template is not shared. f-strings are shorter and offer almost the same amount of flexibility. In these simple cases, it's imo much more readable.

This all started with Charles hitting a non-boolean `if` condition yesterday, which gives a very cryptic and non-informative error message. While expanding the error message, I noticed in how many place we use `.format()` when simple f-strings would be sufficient. So I changed that too ... 

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
