### PR TITLE
fix[next]: make the DaCe determinism check follow gt4py's cache folder naming

### DIFF
--- a/scripts/python/dace_determinism.py
+++ b/scripts/python/dace_determinism.py
@@ -14,10 +14,11 @@ gt4py.next caches each compiled program at ``<root>/<folder>/src/...``, where
 the folder name embeds the program name and a fingerprint of the generated
 source. The folder-name layout is owned by gt4py — ``CACHE_FOLDER_NAME_PATTERN``
 next to ``get_cache_folder`` in ``gt4py/next/otf/compilation/cache.py``, kept in
-sync by a round-trip test there — and the ``ci-check`` subcommand reads it from
-the gt4py installation it drives, so this script follows folder-naming changes
-automatically. The ``check`` subcommand uses a built-in copy of the pattern,
-overridable with ``--folder-pattern``.
+sync by a round-trip test there — and this script always reads it from a gt4py
+installation, so it follows folder-naming changes automatically: ``ci-check``
+asks the interpreter it drives, ``check`` asks the interpreter running the
+script. There is no fallback; if no gt4py can provide the pattern, the check
+fails rather than guessing.
 
 Non-deterministic codegen changes the fingerprint from one run to the next.
 Programs are compared by logical name (the pattern's ``name`` group); a name may
@@ -55,14 +56,17 @@ its dependency (``typer``) is available.
    So ``ci-check`` is either driven by a gt4py-capable interpreter (this is what
    the ``test_next_dace_determinism`` nox session does: it executes the script
    with its session venv's python) or told one explicitly with ``--python``.
-   The ``check`` subcommand has no such requirement — it only reads caches.
+   The ``check`` subcommand only reads caches, but it too needs gt4py — the
+   interpreter executing the script provides the folder-name pattern — so run
+   it through a gt4py environment (e.g. ``uv run python
+   scripts/python/dace_determinism.py check ...``), not ``./scripts/run``.
 
 Usage::
 
-    # Compare two existing build caches:
-    ./scripts/run dace-determinism check --run1 PATH --run2 PATH \\
-        [--folder-pattern REGEX] [--diffs-dir DIR] [--report FILE] \\
-        [--runs-healthy/--no-runs-healthy]
+    # Compare two existing build caches (needs a gt4py-capable interpreter,
+    # see the note above):
+    uv run python scripts/python/dace_determinism.py check --run1 PATH --run2 PATH \\
+        [--diffs-dir DIR] [--report FILE] [--runs-healthy/--no-runs-healthy]
 
     # Run a pytest selection twice and compare (used by the
     # `test_next_dace_determinism` nox session, which omits --python because it
@@ -71,8 +75,8 @@ Usage::
         --workdir DIR -- <pytest args>
 
 Exit codes (both subcommands): 0 deterministic, 1 differs, 2 bad args /
-unsupported backend / no source files / nothing comparable, 3 no programs
-observed.
+unsupported backend / no source files / nothing comparable / folder-name
+pattern unavailable, 3 no programs observed.
 """
 
 from __future__ import annotations
@@ -92,17 +96,6 @@ from typing import Annotated
 import typer
 
 
-# The program cache folder-name layout is owned by gt4py: it is documented by
-# `CACHE_FOLDER_NAME_PATTERN` next to `get_cache_folder` in
-# `gt4py/next/otf/compilation/cache.py`, and a round-trip unit test there keeps
-# the two in sync. `ci-check` reads that pattern from the gt4py installation
-# under test (see `fetch_cache_folder_pattern`), so this constant is only the
-# fallback — and the default for the cache-only `check` subcommand, where no
-# gt4py interpreter is involved.
-DEFAULT_PROGRAM_FOLDER_PATTERN = (
-    r"(?P<name>.+)_(?P<fingerprint>[0-9a-f]{16})_(?P<version_id>.+?)"
-    r"(?:_(?P<build_context_id>[0-9a-f]{16}))?"
-)
 CODEGEN_DIR = "src"
 SUPPORTED_BACKENDS = frozenset({"cpu", "cuda"})
 
@@ -154,6 +147,16 @@ class PytestRunError(RuntimeError):
     Distinct from the comparison exceptions above so the CLI can map it to its
     own exit code without depending on ``except`` ordering against the shared
     ``RuntimeError`` base.
+    """
+
+
+class CacheFolderPatternError(RuntimeError):
+    """gt4py's cache folder-name pattern could not be obtained.
+
+    The pattern (`CACHE_FOLDER_NAME_PATTERN` next to `get_cache_folder` in
+    gt4py/next/otf/compilation/cache.py) is the only source of the folder-name
+    layout — there is deliberately no fallback — so without a gt4py-capable
+    interpreter to provide it, no cache can be scanned.
     """
 
 
@@ -383,12 +386,12 @@ def check_determinism(
     cache1: Path,
     cache2: Path,
     *,
-    folder_pattern: str | None = None,
+    folder_pattern: str,
     runs_healthy: bool | None = None,
     diffs_dir: Path | None = None,
     report_path: Path | None = None,
 ) -> list[ComparisonResult]:
-    folder_re = _compile_folder_pattern(folder_pattern or DEFAULT_PROGRAM_FOLDER_PATTERN)
+    folder_re = _compile_folder_pattern(folder_pattern)
     bags1, n_folders1 = _scan(cache1, folder_re)
     bags2, n_folders2 = _scan(cache2, folder_re)
     results = compare(bags1, bags2)
@@ -456,29 +459,38 @@ _PATTERN_PROBE_SNIPPET = (
 )
 
 
-def fetch_cache_folder_pattern(python: str) -> str | None:
+def fetch_cache_folder_pattern(python: str) -> str:
     """Read the cache folder-name pattern from a gt4py-capable interpreter.
 
     The pattern is owned by gt4py (`CACHE_FOLDER_NAME_PATTERN`, defined next to
     `get_cache_folder` and held in sync with it by a round-trip unit test), so
     reading it from the interpreter under test keeps this script correct across
-    folder-naming changes without edits here. Returns None when the pattern
-    cannot be read (no or too-old gt4py in that interpreter) or is unusable;
-    callers then fall back to `DEFAULT_PROGRAM_FOLDER_PATTERN`.
+    folder-naming changes without edits here. Raises `CacheFolderPatternError`
+    when the pattern cannot be read (no or too-old gt4py in that interpreter)
+    or is unusable — deliberately no fallback, failing beats guessing.
     """
     try:
         result = subprocess.run(
             [python, "-c", _PATTERN_PROBE_SNIPPET], capture_output=True, text=True, timeout=120
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise CacheFolderPatternError(
+            f"could not run `{python}` to read gt4py's cache folder-name pattern: {e}"
+        ) from e
     if result.returncode != 0:
-        return None
+        detail = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "no output"
+        raise CacheFolderPatternError(
+            f"`{python}` could not provide gt4py's cache folder-name pattern "
+            f"(exit {result.returncode}: {detail}). The interpreter must have a gt4py "
+            f"recent enough to define `CACHE_FOLDER_NAME_PATTERN`."
+        )
     pattern = result.stdout.strip()
     try:
         _compile_folder_pattern(pattern)
-    except (re.error, ValueError):
-        return None
+    except (re.error, ValueError) as e:
+        raise CacheFolderPatternError(
+            f"`{python}` reported an unusable cache folder-name pattern `{pattern}`: {e}"
+        ) from e
     return pattern
 
 
@@ -548,22 +560,17 @@ def run_determinism_check(
     The two per-run caches and ``dacecache`` are removed afterwards; ``diffs/``
     and ``report.txt`` under ``workdir`` are kept as debugging artifacts. Returns
     the comparison results, or raises the same exceptions as ``check_determinism``
-    (plus ``PytestRunError`` if a pytest run fails for an infrastructure reason).
+    (plus ``CacheFolderPatternError`` if ``python`` cannot provide gt4py's
+    folder-name pattern and ``PytestRunError`` if a pytest run fails for an
+    infrastructure reason).
     """
     workdir = workdir.expanduser().resolve()
     dacecache = (dacecache or Path.cwd() / ".dacecache").expanduser().resolve()
 
-    # The folder-name pattern comes from the gt4py under test whenever possible,
-    # so a gt4py-side change to the cache folder naming cannot silently turn
+    # The folder-name pattern comes from the gt4py under test — no fallback —
+    # so a gt4py-side change to the cache folder naming can never silently turn
     # every run into "no programs observed".
     folder_pattern = fetch_cache_folder_pattern(python)
-    if folder_pattern is None:
-        print(
-            f"warning: could not read gt4py's cache folder-name pattern from `{python}`; "
-            "falling back to this script's built-in pattern, which may be stale if the "
-            "cache folder naming has changed.",
-            file=sys.stderr,
-        )
 
     # Self-check the comparator first: a broken script aborts here, before the
     # two expensive test-suite runs.
@@ -627,6 +634,7 @@ _EXIT_CODES: dict[type[Exception], int] = {
     UnsupportedBackendError: 2,
     NoSourceFilesObservedError: 2,
     NoComparableProgramsError: 2,
+    CacheFolderPatternError: 2,
     NoProgramsObservedError: 3,
 }
 
@@ -643,18 +651,6 @@ cli = typer.Typer(no_args_is_help=True, name="dace-determinism", help=__doc__)
 def check(
     run1: Annotated[Path, typer.Option("--run1", metavar="PATH", help="First cache root.")],
     run2: Annotated[Path, typer.Option("--run2", metavar="PATH", help="Second cache root.")],
-    folder_pattern: Annotated[
-        str | None,
-        typer.Option(
-            "--folder-pattern",
-            metavar="REGEX",
-            help="Regex (with a `name` capture group) that program cache folder names "
-            "fully match; the `name` group is the logical program name used for "
-            "grouping. Defaults to the built-in copy of gt4py's "
-            "`CACHE_FOLDER_NAME_PATTERN`; pass the pattern of the gt4py version that "
-            "produced the caches if it differs.",
-        ),
-    ] = None,
     diffs_dir: Annotated[
         Path | None,
         typer.Option(
@@ -676,19 +672,29 @@ def check(
         ),
     ] = None,
 ) -> None:
-    """Compare two gt4py.next build caches for deterministic DaCe codegen."""
+    """Compare two gt4py.next build caches for deterministic DaCe codegen.
+
+    Runs the caches against gt4py's cache folder-name pattern, read from the
+    interpreter executing this script — which must therefore have gt4py
+    installed (e.g. run via `uv run python scripts/python/dace_determinism.py`).
+    """
     try:
         results = check_determinism(
             run1.expanduser().resolve(),
             run2.expanduser().resolve(),
-            folder_pattern=folder_pattern,
+            folder_pattern=fetch_cache_folder_pattern(sys.executable),
             runs_healthy=runs_healthy,
             diffs_dir=diffs_dir.expanduser().resolve() if diffs_dir else None,
             report_path=report.expanduser().resolve() if report else None,
         )
-    except (re.error, ValueError) as e:
-        typer.echo(f"error: invalid --folder-pattern: {e}", err=True)
-        raise typer.Exit(2) from e
+    except CacheFolderPatternError as e:
+        typer.echo(
+            f"error: {e}\nhint: `check` needs gt4py to know the cache folder-name "
+            f"pattern; run it with a gt4py-capable interpreter, e.g. "
+            f"`uv run python scripts/python/dace_determinism.py check ...`.",
+            err=True,
+        )
+        raise typer.Exit(_EXIT_CODES[CacheFolderPatternError]) from e
     except DeterminismError as e:
         if report is None:
             typer.echo(render_report(e.results, runs_healthy=runs_healthy))
@@ -768,6 +774,9 @@ def ci_check(
     except PytestRunError as e:
         typer.echo(f"error: {e}", err=True)
         raise typer.Exit(2) from e
+    except CacheFolderPatternError as e:
+        typer.echo(f"error: {e}", err=True)
+        raise typer.Exit(_EXIT_CODES[CacheFolderPatternError]) from e
     except (
         DeterminismError,
         UnsupportedBackendError,

--- a/scripts/python/dace_determinism.py
+++ b/scripts/python/dace_determinism.py
@@ -10,13 +10,20 @@
 
 """Check that gt4py's DaCe backend generates identical source across two runs.
 
-gt4py.next caches each compiled program at ``<root>/<name>_<sha256>/src/...``,
-where the digest is derived from the generated source. Non-deterministic codegen
-therefore changes the digest from one run to the next. Programs are compared by
-logical name (the folder name without the trailing digest); a name may be
-compiled several times with different parameters, so each run yields a multiset
-of source signatures per name. A signature is the set of ``(relpath, sha256)``
-pairs of one compiled program.
+gt4py.next caches each compiled program at ``<root>/<folder>/src/...``, where
+the folder name embeds the program name and a fingerprint of the generated
+source. The folder-name layout is owned by gt4py — ``CACHE_FOLDER_NAME_PATTERN``
+next to ``get_cache_folder`` in ``gt4py/next/otf/compilation/cache.py``, kept in
+sync by a round-trip test there — and the ``ci-check`` subcommand reads it from
+the gt4py installation it drives, so this script follows folder-naming changes
+automatically. The ``check`` subcommand uses a built-in copy of the pattern,
+overridable with ``--folder-pattern``.
+
+Non-deterministic codegen changes the fingerprint from one run to the next.
+Programs are compared by logical name (the pattern's ``name`` group); a name may
+be compiled several times with different parameters, so each run yields a
+multiset of source signatures per name. A signature is the set of
+``(relpath, sha256)`` pairs of one compiled program.
 
 A name is compared only when both runs compiled the same number of programs for
 it. The program count is a function of which tests ran, not of codegen, so equal
@@ -54,7 +61,8 @@ Usage::
 
     # Compare two existing build caches:
     ./scripts/run dace-determinism check --run1 PATH --run2 PATH \\
-        [--diffs-dir DIR] [--report FILE] [--runs-healthy/--no-runs-healthy]
+        [--folder-pattern REGEX] [--diffs-dir DIR] [--report FILE] \\
+        [--runs-healthy/--no-runs-healthy]
 
     # Run a pytest selection twice and compare (used by the
     # `test_next_dace_determinism` nox session, which omits --python because it
@@ -84,9 +92,33 @@ from typing import Annotated
 import typer
 
 
-PROGRAM_FOLDER_RE = re.compile(r"^(?P<name>.+)_[0-9a-f]{64}$")
+# The program cache folder-name layout is owned by gt4py: it is documented by
+# `CACHE_FOLDER_NAME_PATTERN` next to `get_cache_folder` in
+# `gt4py/next/otf/compilation/cache.py`, and a round-trip unit test there keeps
+# the two in sync. `ci-check` reads that pattern from the gt4py installation
+# under test (see `fetch_cache_folder_pattern`), so this constant is only the
+# fallback — and the default for the cache-only `check` subcommand, where no
+# gt4py interpreter is involved.
+DEFAULT_PROGRAM_FOLDER_PATTERN = (
+    r"(?P<name>.+)_(?P<fingerprint>[0-9a-f]{16})_(?P<version_id>.+?)"
+    r"(?:_(?P<build_context_id>[0-9a-f]{16}))?"
+)
 CODEGEN_DIR = "src"
 SUPPORTED_BACKENDS = frozenset({"cpu", "cuda"})
+
+
+def _compile_folder_pattern(pattern: str) -> re.Pattern[str]:
+    """Compile a folder-name pattern, requiring the ``name`` capture group.
+
+    The ``name`` group is what programs are grouped and compared by, so a
+    pattern without it cannot drive the comparison. Raises ``re.error`` on an
+    invalid regex and ``ValueError`` on a missing ``name`` group.
+    """
+    folder_re = re.compile(pattern)
+    if "name" not in folder_re.groupindex:
+        raise ValueError(f"cache folder pattern must define a `name` capture group: `{pattern}`")
+    return folder_re
+
 
 SourceFileHash = tuple[str, str]  # (source file path, source file contents hash)
 ProgramSignature = frozenset[SourceFileHash]  # all source files of one compiled program
@@ -179,7 +211,9 @@ def _sha256_of_contents(path: Path) -> str:
     return h.hexdigest()
 
 
-def _scan(cache_root: Path) -> tuple[dict[str, collections.Counter[ProgramSignature]], int]:
+def _scan(
+    cache_root: Path, folder_re: re.Pattern[str]
+) -> tuple[dict[str, collections.Counter[ProgramSignature]], int]:
     """Return the signature multiset per logical name and the program count.
 
     Each program folder yields one ``ProgramSignature``: the set of
@@ -199,7 +233,7 @@ def _scan(cache_root: Path) -> tuple[dict[str, collections.Counter[ProgramSignat
     )
     n_folders = 0
     for folder in sorted(p for p in cache_root.iterdir() if p.is_dir()):
-        m = PROGRAM_FOLDER_RE.match(folder.name)
+        m = folder_re.fullmatch(folder.name)
         if not m:
             continue
         n_folders += 1
@@ -223,7 +257,7 @@ def _scan(cache_root: Path) -> tuple[dict[str, collections.Counter[ProgramSignat
     return dict(by_name), n_folders
 
 
-def _diagnose_empty(cache_root: Path) -> str:
+def _diagnose_empty(cache_root: Path, folder_re: re.Pattern[str]) -> str:
     if not cache_root.exists():
         return "path does not exist"
     if not cache_root.is_dir():
@@ -231,8 +265,8 @@ def _diagnose_empty(cache_root: Path) -> str:
     subdirs = [p for p in cache_root.iterdir() if p.is_dir()]
     if not subdirs:
         return "no subdirectories (nothing cached)"
-    if not any(PROGRAM_FOLDER_RE.match(p.name) for p in subdirs):
-        return "no subdirectory matches `<name>_<64-hex-digest>/`"
+    if not any(folder_re.fullmatch(p.name) for p in subdirs):
+        return f"no subdirectory matches the program folder pattern `{folder_re.pattern}`"
     return "program folders present but none could be read"
 
 
@@ -349,12 +383,14 @@ def check_determinism(
     cache1: Path,
     cache2: Path,
     *,
+    folder_pattern: str | None = None,
     runs_healthy: bool | None = None,
     diffs_dir: Path | None = None,
     report_path: Path | None = None,
 ) -> list[ComparisonResult]:
-    bags1, n_folders1 = _scan(cache1)
-    bags2, n_folders2 = _scan(cache2)
+    folder_re = _compile_folder_pattern(folder_pattern or DEFAULT_PROGRAM_FOLDER_PATTERN)
+    bags1, n_folders1 = _scan(cache1, folder_re)
+    bags2, n_folders2 = _scan(cache2, folder_re)
     results = compare(bags1, bags2)
 
     if diffs_dir is not None:
@@ -366,8 +402,8 @@ def check_determinism(
     if n_folders1 == 0 and n_folders2 == 0:
         raise NoProgramsObservedError(
             "no programs observed in either cache:\n"
-            f"  run1 ({cache1}): {_diagnose_empty(cache1)}\n"
-            f"  run2 ({cache2}): {_diagnose_empty(cache2)}"
+            f"  run1 ({cache1}): {_diagnose_empty(cache1, folder_re)}\n"
+            f"  run2 ({cache2}): {_diagnose_empty(cache2, folder_re)}"
         )
     if not results:
         raise NoSourceFilesObservedError(
@@ -414,6 +450,36 @@ def check_determinism(
 
 CACHE_SUBDIR = ".gt4py_cache"
 PYTEST_TOLERATED_EXIT_CODES = frozenset({0, 1, 5})  # ok, tests failed, no tests collected
+
+_PATTERN_PROBE_SNIPPET = (
+    "from gt4py.next.otf.compilation import cache; print(cache.CACHE_FOLDER_NAME_PATTERN)"
+)
+
+
+def fetch_cache_folder_pattern(python: str) -> str | None:
+    """Read the cache folder-name pattern from a gt4py-capable interpreter.
+
+    The pattern is owned by gt4py (`CACHE_FOLDER_NAME_PATTERN`, defined next to
+    `get_cache_folder` and held in sync with it by a round-trip unit test), so
+    reading it from the interpreter under test keeps this script correct across
+    folder-naming changes without edits here. Returns None when the pattern
+    cannot be read (no or too-old gt4py in that interpreter) or is unusable;
+    callers then fall back to `DEFAULT_PROGRAM_FOLDER_PATTERN`.
+    """
+    try:
+        result = subprocess.run(
+            [python, "-c", _PATTERN_PROBE_SNIPPET], capture_output=True, text=True, timeout=120
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    pattern = result.stdout.strip()
+    try:
+        _compile_folder_pattern(pattern)
+    except (re.error, ValueError):
+        return None
+    return pattern
 
 
 def _run_is_healthy(junit_xml: Path) -> bool:
@@ -469,7 +535,9 @@ def run_determinism_check(
     ``pytest_args`` are the arguments passed to ``python -m pytest`` (without the
     leading ``pytest``) for each of the two runs. ``python`` is the interpreter
     used to run the suite (defaults to the current one, i.e. the environment that
-    has gt4py installed when this script is executed there). Each run sets
+    has gt4py installed when this script is executed there); it is also asked for
+    gt4py's cache folder-name pattern, so the comparison recognizes program
+    folders even after gt4py changes its naming scheme. Each run sets
     ``GT4PY_BUILD_CACHE_DIR`` so its cache lands at ``<run_dir>/.gt4py_cache/``.
 
     ``dacecache`` is DaCe's build-cache directory, wiped before each run so the
@@ -484,6 +552,18 @@ def run_determinism_check(
     """
     workdir = workdir.expanduser().resolve()
     dacecache = (dacecache or Path.cwd() / ".dacecache").expanduser().resolve()
+
+    # The folder-name pattern comes from the gt4py under test whenever possible,
+    # so a gt4py-side change to the cache folder naming cannot silently turn
+    # every run into "no programs observed".
+    folder_pattern = fetch_cache_folder_pattern(python)
+    if folder_pattern is None:
+        print(
+            f"warning: could not read gt4py's cache folder-name pattern from `{python}`; "
+            "falling back to this script's built-in pattern, which may be stale if the "
+            "cache folder naming has changed.",
+            file=sys.stderr,
+        )
 
     # Self-check the comparator first: a broken script aborts here, before the
     # two expensive test-suite runs.
@@ -526,6 +606,7 @@ def run_determinism_check(
         return check_determinism(
             run1_dir / CACHE_SUBDIR,
             run2_dir / CACHE_SUBDIR,
+            folder_pattern=folder_pattern,
             runs_healthy=runs_healthy,
             diffs_dir=workdir / "diffs",
             report_path=workdir / "report.txt",
@@ -562,6 +643,18 @@ cli = typer.Typer(no_args_is_help=True, name="dace-determinism", help=__doc__)
 def check(
     run1: Annotated[Path, typer.Option("--run1", metavar="PATH", help="First cache root.")],
     run2: Annotated[Path, typer.Option("--run2", metavar="PATH", help="Second cache root.")],
+    folder_pattern: Annotated[
+        str | None,
+        typer.Option(
+            "--folder-pattern",
+            metavar="REGEX",
+            help="Regex (with a `name` capture group) that program cache folder names "
+            "fully match; the `name` group is the logical program name used for "
+            "grouping. Defaults to the built-in copy of gt4py's "
+            "`CACHE_FOLDER_NAME_PATTERN`; pass the pattern of the gt4py version that "
+            "produced the caches if it differs.",
+        ),
+    ] = None,
     diffs_dir: Annotated[
         Path | None,
         typer.Option(
@@ -588,10 +681,14 @@ def check(
         results = check_determinism(
             run1.expanduser().resolve(),
             run2.expanduser().resolve(),
+            folder_pattern=folder_pattern,
             runs_healthy=runs_healthy,
             diffs_dir=diffs_dir.expanduser().resolve() if diffs_dir else None,
             report_path=report.expanduser().resolve() if report else None,
         )
+    except (re.error, ValueError) as e:
+        typer.echo(f"error: invalid --folder-pattern: {e}", err=True)
+        raise typer.Exit(2) from e
     except DeterminismError as e:
         if report is None:
             typer.echo(render_report(e.results, runs_healthy=runs_healthy))

--- a/scripts/tests/python/test_dace_determinism.py
+++ b/scripts/tests/python/test_dace_determinism.py
@@ -19,28 +19,43 @@ import sys
 
 import pytest
 from dace_determinism import (
+    DEFAULT_PROGRAM_FOLDER_PATTERN,
     DeterminismError,
     NoComparableProgramsError,
     NoProgramsObservedError,
     NoSourceFilesObservedError,
     PytestRunError,
     UnsupportedBackendError,
+    _compile_folder_pattern,
     _scan,
     check_determinism,
     cli,
     compare,
+    fetch_cache_folder_pattern,
     render_report,
     run_determinism_check,
 )
 from typer.testing import CliRunner
 
 
+_DEFAULT_FOLDER_RE = _compile_folder_pattern(DEFAULT_PROGRAM_FOLDER_PATTERN)
+
+
 def _bags(cache: pathlib.Path):
-    return _scan(cache)[0]
+    return _scan(cache, _DEFAULT_FOLDER_RE)[0]
+
+
+def _hex16(salt: str) -> str:
+    return hashlib.sha256(salt.encode()).hexdigest()[:16]
+
+
+def _folder_name(name: str, salt: str) -> str:
+    # Mirrors gt4py's current naming: {name}_{fingerprint}_{version_id}_{context_id}.
+    return f"{name}_{_hex16(salt)}_1.0.0_{_hex16('build config')}"
 
 
 def _program(cache: pathlib.Path, name: str, salt: str, sources: dict[str, str]) -> None:
-    folder = cache / f"{name}_{hashlib.sha256(salt.encode()).hexdigest()}"
+    folder = cache / _folder_name(name, salt)
     for rel, content in sources.items():
         path = folder / rel
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -69,7 +84,7 @@ def test_collect_unsupported_backend_raises(tmp_path):
 
 def test_empty_src_program_excluded(tmp_path):
     cache = tmp_path / ".gt4py_cache"
-    (cache / f"p_{hashlib.sha256(b'a').hexdigest()}" / "src").mkdir(parents=True)
+    (cache / _folder_name("p", "a") / "src").mkdir(parents=True)
     assert "p" not in _bags(cache)
 
 
@@ -212,9 +227,8 @@ def test_no_programs_raises(tmp_path):
 def test_no_source_files_raises(tmp_path):
     c1 = tmp_path / "r1" / ".gt4py_cache"
     c2 = tmp_path / "r2" / ".gt4py_cache"
-    digest = hashlib.sha256(b"a").hexdigest()
-    (c1 / f"p_{digest}").mkdir(parents=True)
-    (c2 / f"p_{digest}").mkdir(parents=True)
+    (c1 / _folder_name("p", "a")).mkdir(parents=True)
+    (c2 / _folder_name("p", "a")).mkdir(parents=True)
     with pytest.raises(NoSourceFilesObservedError, match="development"):
         check_determinism(c1, c2)
 
@@ -290,17 +304,29 @@ def test_report_marks_count_as_failure_when_healthy(tmp_path):
 # fabricating a `.gt4py_cache` program tree under GT4PY_BUILD_CACHE_DIR plus a
 # JUnit XML, so the loop, health parsing, and comparison are exercised without
 # needing gt4py installed.
+#
+# The stub also answers the folder-name pattern probe (`python -c ...`) with its
+# OWN naming scheme, which deliberately does NOT match this script's built-in
+# default (no version/context segments). The orchestration therefore only finds
+# the stub's program folders if it really uses the fetched pattern — making
+# these tests an end-to-end guard on the pattern-fetch mechanism.
+
+_STUB_FOLDER_PATTERN = r"(?P<name>.+)_(?P<salt>[0-9a-f]{16})"
 
 _STUB_PYTEST = """\
 #!{python}
 import hashlib, os, pathlib, sys
+
+if sys.argv[1:2] == ["-c"]:  # the folder-name pattern probe
+    print({pattern!r})
+    sys.exit(0)
 
 junit = next(a.split("=", 1)[1] for a in sys.argv if a.startswith("--junit-xml="))
 cache = pathlib.Path(os.environ["GT4PY_BUILD_CACHE_DIR"]) / ".gt4py_cache"
 run_name = pathlib.Path(os.environ["GT4PY_BUILD_CACHE_DIR"]).name
 # Codegen differs between runs only when perturbation is requested.
 content = run_name if os.environ.get("FAKE_PERTURB") else "stable"
-folder = cache / ("prog_" + hashlib.sha256(b"prog").hexdigest()) / "src" / "cpu"
+folder = cache / ("prog_" + hashlib.sha256(b"prog").hexdigest()[:16]) / "src" / "cpu"
 folder.mkdir(parents=True, exist_ok=True)
 (folder / "k.cpp").write_text(content)
 pathlib.Path(junit).write_text('<testsuite tests="1" failures="0" errors="0" />')
@@ -309,7 +335,7 @@ pathlib.Path(junit).write_text('<testsuite tests="1" failures="0" errors="0" />'
 
 def _stub_interpreter(tmp_path: pathlib.Path) -> str:
     stub = tmp_path / "fake_pytest.py"
-    stub.write_text(_STUB_PYTEST.format(python=sys.executable))
+    stub.write_text(_STUB_PYTEST.format(python=sys.executable, pattern=_STUB_FOLDER_PATTERN))
     stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
     return str(stub)
 
@@ -447,3 +473,103 @@ def test_ci_check_command_success_echoes_report(monkeypatch, tmp_path):
     result = CliRunner().invoke(cli, ["ci-check", "--workdir", str(workdir), "--no-self-check"])
     assert result.exit_code == 0
     assert "deterministic" in result.output
+
+
+# --- folder-name pattern handling ---
+#
+# The folder-name layout belongs to gt4py: `CACHE_FOLDER_NAME_PATTERN` in
+# gt4py/next/otf/compilation/cache.py, held in sync with `get_cache_folder` by a
+# round-trip test there. These tests cover this script's side of the contract:
+# the built-in fallback parses real-world names, custom patterns are honored,
+# and the runtime fetch degrades cleanly.
+
+
+@pytest.mark.parametrize(
+    ("folder", "expected"),
+    [
+        (
+            "__field_operator_solve_tridiag_pyext_ebf83e9be18232fd_1.1.12_db5ed39d9f2c69fb",
+            "__field_operator_solve_tridiag_pyext",
+        ),
+        (  # no build context id (e.g. the cmake build system passes none)
+            "__field_operator_solve_tridiag_pyext_ebf83e9be18232fd_1.1.12",
+            "__field_operator_solve_tridiag_pyext",
+        ),
+        (  # dev-install version tags contain dots and plus signs
+            "prog_pyext_0123456789abcdef_1.1.13.dev4+g1234abc.d20260722_fedcba9876543210",
+            "prog_pyext",
+        ),
+        ("translation_cache", None),
+        ("run1", None),
+    ],
+)
+def test_default_pattern_extracts_program_name(folder, expected):
+    m = _DEFAULT_FOLDER_RE.fullmatch(folder)
+    assert (m["name"] if m else None) == expected
+
+
+def test_pattern_without_name_group_rejected(tmp_path):
+    with pytest.raises(ValueError, match="name"):
+        check_determinism(tmp_path / "r1", tmp_path / "r2", folder_pattern=r".+_[0-9a-f]{16}")
+
+
+def test_check_cli_honors_folder_pattern(tmp_path):
+    c1 = tmp_path / "r1" / ".gt4py_cache"
+    c2 = tmp_path / "r2" / ".gt4py_cache"
+    for cache in (c1, c2):
+        src = cache / "copy-ABC" / "src" / "cpu"
+        src.mkdir(parents=True)
+        (src / "k.cpp").write_text("stable")
+
+    runner = CliRunner()
+    default = runner.invoke(cli, ["check", "--run1", str(c1), "--run2", str(c2)])
+    assert default.exit_code == 3  # the built-in pattern does not recognize these folders
+
+    custom = runner.invoke(
+        cli,
+        [
+            "check",
+            "--run1",
+            str(c1),
+            "--run2",
+            str(c2),
+            "--folder-pattern",
+            r"(?P<name>.+)-[A-Z]{3}",
+        ],
+    )
+    assert custom.exit_code == 0
+    assert "deterministic" in custom.output
+
+
+def test_check_cli_rejects_pattern_without_name_group(tmp_path):
+    (tmp_path / "r1").mkdir()
+    (tmp_path / "r2").mkdir()
+    r1, r2 = str(tmp_path / "r1"), str(tmp_path / "r2")
+    result = CliRunner().invoke(
+        cli,
+        ["check", "--run1", r1, "--run2", r2, "--folder-pattern", "no_name_group_[0-9a-f]{16}"],
+    )
+    assert result.exit_code == 2
+
+
+def _fake_interpreter(tmp_path: pathlib.Path, body: str) -> str:
+    stub = tmp_path / "fake_python.py"
+    stub.write_text(f"#!{sys.executable}\n{body}")
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
+    return str(stub)
+
+
+def test_fetch_pattern_returns_advertised_pattern(tmp_path):
+    python = _fake_interpreter(tmp_path, f"print({_STUB_FOLDER_PATTERN!r})\n")
+    assert fetch_cache_folder_pattern(python) == _STUB_FOLDER_PATTERN
+
+
+def test_fetch_pattern_none_on_failing_interpreter(tmp_path):
+    python = _fake_interpreter(tmp_path, "import sys; sys.exit(1)\n")
+    assert fetch_cache_folder_pattern(python) is None
+
+
+def test_fetch_pattern_none_on_unusable_pattern(tmp_path):
+    for body in ("print('no name group here')\n", "print('(?P<name>unbalanced')\n", "print()\n"):
+        python = _fake_interpreter(tmp_path, body)
+        assert fetch_cache_folder_pattern(python) is None

--- a/scripts/tests/python/test_dace_determinism.py
+++ b/scripts/tests/python/test_dace_determinism.py
@@ -19,7 +19,7 @@ import sys
 
 import pytest
 from dace_determinism import (
-    DEFAULT_PROGRAM_FOLDER_PATTERN,
+    CacheFolderPatternError,
     DeterminismError,
     NoComparableProgramsError,
     NoProgramsObservedError,
@@ -38,11 +38,19 @@ from dace_determinism import (
 from typer.testing import CliRunner
 
 
-_DEFAULT_FOLDER_RE = _compile_folder_pattern(DEFAULT_PROGRAM_FOLDER_PATTERN)
+# Mirrors gt4py's current cache folder naming, purely to shape realistic test
+# fixtures. The authoritative pattern lives in gt4py (`CACHE_FOLDER_NAME_PATTERN`,
+# round-trip tested against `get_cache_folder` there) and the script always
+# fetches that one at runtime — it has no built-in copy.
+_FOLDER_PATTERN = (
+    r"(?P<name>.+)_(?P<fingerprint>[0-9a-f]{16})_(?P<version_id>.+?)"
+    r"(?:_(?P<build_context_id>[0-9a-f]{16}))?"
+)
+_FOLDER_RE = _compile_folder_pattern(_FOLDER_PATTERN)
 
 
 def _bags(cache: pathlib.Path):
-    return _scan(cache, _DEFAULT_FOLDER_RE)[0]
+    return _scan(cache, _FOLDER_RE)[0]
 
 
 def _hex16(salt: str) -> str:
@@ -140,7 +148,7 @@ def test_equal_count_source_mismatch_differs(tmp_path):
     (r,) = compare(_bags(c1), _bags(c2))
     assert r.comparable and r.differs
     with pytest.raises(DeterminismError):
-        check_determinism(c1, c2)
+        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
 
 
 def test_count_mismatch_skipped_but_others_compared(tmp_path):
@@ -156,7 +164,7 @@ def test_count_mismatch_skipped_but_others_compared(tmp_path):
     by_name = {r.name: r for r in compare(_bags(c1), _bags(c2))}
     assert by_name["ok"].match
     assert by_name["flaky"].skipped and not by_name["flaky"].match
-    check_determinism(c1, c2)  # passes: the comparable name matched
+    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)  # passes: the comparable name matched
 
 
 def test_missing_on_one_side_skipped(tmp_path):
@@ -167,7 +175,7 @@ def test_missing_on_one_side_skipped(tmp_path):
     _program(c1, "only1", "a", {"src/cpu/k.cpp": "x"})
     by_name = {r.name: r for r in compare(_bags(c1), _bags(c2))}
     assert by_name["only1"].skipped and not by_name["only1"].match
-    check_determinism(c1, c2)
+    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
 
 
 def test_nothing_comparable_raises(tmp_path):
@@ -178,7 +186,7 @@ def test_nothing_comparable_raises(tmp_path):
     _program(c1, "a", "2", {"src/cpu/k.cpp": "A2"})
     _program(c2, "a", "1", {"src/cpu/k.cpp": "A1"})
     with pytest.raises(NoComparableProgramsError):
-        check_determinism(c1, c2)
+        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
 
 
 def test_one_empty_run_raises_not_green(tmp_path):
@@ -188,7 +196,7 @@ def test_one_empty_run_raises_not_green(tmp_path):
     _program(c1, "p", "a", {"src/cpu/k.cpp": "S1"})
     c2.mkdir(parents=True)
     with pytest.raises(NoComparableProgramsError):
-        check_determinism(c1, c2)
+        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
 
 
 def test_check_determinism_pass_writes_report(tmp_path):
@@ -197,7 +205,7 @@ def test_check_determinism_pass_writes_report(tmp_path):
     _program(c1, "copy", "a", {"src/cpu/k.cpp": "stable"})
     _program(c2, "copy", "a", {"src/cpu/k.cpp": "stable"})
     report = tmp_path / "report.txt"
-    results = check_determinism(c1, c2, report_path=report)
+    results = check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, report_path=report)
     assert all(r.match for r in results)
     assert "deterministic" in report.read_text()
 
@@ -209,7 +217,7 @@ def test_check_determinism_differs_writes_diff(tmp_path):
     _program(c2, "abs", "b", {"src/cpu/k.cpp": "B"})
     diffs = tmp_path / "diffs"
     with pytest.raises(DeterminismError):
-        check_determinism(c1, c2, diffs_dir=diffs)
+        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, diffs_dir=diffs)
     body = (diffs / "abs.txt").read_text().splitlines()
     assert body[0] == "abs"
     assert "src/cpu/k.cpp" in body
@@ -221,7 +229,7 @@ def test_no_programs_raises(tmp_path):
     c1.mkdir(parents=True)
     c2.mkdir(parents=True)
     with pytest.raises(NoProgramsObservedError):
-        check_determinism(c1, c2)
+        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
 
 
 def test_no_source_files_raises(tmp_path):
@@ -230,7 +238,7 @@ def test_no_source_files_raises(tmp_path):
     (c1 / _folder_name("p", "a")).mkdir(parents=True)
     (c2 / _folder_name("p", "a")).mkdir(parents=True)
     with pytest.raises(NoSourceFilesObservedError, match="development"):
-        check_determinism(c1, c2)
+        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
 
 
 def test_report_lists_mismatching_sources(tmp_path):
@@ -268,10 +276,14 @@ def test_count_mismatch_fails_when_runs_healthy(tmp_path):
     _program(c1, "wobble", "a", {"src/cpu/k.cpp": "W1"})
     _program(c1, "wobble", "b", {"src/cpu/k.cpp": "W2"})
     _program(c2, "wobble", "x", {"src/cpu/k.cpp": "W1"})
-    check_determinism(c1, c2)  # health unknown -> tolerated skip
-    check_determinism(c1, c2, runs_healthy=False)  # a test failed -> tolerated skip
+    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)  # health unknown -> tolerated skip
+    check_determinism(
+        c1, c2, folder_pattern=_FOLDER_PATTERN, runs_healthy=False
+    )  # a test failed -> tolerated skip
     with pytest.raises(DeterminismError):
-        check_determinism(c1, c2, runs_healthy=True)  # clean pair -> failure
+        check_determinism(
+            c1, c2, folder_pattern=_FOLDER_PATTERN, runs_healthy=True
+        )  # clean pair -> failure
 
 
 def test_clean_pair_all_match_passes(tmp_path):
@@ -279,7 +291,7 @@ def test_clean_pair_all_match_passes(tmp_path):
     c2 = tmp_path / "r2" / ".gt4py_cache"
     _program(c1, "copy", "a", {"src/cpu/k.cpp": "S1"})
     _program(c2, "copy", "a", {"src/cpu/k.cpp": "S1"})
-    check_determinism(c1, c2, runs_healthy=True)
+    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, runs_healthy=True)
 
 
 def test_report_marks_count_as_failure_when_healthy(tmp_path):
@@ -306,10 +318,10 @@ def test_report_marks_count_as_failure_when_healthy(tmp_path):
 # needing gt4py installed.
 #
 # The stub also answers the folder-name pattern probe (`python -c ...`) with its
-# OWN naming scheme, which deliberately does NOT match this script's built-in
-# default (no version/context segments). The orchestration therefore only finds
-# the stub's program folders if it really uses the fetched pattern — making
-# these tests an end-to-end guard on the pattern-fetch mechanism.
+# OWN naming scheme (no version/context segments, unlike gt4py's). The
+# orchestration only finds the stub's program folders through the fetched
+# pattern — there is no fallback — making these tests an end-to-end guard on
+# the pattern-fetch mechanism.
 
 _STUB_FOLDER_PATTERN = r"(?P<name>.+)_(?P<salt>[0-9a-f]{16})"
 
@@ -376,9 +388,18 @@ def test_run_determinism_check_detects_nondeterminism(tmp_path, monkeypatch):
 
 
 def test_run_determinism_check_infra_failure_raises(tmp_path):
-    # An interpreter that exits non-zero (and != 1/5) is an infrastructure error.
+    # An interpreter that exits non-zero (and != 1/5) on the pytest run is an
+    # infrastructure error. (It still answers the pattern probe: an unanswered
+    # probe would abort earlier with CacheFolderPatternError instead.)
     stub = tmp_path / "boom.py"
-    stub.write_text(f"#!{sys.executable}\nimport sys; sys.exit(2)\n")
+    stub.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        "if sys.argv[1:2] == ['-c']:\n"
+        f"    print({_STUB_FOLDER_PATTERN!r})\n"
+        "    sys.exit(0)\n"
+        "sys.exit(2)\n"
+    )
     stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
     with pytest.raises(PytestRunError, match="unexpected code"):
         run_determinism_check(
@@ -415,6 +436,9 @@ def test_run_determinism_check_env_overrides_are_set(tmp_path):
     stub.write_text(
         f"#!{sys.executable}\n"
         "import os, pathlib, sys\n"
+        "if sys.argv[1:2] == ['-c']:\n"
+        f"    print({_STUB_FOLDER_PATTERN!r})\n"
+        "    sys.exit(0)\n"
         "junit = next(a.split('=', 1)[1] for a in sys.argv if a.startswith('--junit-xml='))\n"
         "cache = pathlib.Path(os.environ['GT4PY_BUILD_CACHE_DIR']) / '.gt4py_cache'\n"
         "rec = cache.parent.parent / (pathlib.Path(os.environ['GT4PY_BUILD_CACHE_DIR']).name + '.env')\n"
@@ -452,6 +476,7 @@ def test_run_determinism_check_env_overrides_are_set(tmp_path):
         (NoSourceFilesObservedError("no sources"), 2),
         (UnsupportedBackendError("bad backend"), 2),
         (PytestRunError("pytest exited with unexpected code 2"), 2),
+        (CacheFolderPatternError("pattern unavailable"), 2),
     ],
 )
 def test_ci_check_command_maps_exceptions_to_exit_codes(monkeypatch, tmp_path, exc, expected_code):
@@ -480,32 +505,9 @@ def test_ci_check_command_success_echoes_report(monkeypatch, tmp_path):
 # The folder-name layout belongs to gt4py: `CACHE_FOLDER_NAME_PATTERN` in
 # gt4py/next/otf/compilation/cache.py, held in sync with `get_cache_folder` by a
 # round-trip test there. These tests cover this script's side of the contract:
-# the built-in fallback parses real-world names, custom patterns are honored,
-# and the runtime fetch degrades cleanly.
-
-
-@pytest.mark.parametrize(
-    ("folder", "expected"),
-    [
-        (
-            "__field_operator_solve_tridiag_pyext_ebf83e9be18232fd_1.1.12_db5ed39d9f2c69fb",
-            "__field_operator_solve_tridiag_pyext",
-        ),
-        (  # no build context id (e.g. the cmake build system passes none)
-            "__field_operator_solve_tridiag_pyext_ebf83e9be18232fd_1.1.12",
-            "__field_operator_solve_tridiag_pyext",
-        ),
-        (  # dev-install version tags contain dots and plus signs
-            "prog_pyext_0123456789abcdef_1.1.13.dev4+g1234abc.d20260722_fedcba9876543210",
-            "prog_pyext",
-        ),
-        ("translation_cache", None),
-        ("run1", None),
-    ],
-)
-def test_default_pattern_extracts_program_name(folder, expected):
-    m = _DEFAULT_FOLDER_RE.fullmatch(folder)
-    assert (m["name"] if m else None) == expected
+# the pattern is always fetched from a gt4py interpreter, an unusable or
+# unavailable pattern is a hard error (no fallback), and the `check` subcommand
+# uses the fetched pattern.
 
 
 def test_pattern_without_name_group_rejected(tmp_path):
@@ -513,7 +515,9 @@ def test_pattern_without_name_group_rejected(tmp_path):
         check_determinism(tmp_path / "r1", tmp_path / "r2", folder_pattern=r".+_[0-9a-f]{16}")
 
 
-def test_check_cli_honors_folder_pattern(tmp_path):
+def test_check_cli_uses_fetched_pattern(monkeypatch, tmp_path):
+    # The check subcommand reads the pattern from the interpreter running the
+    # script; stub the fetch so the test is independent of this environment.
     c1 = tmp_path / "r1" / ".gt4py_cache"
     c2 = tmp_path / "r2" / ".gt4py_cache"
     for cache in (c1, c2):
@@ -521,33 +525,23 @@ def test_check_cli_honors_folder_pattern(tmp_path):
         src.mkdir(parents=True)
         (src / "k.cpp").write_text("stable")
 
-    runner = CliRunner()
-    default = runner.invoke(cli, ["check", "--run1", str(c1), "--run2", str(c2)])
-    assert default.exit_code == 3  # the built-in pattern does not recognize these folders
-
-    custom = runner.invoke(
-        cli,
-        [
-            "check",
-            "--run1",
-            str(c1),
-            "--run2",
-            str(c2),
-            "--folder-pattern",
-            r"(?P<name>.+)-[A-Z]{3}",
-        ],
+    monkeypatch.setattr(
+        "dace_determinism.fetch_cache_folder_pattern", lambda python: r"(?P<name>.+)-[A-Z]{3}"
     )
-    assert custom.exit_code == 0
-    assert "deterministic" in custom.output
+    result = CliRunner().invoke(cli, ["check", "--run1", str(c1), "--run2", str(c2)])
+    assert result.exit_code == 0
+    assert "deterministic" in result.output
 
 
-def test_check_cli_rejects_pattern_without_name_group(tmp_path):
+def test_check_cli_fails_without_pattern_source(monkeypatch, tmp_path):
+    def boom(python):
+        raise CacheFolderPatternError("no gt4py in this interpreter")
+
+    monkeypatch.setattr("dace_determinism.fetch_cache_folder_pattern", boom)
     (tmp_path / "r1").mkdir()
     (tmp_path / "r2").mkdir()
-    r1, r2 = str(tmp_path / "r1"), str(tmp_path / "r2")
     result = CliRunner().invoke(
-        cli,
-        ["check", "--run1", r1, "--run2", r2, "--folder-pattern", "no_name_group_[0-9a-f]{16}"],
+        cli, ["check", "--run1", str(tmp_path / "r1"), "--run2", str(tmp_path / "r2")]
     )
     assert result.exit_code == 2
 
@@ -564,12 +558,28 @@ def test_fetch_pattern_returns_advertised_pattern(tmp_path):
     assert fetch_cache_folder_pattern(python) == _STUB_FOLDER_PATTERN
 
 
-def test_fetch_pattern_none_on_failing_interpreter(tmp_path):
+def test_fetch_pattern_raises_on_failing_interpreter(tmp_path):
     python = _fake_interpreter(tmp_path, "import sys; sys.exit(1)\n")
-    assert fetch_cache_folder_pattern(python) is None
+    with pytest.raises(CacheFolderPatternError, match="could not provide"):
+        fetch_cache_folder_pattern(python)
 
 
-def test_fetch_pattern_none_on_unusable_pattern(tmp_path):
+def test_fetch_pattern_raises_on_unusable_pattern(tmp_path):
     for body in ("print('no name group here')\n", "print('(?P<name>unbalanced')\n", "print()\n"):
         python = _fake_interpreter(tmp_path, body)
-        assert fetch_cache_folder_pattern(python) is None
+        with pytest.raises(CacheFolderPatternError, match="unusable"):
+            fetch_cache_folder_pattern(python)
+
+
+def test_run_determinism_check_aborts_without_pattern(tmp_path):
+    # No pattern source -> abort before any test run, instead of guessing.
+    python = _fake_interpreter(tmp_path, "import sys; sys.exit(1)\n")
+    with pytest.raises(CacheFolderPatternError):
+        run_determinism_check(
+            ["-q"],
+            workdir=tmp_path / "_workdir",
+            python=python,
+            dacecache=tmp_path / ".dacecache",
+            self_check=False,
+        )
+    assert not (tmp_path / "_workdir").exists()  # aborted before creating anything

--- a/src/gt4py/next/otf/compilation/cache.py
+++ b/src/gt4py/next/otf/compilation/cache.py
@@ -10,10 +10,26 @@
 
 import pathlib
 import tempfile
+from typing import Final
 
 from gt4py.next import config, fingerprinting
 from gt4py.next.otf import stages
 
+
+#: Regex describing the folder names produced by `get_cache_folder` (use
+#: `re.fullmatch`): `{name}_{fingerprint}_{version_id}`, plus a trailing
+#: `_{build_context_id}` when a fingerprint-style (16-hex) build context id was
+#: given. Where `get_cache_folder` assembles a folder name from these parts, the
+#: pattern's capture groups take an existing folder name apart again — most
+#: importantly recovering the program `name`. External tools use it to recognize
+#: cached program folders — e.g. `scripts/python/dace_determinism.py` reads this
+#: pattern from the installed gt4py at runtime. When changing the naming scheme
+#: in `get_cache_folder`, update this pattern with it; the round-trip test in
+#: `test_cache.py` fails otherwise.
+CACHE_FOLDER_NAME_PATTERN: Final[str] = (
+    r"(?P<name>.+)_(?P<fingerprint>[0-9a-f]{16})_(?P<version_id>.+?)"
+    r"(?:_(?P<build_context_id>[0-9a-f]{16}))?"
+)
 
 _session_cache_dir = tempfile.TemporaryDirectory(prefix="gt4py_session_")
 
@@ -47,6 +63,9 @@ def get_cache_folder(
     An optional ``build_context_id`` can be provided to distinguish between different contexts
     that may produce different artifacts for the same extension source.
     The returned path points to an existing folder in all cases.
+
+    The folder name layout is documented by ``CACHE_FOLDER_NAME_PATTERN``; keep the
+    two in sync when changing the naming scheme here.
     """
     fingerprinter = fingerprinting.strict_fingerprinter
     slug = ext_source.program_source.entry_point.name

--- a/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_cache.py
+++ b/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_cache.py
@@ -7,8 +7,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import dataclasses
+import re
 
-from gt4py.next import config
+import pytest
+
+from gt4py.next import config, fingerprinting
 from gt4py.next.otf.compilation import cache
 
 from next_tests.unit_tests.otf_tests.compilation_tests.build_systems_tests.conftest import (
@@ -58,3 +61,34 @@ def test_build_context_id_busts_cache_folder(extension_source_example):
 
     assert folder_a != folder_b
     assert folder_b.name.endswith("_ctx")
+
+
+@pytest.mark.parametrize("with_bindings", [True, False])
+@pytest.mark.parametrize("with_context_id", [True, False])
+def test_folder_name_round_trips_through_documented_pattern(
+    extension_source_example, with_bindings, with_context_id
+):
+    """Names built by `get_cache_folder` must parse back through `CACHE_FOLDER_NAME_PATTERN`.
+
+    External tooling (e.g. `scripts/python/dace_determinism.py`) recognizes cached
+    program folders and recovers the program name through this pattern, so any
+    change to the folder naming scheme must update the pattern together with it.
+    """
+    ext_source = (
+        extension_source_example
+        if with_bindings
+        else dataclasses.replace(extension_source_example, binding_source=None)
+    )
+    context_id = (
+        fingerprinting.strict_fingerprinter("build configuration") if with_context_id else ""
+    )
+    folder = cache.get_cache_folder(
+        ext_source, config.BuildCacheLifetime.SESSION, build_context_id=context_id
+    )
+
+    match = re.fullmatch(cache.CACHE_FOLDER_NAME_PATTERN, folder.name)
+    assert match is not None
+    expected_name = ext_source.program_source.entry_point.name + ("_pyext" if with_bindings else "")
+    assert match["name"] == expected_name
+    assert match["version_id"] == config.BUILD_CACHE_VERSION_ID
+    assert match["build_context_id"] == (context_id if with_context_id else None)


### PR DESCRIPTION
## Description

The format of the SDFG build folder name changed in #2650: the fingerprint became a 16-hex xxhash64 and the name gained `_{version_id}` and `_{build_context_id}` suffixes (e.g. `__field_operator_solve_tridiag_pyext_ebf83e9be18232fd_1.1.12_db5ed39d9f2c69fb`). The dace-determinism script still expected `<name>_<64-hex-sha256>`, so the standalone `dace-determinism` CI pipeline failed every run with "no programs observed" (exit 3).

This fixes the breakage and makes the coupling robust against future renames by single-sourcing the naming scheme in gt4py:

- `otf/compilation/cache.py` now exposes `CACHE_FOLDER_NAME_PATTERN` right next to `get_cache_folder`; a new round-trip unit test builds folder names with `get_cache_folder` and asserts the pattern parses them back, so a future change to the naming scheme fails the test in the same PR that makes it.
- `scripts/python/dace_determinism.py` always reads that pattern from a gt4py installation at runtime: `ci-check` asks the interpreter it drives, `check` asks the interpreter running the script (which therefore needs gt4py installed, e.g. run it via `uv run python scripts/python/dace_determinism.py check ...`). There is deliberately no fallback — if no gt4py can provide the pattern, the check aborts with a clear error (exit 2) instead of guessing with a possibly stale copy.
- The script's orchestration tests drive it against a stub interpreter that advertises its own folder-naming scheme and writes its fake caches in that scheme, so they fail immediately if the pattern fetch is ever broken.

Verified locally: `ci-check` on a single dace test (`test_basic.py::test_copy[dace.run_dace_cpu]`) reproduces the CI failure on `main` (exit 3, "no subdirectory matches") and reports `codegen deterministic` with this change (exit 0).
