### PR TITLE
fix[next]: keep scan compute domain within the statement colum

### DIFF
--- a/src/gt4py/next/iterator/transforms/infer_domain.py
+++ b/src/gt4py/next/iterator/transforms/infer_domain.py
@@ -12,7 +12,7 @@ import typing
 
 from gt4py import eve
 from gt4py.eve import utils as eve_utils
-from gt4py.eve.extended_typing import Callable, Optional, TypeAlias, Unpack
+from gt4py.eve.extended_typing import Callable, NotRequired, Optional, TypeAlias, Unpack
 from gt4py.next import common, utils as gtx_utils
 from gt4py.next.iterator import builtins, ir as itir
 from gt4py.next.iterator.ir_utils import (
@@ -51,13 +51,18 @@ NonTupleDomainAccess: TypeAlias = domain_utils.SymbolicDomain | DomainAccessDesc
 #: fine to a tuple of a vertex and an edge domain.
 DomainAccess: TypeAlias = NonTupleDomainAccess | tuple["DomainAccess", ...]
 AccessedDomains: TypeAlias = dict[str, DomainAccess]
+ScanVerticalBounds: TypeAlias = dict[common.Dimension, domain_utils.SymbolicRange]
 
 
-class InferenceOptions(typing.TypedDict):
+class StatementInferenceOptions(typing.TypedDict):
     offset_provider: common.OffsetProvider | common.OffsetProviderType
     symbolic_domain_sizes: dict[str, itir.Expr] | None
     allow_uninferred: bool
     keep_existing_domains: bool
+
+
+class InferenceOptions(StatementInferenceOptions):
+    scan_vertical_bounds: NotRequired[ScanVerticalBounds | None]
 
 
 class DomainAnnexDebugger(eve.NodeVisitor):
@@ -168,10 +173,14 @@ def _filter_domain_dimensions(
 
 def _extract_vertical_dims(
     domain: domain_utils.SymbolicDomain,
-) -> dict[common.Dimension, domain_utils.SymbolicRange]:
+    scan_vertical_bounds: ScanVerticalBounds | None = None,
+) -> ScanVerticalBounds:
+    # For each vertical dimension of `domain`, take its range from `scan_vertical_bounds` if that
+    # dimension is present there, otherwise from `domain`.
     assert isinstance(domain, domain_utils.SymbolicDomain)
+    scan_vertical_bounds = scan_vertical_bounds or {}
     return {
-        dim: range_
+        dim: scan_vertical_bounds.get(dim, range_)
         for dim, range_ in domain.ranges.items()
         if dim.kind == common.DimensionKind.VERTICAL
     }
@@ -185,6 +194,7 @@ def _infer_as_fieldop(
     symbolic_domain_sizes: Optional[dict[str, itir.Expr]],
     allow_uninferred: bool,
     keep_existing_domains: bool,
+    scan_vertical_bounds: ScanVerticalBounds | None = None,
 ) -> tuple[itir.FunCall, AccessedDomains]:
     assert isinstance(applied_fieldop, itir.FunCall)
     assert cpm.is_call_to(applied_fieldop.fun, "as_fieldop")
@@ -234,6 +244,7 @@ def _infer_as_fieldop(
             symbolic_domain_sizes=symbolic_domain_sizes,
             allow_uninferred=allow_uninferred,
             keep_existing_domains=keep_existing_domains,
+            scan_vertical_bounds=scan_vertical_bounds,
         )
         transformed_inputs.append(transformed_input)
 
@@ -442,6 +453,7 @@ def infer_expr(
     symbolic_domain_sizes: Optional[dict[str, itir.Expr]] = None,
     allow_uninferred: bool = False,
     keep_existing_domains: bool = False,
+    scan_vertical_bounds: ScanVerticalBounds | None = None,
 ) -> tuple[itir.Expr, AccessedDomains]:
     """
     Infer the domain of all field subexpressions of `expr`.
@@ -485,9 +497,12 @@ def infer_expr(
     )
 
     if cpm.is_applied_as_fieldop(expr) and cpm.is_call_to(expr.fun.args[0], "scan"):
+        # Re-add the scan's vertical (column) dimension, clamped to the statement column.
         additional_dims = gtx_utils.tree_map(
             lambda d: (
-                _extract_vertical_dims(d) if isinstance(d, domain_utils.SymbolicDomain) else {}
+                _extract_vertical_dims(d, scan_vertical_bounds)
+                if isinstance(d, domain_utils.SymbolicDomain)
+                else {}
             )
         )(domain)
     else:
@@ -512,6 +527,7 @@ def infer_expr(
         symbolic_domain_sizes=symbolic_domain_sizes,
         allow_uninferred=allow_uninferred,
         keep_existing_domains=keep_existing_domains,
+        scan_vertical_bounds=scan_vertical_bounds,
     )
     if not keep_existing_domains or not hasattr(expr.annex, "domain"):
         expr.annex.domain = domain
@@ -528,7 +544,7 @@ def _make_symbolic_domain_tuple(domains: itir.Node) -> DomainAccess:
 
 def _infer_stmt(
     stmt: itir.Stmt,
-    **kwargs: Unpack[InferenceOptions],
+    **kwargs: Unpack[StatementInferenceOptions],
 ):
     if isinstance(stmt, itir.SetAt):
         # constant fold once otherwise constant folding after domain inference might create (syntactic) differences
@@ -537,7 +553,21 @@ def _infer_stmt(
 
         symbolic_domain = _make_symbolic_domain_tuple(domain)
 
-        transformed_call, _ = infer_expr(stmt.expr, symbolic_domain, **kwargs)
+        # All fields of a `SetAt` share one vertical column; pass any concrete target domain down so
+        # every scan is forced to compute it, ignoring vertical offsets on its result.
+        representative_domain = next(
+            (d for d in flatten_nested_tuple((symbolic_domain,)) if isinstance(d, SymbolicDomain)),
+            None,
+        )
+        scan_vertical_bounds = (
+            _extract_vertical_dims(representative_domain)
+            if representative_domain is not None
+            else None
+        )
+
+        transformed_call, _ = infer_expr(
+            stmt.expr, symbolic_domain, scan_vertical_bounds=scan_vertical_bounds, **kwargs
+        )
 
         return itir.SetAt(
             expr=transformed_call,

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_domain_inference.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_domain_inference.py
@@ -1167,6 +1167,43 @@ def test_scan():
     )
 
 
+def test_scan_result_vertical_offset():
+    # Reading a scan result at a vertical offset (backward scan reading the forward result at
+    # `Koff[-2]`) must not extend the scan's compute domain, which would read out of bounds.
+    field = ts.FieldType(dims=[KDim], dtype=float_type)
+    domain = im.domain(common.GridType.CARTESIAN, {KDim: (0, 11)})
+    forward = im.scan(im.lambda_("state", "x")(im.plus("state", im.deref("x"))), True, 0.0)
+    backward = im.scan(
+        im.lambda_("state", "ff", "ff2")(
+            im.plus(im.plus("state", im.deref("ff")), im.deref("ff2"))
+        ),
+        False,
+        0.0,
+    )
+    testee = im.let("ff", im.as_fieldop(forward)(im.ref("x", field)))(
+        im.as_fieldop(backward)(im.ref("ff", field), premap_field(im.ref("ff", field), Koff, -2))
+    )
+    program = itir.Program(
+        id="fused_scan",
+        function_definitions=[],
+        params=[im.sym("x", field), im.sym("out", field)],
+        declarations=[],
+        body=[itir.SetAt(expr=testee, domain=domain, target=im.ref("out"))],
+    )
+
+    actual = infer_domain.infer_program(program, offset_provider={})
+
+    scan_domains = [
+        constant_fold_domain_exprs(node.fun.args[1])
+        for node in eve.walk_values(actual).if_isinstance(itir.FunCall)
+        if cpm.is_applied_as_fieldop(node)
+        and cpm.is_call_to(node.fun.args[0], "scan")
+        and len(node.fun.args) == 2
+    ]
+    assert len(scan_domains) == 2  # forward and backward scan
+    assert all(d == constant_fold_domain_exprs(domain) for d in scan_domains)
+
+
 def test_symbolic_domain_sizes(unstructured_offset_provider):
     stencil = im.lambda_("arg0")(im.deref(im.shift("E2V", 1)("arg0")))
     domain = im.domain(common.GridType.UNSTRUCTURED, {Edge: (0, 1)})


### PR DESCRIPTION
A scan computes its entire vertical column sequentially and cannot read its inputs outside that column. When a scan's result is read at a vertical offset — e.g. a backward scan reading a forward scan's result at `Koff[-2]` — domain inference back propagated that offset and extended the scan's compute domain (to `[-2, 11)` instead of `[0, 11)`). The scan then reads its inputs out of bounds.

This was fixed by making `_infer_stmt` now derive the statement's vertical column and thread it (`scan_vertical_bounds`) through `infer_expr`. When a scan's vertical dimension is re-added to its domain, the range is taken from that column rather than from the (offset-extended) back-propagated domain, so every scan in a `SetAt` is pinned to the statement column. All fields written by a `SetAt` share one vertical column, so any concrete target domain is representative of it.

A new unit test `test_scan_result_vertical_offset`  with a fused forward/backward scan program where the backward scan reads the forward result at `Koff[-2]` was added.
