### PR TITLE
feat[next]: External memory - step 1

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
@@ -85,7 +85,7 @@ from .strides import (
     gt_propagate_strides_from_access_node,
     gt_propagate_strides_of,
 )
-from .utils import gt_make_transients_external, gt_make_transients_persistent
+from .utils import gt_configure_transient_lifetime
 
 
 __all__ = [
@@ -128,14 +128,13 @@ __all__ = [
     "gt_auto_optimize",
     "gt_change_strides",
     "gt_check_if_concat_where_node_is_replaceable",
+    "gt_configure_transient_lifetime",
     "gt_create_local_double_buffering",
     "gt_eliminate_dead_dataflow",
     "gt_gpu_transform_non_standard_memlet",
     "gt_gpu_transformation",
     "gt_horizontal_map_split_fusion",
     "gt_inline_nested_sdfg",
-    "gt_make_transients_external",
-    "gt_make_transients_persistent",
     "gt_map_strides_to_dst_nested_sdfg",
     "gt_map_strides_to_src_nested_sdfg",
     "gt_multi_state_global_self_copy_elimination",

--- a/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
@@ -17,6 +17,7 @@ from .auto_optimize import (
     GT4PyAutoOptHook,
     GT4PyAutoOptHookFun,
     GT4PyAutoOptHookStage,
+    TransientMemoryMode,
     gt_auto_optimize,
 )
 from .concat_where_mapper import (
@@ -84,7 +85,7 @@ from .strides import (
     gt_propagate_strides_from_access_node,
     gt_propagate_strides_of,
 )
-from .utils import gt_make_transients_persistent
+from .utils import gt_make_transients_external, gt_make_transients_persistent
 
 
 __all__ = [
@@ -119,6 +120,7 @@ __all__ = [
     "SingleStateGlobalSelfCopyElimination",
     "SplitAccessNode",
     "SplitConsumerMemlet",
+    "TransientMemoryMode",
     "VerticalMapFusionCallback",
     "VerticalMapSplitCallback",
     "constants",
@@ -132,6 +134,7 @@ __all__ = [
     "gt_gpu_transformation",
     "gt_horizontal_map_split_fusion",
     "gt_inline_nested_sdfg",
+    "gt_make_transients_external",
     "gt_make_transients_persistent",
     "gt_map_strides_to_dst_nested_sdfg",
     "gt_map_strides_to_src_nested_sdfg",

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -111,11 +111,20 @@ GT4PyAutoOptHookFun: TypeAlias = Union[
 ]
 
 
+class TransientMemoryMode(str, enum.Enum):
+    """Policy selecting the lifetime/allocation strategy of transient arrays."""
+
+    SCOPED = "scoped"
+    PERSISTENT = "persistent"
+    POOL = "pool"
+    EXTERNAL = "external"
+
+
 def gt_auto_optimize(
     sdfg: dace.SDFG,
     gpu: bool,
     unit_strides_kind: Optional[gtx_common.DimensionKind] = None,
-    make_persistent: bool = False,
+    transient_memory_mode: TransientMemoryMode = TransientMemoryMode.POOL,
     gpu_block_size: Optional[Sequence[int | str] | str] = (32, 8, 1),
     gpu_block_size_1d: Optional[Sequence[int | str] | str] = (64, 1, 1),
     gpu_block_size_2d: Optional[Sequence[int | str] | str] = None,
@@ -130,7 +139,6 @@ def gt_auto_optimize(
     reuse_transients: bool = False,
     gpu_launch_bounds: Optional[int | str] = None,
     gpu_launch_factor: Optional[int] = None,
-    gpu_memory_pool: bool = True,
     constant_symbols: Optional[dict[str, Any]] = None,
     assume_pointwise: bool = True,
     optimization_hooks: Optional[dict[GT4PyAutoOptHook, GT4PyAutoOptHookFun]] = None,
@@ -174,9 +182,7 @@ def gt_auto_optimize(
         gpu: Optimize for GPU or CPU.
         unit_strides_kind: All dimensions of this kind are considered to have unit
             strides, see `gt_set_iteration_order()` for more.
-        make_persistent: Turn all transients to persistent lifetime, thus they are
-            allocated over the whole lifetime of the program, even if the kernel exits.
-            Thus the SDFG can not be called by different threads.
+        transient_memory_mode: Modify the lifetime of transient arrays.
         gpu_block_size: This is used as default thread block size for GPU Maps. See
             also the `gpu_block_size_*d` arguments
         gpu_block_size_{1, 2, 3}d: Allows to specify the GPU thread block size for
@@ -194,7 +200,6 @@ def gt_auto_optimize(
         gpu_launch_bounds: Use this value as `__launch_bounds__` for _all_ GPU Maps.
         gpu_launch_factor: Use the number of threads times this value as `__launch_bounds__`
             for _all_ GPU Maps.
-        gpu_memory_pool: Enable CUDA memory pool in gpu codegen.
         constant_symbols: Symbols listed in this `dict` will be replaced by the
             respective value inside the SDFG. This might increase performance.
         assume_pointwise: Assume that the SDFG has no risk for race condition in
@@ -400,13 +405,12 @@ def gt_auto_optimize(
         sdfg = _gt_auto_post_processing(
             sdfg=sdfg,
             gpu=gpu,
-            make_persistent=make_persistent,
+            transient_memory_mode=transient_memory_mode,
             # TODO(phimuell): In general `TransientReuse` is a good idea, but the
             #   current implementation also reuses transients scalars inside Map
             #   scopes, which I do not like. Thus we should fix the transformation
             #   to avoid that.
             reuse_transients=reuse_transients,
-            gpu_memory_pool=gpu_memory_pool,
             validate_all=validate_all,
         )
 
@@ -918,9 +922,8 @@ def _gt_auto_configure_maps_and_strides(
 def _gt_auto_post_processing(
     sdfg: dace.SDFG,
     gpu: bool,
-    make_persistent: bool,
+    transient_memory_mode: TransientMemoryMode,
     reuse_transients: bool,
-    gpu_memory_pool: bool,
     validate_all: bool,
 ) -> dace.SDFG:
     """Perform post processing on the SDFG.
@@ -939,26 +942,25 @@ def _gt_auto_post_processing(
     # TODO(phimuell): Fix the bug, it uses the tile value and not the stack array value.
     dace_aoptimize.move_small_arrays_to_stack(sdfg)
 
-    if make_persistent and gpu_memory_pool:
-        raise ValueError("Cannot set both 'make_persistent' and 'gpu_memory_pool'.")
+    if transient_memory_mode in (TransientMemoryMode.PERSISTENT, TransientMemoryMode.EXTERNAL):
+        if transient_memory_mode == TransientMemoryMode.PERSISTENT:
+            gtx_transformations.gt_make_transients_persistent(sdfg)
+        else:
+            gtx_transformations.gt_make_transients_external(sdfg)
 
-    if make_persistent:
-        device = dace.DeviceType.GPU if gpu else dace.DeviceType.CPU
-        gtx_transformations.gt_make_transients_persistent(sdfg=sdfg, device=device)
-
-        if device == dace.DeviceType.GPU:
-            # NOTE: For unknown reasons the counterpart of the
-            #   `gt_make_transients_persistent()` function in DaCe, resets the
-            #   `wcr_nonatomic` property of every memlet, i.e. makes it atomic.
-            #   However, it does this only for edges on the top level and on GPU.
-            #   For compatibility with DaCe (and until we found out why) the GT4Py
-            #   auto optimizer will emulate this behaviour.
+        if gpu:
+            # NOTE: The counterpart of the `gt_make_transients_persistent()` function
+            #   in DaCe, for unknown reasons, resets the `wcr_nonatomic` property
+            #   of every memlet, i.e. makes it atomic. However, it does this only
+            #   for edges on the top level and on GPU. For compatibility with DaCe
+            #   (and until we found out why) the GT4Py auto optimizer will emulate
+            #   this behaviour, for both `PERSISTENT` and `EXTERNAL` mode.
             for state in sdfg.states():
                 assert isinstance(state, dace.SDFGState)
                 for edge in state.edges():
                     edge.data.wcr_nonatomic = False
 
-    if gpu and gpu_memory_pool:
+    elif transient_memory_mode == TransientMemoryMode.POOL and gpu:
         gtx_transformations.gpu_utils.gt_gpu_apply_mempool(sdfg)
 
     if validate_all:

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -116,29 +116,30 @@ class TransientMemoryMode(str, enum.Enum):
     Policy selecting the lifetime/allocation strategy of transient arrays.
 
     Supported strategies are:
-    - `scoped`: Transients are allocated and deallocated in the scope of the SDFG
+    - `SCOPED`: Transients are allocated and deallocated in the scope of the SDFG
         where they are defined, being it the top-level SDFG or a nested one.
         This is the default strategy.
-    - `persistent`: Transients are allocated at the beginning of the program and
-        deallocated at the end of the program, for all SDFGs.
-    - `pool`: Transients are allocated in a memory pool, associated to the GPU
+    - `PERSISTENT`: Transients are allocated the first time the SDFG is called and
+        retained through the entire life of the compiled SDFG, and freed only once
+        it goes out of scope.
+    - `POOL`: Transients are allocated in a memory pool, associated to the GPU
         default stream. These allocations are managed by an asynchronous allocator,
         since all memory is allocated and freed in stream order.
-    - `external`: Transients are allocated and deallocated by an external allocator.
+    - `EXTERNAL`: Transients are allocated and deallocated by an external allocator.
         This strategy allows to reuse a workspace memory for multiple SDFGs, relying
         on sequential execution of the programs on the default stream.
     Note:
-        The `external` strategy requires that the `external_memory_allocator`
+        The `EXTERNAL` strategy requires that the `external_memory_allocator`
         attribute of the dace backend workflow is set to a callable that takes
-        `(required_nbytes, device_type)` and returns a numpy-like array to the
-        allocated memory. The callable is expected to raise an exception if the
-        allocation fails.
+        `(required_nbytes, device_type)` and returns the allocated memory, in the
+        form of an array object that can handled by `dace.dtypes.array_interface_ptr()`.
+        The callable is expected to raise an exception if the allocation fails.
     """
 
-    SCOPED = "scoped"
-    PERSISTENT = "persistent"
-    POOL = "pool"
-    EXTERNAL = "external"
+    SCOPED = "SCOPED"
+    PERSISTENT = "PERSISTENT"
+    POOL = "POOL"
+    EXTERNAL = "EXTERNAL"
 
 
 def gt_auto_optimize(
@@ -203,7 +204,7 @@ def gt_auto_optimize(
         gpu: Optimize for GPU or CPU.
         unit_strides_kind: All dimensions of this kind are considered to have unit
             strides, see `gt_set_iteration_order()` for more.
-        transient_memory_mode: Modify the lifetime of transient arrays.
+        transient_memory_mode: Lifetime for transient arrays.
         gpu_block_size: This is used as default thread block size for GPU Maps. See
             also the `gpu_block_size_*d` arguments
         gpu_block_size_{1, 2, 3}d: Allows to specify the GPU thread block size for
@@ -973,14 +974,13 @@ def _gt_auto_post_processing(
                 sdfg=sdfg, lifetime=dace.AllocationLifetime.External
             )
 
-        if gpu:
-            # NOTE: The counterpart of the `gt_make_transients_persistent()` function
-            #   in DaCe, for unknown reasons, resets the `wcr_nonatomic` property
-            #   of every memlet, i.e. makes it atomic. However, it does this only
-            #   for edges on the top level and on GPU. For compatibility with DaCe
-            #   (and until we found out why) the GT4Py auto optimizer will emulate
-            #   this behaviour, for both `PERSISTENT` and `EXTERNAL` mode.
-            # TODO(phimuell): Find out if we can remove it.
+        if gpu and transient_memory_mode == TransientMemoryMode.PERSISTENT:
+            # NOTE: For unknown reasons the counterpart of the
+            #   `gt_make_transients_persistent()` function in DaCe, resets the
+            #   `wcr_nonatomic` property of every memlet, i.e. makes it atomic.
+            #   However, it does this only for edges on the top level and on GPU.
+            #   For compatibility with DaCe (and until we found out why) the GT4Py
+            #   auto optimizer will emulate this behaviour.
             for state in sdfg.states():
                 assert isinstance(state, dace.SDFGState)
                 for edge in state.edges():

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -964,30 +964,34 @@ def _gt_auto_post_processing(
     # TODO(phimuell): Fix the bug, it uses the tile value and not the stack array value.
     dace_aoptimize.move_small_arrays_to_stack(sdfg)
 
-    if transient_memory_mode in (TransientMemoryMode.PERSISTENT, TransientMemoryMode.EXTERNAL):
-        if transient_memory_mode == TransientMemoryMode.PERSISTENT:
+    match transient_memory_mode:
+        case TransientMemoryMode.PERSISTENT:
             gtx_transformations.gt_configure_transient_lifetime(
                 sdfg=sdfg, lifetime=dace.AllocationLifetime.Persistent
             )
-        else:
+            if gpu:
+                # NOTE: For unknown reasons the counterpart of the
+                #   `gt_make_transients_persistent()` function in DaCe, resets the
+                #   `wcr_nonatomic` property of every memlet, i.e. makes it atomic.
+                #   However, it does this only for edges on the top level and on GPU.
+                #   For compatibility with DaCe (and until we found out why) the GT4Py
+                #   auto optimizer will emulate this behaviour.
+                for state in sdfg.states():
+                    assert isinstance(state, dace.SDFGState)
+                    for edge in state.edges():
+                        edge.data.wcr_nonatomic = False
+
+        case TransientMemoryMode.EXTERNAL:
             gtx_transformations.gt_configure_transient_lifetime(
                 sdfg=sdfg, lifetime=dace.AllocationLifetime.External
             )
 
-        if gpu and transient_memory_mode == TransientMemoryMode.PERSISTENT:
-            # NOTE: For unknown reasons the counterpart of the
-            #   `gt_make_transients_persistent()` function in DaCe, resets the
-            #   `wcr_nonatomic` property of every memlet, i.e. makes it atomic.
-            #   However, it does this only for edges on the top level and on GPU.
-            #   For compatibility with DaCe (and until we found out why) the GT4Py
-            #   auto optimizer will emulate this behaviour.
-            for state in sdfg.states():
-                assert isinstance(state, dace.SDFGState)
-                for edge in state.edges():
-                    edge.data.wcr_nonatomic = False
+        case TransientMemoryMode.POOL:
+            if gpu:
+                gtx_transformations.gpu_utils.gt_gpu_apply_mempool(sdfg)
 
-    elif transient_memory_mode == TransientMemoryMode.POOL and gpu:
-        gtx_transformations.gpu_utils.gt_gpu_apply_mempool(sdfg)
+        case TransientMemoryMode.SCOPED:
+            pass
 
     if validate_all:
         sdfg.validate()

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -112,7 +112,28 @@ GT4PyAutoOptHookFun: TypeAlias = Union[
 
 
 class TransientMemoryMode(str, enum.Enum):
-    """Policy selecting the lifetime/allocation strategy of transient arrays."""
+    """
+    Policy selecting the lifetime/allocation strategy of transient arrays.
+
+    Supported strategies are:
+    - `scoped`: Transients are allocated and deallocated in the scope of the SDFG
+        where they are defined, being it the top-level SDFG or a nested one.
+        This is the default strategy.
+    - `persistent`: Transients are allocated at the beginning of the program and
+        deallocated at the end of the program, for all SDFGs.
+    - `pool`: Transients are allocated in a memory pool, associated to the GPU
+        default stream. These allocations are managed by an asynchronous allocator,
+        since all memory is allocated and freed in stream order.
+    - `external`: Transients are allocated and deallocated by an external allocator.
+        This strategy allows to reuse a workspace memory for multiple SDFGs, relying
+        on sequential execution of the programs on the default stream.
+    Note:
+        The `external` strategy requires that the `external_memory_allocator`
+        attribute of the dace backend workflow is set to a callable that takes
+        `(required_nbytes, device_type)` and returns a numpy-like array to the
+        allocated memory. The callable is expected to raise an exception if the
+        allocation fails.
+    """
 
     SCOPED = "scoped"
     PERSISTENT = "persistent"
@@ -944,9 +965,13 @@ def _gt_auto_post_processing(
 
     if transient_memory_mode in (TransientMemoryMode.PERSISTENT, TransientMemoryMode.EXTERNAL):
         if transient_memory_mode == TransientMemoryMode.PERSISTENT:
-            gtx_transformations.gt_make_transients_persistent(sdfg)
+            gtx_transformations.gt_configure_transient_lifetime(
+                sdfg=sdfg, lifetime=dace.AllocationLifetime.Persistent
+            )
         else:
-            gtx_transformations.gt_make_transients_external(sdfg)
+            gtx_transformations.gt_configure_transient_lifetime(
+                sdfg=sdfg, lifetime=dace.AllocationLifetime.External
+            )
 
         if gpu:
             # NOTE: The counterpart of the `gt_make_transients_persistent()` function
@@ -955,6 +980,7 @@ def _gt_auto_post_processing(
             #   for edges on the top level and on GPU. For compatibility with DaCe
             #   (and until we found out why) the GT4Py auto optimizer will emulate
             #   this behaviour, for both `PERSISTENT` and `EXTERNAL` mode.
+            # TODO(phimuell): Find out if we can remove it.
             for state in sdfg.states():
                 assert isinstance(state, dace.SDFGState)
                 for edge in state.edges():

--- a/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
@@ -10,29 +10,33 @@
 
 from __future__ import annotations
 
-from typing import Optional, Sequence, TypeVar, Union
+from typing import Optional, Sequence, Union
 
 import dace
 from dace import data as dace_data, subsets as dace_sbs, symbolic as dace_sym
 from dace.libraries import standard as dace_stdlib
 from dace.sdfg import graph as dace_graph, nodes as dace_nodes
-from dace.transformation import pass_pipeline as dace_ppl
 from dace.transformation.passes import analysis as dace_analysis
 from ordered_set import OrderedSet
 
 from gt4py.next.program_processors.runners.dace import library_nodes as gtx_lib
 
 
-_PassT = TypeVar("_PassT", bound=dace_ppl.Pass)
-
-
-def _gt_configure_transient_lifetime(
+def gt_configure_transient_lifetime(
     sdfg: dace.SDFG,
     lifetime: dace.AllocationLifetime,
 ) -> dict[int, set[str]]:
-    """Configure transient lifetimes for top-level eligible data nodes.
+    """
+    Configure transient lifetime for eligible data nodes in the given SDFG and all nested SDFGs.
 
-    Supported target lifetimes are `Persistent` and `External`.
+    Supported target lifetimes are `Persistent` and `External`, refer to
+    dace documentation for `dace.AllocationLifetime`.
+
+    Eligible data nodes are transient arrays or scalars excluding:
+    - data nodes with storage type `Register` (relevant for scalars)
+    - data nodes with lifetime `External` (already externally managed)
+    - data nodes used inside a scope (e.g., maps)
+    - data nodes whose size is not fully determined by the SDFG's free symbols (dynamic allocations)
     """
     if lifetime not in {dace.AllocationLifetime.Persistent, dace.AllocationLifetime.External}:
         raise ValueError(f"Unsupported transient lifetime '{lifetime}'.")
@@ -90,57 +94,6 @@ def _gt_configure_transient_lifetime(
             nsdfg.arrays[aname].lifetime = lifetime
 
     return result
-
-
-def gt_make_transients_persistent(
-    sdfg: dace.SDFG,
-) -> dict[int, set[str]]:
-    """
-    Changes the lifetime of certain transients to `Persistent`.
-
-    A persistent lifetime means that the transient is allocated only the very first
-    time the SDFG is executed and only deallocated if the underlying `CompiledSDFG`
-    object goes out of scope. The main advantage is, that memory must not be
-    allocated every time the SDFG is run. The downside is that the SDFG can not be
-    called by different threads.
-
-    Args:
-        sdfg: The SDFG to process.
-
-    Returns:
-        A `dict` mapping SDFG IDs to a set of transient arrays that
-        were made persistent.
-
-    Note:
-        This function is based on a similar function in DaCe. However, the DaCe
-        function does, for unknown reasons, also reset the `wcr_nonatomic` property,
-        but only for GPU.
-    """
-    return _gt_configure_transient_lifetime(
-        sdfg=sdfg,
-        lifetime=dace.AllocationLifetime.Persistent,
-    )
-
-
-def gt_make_transients_external(
-    sdfg: dace.SDFG,
-) -> dict[int, set[str]]:
-    """Changes the lifetime of eligible transients to ``External``.
-
-    External lifetime means storage is provided by the caller through DaCe's
-    workspace mechanism (``CompiledSDFG.set_workspace``).
-
-    Args:
-        sdfg: The SDFG to process.
-
-    Returns:
-        A ``dict`` mapping SDFG IDs to the set of transient arrays that were
-        changed to external lifetime.
-    """
-    return _gt_configure_transient_lifetime(
-        sdfg=sdfg,
-        lifetime=dace.AllocationLifetime.External,
-    )
 
 
 def is_accessed_downstream(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
@@ -26,32 +26,17 @@ from gt4py.next.program_processors.runners.dace import library_nodes as gtx_lib
 _PassT = TypeVar("_PassT", bound=dace_ppl.Pass)
 
 
-def gt_make_transients_persistent(
+def _gt_configure_transient_lifetime(
     sdfg: dace.SDFG,
-    device: dace.DeviceType,
+    lifetime: dace.AllocationLifetime,
 ) -> dict[int, set[str]]:
+    """Configure transient lifetimes for top-level eligible data nodes.
+
+    Supported target lifetimes are `Persistent` and `External`.
     """
-    Changes the lifetime of certain transients to `Persistent`.
+    if lifetime not in {dace.AllocationLifetime.Persistent, dace.AllocationLifetime.External}:
+        raise ValueError(f"Unsupported transient lifetime '{lifetime}'.")
 
-    A persistent lifetime means that the transient is allocated only the very first
-    time the SDFG is executed and only deallocated if the underlying `CompiledSDFG`
-    object goes out of scope. The main advantage is, that memory must not be
-    allocated every time the SDFG is run. The downside is that the SDFG can not be
-    called by different threads.
-
-    Args:
-        sdfg: The SDFG to process.
-        device: The device type.
-
-    Returns:
-        A `dict` mapping SDFG IDs to a set of transient arrays that
-        were made persistent.
-
-    Note:
-        This function is based on a similar function in DaCe. However, the DaCe
-        function does, for unknown reasons, also reset the `wcr_nonatomic` property,
-        but only for GPU.
-    """
     result: dict[int, set[str]] = {}
     for nsdfg in sdfg.all_sdfgs_recursive():
         fsyms: set[str] = nsdfg.free_symbols
@@ -81,10 +66,8 @@ def gt_make_transients_persistent(
                     continue
 
                 # If the data is referenced inside a scope, such as a map, it might be possible
-                #  that it is only used inside that scope. If we would make it persistent, then
-                #  it would essentially be allocated outside and be shared among the different
-                #  map iterations. So we can not make it persistent.
-                #  The downside is, that we might have to perform dynamic allocation.
+                #  that it is only used inside that scope. If we would make it global-lifetime,
+                #  it would effectively be shared among map iterations, which is unsafe.
                 if scope_dict[dnode] is not None:
                     not_modify_lifetime.add(dnode.data)
                     continue
@@ -100,15 +83,64 @@ def gt_make_transients_persistent(
                 except AttributeError:  # total_size is an integer / has no free symbols
                     pass
 
-                # Make it persistent.
                 modify_lifetime.add(dnode.data)
 
-        # Now setting the lifetime.
         result[nsdfg.cfg_id] = modify_lifetime - not_modify_lifetime
         for aname in result[nsdfg.cfg_id]:
-            nsdfg.arrays[aname].lifetime = dace.AllocationLifetime.Persistent
+            nsdfg.arrays[aname].lifetime = lifetime
 
     return result
+
+
+def gt_make_transients_persistent(
+    sdfg: dace.SDFG,
+) -> dict[int, set[str]]:
+    """
+    Changes the lifetime of certain transients to `Persistent`.
+
+    A persistent lifetime means that the transient is allocated only the very first
+    time the SDFG is executed and only deallocated if the underlying `CompiledSDFG`
+    object goes out of scope. The main advantage is, that memory must not be
+    allocated every time the SDFG is run. The downside is that the SDFG can not be
+    called by different threads.
+
+    Args:
+        sdfg: The SDFG to process.
+
+    Returns:
+        A `dict` mapping SDFG IDs to a set of transient arrays that
+        were made persistent.
+
+    Note:
+        This function is based on a similar function in DaCe. However, the DaCe
+        function does, for unknown reasons, also reset the `wcr_nonatomic` property,
+        but only for GPU.
+    """
+    return _gt_configure_transient_lifetime(
+        sdfg=sdfg,
+        lifetime=dace.AllocationLifetime.Persistent,
+    )
+
+
+def gt_make_transients_external(
+    sdfg: dace.SDFG,
+) -> dict[int, set[str]]:
+    """Changes the lifetime of eligible transients to ``External``.
+
+    External lifetime means storage is provided by the caller through DaCe's
+    workspace mechanism (``CompiledSDFG.set_workspace``).
+
+    Args:
+        sdfg: The SDFG to process.
+
+    Returns:
+        A ``dict`` mapping SDFG IDs to the set of transient arrays that were
+        changed to external lifetime.
+    """
+    return _gt_configure_transient_lifetime(
+        sdfg=sdfg,
+        lifetime=dace.AllocationLifetime.External,
+    )
 
 
 def is_accessed_downstream(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
@@ -29,14 +29,19 @@ def gt_configure_transient_lifetime(
     """
     Configure transient lifetime for eligible data nodes in the given SDFG and all nested SDFGs.
 
-    Supported target lifetimes are `Persistent` and `External`, refer to
-    dace documentation for `dace.AllocationLifetime`.
-
     Eligible data nodes are transient arrays or scalars excluding:
     - data nodes with storage type `Register` (relevant for scalars)
     - data nodes with lifetime `External` (already externally managed)
     - data nodes used inside a scope (e.g., maps)
     - data nodes whose size is not fully determined by the SDFG's free symbols (dynamic allocations)
+
+    Args:
+        sdfg: The SDFG to process.
+        lifetime: The desired lifetime to set for eligible transient data nodes.
+
+    Returns:
+        A dictionary mapping SDFG configuration IDs to the data node names whose
+        lifetimes were modified.
     """
     if lifetime not in {dace.AllocationLifetime.Persistent, dace.AllocationLifetime.External}:
         raise ValueError(f"Unsupported transient lifetime '{lifetime}'.")
@@ -59,6 +64,7 @@ def gt_configure_transient_lifetime(
 
                 desc = dnode.desc(nsdfg)
                 if not desc.transient or type(desc) not in {dace.data.Array, dace.data.Scalar}:
+                    # TODO(phimuell): Find out why scalars are processed.
                     not_modify_lifetime.add(dnode.data)
                     continue
                 if desc.storage == dace.StorageType.Register:

--- a/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
@@ -91,7 +91,11 @@ def gt_configure_transient_lifetime(
 
         result[nsdfg.cfg_id] = modify_lifetime - not_modify_lifetime
         for aname in result[nsdfg.cfg_id]:
-            nsdfg.arrays[aname].lifetime = lifetime
+            adesc = nsdfg.arrays[aname]
+            adesc.lifetime = lifetime
+            if adesc.storage == dace.StorageType.Default and isinstance(adesc, dace.data.Array):
+                # GPU transformation have already change the storage for GPU arrays.
+                adesc.storage = dace.StorageType.CPU_Heap
 
     return result
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
@@ -94,7 +94,16 @@ def gt_configure_transient_lifetime(
             adesc = nsdfg.arrays[aname]
             adesc.lifetime = lifetime
             if adesc.storage == dace.StorageType.Default and isinstance(adesc, dace.data.Array):
-                # GPU transformation have already change the storage for GPU arrays.
+                # GPU transformation have already changed the storage for GPU arrays.
+                # NOTE: If we do not change the storage during lowering / transformations,
+                #  it will be done in code generation when calling `sdfg.compile()`.
+                #  This side effect is a potential issue, because we do not store
+                #  the program handle, see `sdfg.compile(return_program_handle=False)`
+                #  in `compilation.py`; therefore, we do not have the modified SDFG.
+                #  The original SDFG is deserialized, at call time, and the storage
+                #  type is reset to `Default`. This is a problem for arrays with
+                #  external storage, because `CompiledSDFG.set_workspace()` will
+                #  try to load a symbol from the library for the wrong storage type.
                 adesc.storage = dace.StorageType.CPU_Heap
 
     return result

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from typing import Any, Final
 
 import factory
@@ -16,6 +17,7 @@ import factory
 import gt4py.next.custom_layout_allocators as next_allocators
 from gt4py._core import definitions as core_defs
 from gt4py.next import backend, common, config
+from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
 from gt4py.next.program_processors.runners.dace.workflow.factory import DaCeWorkflowFactory
 
 
@@ -35,6 +37,7 @@ class DaCeBackendFactory(factory.Factory):
     class Params:
         name_device = "cpu"
         name_postfix = ""
+        external_memory_allocator = None
         gpu = factory.Trait(
             allocator=next_allocators.StandardGPUFieldBufferAllocator(),
             device_type=core_defs.CUPY_DEVICE_TYPE or core_defs.DeviceType.CUDA,
@@ -46,6 +49,7 @@ class DaCeBackendFactory(factory.Factory):
             cached_translation=True,
             device_type=factory.SelfAttribute("..device_type"),
             auto_optimize=factory.SelfAttribute("..auto_optimize"),
+            external_memory_allocator=factory.SelfAttribute("..external_memory_allocator"),
         )
         auto_optimize = factory.Trait(name_postfix="_opt")
 
@@ -60,6 +64,7 @@ def make_dace_backend(
     auto_optimize: bool = True,
     async_sdfg_call: bool = True,
     optimization_args: dict[str, Any] | None = None,
+    external_memory_allocator: Callable[[int], Any] | None = None,
     unstructured_horizontal_has_unit_stride: bool = config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE,
     use_metrics: bool = True,
     use_zero_origin: bool = False,
@@ -74,6 +79,8 @@ def make_dace_backend(
             of GPU kernel execution with the Python driver code.
         optimization_args: A `dict` containing configuration parameters for
             the SDFG auto-optimize pipeline, see `gt_auto_optimize()`.
+        external_memory_allocator: Callable used later for external-memory workspace
+            allocation. Threaded through the backend workflow for now.
         unstructured_horizontal_has_unit_stride: When the memory layout has unit stride
             in the horizontal dimension, replace the field stride symbol with '1'.
         use_metrics: Add SDFG instrumentation to collect the metric for stencil
@@ -110,11 +117,25 @@ def make_dace_backend(
         else None
     }
 
+    if external_memory_allocator is not None:
+        expected_mode = gtx_transformations.TransientMemoryMode.EXTERNAL
+        if "transient_memory_mode" in optimization_args:
+            if (
+                transient_memory_mode := optimization_args["transient_memory_mode"]
+            ) is not expected_mode:
+                raise ValueError(
+                    f"'external_memory_allocator' requires 'transient_memory_mode=external', found {transient_memory_mode}."
+                )
+        else:
+            optimization_args["transient_memory_mode"] = expected_mode
+
     return DaCeBackendFactory(  # type: ignore[return-value] # factory-boy typing not precise enough
         gpu=gpu,
         auto_optimize=auto_optimize,
+        external_memory_allocator=external_memory_allocator,
         otf_workflow__bare_translation__async_sdfg_call=(async_sdfg_call if gpu else False),
         otf_workflow__bare_translation__auto_optimize_args=optimization_args,
+        otf_workflow__compilation__external_memory_allocator=external_memory_allocator,
         otf_workflow__bare_translation__unstructured_horizontal_has_unit_stride=unstructured_horizontal_has_unit_stride,
         otf_workflow__bare_translation__use_metrics=use_metrics,
         otf_workflow__bare_translation__disable_field_origin_on_program_arguments=use_zero_origin,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 import factory
 
@@ -19,6 +19,10 @@ from gt4py._core import definitions as core_defs
 from gt4py.next import backend, common, config
 from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
 from gt4py.next.program_processors.runners.dace.workflow.factory import DaCeWorkflowFactory
+
+
+if TYPE_CHECKING:
+    import dace
 
 
 class DaCeBackendFactory(factory.Factory):
@@ -64,7 +68,7 @@ def make_dace_backend(
     auto_optimize: bool = True,
     async_sdfg_call: bool = True,
     optimization_args: dict[str, Any] | None = None,
-    external_memory_allocator: Callable[[int], Any] | None = None,
+    external_memory_allocator: Callable[[int, dace.StorageType], Any] | None = None,
     unstructured_horizontal_has_unit_stride: bool = config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE,
     use_metrics: bool = True,
     use_zero_origin: bool = False,
@@ -79,8 +83,9 @@ def make_dace_backend(
             of GPU kernel execution with the Python driver code.
         optimization_args: A `dict` containing configuration parameters for
             the SDFG auto-optimize pipeline, see `gt_auto_optimize()`.
-        external_memory_allocator: Callable used later for external-memory workspace
-            allocation. Threaded through the backend workflow for now.
+        external_memory_allocator: Callable taking `(required_nbytes, storage_type)`
+            used later for external-memory workspace allocation. Threaded through
+            the backend workflow for now.
         unstructured_horizontal_has_unit_stride: When the memory layout has unit stride
             in the horizontal dimension, replace the field stride symbol with '1'.
         use_metrics: Add SDFG instrumentation to collect the metric for stencil

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -124,8 +124,9 @@ def make_dace_backend(
             if (
                 transient_memory_mode := optimization_args["transient_memory_mode"]
             ) is not expected_mode:
-                raise ValueError(
-                    f"'external_memory_allocator' requires 'transient_memory_mode=external', found {transient_memory_mode}."
+                warnings.warn(
+                    f"External memory allocator provided but 'transient_memory_mode' is '{transient_memory_mode}', it requires '{expected_mode}'.",
+                    stacklevel=2,
                 )
         else:
             optimization_args["transient_memory_mode"] = expected_mode

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Final
+from typing import Any, Final
 
 import factory
 
@@ -19,10 +19,6 @@ from gt4py._core import definitions as core_defs
 from gt4py.next import backend, common, config
 from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
 from gt4py.next.program_processors.runners.dace.workflow.factory import DaCeWorkflowFactory
-
-
-if TYPE_CHECKING:
-    import dace
 
 
 class DaCeBackendFactory(factory.Factory):
@@ -68,7 +64,7 @@ def make_dace_backend(
     auto_optimize: bool = True,
     async_sdfg_call: bool = True,
     optimization_args: dict[str, Any] | None = None,
-    external_memory_allocator: Callable[[int, dace.StorageType], Any] | None = None,
+    external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None = None,
     unstructured_horizontal_has_unit_stride: bool = config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE,
     use_metrics: bool = True,
     use_zero_origin: bool = False,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -181,7 +181,7 @@ class DaCeCompiler(
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
-    external_memory_allocator: Callable[[int], Any] | None = None
+    external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None = None
     add_gpu_trace_markers: bool = dataclasses.field(
         default_factory=lambda: config.ADD_GPU_TRACE_MARKERS
     )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -181,6 +181,7 @@ class DaCeCompiler(
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
+    external_memory_allocator: Callable[[int], Any] | None = None
     add_gpu_trace_markers: bool = dataclasses.field(
         default_factory=lambda: config.ADD_GPU_TRACE_MARKERS
     )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/factory.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/factory.py
@@ -35,6 +35,7 @@ class DaCeWorkflowFactory(factory.Factory):
 
     class Params:
         auto_optimize: bool = False
+        external_memory_allocator = None
         device_type: core_defs.DeviceType = core_defs.DeviceType.CPU
         cmake_build_type: config.CMakeBuildType = factory.LazyFunction(  # type: ignore[assignment] # factory-boy typing not precise enough
             lambda: config.CMAKE_BUILD_TYPE
@@ -73,5 +74,6 @@ class DaCeWorkflowFactory(factory.Factory):
         bind_func_name=_GT_DACE_BINDING_FUNCTION_NAME,
         cache_lifetime=factory.LazyFunction(lambda: config.BUILD_CACHE_LIFETIME),
         device_type=factory.SelfAttribute("..device_type"),
+        external_memory_allocator=factory.SelfAttribute("..external_memory_allocator"),
         cmake_build_type=factory.SelfAttribute("..cmake_build_type"),
     )

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
@@ -149,7 +149,7 @@ def test_make_backend(auto_optimize, device_type, monkeypatch):
 
 
 def test_make_backend_accepts_external_allocator_with_external_mode():
-    external_memory_allocator = lambda size: bytearray(size)
+    external_memory_allocator = lambda size, storage: bytearray(size)
 
     backend = dace_wf_backend.make_dace_backend(
         gpu=False,
@@ -165,7 +165,7 @@ def test_make_backend_accepts_external_allocator_with_external_mode():
 
 
 def test_make_backend_infers_external_mode_when_allocator_is_provided():
-    external_memory_allocator = lambda size: bytearray(size)
+    external_memory_allocator = lambda size, storage: bytearray(size)
 
     backend = dace_wf_backend.make_dace_backend(
         gpu=False,
@@ -190,5 +190,5 @@ def test_make_backend_rejects_external_allocator_without_external_mode():
             optimization_args={
                 "transient_memory_mode": gtx_transformations.TransientMemoryMode.POOL,
             },
-            external_memory_allocator=lambda size: bytearray(size),
+            external_memory_allocator=lambda size, storage: bytearray(size),
         )

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
@@ -54,20 +54,18 @@ def test_make_backend(auto_optimize, device_type, monkeypatch):
         optimization_args = {}
     elif on_gpu:
         optimization_args = {
-            "make_persistent": False,
+            "transient_memory_mode": gtx_transformations.TransientMemoryMode.POOL,
             "gpu_block_size": (32, 8, 1),
             "gpu_block_size_2d": (20, 20),
-            "gpu_memory_pool": True,
             "optimization_hooks": {
                 gtx_transformations.GT4PyAutoOptHook.TopLevelDataFlowPost: mock_top_level_dataflow_hook1,
             },
         }
     else:
         optimization_args = {
-            "make_persistent": True,
+            "transient_memory_mode": gtx_transformations.TransientMemoryMode.PERSISTENT,
             "blocking_dim": KDim,
             "blocking_size": 10,
-            "gpu_memory_pool": False,
             "optimization_hooks": {
                 gtx_transformations.GT4PyAutoOptHook.TopLevelDataFlowPost: mock_top_level_dataflow_hook2,
             },
@@ -123,10 +121,9 @@ def test_make_backend(auto_optimize, device_type, monkeypatch):
                     "__b_IDim_stride": 1,
                     "__out_IDim_stride": 1,
                 },
-                make_persistent=optimization_args["make_persistent"],
+                transient_memory_mode=optimization_args["transient_memory_mode"],
                 gpu_block_size=optimization_args["gpu_block_size"],
                 gpu_block_size_2d=optimization_args["gpu_block_size_2d"],
-                gpu_memory_pool=optimization_args["gpu_memory_pool"],
                 optimization_hooks=optimization_args["optimization_hooks"],
                 unit_strides_kind=gtx.common.DimensionKind.HORIZONTAL,
             )
@@ -137,10 +134,9 @@ def test_make_backend(auto_optimize, device_type, monkeypatch):
                 sdfg,
                 gpu=on_gpu,
                 constant_symbols={},
-                make_persistent=optimization_args["make_persistent"],
+                transient_memory_mode=optimization_args["transient_memory_mode"],
                 blocking_dim=optimization_args["blocking_dim"],
                 blocking_size=optimization_args["blocking_size"],
-                gpu_memory_pool=optimization_args["gpu_memory_pool"],
                 optimization_hooks=optimization_args["optimization_hooks"],
                 unit_strides_kind=None,
             )
@@ -150,3 +146,49 @@ def test_make_backend(auto_optimize, device_type, monkeypatch):
         mock_auto_optimize.assert_not_called()
         mock_top_level_dataflow_hook1.assert_not_called()
         mock_top_level_dataflow_hook2.assert_not_called()
+
+
+def test_make_backend_accepts_external_allocator_with_external_mode():
+    external_memory_allocator = lambda size: bytearray(size)
+
+    backend = dace_wf_backend.make_dace_backend(
+        gpu=False,
+        auto_optimize=True,
+        async_sdfg_call=False,
+        optimization_args={
+            "transient_memory_mode": gtx_transformations.TransientMemoryMode.EXTERNAL,
+        },
+        external_memory_allocator=external_memory_allocator,
+    )
+
+    assert backend.executor.compilation.external_memory_allocator is external_memory_allocator
+
+
+def test_make_backend_infers_external_mode_when_allocator_is_provided():
+    external_memory_allocator = lambda size: bytearray(size)
+
+    backend = dace_wf_backend.make_dace_backend(
+        gpu=False,
+        auto_optimize=True,
+        async_sdfg_call=False,
+        external_memory_allocator=external_memory_allocator,
+    )
+
+    assert (
+        backend.executor.translation.step.auto_optimize_args["transient_memory_mode"]
+        == gtx_transformations.TransientMemoryMode.EXTERNAL
+    )
+    assert backend.executor.compilation.external_memory_allocator is external_memory_allocator
+
+
+def test_make_backend_rejects_external_allocator_without_external_mode():
+    with pytest.raises(ValueError, match="transient_memory_mode=external"):
+        dace_wf_backend.make_dace_backend(
+            gpu=False,
+            auto_optimize=True,
+            async_sdfg_call=False,
+            optimization_args={
+                "transient_memory_mode": gtx_transformations.TransientMemoryMode.POOL,
+            },
+            external_memory_allocator=lambda size: bytearray(size),
+        )

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
@@ -181,14 +181,23 @@ def test_make_backend_infers_external_mode_when_allocator_is_provided():
     assert backend.executor.compilation.external_memory_allocator is external_memory_allocator
 
 
-def test_make_backend_rejects_external_allocator_without_external_mode():
-    with pytest.raises(ValueError, match="transient_memory_mode=external"):
-        dace_wf_backend.make_dace_backend(
+def test_make_backend_warns_external_allocator_without_external_mode():
+    external_memory_allocator = lambda size, storage: bytearray(size)
+
+    with pytest.warns(UserWarning, match="External memory allocator provided"):
+        backend = dace_wf_backend.make_dace_backend(
             gpu=False,
             auto_optimize=True,
             async_sdfg_call=False,
             optimization_args={
                 "transient_memory_mode": gtx_transformations.TransientMemoryMode.POOL,
             },
-            external_memory_allocator=lambda size, storage: bytearray(size),
+            external_memory_allocator=external_memory_allocator,
         )
+
+    # Explicit mode stays as requested by the caller; backend only warns.
+    assert (
+        backend.executor.translation.step.auto_optimize_args["transient_memory_mode"]
+        == gtx_transformations.TransientMemoryMode.POOL
+    )
+    assert backend.executor.compilation.external_memory_allocator is external_memory_allocator

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_transient_memory_mode.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_transient_memory_mode.py
@@ -48,7 +48,7 @@ def _make_sdfg_with_top_level_transient(storage):
 @pytest.mark.parametrize(
     "storage",
     [
-        dace.StorageType.CPU_Heap,
+        dace.StorageType.Default,
         dace.StorageType.GPU_Global,
     ],
 )
@@ -60,4 +60,8 @@ def test_configure_transient_lifetime(lifetime, storage):
     assert candidates == {"tmp_arr", "tmp_scalar"}
 
     assert sdfg.arrays["tmp_arr"].lifetime == lifetime
+    assert sdfg.arrays["tmp_arr"].storage == (
+        dace.StorageType.CPU_Heap if storage == dace.StorageType.Default else storage
+    )
     assert sdfg.arrays["tmp_scalar"].lifetime == lifetime
+    assert sdfg.arrays["tmp_scalar"].storage == dace.StorageType.Default

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_transient_memory_mode.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_transient_memory_mode.py
@@ -1,0 +1,64 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from gt4py._core import definitions as core_defs
+from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
+
+dace = pytest.importorskip("dace")
+
+
+def _make_sdfg_with_top_level_transient(storage):
+    sdfg = dace.SDFG("external_mode_scalar_test")
+    state = sdfg.add_state("state", is_start_block=True)
+    sdfg.add_array("a", [10], dace.float64, transient=False, storage=storage)
+    sdfg.add_array("tmp_arr", [10], dace.float64, transient=True, storage=storage)
+    sdfg.add_scalar("tmp_scalar", dace.float64, transient=True)
+    sdfg.add_array("b", [10], dace.float64, transient=False, storage=storage)
+
+    a = state.add_access("a")
+    tmp_arr = state.add_access("tmp_arr")
+    tmp_scalar = state.add_access("tmp_scalar")
+    b = state.add_access("b")
+    state.add_nedge(a, tmp_arr, dace.Memlet("a[0:10]"))
+    state.add_nedge(tmp_arr, b, dace.Memlet("tmp_arr[0:10]"))
+    init_scalar = state.add_tasklet(
+        "init_scalar",
+        inputs={},
+        outputs={"out"},
+        code="out = 1.0",
+    )
+    state.add_edge(init_scalar, "out", tmp_scalar, None, dace.Memlet("tmp_scalar"))
+    sdfg.validate()
+    return sdfg
+
+
+@pytest.mark.parametrize(
+    ("transform", "expected_lifetime"),
+    [
+        (gtx_transformations.gt_make_transients_persistent, dace.AllocationLifetime.Persistent),
+        (gtx_transformations.gt_make_transients_external, dace.AllocationLifetime.External),
+    ],
+)
+@pytest.mark.parametrize(
+    "storage",
+    [
+        dace.StorageType.CPU_Heap,
+        dace.StorageType.GPU_Global,
+    ],
+)
+def test_configure_transient_lifetime(transform, expected_lifetime, storage):
+    sdfg = _make_sdfg_with_top_level_transient(storage)
+
+    result = transform(sdfg)
+    candidates = next(iter(result.values()))
+    assert candidates == {"tmp_arr", "tmp_scalar"}
+
+    assert sdfg.arrays["tmp_arr"].lifetime == expected_lifetime
+    assert sdfg.arrays["tmp_scalar"].lifetime == expected_lifetime

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_transient_memory_mode.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_transient_memory_mode.py
@@ -8,7 +8,6 @@
 
 import pytest
 
-from gt4py._core import definitions as core_defs
 from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
 
 dace = pytest.importorskip("dace")
@@ -40,10 +39,10 @@ def _make_sdfg_with_top_level_transient(storage):
 
 
 @pytest.mark.parametrize(
-    ("transform", "expected_lifetime"),
+    "lifetime",
     [
-        (gtx_transformations.gt_make_transients_persistent, dace.AllocationLifetime.Persistent),
-        (gtx_transformations.gt_make_transients_external, dace.AllocationLifetime.External),
+        dace.AllocationLifetime.Persistent,
+        dace.AllocationLifetime.External,
     ],
 )
 @pytest.mark.parametrize(
@@ -53,12 +52,12 @@ def _make_sdfg_with_top_level_transient(storage):
         dace.StorageType.GPU_Global,
     ],
 )
-def test_configure_transient_lifetime(transform, expected_lifetime, storage):
+def test_configure_transient_lifetime(lifetime, storage):
     sdfg = _make_sdfg_with_top_level_transient(storage)
 
-    result = transform(sdfg)
+    result = gtx_transformations.gt_configure_transient_lifetime(sdfg, lifetime)
     candidates = next(iter(result.values()))
     assert candidates == {"tmp_arr", "tmp_scalar"}
 
-    assert sdfg.arrays["tmp_arr"].lifetime == expected_lifetime
-    assert sdfg.arrays["tmp_scalar"].lifetime == expected_lifetime
+    assert sdfg.arrays["tmp_arr"].lifetime == lifetime
+    assert sdfg.arrays["tmp_scalar"].lifetime == lifetime


### PR DESCRIPTION
This pull request introduces a more flexible and extensible way to control the allocation and lifetime of transient arrays in the DaCe backend, replacing the previous `make_persistent` and `gpu_memory_pool` options with a new `TransientMemoryMode` policy. It also adds support for externally managed memory via an `external_memory_allocator` parameter, and refactors related utility functions to support these changes.

**API and Configuration Improvements:**

* Introduced the `TransientMemoryMode` enum to specify transient array lifetime/allocation strategies (`SCOPED`, `PERSISTENT`, `POOL`, `EXTERNAL`), and replaced the `make_persistent` and `gpu_memory_pool` parameters throughout the codebase with this unified approach. [[1]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706R114-R127) [[2]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L133) [[3]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L177-R185) [[4]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L197) [[5]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L403-L409) [[6]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L921-L923) [[7]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L942-R963) [[8]](diffhunk://#diff-c7967b0fa16e0de89cb43f3c81e9aee884122772946f031d50fb31d1cb16215bR20) [[9]](diffhunk://#diff-c7967b0fa16e0de89cb43f3c81e9aee884122772946f031d50fb31d1cb16215bR123)

* Added support for an `external_memory_allocator` parameter in the DaCe backend and workflow, which allows users to provide custom allocation logic for external memory. This is validated to only be used with `transient_memory_mode=external`. [[1]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbR40) [[2]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbR52) [[3]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbR67) [[4]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbR82-R83) [[5]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbR120-R138) [[6]](diffhunk://#diff-89b749ff9b80be5fdb8a7e0d05411d2b992b6a5892f819c7a3e001c4241a6c0dR184) [[7]](diffhunk://#diff-91264fda895ecc56c869858ac9724e1ff60ed6514a121d1cd4f323197053e5aaR38) [[8]](diffhunk://#diff-91264fda895ecc56c869858ac9724e1ff60ed6514a121d1cd4f323197053e5aaR77)

**Utility Function Refactoring:**

* Refactored the persistent transients utility into a more general `_gt_configure_transient_lifetime` function, which now supports both `Persistent` and `External` lifetimes. Exposed two public functions: `gt_make_transients_persistent` and the new `gt_make_transients_external`. [[1]](diffhunk://#diff-6ce6c03a192e5b5b7e735ecc3aa1071dc7ce0ac5d90f206f948b1e3f8e952637L29-R39) [[2]](diffhunk://#diff-6ce6c03a192e5b5b7e735ecc3aa1071dc7ce0ac5d90f206f948b1e3f8e952637L84-R70) [[3]](diffhunk://#diff-c7967b0fa16e0de89cb43f3c81e9aee884122772946f031d50fb31d1cb16215bL87-R88) [[4]](diffhunk://#diff-c7967b0fa16e0de89cb43f3c81e9aee884122772946f031d50fb31d1cb16215bR137)

**Documentation and Safety:**

* Updated docstrings and comments to reflect the new transient memory modes and clarify the behavior and constraints of each mode, including safety considerations when using global-lifetime transients. [[1]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L177-R185) [[2]](diffhunk://#diff-6ce6c03a192e5b5b7e735ecc3aa1071dc7ce0ac5d90f206f948b1e3f8e952637L84-R70)

These changes make the backend's memory management more robust and adaptable, and lay the groundwork for advanced use cases such as externally managed memory.