### PR TITLE
WIP: fix[cartesian]: SDFG validation warnings after freezing for "read after write"-fields

### DIFF
--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -267,6 +267,10 @@ def freeze_origin_domain_sdfg(
 
     # gather inputs & outputs (i.e. reads/writes without transients)
     inputs, outputs = inner_sdfg.read_and_write_sets()
+    # NOTE: DaCe is lying to us! `read_and_write_sets()` will not consider read after write
+    # situations and thus happily report reads that happen after writes as inputs to the
+    # NestedSDFG.
+    # The filtering of transients is not necessary, I think (at least it shouldn't be imo).
     inputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, inputs))
     outputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, outputs))
 

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_dace_parsing.py
@@ -587,3 +587,36 @@ def test_lazy_sdfg():
     call_lazy_s.compile(locoutp=outp, locinp=inp)
 
     assert "implementation" not in lazy_s.__dict__
+
+
+def test_lazy_sdfg_raw():
+    def raw_stencil(
+        in_field: gtscript.Field[np.float64],  # type: ignore
+        out_field: gtscript.Field[np.float64],  # type: ignore
+    ) -> None:
+        with computation(PARALLEL), interval(...):
+            out_field = in_field
+
+        with computation(PARALLEL), interval(...):
+            out_field += 10
+
+    backend = "dace:cpu"
+    builder = StencilBuilder(raw_stencil, backend=backend).with_options(
+        name="simple_stencil", module=raw_stencil.__module__
+    )
+    lazy_raw_stencil = DaCeLazyStencil(builder)
+
+    @dace.program
+    def call_lazy_raw_stencil(in_field, out_field):
+        lazy_raw_stencil(in_field, out_field)
+
+    domain = (2, 2, 5)
+    in_field = gt_storage.ones(backend=backend, shape=domain, dtype=np.float64)
+    out_field = gt_storage.zeros(backend=backend, shape=domain, dtype=np.float64)
+
+    call_lazy_raw_stencil(in_field, out_field)
+
+    # TODO
+    # assert valid SDFG without warnings (not yet sure how to do so ...)
+
+    assert out_field  # just for testing


### PR DESCRIPTION
## Description

SDFG freezing (in the lazy stencil pathway) produces frozen SDFGs that emit validation warnings for fields reading memory that has previously been written (inside the same "to-be-frozen" SDFG).

Related issue: https://github.com/GridTools/gt4py/issues/2665

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
