### PR TITLE
refactor[cartesian]: skip `LiftTrivalIf` in `sdfg.simplify()` pipeline

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -426,7 +426,11 @@ class SDFGManager:
         sdfg = stree.as_sdfg(
             validate=validate,
             simplify=simplify,
-            skip={"ScalarToSymbolPromotion", "ControlFlowRaising"},
+            # We skip
+            #  - `ScalarToSymbolPromotion` because we've seen validation issue in the past
+            #  - `ControlFlowRaising` because we already generate CFGs in stree -> SDFG
+            #  - `LiftTrivialIf` because it's dead slow (e.g. fv3 acoustics parsing takes >90min compared to 10-15min without)
+            skip={"ScalarToSymbolPromotion", "ControlFlowRaising", "LiftTrivialIf"},
         )
 
         if do_cache:
@@ -485,11 +489,11 @@ class DaCeExtGenerator(BackendCodegen):
         manager = SDFGManager(self.backend.builder)
 
         sdfg = manager.sdfg_via_schedule_tree()
-        _specialize_transient_strides(
-            sdfg,
-            self.backend.storage_info,
-        )
-        sdfg.simplify(validate=True, skip={"ScalarToSymbolPromotion"})
+        _specialize_transient_strides(sdfg, self.backend.storage_info)
+        # We skip
+        #  - `ScalarToSymbolPromotion` because we've seen validation issues in the past
+        #  - `LiftTrivialIf` because it's dead slow (e.g. fv3 acoustics parsing takes >90min compared to 10-15min without)
+        sdfg.simplify(validate=True, skip={"ScalarToSymbolPromotion", "LiftTrivialIf"})
 
         # NOTE
         # The glue code in DaCeComputationCodegen.apply() (just below) will define all the


### PR DESCRIPTION
## Description

PR https://github.com/GridTools/gt4py/pull/2635 bumped the DaCe version from alpha3 to alpha4. This brought a new simplify pass: `LiftTrivialIf` which aims at inspecting the conditions of if statements and inlines code under trivially true/false conditions, see https://github.com/spcl/dace/pull/2138.

The new pass increases the runtime of simplify such that it is unusable for large-scale / real-world SDFGs, e.g. parsing the acoustics loop of fv3 in NDSL with dace orchestration will take >90min with the new pass compared to 10-15min without. In total, the runtime of the acoustics translate test blows up from ~30min to nearly 5h with that pass.

Preliminary, crude analysis shows that the bulk of the additional time is spent in the simplify step of sympy when the condition is evluated. This puts the slowdown at the heart of the pass, making an easy fix unlikely.

This PR suggests to just skip the new pass until the runtime drops to usable levels.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A. Covered by existing test cases.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A