### PR TITLE
refactor[next]: Introduce ExternalMemoryAllocator protocol

### DIFF
--- a/docs/development/ADRs/next/0026-External_Memory_Allocator.md
+++ b/docs/development/ADRs/next/0026-External_Memory_Allocator.md
@@ -14,7 +14,7 @@ many times (e.g. inside a time loop), facing per-call GPU transient allocation
 overhead and the desire to bound workspace memory to one SDFG's transient
 footprint, we decided to add an explicit `EXTERNAL` transient-memory mode
 backed by a caller-supplied `ExternalMemoryAllocator` protocol (allocate once
-per SDFG storage type, release when the compiled program is closed).
+per SDFG storage type, release when the compiled program is finalized).
 
 ## Context
 
@@ -37,7 +37,7 @@ The existing `PERSISTENT` mode ties one workspace to exactly one SDFG:
 transients are allocated once and retained for that SDFG's lifetime, so the
 workspace grows without bound across distinct SDFGs and is owned by the
 compiled program, not the caller. `EXTERNAL` can reproduce that behaviour --
-allocate once, retain, release at close -- but is more general: it hands
+allocate once, retain, release at finalize -- but is more general: it hands
 ownership of the workspace memory to the caller. With that ownership the
 caller can reuse a single workspace buffer across multiple compiled programs
 (sized to the largest, or per storage type), which `PERSISTENT` cannot.
@@ -71,15 +71,15 @@ allocator.
   installs it via `sdfg_program.set_workspace(...)`. The buffers are kept on
   the `CompiledDaceProgram` for its lifetime.
 - Teardown is explicit and pool-driven, not `__del__`-based:
-  `CompiledDaceProgram.close()` calls `deallocate` once per storage type (and
-  is idempotent and resilient: a failing `deallocate` is warned, not raised,
-  so one bad buffer does not strand the rest). `decorated_program` in
-  `workflow/decoration.py` forwards `close()` to the underlying
-  `CompiledDaceProgram`, and `CompiledProgramsPool.__post_init__` registers a
-  `weakref.finalize` that walks `compiled_programs` and calls `close()` on
-  each when the pool is collected. This mirrors the existing
-  `metrics_source_key` finalizer and its "avoid id reuse once a pool dies"
-  rationale.
+  `CompiledDaceProgram.finalize()` finalizes the underlying SDFG and calls
+  `deallocate` once per storage type (and is idempotent and resilient: a
+  failing `deallocate` is warned, not raised, so one bad buffer does not
+  strand the rest). `DaCeDecoratedProgram` in `workflow/decoration.py`
+  forwards `finalize()` to the underlying `CompiledDaceProgram`, and
+  `CompiledProgramsPool.__post_init__` registers a `weakref.finalize` that
+  walks `compiled_programs` and calls `finalize()` on each when the pool is
+  collected. This mirrors the existing `metrics_source_key` finalizer and its
+  "avoid id reuse once a pool dies" rationale.
 - The allocator is part of `DaCeCompilationArtifact` and is therefore
   **picklable**: when the OTF runner offloads compilation to a
   `ProcessPoolExecutor` it pickles the executor chain, which carries the
@@ -98,7 +98,7 @@ allocator.
   runtime path while keeping memory bounded to one SDFG's transient footprint.
 - Workspace lifetime is explicit and tied to the compiled program's lifetime
   through the pool finalizer, not to GC timing. Backends owning external
-  resources (this one) get `close()` called at pool teardown.
+  resources (this one) get `finalize()` called at pool teardown.
 - The public API has a typed allocator protocol and a single mode enum;
   incompatible combinations (e.g. an allocator with a non-`EXTERNAL` mode)
   are detected and warned at backend construction.
@@ -117,7 +117,7 @@ allocator.
 - Bad, because the codebase strongly prefers `weakref.finalize` over `__del__`
   (hostile conditions at interpreter shutdown, partial initialization, and an
   allocator that may already be gone). Rejected in favor of the explicit
-  `close()` forwarded through the closure and driven by the pool finalizer.
+  `finalize()` forwarded through the callable and driven by the pool finalizer.
 
 ### A DLPack-consuming `set_workspace`
 
@@ -135,12 +135,12 @@ allocator.
   (`ExternalMemoryAllocator`, `AllocationRequest`, `Buffer`,
   `TransientMemoryMode`, `_gt_auto_post_processing`).
 - `src/gt4py/next/program_processors/runners/dace/workflow/compilation.py`
-  (`CompiledDaceProgram.construct_arguments`/`close`,
+  (`CompiledDaceProgram.construct_arguments`/`finalize`,
   `DaCeCompilationArtifact`, `DaCeCompiler`, `AllocatorNotPicklableError`).
 - `src/gt4py/next/program_processors/runners/dace/workflow/decoration.py`
-  (`decorated_program.close` forwarding).
+  (`DaCeDecoratedProgram.finalize` forwarding).
 - `src/gt4py/next/otf/compiled_program.py`
-  (`_close_compiled_programs`, `CompiledProgramsPool.__post_init__`
+  (`_finalize_compiled_programs`, `CompiledProgramsPool.__post_init__`
   finalizer).
 - [ADR 0023](0023-Fingerprinting.md) and
   [ADR 0025](0025-Crash_Consistent_Build_Caches.md) for the cache and

--- a/docs/development/ADRs/next/0026-External_Memory_Allocator.md
+++ b/docs/development/ADRs/next/0026-External_Memory_Allocator.md
@@ -1,0 +1,147 @@
+---
+tags: []
+---
+
+# External Memory Allocator for DaCe Transients
+
+- **Status**: valid
+- **Authors**: Edoardo Paone (@edopao)
+- **Created**: 2026-07-27
+- **Updated**: 2026-07-27
+
+In the context of `gt4py.next` DaCe backends that run the same compiled SDFG
+many times (e.g. inside a time loop), facing per-call GPU transient allocation
+overhead and the desire to bound workspace memory to one SDFG's transient
+footprint, we decided to add an explicit `EXTERNAL` transient-memory mode
+backed by a caller-supplied `ExternalMemoryAllocator` protocol (allocate once
+per SDFG storage type, release when the compiled program is closed).
+
+## Context
+
+DaCe transients default to `AllocationLifetime.SDFG` (scoped): the generated
+code allocates and frees them around every SDFG call. For workloads that run
+the same compiled SDFG many times, this per-call allocation/free is overhead,
+and for workloads that run many distinct SDFGs in a loop, the natural goal is a
+single reusable workspace buffer per storage type, bounded to one SDFG's
+transient footprint.
+
+Two properties are required of such a mode:
+
+- **Allocate once, reuse across calls.** The workspace is sized once (from the
+  SDFG's own `get_workspace_sizes()`) and installed via `set_workspace(...)`,
+  so no per-call allocation appears in the generated runtime path.
+- **Explicit, pool-driven lifetime.** The workspace is released when the
+  compiled program is done — not at GC time, and not per call.
+
+The existing `PERSISTENT` mode ties one workspace to exactly one SDFG:
+transients are allocated once and retained for that SDFG's lifetime, so the
+workspace grows without bound across distinct SDFGs and is owned by the
+compiled program, not the caller. `EXTERNAL` can reproduce that behaviour --
+allocate once, retain, release at close -- but is more general: it hands
+ownership of the workspace memory to the caller. With that ownership the
+caller can reuse a single workspace buffer across multiple compiled programs
+(sized to the largest, or per storage type), which `PERSISTENT` cannot.
+Reuse is the caller's responsibility: `EXTERNAL` issues one workspace per
+storage type and the generated runtime path assumes the SDFG runs
+sequentially on the default stream, so the caller must ensure no two
+programs using the same workspace run concurrently. `POOL` is also not a
+fit for this reuse-across-programs goal: it still allocates per SDFG, just
+amortized through the mempool.
+
+## Decision
+
+A single explicit `EXTERNAL` transient-memory mode, backed by a caller-supplied
+allocator.
+
+- `TransientMemoryMode` enum (`SCOPED`, `PERSISTENT`, `POOL`, `EXTERNAL`),
+  mutually exclusive, threaded through `gt_auto_optimize()` and the backend
+  factory. `_gt_auto_post_processing` dispatches per mode: `SCOPED` is a
+  no-op, `PERSISTENT` sets `AllocationLifetime.Persistent`, `POOL` applies the
+  GPU mempool pass, and `EXTERNAL` sets `AllocationLifetime.External` on
+  eligible transients via `gt_configure_transient_lifetime`.
+- A public `ExternalMemoryAllocator` Protocol
+  (`allocate(request: AllocationRequest) -> Buffer` /
+  `deallocate(buffer) -> None`), defined in `transformations/auto_optimize.py`
+  alongside `AllocationRequest` (`nbytes`, `device`, `alignment=256`) and
+  `Buffer` (a `TypeAlias` over the existing `ArrayInterface` /
+  `CUDAArrayInterface` from `gt4py.eve.extended_typing`, not a new protocol).
+- At runtime, `CompiledDaceProgram.construct_arguments` calls
+  `sdfg_program.get_workspace_sizes()`, invokes `allocate` once per storage
+  type, validates the returned buffer (array interface, size, alignment) and
+  installs it via `sdfg_program.set_workspace(...)`. The buffers are kept on
+  the `CompiledDaceProgram` for its lifetime.
+- Teardown is explicit and pool-driven, not `__del__`-based:
+  `CompiledDaceProgram.close()` calls `deallocate` once per storage type (and
+  is idempotent and resilient: a failing `deallocate` is warned, not raised,
+  so one bad buffer does not strand the rest). `decorated_program` in
+  `workflow/decoration.py` forwards `close()` to the underlying
+  `CompiledDaceProgram`, and `CompiledProgramsPool.__post_init__` registers a
+  `weakref.finalize` that walks `compiled_programs` and calls `close()` on
+  each when the pool is collected. This mirrors the existing
+  `metrics_source_key` finalizer and its "avoid id reuse once a pool dies"
+  rationale.
+- The allocator is part of `DaCeCompilationArtifact` and is therefore
+  **picklable**: when the OTF runner offloads compilation to a
+  `ProcessPoolExecutor` it pickles the executor chain, which carries the
+  allocator. `DaCeCompiler.__post_init__` probes the allocator with
+  `pickle.dumps` and raises `AllocatorNotPicklableError` (a `TypeError`) at
+  backend construction if it cannot be pickled, rather than letting a closure
+  or lambda silently degrade to in-process compilation via the generic runner
+  warning. The error chains the original pickle failure and names the
+  recommended shape (module-level class or `functools.partial` of picklable
+  callables).
+
+## Consequences
+
+- A single reusable workspace buffer per storage type can back many sequential
+  SDFG calls, removing per-call transient allocation/free in the generated
+  runtime path while keeping memory bounded to one SDFG's transient footprint.
+- Workspace lifetime is explicit and tied to the compiled program's lifetime
+  through the pool finalizer, not to GC timing. Backends owning external
+  resources (this one) get `close()` called at pool teardown.
+- The public API has a typed allocator protocol and a single mode enum;
+  incompatible combinations (e.g. an allocator with a non-`EXTERNAL` mode)
+  are detected and warned at backend construction.
+- A non-picklable allocator fails loudly at construction instead of silently
+  serializing compilation, at the cost of probing every allocator once with
+  `pickle.dumps` (cheap for the common module-level-class shape).
+- Multi-stream safety is explicitly **out of scope** for this delivery:
+  `EXTERNAL` reuses one workspace across sequential SDFG calls on the default
+  stream. Concurrent use across streams is a follow-up (the plan's Phase 6).
+
+## Alternatives considered
+
+### `__del__`-based teardown on `CompiledDaceProgram`
+
+- Good, because it needs no pool integration.
+- Bad, because the codebase strongly prefers `weakref.finalize` over `__del__`
+  (hostile conditions at interpreter shutdown, partial initialization, and an
+  allocator that may already be gone). Rejected in favor of the explicit
+  `close()` forwarded through the closure and driven by the pool finalizer.
+
+### A DLPack-consuming `set_workspace`
+
+- Good, because DLPack is the cross-framework standard for zero-copy.
+- Bad, because `dace.dtypes.array_interface_ptr()` (what DaCe uses for
+  `set_workspace`) duck-types via `__array_interface__` /
+  `__cuda_array_interface__` and `hasattr('data_ptr')`, and does not consume
+  DLPack for this path. Introducing a DLPack requirement would narrow the set
+  of accepted buffers without buying anything on this code path. Rejected;
+  `Buffer` is kept as a `TypeAlias` over the two array interfaces.
+
+## References
+
+- `src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py`
+  (`ExternalMemoryAllocator`, `AllocationRequest`, `Buffer`,
+  `TransientMemoryMode`, `_gt_auto_post_processing`).
+- `src/gt4py/next/program_processors/runners/dace/workflow/compilation.py`
+  (`CompiledDaceProgram.construct_arguments`/`close`,
+  `DaCeCompilationArtifact`, `DaCeCompiler`, `AllocatorNotPicklableError`).
+- `src/gt4py/next/program_processors/runners/dace/workflow/decoration.py`
+  (`decorated_program.close` forwarding).
+- `src/gt4py/next/otf/compiled_program.py`
+  (`_close_compiled_programs`, `CompiledProgramsPool.__post_init__`
+  finalizer).
+- [ADR 0023](0023-Fingerprinting.md) and
+  [ADR 0025](0025-Crash_Consistent_Build_Caches.md) for the cache and
+  build-folder guarantees the external-memory path must not regress.

--- a/docs/development/ADRs/next/0026-External_Memory_Allocator.md
+++ b/docs/development/ADRs/next/0026-External_Memory_Allocator.md
@@ -60,10 +60,10 @@ allocator.
   GPU mempool pass, and `EXTERNAL` sets `AllocationLifetime.External` on
   eligible transients via `gt_configure_transient_lifetime`.
 - A public `ExternalMemoryAllocator` Protocol
-  (`allocate(request: AllocationRequest) -> Buffer` /
-  `deallocate(buffer) -> None`), defined in `transformations/auto_optimize.py`
+  (`allocate(request: AllocationRequest) -> ExternalWorkspace` /
+  `deallocate(wsp) -> None`), defined in `transformations/auto_optimize.py`
   alongside `AllocationRequest` (`nbytes`, `device`, `alignment=256`) and
-  `Buffer` (a `TypeAlias` over the existing `ArrayInterface` /
+  `ExternalWorkspace` (a `TypeAlias` over the existing `ArrayInterface` /
   `CUDAArrayInterface` from `gt4py.eve.extended_typing`, not a new protocol).
 - At runtime, `CompiledDaceProgram.construct_arguments` calls
   `sdfg_program.get_workspace_sizes()`, invokes `allocate` once per storage
@@ -127,12 +127,12 @@ allocator.
   `__cuda_array_interface__` and `hasattr('data_ptr')`, and does not consume
   DLPack for this path. Introducing a DLPack requirement would narrow the set
   of accepted buffers without buying anything on this code path. Rejected;
-  `Buffer` is kept as a `TypeAlias` over the two array interfaces.
+  `ExternalWorkspace` is kept as a `TypeAlias` over the two array interfaces.
 
 ## References
 
 - `src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py`
-  (`ExternalMemoryAllocator`, `AllocationRequest`, `Buffer`,
+  (`ExternalMemoryAllocator`, `AllocationRequest`, `ExternalWorkspace`,
   `TransientMemoryMode`, `_gt_auto_post_processing`).
 - `src/gt4py/next/program_processors/runners/dace/workflow/compilation.py`
   (`CompiledDaceProgram.construct_arguments`/`finalize`,

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -85,6 +85,32 @@ def metrics_source_key(pool: CompiledProgramsPool, key: CompiledProgramsKey) -> 
         return source_key
 
 
+def _close_compiled_programs(programs: stages.ExecutableProgram | dict[Any, Any]) -> None:
+    """Best-effort cleanup of compiled programs when their pool is deleted.
+
+    Invoked via :py:func:`weakref.finalize` on a
+    :py:class:`CompiledProgramsPool`. The pool holds each compiled program
+    as a generic :py:data:`stages.ExecutableProgram` (a backend-specific
+    callable, e.g. the DaCe ``decorated_program`` closure); backends that
+    own external resources expose a ``close()`` method, which is forwarded
+    to the underlying compiled object. Failures are surfaced as warnings
+    rather than raised, because finalizers cannot propagate exceptions.
+    """
+    values = programs.values() if isinstance(programs, dict) else (programs,)
+    for program in values:
+        close = getattr(program, "close", None)
+        if close is None:
+            continue
+        try:
+            close()
+        except Exception:
+            warnings.warn(
+                f"Compiled program {type(program).__name__!r} raised during "
+                f"pool teardown; its resources may be leaked.",
+                stacklevel=1,
+            )
+
+
 @hook_machinery.event_hook
 def compile_variant_hook(
     program_pool: CompiledProgramsPool,
@@ -375,6 +401,20 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
         return self.definition_stage.definition
 
     def __post_init__(self) -> None:
+        # Best-effort teardown: when this pool is deleted (and its
+        # ``compiled_programs`` dict goes with it), close any compiled
+        # program that exposes a ``close()`` method so backends that own
+        # external resources -- e.g. the DaCe external-memory allocator --
+        # can release them. The dict is passed by reference so the
+        # finalizer walks the live collection (programs may be added after
+        # registration); the pool is held weakly so this does not extend
+        # its lifetime. Mirrors the finalizer registered in
+        # ``metrics_source_key`` (which avoids id reuse once a pool dies).
+        #
+        # Registered first so a ``__post_init__`` that fails validation
+        # still installs teardown for whatever is already cached.
+        weakref.finalize(self, _close_compiled_programs, self.compiled_programs)
+
         # TODO(havogt): We currently don't support pos_only or kw_only args at the program level.
         # This check makes sure we don't miss updating this code if we add support for them in the future.
         assert not self.program_type.definition.kw_only_args

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -85,24 +85,24 @@ def metrics_source_key(pool: CompiledProgramsPool, key: CompiledProgramsKey) -> 
         return source_key
 
 
-def _close_compiled_programs(programs: stages.ExecutableProgram | dict[Any, Any]) -> None:
+def _finalize_compiled_programs(programs: stages.ExecutableProgram | dict[Any, Any]) -> None:
     """Best-effort cleanup of compiled programs when their pool is deleted.
 
     Invoked via :py:func:`weakref.finalize` on a
     :py:class:`CompiledProgramsPool`. The pool holds each compiled program
     as a generic :py:data:`stages.ExecutableProgram` (a backend-specific
-    callable, e.g. the DaCe ``decorated_program`` closure); backends that
-    own external resources expose a ``close()`` method, which is forwarded
+    callable, e.g. the DaCe ``DaCeDecoratedProgram``); backends that
+    own external resources expose a ``finalize()`` method, which is forwarded
     to the underlying compiled object. Failures are surfaced as warnings
     rather than raised, because finalizers cannot propagate exceptions.
     """
     values = programs.values() if isinstance(programs, dict) else (programs,)
     for program in values:
-        close = getattr(program, "close", None)
-        if close is None:
+        finalize = getattr(program, "finalize", None)
+        if finalize is None:
             continue
         try:
-            close()
+            finalize()
         except Exception:
             warnings.warn(
                 f"Compiled program {type(program).__name__!r} raised during "
@@ -402,8 +402,8 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
 
     def __post_init__(self) -> None:
         # Best-effort teardown: when this pool is deleted (and its
-        # ``compiled_programs`` dict goes with it), close any compiled
-        # program that exposes a ``close()`` method so backends that own
+        # ``compiled_programs`` dict goes with it), finalize any compiled
+        # program that exposes a ``finalize()`` method so backends that own
         # external resources -- e.g. the DaCe external-memory allocator --
         # can release them. The dict is passed by reference so the
         # finalizer walks the live collection (programs may be added after
@@ -413,7 +413,7 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
         #
         # Registered first so a ``__post_init__`` that fails validation
         # still installs teardown for whatever is already cached.
-        weakref.finalize(self, _close_compiled_programs, self.compiled_programs)
+        weakref.finalize(self, _finalize_compiled_programs, self.compiled_programs)
 
         # TODO(havogt): We currently don't support pos_only or kw_only args at the program level.
         # This check makes sure we don't miss updating this code if we add support for them in the future.

--- a/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
@@ -15,8 +15,8 @@ that explains the general structure and requirements on the SDFGs.
 from . import constants, splitting_tools
 from .auto_optimize import (  # re-exported for the external-memory public API
     AllocationRequest,
-    Buffer,
     ExternalMemoryAllocator,
+    ExternalWorkspace,
     GT4PyAutoOptHook,
     GT4PyAutoOptHookFun,
     GT4PyAutoOptHookStage,
@@ -93,10 +93,10 @@ from .utils import gt_configure_transient_lifetime
 
 __all__ = [
     "AllocationRequest",
-    "Buffer",
     "CopyChainRemover",
     "DoubleWriteRemover",
     "ExternalMemoryAllocator",
+    "ExternalWorkspace",
     "FuseHorizontalConditionBlocks",
     "GPUSetBlockSize",
     "GT4PyAutoOptHook",

--- a/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/__init__.py
@@ -13,7 +13,10 @@ that explains the general structure and requirements on the SDFGs.
 """
 
 from . import constants, splitting_tools
-from .auto_optimize import (
+from .auto_optimize import (  # re-exported for the external-memory public API
+    AllocationRequest,
+    Buffer,
+    ExternalMemoryAllocator,
     GT4PyAutoOptHook,
     GT4PyAutoOptHookFun,
     GT4PyAutoOptHookStage,
@@ -89,8 +92,11 @@ from .utils import gt_configure_transient_lifetime
 
 
 __all__ = [
+    "AllocationRequest",
+    "Buffer",
     "CopyChainRemover",
     "DoubleWriteRemover",
+    "ExternalMemoryAllocator",
     "FuseHorizontalConditionBlocks",
     "GPUSetBlockSize",
     "GT4PyAutoOptHook",

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -141,7 +141,7 @@ class AllocationRequest:
 #: bytes; allocators that return a larger slab are acceptable. Reuses the
 #: existing array-interface protocols from :mod:`gt4py.eve.extended_typing`
 #: rather than introducing a new one.
-Buffer: TypeAlias = xtyping.ArrayInterface | xtyping.CUDAArrayInterface
+ExternalWorkspace: TypeAlias = xtyping.ArrayInterface | xtyping.CUDAArrayInterface
 
 
 @runtime_checkable
@@ -150,28 +150,26 @@ class ExternalMemoryAllocator(Protocol):
 
     The allocator owns the lifetime of the memory it hands out. For each SDFG
     that requires external workspaces, ``allocate`` is called once per
-    SDFG storage type during
-    :py:meth:`~gt4py.next.program_processors.runners.dace.workflow.compilation.CompiledDaceProgram.construct_arguments`,
-    and ``deallocate`` is called once per storage type when the
-    :py:class:`~gt4py.next.program_processors.runners.dace.workflow.compilation.CompiledDaceProgram`
-    is closed. Allocators that wish to reuse a single slab across many programs
+    SDFG storage type during `CompiledDaceProgram.construct_arguments`,
+    and ``deallocate`` is called once per storage type when the `CompiledDaceProgram`
+    is finalized. Allocators that wish to reuse a single slab across many programs
     must keep the slab alive after ``deallocate`` returns: ``deallocate``
-    signals "this program is done with the buffer", not "destroy the memory".
+    signals "this program is done with the workspace", not "destroy the memory".
 
     Implementations must be picklable (module-level classes or
     :py:func:`functools.partial` of picklable callables are recommended),
     because the allocator is part of the compilation artifact.
     """
 
-    def allocate(self, request: AllocationRequest) -> Buffer:
+    def allocate(self, request: AllocationRequest) -> ExternalWorkspace:
         """Return a buffer of at least ``request.nbytes`` bytes on
         ``request.device``. Must raise on failure; never return ``None``.
         """
         ...
 
-    def deallocate(self, buffer: Buffer) -> None:
-        """Release or reclaim ``buffer``. Called once per buffer when the
-        owning compiled program is closed.
+    def deallocate(self, wsp: ExternalWorkspace) -> None:
+        """Release or reclaim ``wsp``. Called once per workspace when the
+        owning compiled program is finalized.
         """
         ...
 
@@ -198,7 +196,7 @@ class TransientMemoryMode(str, enum.Enum):
         attribute of the dace backend workflow is set to an
         `ExternalMemoryAllocator`. Workspaces are allocated once per compiled
         program (one `allocate` call per SDFG storage type) and freed when the
-        compiled program is closed (one `deallocate` call per storage type).
+        compiled program is finalized (one `deallocate` call per storage type).
         The allocator must be picklable.
     """
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -8,9 +8,10 @@
 
 """Fast access to the auto optimization on DaCe."""
 
+import dataclasses
 import enum
 import warnings
-from typing import Any, Callable, Optional, Sequence, TypeAlias, Union
+from typing import Any, Callable, Optional, Protocol, Sequence, TypeAlias, Union, runtime_checkable
 
 import dace
 from dace import data as dace_data
@@ -19,6 +20,8 @@ from dace.transformation import dataflow as dace_dataflow
 from dace.transformation.auto import auto_optimize as dace_aoptimize
 from dace.transformation.passes import analysis as dace_analysis
 
+from gt4py._core import definitions as core_defs
+from gt4py.eve import extended_typing as xtyping
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.program_processors.runners.dace import (
     library_nodes as gtx_library_nodes,
@@ -111,6 +114,68 @@ GT4PyAutoOptHookFun: TypeAlias = Union[
 ]
 
 
+@dataclasses.dataclass(frozen=True)
+class AllocationRequest:
+    """A single workspace allocation request issued by the DaCe runtime.
+
+    Attributes:
+        nbytes: Number of bytes the compiled SDFG requires for this workspace.
+        device: Target device for the workspace, derived from the SDFG
+            transient storage type (``CPU`` for ``CPU_Heap``, the configured
+            GPU device for ``GPU_Global``).
+        alignment: Minimum byte alignment required for the returned buffer.
+            Allocators may return more strictly aligned memory; the default
+            matches the alignment DaCe assumes for transient storage on the
+            target device.
+    """
+
+    nbytes: int
+    device: core_defs.DeviceType
+    alignment: int = 256
+
+
+#: Array-like object that ``dace.dtypes.array_interface_ptr()`` accepts as a
+#: workspace: a host array exposing :class:`~gt4py.eve.extended_typing.ArrayInterface`
+#: or a device array exposing :class:`~gt4py.eve.extended_typing.CUDAArrayInterface`.
+#: The returned object must be at least as large as the requested number of
+#: bytes; allocators that return a larger slab are acceptable. Reuses the
+#: existing array-interface protocols from :mod:`gt4py.eve.extended_typing`
+#: rather than introducing a new one.
+Buffer: TypeAlias = xtyping.ArrayInterface | xtyping.CUDAArrayInterface
+
+
+@runtime_checkable
+class ExternalMemoryAllocator(Protocol):
+    """Allocates and frees workspace memory for ``TransientMemoryMode.EXTERNAL``.
+
+    The allocator owns the lifetime of the memory it hands out. For each SDFG
+    that requires external workspaces, ``allocate`` is called once per
+    SDFG storage type during
+    :py:meth:`~gt4py.next.program_processors.runners.dace.workflow.compilation.CompiledDaceProgram.construct_arguments`,
+    and ``deallocate`` is called once per storage type when the
+    :py:class:`~gt4py.next.program_processors.runners.dace.workflow.compilation.CompiledDaceProgram`
+    is closed. Allocators that wish to reuse a single slab across many programs
+    must keep the slab alive after ``deallocate`` returns: ``deallocate``
+    signals "this program is done with the buffer", not "destroy the memory".
+
+    Implementations must be picklable (module-level classes or
+    :py:func:`functools.partial` of picklable callables are recommended),
+    because the allocator is part of the compilation artifact.
+    """
+
+    def allocate(self, request: AllocationRequest) -> Buffer:
+        """Return a buffer of at least ``request.nbytes`` bytes on
+        ``request.device``. Must raise on failure; never return ``None``.
+        """
+        ...
+
+    def deallocate(self, buffer: Buffer) -> None:
+        """Release or reclaim ``buffer``. Called once per buffer when the
+        owning compiled program is closed.
+        """
+        ...
+
+
 class TransientMemoryMode(str, enum.Enum):
     """
     Policy selecting the lifetime/allocation strategy of transient arrays.
@@ -130,10 +195,11 @@ class TransientMemoryMode(str, enum.Enum):
         on sequential execution of the programs on the default stream.
     Note:
         The `EXTERNAL` strategy requires that the `external_memory_allocator`
-        attribute of the dace backend workflow is set to a callable that takes
-        `(required_nbytes, device_type)` and returns the allocated memory, in the
-        form of an array object that can handled by `dace.dtypes.array_interface_ptr()`.
-        The callable is expected to raise an exception if the allocation fails.
+        attribute of the dace backend workflow is set to an
+        `ExternalMemoryAllocator`. Workspaces are allocated once per compiled
+        program (one `allocate` call per SDFG storage type) and freed when the
+        compiled program is closed (one `deallocate` call per storage type).
+        The allocator must be picklable.
     """
 
     SCOPED = "SCOPED"

--- a/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/backend.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
 from typing import Any, Final
 
 import factory
@@ -64,7 +63,7 @@ def make_dace_backend(
     auto_optimize: bool = True,
     async_sdfg_call: bool = True,
     optimization_args: dict[str, Any] | None = None,
-    external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None = None,
+    external_memory_allocator: gtx_transformations.ExternalMemoryAllocator | None = None,
     unstructured_horizontal_has_unit_stride: bool = config.UNSTRUCTURED_HORIZONTAL_HAS_UNIT_STRIDE,
     use_metrics: bool = True,
     use_zero_origin: bool = False,
@@ -79,9 +78,11 @@ def make_dace_backend(
             of GPU kernel execution with the Python driver code.
         optimization_args: A `dict` containing configuration parameters for
             the SDFG auto-optimize pipeline, see `gt_auto_optimize()`.
-        external_memory_allocator: Callable taking `(required_nbytes, storage_type)`
-            used later for external-memory workspace allocation. Threaded through
-            the backend workflow for now.
+        external_memory_allocator: Allocator used to provide workspace memory
+            when `transient_memory_mode` is `EXTERNAL`. Threaded through the
+            backend workflow and called once per SDFG storage type when
+            arguments are constructed; see
+            `gtx_transformations.ExternalMemoryAllocator` for the contract.
         unstructured_horizontal_has_unit_stride: When the memory layout has unit stride
             in the horizontal dimension, replace the field stride symbol with '1'.
         use_metrics: Add SDFG instrumentation to collect the metric for stencil

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -28,8 +28,8 @@ from gt4py.next.otf import code_specs, definitions, stages, workflow
 from gt4py.next.otf.compilation import cache as gtx_cache
 from gt4py.next.program_processors.runners.dace.transformations.auto_optimize import (
     AllocationRequest,
-    Buffer,
     ExternalMemoryAllocator,
+    ExternalWorkspace,
 )
 from gt4py.next.program_processors.runners.dace.workflow import (
     common as gtx_wfdcommon,
@@ -100,30 +100,28 @@ def _map_workspace_storage_to_device(storage: dace.StorageType) -> core_defs.Dev
 
 
 def _validate_external_workspace(
-    storage: dace.StorageType, request: AllocationRequest, buffer: Buffer
+    storage: dace.StorageType, request: AllocationRequest, wsp: ExternalWorkspace
 ) -> None:
-    """Validate that ``buffer`` satisfies ``request`` for ``storage``.
+    """Validate that ``wsp`` satisfies ``request`` for ``storage``.
 
     Args:
-        storage: SDFG storage type the buffer is being installed for.
+        storage: SDFG storage type the workspace buffer is being installed for.
         request: Allocation request that was issued.
-        buffer: Buffer returned by the external allocator.
+        wsp: External workspace returned by the external allocator.
 
     Raises:
-        TypeError: If ``buffer`` exposes neither ``__array_interface__`` nor
+        TypeError: If ``wsp`` exposes neither ``__array_interface__`` nor
             ``__cuda_array_interface__``.
-        ValueError: If ``buffer`` is smaller than ``request.nbytes`` or its
+        ValueError: If ``wsp`` is smaller than ``request.nbytes`` or its
             base pointer is not aligned to ``request.alignment`` bytes.
     """
-    if not (
-        xtyping.supports_array_interface(buffer) or xtyping.supports_cuda_array_interface(buffer)
-    ):
+    if not (xtyping.supports_array_interface(wsp) or xtyping.supports_cuda_array_interface(wsp)):
         raise TypeError(
-            f"External memory allocator returned {type(buffer).__name__!r} for storage "
+            f"External memory allocator returned {type(wsp).__name__!r} for storage "
             f"{storage!r}, which does not expose `__array_interface__` or "
             f"`__cuda_array_interface__`."
         )
-    nbytes = getattr(buffer, "nbytes", None)
+    nbytes = getattr(wsp, "nbytes", None)
     if nbytes is not None and nbytes < request.nbytes:
         raise ValueError(
             f"External memory allocator returned a buffer of {nbytes} bytes for storage "
@@ -134,9 +132,9 @@ def _validate_external_workspace(
     # optional on the host array interface; if it is missing the alignment
     # contract is trust-based and the check is skipped, mirroring ``nbytes``.
     interface = (
-        getattr(buffer, "__cuda_array_interface__", None)
+        getattr(wsp, "__cuda_array_interface__", None)
         if storage == dace.StorageType.GPU_Global
-        else getattr(buffer, "__array_interface__", None)
+        else getattr(wsp, "__array_interface__", None)
     )
     data = interface.get("data") if interface is not None else None
     if data is not None and request.alignment > 1 and data[0] % request.alignment != 0:
@@ -174,7 +172,7 @@ class CompiledDaceProgram:
     csdfg_argv: MutableSequence[Any] | None
     csdfg_init_argv: Sequence[Any] | None
     external_memory_allocator: ExternalMemoryAllocator | None
-    external_workspaces: dict[dace.StorageType, Buffer]
+    external_workspaces: dict[dace.StorageType, ExternalWorkspace]
 
     def __init__(
         self,
@@ -231,7 +229,7 @@ class CompiledDaceProgram:
 
         Finalizes the underlying ``sdfg_program`` and calls ``deallocate``
         once per allocated storage type. Safe to call multiple times: after
-        the first call the per-storage buffers are dropped from
+        the first call the per-storage workspace buffers are dropped from
         ``external_workspaces`` and subsequent calls are no-ops. A ``None``
         allocator performs no work but still clears any externally-installed
         workspaces.
@@ -242,13 +240,13 @@ class CompiledDaceProgram:
         """
         self.sdfg_program.finalize()
         if self.external_memory_allocator is not None:
-            for buffer in self.external_workspaces.values():
+            for wsp in self.external_workspaces.values():
                 try:
-                    self.external_memory_allocator.deallocate(buffer)
+                    self.external_memory_allocator.deallocate(wsp)
                 except Exception:
                     warnings.warn(
                         f"Failed to deallocate external workspace "
-                        f"({type(buffer).__name__!r}); it may be leaked.",
+                        f"({type(wsp).__name__!r}); it may be leaked.",
                         stacklevel=1,
                     )
         self.external_workspaces = {}

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -21,9 +21,15 @@ import dace.codegen.compiler as dace_compiler
 import factory
 
 from gt4py._core import definitions as core_defs, locking
+from gt4py.eve import extended_typing as xtyping
 from gt4py.next import common, config, fingerprinting
 from gt4py.next.otf import code_specs, definitions, stages, workflow
 from gt4py.next.otf.compilation import cache as gtx_cache
+from gt4py.next.program_processors.runners.dace.transformations.auto_optimize import (
+    AllocationRequest,
+    Buffer,
+    ExternalMemoryAllocator,
+)
 from gt4py.next.program_processors.runners.dace.workflow import (
     common as gtx_wfdcommon,
     decoration as gtx_wfddecoration,
@@ -59,6 +65,37 @@ def _map_workspace_storage_to_device(storage: dace.StorageType) -> core_defs.Dev
     return device
 
 
+def _validate_external_workspace(
+    storage: dace.StorageType, request: AllocationRequest, buffer: Buffer
+) -> None:
+    """Validate that ``buffer`` satisfies ``request`` for ``storage``.
+
+    Args:
+        storage: SDFG storage type the buffer is being installed for.
+        request: Allocation request that was issued.
+        buffer: Buffer returned by the external allocator.
+
+    Raises:
+        TypeError: If ``buffer`` exposes neither ``__array_interface__`` nor
+            ``__cuda_array_interface__``.
+        ValueError: If ``buffer`` is smaller than ``request.nbytes``.
+    """
+    if not (
+        xtyping.supports_array_interface(buffer) or xtyping.supports_cuda_array_interface(buffer)
+    ):
+        raise TypeError(
+            f"External memory allocator returned {type(buffer).__name__!r} for storage "
+            f"{storage!r}, which does not expose `__array_interface__` or "
+            f"`__cuda_array_interface__`."
+        )
+    nbytes = getattr(buffer, "nbytes", None)
+    if nbytes is not None and nbytes < request.nbytes:
+        raise ValueError(
+            f"External memory allocator returned a buffer of {nbytes} bytes for storage "
+            f"{storage!r}, but at least {request.nbytes} were required."
+        )
+
+
 class CompiledDaceProgram:
     sdfg_program: dace.CompiledSDFG
 
@@ -85,15 +122,15 @@ class CompiledDaceProgram:
     #       never updated.
     csdfg_argv: MutableSequence[Any] | None
     csdfg_init_argv: Sequence[Any] | None
-    external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None
-    external_workspaces: dict[dace.StorageType, Any]
+    external_memory_allocator: ExternalMemoryAllocator | None
+    external_workspaces: dict[dace.StorageType, Buffer]
 
     def __init__(
         self,
         program: dace.CompiledSDFG,
         bind_func_name: str,
         binding_source_code: str,
-        external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None = None,
+        external_memory_allocator: ExternalMemoryAllocator | None = None,
     ):
         self.sdfg_program = program
 
@@ -131,10 +168,26 @@ class CompiledDaceProgram:
                 )
             for storage, required_nbytes in workspace_sizes.items():
                 device = _map_workspace_storage_to_device(storage)
-                workspace = self.external_memory_allocator(required_nbytes, device)
+                request = AllocationRequest(nbytes=required_nbytes, device=device)
+                workspace = self.external_memory_allocator.allocate(request)
+                _validate_external_workspace(storage, request, workspace)
                 self.sdfg_program.set_workspace(storage, workspace)
                 # Keep the workspace buffers alive as long as the compiled program lives.
                 self.external_workspaces[storage] = workspace
+
+    def close(self) -> None:
+        """Release external workspaces.
+
+        Calls ``deallocate`` once per allocated storage type. Safe to call
+        multiple times: after the first call the per-storage buffers are
+        dropped from :pyattr:`external_workspaces` and subsequent calls are
+        no-ops. A ``None`` allocator performs no work but still clears any
+        externally-installed workspaces.
+        """
+        if self.external_memory_allocator is not None:
+            for buffer in self.external_workspaces.values():
+                self.external_memory_allocator.deallocate(buffer)
+        self.external_workspaces = {}
 
     def construct_arguments(self, **kwargs: Any) -> None:
         """
@@ -191,7 +244,7 @@ class DaCeCompilationArtifact:
     binding_source_code: str
     bind_func_name: str
     device_type: core_defs.DeviceType
-    external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None = None
+    external_memory_allocator: ExternalMemoryAllocator | None = None
 
     def load(self) -> stages.ExecutableProgram:
         # TODO(phimuell): Drop ``sdfg_json`` from the artifact once dace
@@ -225,7 +278,7 @@ class DaCeCompiler(
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
-    external_memory_allocator: Callable[[int, core_defs.DeviceType], Any] | None = None
+    external_memory_allocator: ExternalMemoryAllocator | None = None
     add_gpu_trace_markers: bool = dataclasses.field(
         default_factory=lambda: config.ADD_GPU_TRACE_MARKERS
     )

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -78,7 +78,8 @@ def _validate_external_workspace(
     Raises:
         TypeError: If ``buffer`` exposes neither ``__array_interface__`` nor
             ``__cuda_array_interface__``.
-        ValueError: If ``buffer`` is smaller than ``request.nbytes``.
+        ValueError: If ``buffer`` is smaller than ``request.nbytes`` or its
+            base pointer is not aligned to ``request.alignment`` bytes.
     """
     if not (
         xtyping.supports_array_interface(buffer) or xtyping.supports_cuda_array_interface(buffer)
@@ -93,6 +94,22 @@ def _validate_external_workspace(
         raise ValueError(
             f"External memory allocator returned a buffer of {nbytes} bytes for storage "
             f"{storage!r}, but at least {request.nbytes} were required."
+        )
+    # Validate alignment against the base pointer DaCe will hand to the SDFG
+    # (see ``dace.dtypes.array_interface_ptr``). The ``data`` field is
+    # optional on the host array interface; if it is missing the alignment
+    # contract is trust-based and the check is skipped, mirroring ``nbytes``.
+    interface = (
+        getattr(buffer, "__cuda_array_interface__", None)
+        if storage == dace.StorageType.GPU_Global
+        else getattr(buffer, "__array_interface__", None)
+    )
+    data = interface.get("data") if interface is not None else None
+    if data is not None and request.alignment > 1 and data[0] % request.alignment != 0:
+        raise ValueError(
+            f"External memory allocator returned a buffer for storage {storage!r} "
+            f"whose base pointer ({data[0]}) is not aligned to the required "
+            f"{request.alignment} bytes."
         )
 
 
@@ -180,13 +197,24 @@ class CompiledDaceProgram:
 
         Calls ``deallocate`` once per allocated storage type. Safe to call
         multiple times: after the first call the per-storage buffers are
-        dropped from :pyattr:`external_workspaces` and subsequent calls are
+        dropped from ``external_workspaces`` and subsequent calls are
         no-ops. A ``None`` allocator performs no work but still clears any
         externally-installed workspaces.
+
+        Failures during deallocation are surfaced as warnings rather than
+        raised, so that one failing buffer does not prevent the remaining
+        workspaces from being released.
         """
         if self.external_memory_allocator is not None:
             for buffer in self.external_workspaces.values():
-                self.external_memory_allocator.deallocate(buffer)
+                try:
+                    self.external_memory_allocator.deallocate(buffer)
+                except Exception:
+                    warnings.warn(
+                        f"Failed to deallocate external workspace "
+                        f"({type(buffer).__name__!r}); it may be leaked.",
+                        stacklevel=1,
+                    )
         self.external_workspaces = {}
 
     def construct_arguments(self, **kwargs: Any) -> None:

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -226,19 +226,21 @@ class CompiledDaceProgram:
                 # Keep the workspace buffers alive as long as the compiled program lives.
                 self.external_workspaces[storage] = workspace
 
-    def close(self) -> None:
+    def finalize(self) -> None:
         """Release external workspaces.
 
-        Calls ``deallocate`` once per allocated storage type. Safe to call
-        multiple times: after the first call the per-storage buffers are
-        dropped from ``external_workspaces`` and subsequent calls are
-        no-ops. A ``None`` allocator performs no work but still clears any
-        externally-installed workspaces.
+        Finalizes the underlying ``sdfg_program`` and calls ``deallocate``
+        once per allocated storage type. Safe to call multiple times: after
+        the first call the per-storage buffers are dropped from
+        ``external_workspaces`` and subsequent calls are no-ops. A ``None``
+        allocator performs no work but still clears any externally-installed
+        workspaces.
 
         Failures during deallocation are surfaced as warnings rather than
         raised, so that one failing buffer does not prevent the remaining
         workspaces from being released.
         """
+        self.sdfg_program.finalize()
         if self.external_memory_allocator is not None:
             for buffer in self.external_workspaces.values():
                 try:
@@ -320,7 +322,7 @@ class DaCeCompilationArtifact:
             self.binding_source_code,
             external_memory_allocator=self.external_memory_allocator,
         )
-        return gtx_wfddecoration.convert_args(program, device=self.device_type)
+        return gtx_wfddecoration.DaCeDecoratedProgram(program, device_type=self.device_type)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -12,6 +12,7 @@ import dataclasses
 import json
 import os
 import pathlib
+import pickle
 import warnings
 from collections.abc import Callable, MutableSequence, Sequence
 from typing import Any, Final
@@ -37,6 +38,39 @@ from gt4py.next.program_processors.runners.dace.workflow import (
 
 
 _COMPILE_COMPLETE_MARKER: Final = ".gt4py_compile_complete"
+
+
+class AllocatorNotPicklableError(TypeError):
+    """Raised when an ``external_memory_allocator`` cannot be pickled.
+
+    The allocator is part of the compilation artifact and is pickled when
+    compilation is offloaded to a worker process. Allocators that can not be
+    pickled -- typically closures, lambdas, or classes defined inside a
+    function -- would otherwise degrade silently to in-process compilation
+    via a generic runner warning. This error surfaces the contract failure
+    early, at backend construction, with the original :mod:`pickle` error
+    chained as ``__cause__``.
+    """
+
+
+def _assert_allocator_picklable(allocator: ExternalMemoryAllocator) -> None:
+    """Fail fast if ``allocator`` is not picklable.
+
+    Args:
+        allocator: The allocator to probe; must not be ``None``.
+
+    Raises:
+        AllocatorNotPicklableError: If ``pickle.dumps(allocator)`` raises.
+    """
+    try:
+        pickle.dumps(allocator)
+    except Exception as error:  # pickle raises arbitrary exceptions
+        raise AllocatorNotPicklableError(
+            f"external_memory_allocator {allocator!r} is not picklable: {error!s}."
+            " The allocator is part of the compilation artifact and is pickled"
+            " when compilation is offloaded to a worker process. Use a"
+            " module-level class or functools.partial of picklable callables."
+        ) from error
 
 
 def _add_tx_markers(sdfg: dace.SDFG) -> None:
@@ -306,6 +340,10 @@ class DaCeCompiler(
     bind_func_name: str
     cache_lifetime: config.BuildCacheLifetime
     device_type: core_defs.DeviceType
+    #: Allocator providing external workspace memory when
+    #: ``transient_memory_mode`` is ``EXTERNAL``. Must be picklable (a
+    #: module-level class or :py:func:`functools.partial` of picklable
+    #: callables is recommended); probed at construction time.
     external_memory_allocator: ExternalMemoryAllocator | None = None
     add_gpu_trace_markers: bool = dataclasses.field(
         default_factory=lambda: config.ADD_GPU_TRACE_MARKERS
@@ -317,6 +355,13 @@ class DaCeCompiler(
     dace_config_nondefaults: dict[str, Any] = dataclasses.field(init=False)
 
     def __post_init__(self) -> None:
+        # The allocator is part of the compilation artifact and is pickled
+        # when compilation is offloaded to a worker process. Probe it here,
+        # at backend construction, so a non-picklable allocator (closure,
+        # lambda, local class) fails fast with an actionable error instead
+        # of silently degrading to in-process compilation.
+        if self.external_memory_allocator is not None:
+            _assert_allocator_picklable(self.external_memory_allocator)
         with gtx_wfdcommon.dace_context(
             device_type=self.device_type,
             cmake_build_type=self.cmake_build_type,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
@@ -79,4 +79,12 @@ def convert_args(
         if collect_time:
             metrics.add_sample_to_current_source(metrics.COMPUTE_METRIC, collect_time_arg[0].item())
 
+    # Forward teardown to the underlying ``CompiledDaceProgram`` so that the
+    # generic otf pool -- which only sees this closure -- can release
+    # external-memory workspaces when the pool is finalized.
+    def close() -> None:
+        fun.close()
+
+    decorated_program.close = close  # type: ignore[attr-defined]
+
     return decorated_program

--- a/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/decoration.py
@@ -16,7 +16,6 @@ import numpy as np
 from gt4py._core import definitions as core_defs
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.instrumentation import metrics
-from gt4py.next.otf import stages
 from gt4py.next.program_processors.runners.dace import sdfg_callable
 from gt4py.next.program_processors.runners.dace.workflow import common as gtx_wfdcommon
 
@@ -26,21 +25,35 @@ if TYPE_CHECKING:
     from gt4py.next.program_processors.runners.dace.workflow.compilation import CompiledDaceProgram
 
 
-def convert_args(
-    fun: CompiledDaceProgram,
-    device: core_defs.DeviceType = core_defs.DeviceType.CPU,
-) -> stages.ExecutableProgram:
-    # Retieve metrics level from GT4Py environment variable.
-    collect_time = metrics.is_level_enabled(metrics.PERFORMANCE)
-    collect_time_arg = np.array(
-        [1], dtype=gtx_wfdcommon.SDFG_ARG_METRIC_COMPUTE_TIME_DTYPE.as_numpy_dtype()
-    )
-    # We use the callback function provided by the compiled program to update the SDFG arglist.
-    update_sdfg_call_args = functools.partial(
-        fun.update_sdfg_ctype_arglist, device, fun.sdfg_argtypes
-    )
+class DaCeDecoratedProgram:
+    """A compiled DaCe program wrapped as a GT4Py-callable ``ExecutableProgram``.
 
-    def decorated_program(
+    On the first call the full SDFG argument vector is constructed via
+    ``CompiledDaceProgram.construct_arguments``; subsequent calls only update
+    the argument vector in place through the binding function generated for the
+    program. Teardown is forwarded to the underlying ``CompiledDaceProgram``
+    so that the generic otf pool -- which only sees this callable -- can
+    release external-memory workspaces when the pool is finalized.
+    """
+
+    def __init__(
+        self,
+        fun: CompiledDaceProgram,
+        device_type: core_defs.DeviceType = core_defs.DeviceType.CPU,
+    ) -> None:
+        self._fun = fun
+        # Retrieve metrics level from GT4Py environment variable.
+        self._collect_time = metrics.is_level_enabled(metrics.PERFORMANCE)
+        self._collect_time_arg = np.array(
+            [1], dtype=gtx_wfdcommon.SDFG_ARG_METRIC_COMPUTE_TIME_DTYPE.as_numpy_dtype()
+        )
+        # We use the callback function provided by the compiled program to update the SDFG arglist.
+        self._update_sdfg_call_args = functools.partial(
+            fun.update_sdfg_ctype_arglist, device_type, fun.sdfg_argtypes
+        )
+
+    def __call__(
+        self,
         *args: Any,
         offset_provider: gtx_common.OffsetProvider,
         out: Any = None,
@@ -55,36 +68,36 @@ def convert_args(
             #   `fun.csdfg_args` is `None`
             # TODO(phimuell, edopao): Think about refactor the code such that the update
             #   of the argument vector is a Method of the `CompiledDaceProgram`.
-            update_sdfg_call_args(args, fun.csdfg_argv, offset_provider)  # type: ignore[arg-type]  # Will error out in first call.
+            self._update_sdfg_call_args(args, self._fun.csdfg_argv, offset_provider)  # type: ignore[arg-type]  # Will error out in first call.
 
         except TypeError:
             # First call. Construct the initial argument vector of the `CompiledDaceProgram`.
-            assert fun.csdfg_argv is None and fun.csdfg_init_argv is None
+            assert self._fun.csdfg_argv is None and self._fun.csdfg_init_argv is None
             flat_args: Sequence[Any] = gtx_utils.flatten_nested_tuple(args)
             this_call_args = sdfg_callable.get_sdfg_args(
-                fun.sdfg_program.sdfg,
+                self._fun.sdfg_program.sdfg,
                 offset_provider,
                 *flat_args,
                 filter_args=False,
             )
             this_call_args |= {
                 gtx_wfdcommon.SDFG_ARG_METRIC_LEVEL: metrics.get_current_level(),
-                gtx_wfdcommon.SDFG_ARG_METRIC_COMPUTE_TIME: collect_time_arg,
+                gtx_wfdcommon.SDFG_ARG_METRIC_COMPUTE_TIME: self._collect_time_arg,
             }
-            fun.construct_arguments(**this_call_args)
+            self._fun.construct_arguments(**this_call_args)
 
         # Perform the call to the SDFG.
-        fun.fast_call()
+        self._fun.fast_call()
 
-        if collect_time:
-            metrics.add_sample_to_current_source(metrics.COMPUTE_METRIC, collect_time_arg[0].item())
+        if self._collect_time:
+            metrics.add_sample_to_current_source(
+                metrics.COMPUTE_METRIC, self._collect_time_arg[0].item()
+            )
 
-    # Forward teardown to the underlying ``CompiledDaceProgram`` so that the
-    # generic otf pool -- which only sees this closure -- can release
-    # external-memory workspaces when the pool is finalized.
-    def close() -> None:
-        fun.close()
+    def finalize(self) -> None:
+        """Forward teardown to the underlying ``CompiledDaceProgram``.
 
-    decorated_program.close = close  # type: ignore[attr-defined]
-
-    return decorated_program
+        Allows the generic otf pool -- which only sees this callable -- to
+        release external-memory workspaces when the pool is finalized.
+        """
+        self._fun.finalize()

--- a/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
@@ -316,53 +316,53 @@ def test_metrics_source_key_finalizer_removes_cache_entry_when_pool_is_deleted()
     ctx.run(test_f)
 
 
-class _CloseableProgram:
-    """Minimal stand-in for a backend compiled program exposing ``close()``."""
+class _FinalizableProgram:
+    """Minimal stand-in for a backend compiled program exposing ``finalize()``."""
 
     def __init__(self) -> None:
-        self.close_count = 0
+        self.finalize_count = 0
 
-    def close(self) -> None:
-        self.close_count += 1
+    def finalize(self) -> None:
+        self.finalize_count += 1
 
 
-class _FailingCloseProgram:
-    def close(self) -> None:
+class _FailingFinalizeProgram:
+    def finalize(self) -> None:
         raise RuntimeError("teardown blew up")
 
 
-def test_close_compiled_programs_calls_close_on_each_value():
-    a = _CloseableProgram()
-    b = _CloseableProgram()
+def test_finalize_compiled_programs_calls_finalize_on_each_value():
+    a = _FinalizableProgram()
+    b = _FinalizableProgram()
     programs = {("a",): a, ("b",): b}
 
-    compiled_program._close_compiled_programs(programs)
+    compiled_program._finalize_compiled_programs(programs)
 
-    assert a.close_count == 1
-    assert b.close_count == 1
+    assert a.finalize_count == 1
+    assert b.finalize_count == 1
 
 
-def test_close_compiled_programs_skips_programs_without_close():
-    class _NoClose:
+def test_finalize_compiled_programs_skips_programs_without_finalize():
+    class _NoFinalize:
         pass
 
-    programs = {("a",): _NoClose(), ("b",): _CloseableProgram()}
-    compiled_program._close_compiled_programs(programs)  # must not raise on _NoClose
+    programs = {("a",): _NoFinalize(), ("b",): _FinalizableProgram()}
+    compiled_program._finalize_compiled_programs(programs)  # must not raise on _NoFinalize
 
 
-def test_close_compiled_programs_surfaces_close_failures_as_warnings():
-    programs = {("a",): _FailingCloseProgram(), ("b",): _CloseableProgram()}
+def test_finalize_compiled_programs_surfaces_finalize_failures_as_warnings():
+    programs = {("a",): _FailingFinalizeProgram(), ("b",): _FinalizableProgram()}
     ok = programs[("b",)]
 
     with pytest.warns(UserWarning, match="raised during pool teardown"):
-        compiled_program._close_compiled_programs(programs)
+        compiled_program._finalize_compiled_programs(programs)
 
     # A failing program does not stop teardown of the rest.
-    assert ok.close_count == 1
+    assert ok.finalize_count == 1
 
 
-def test_pool_finalizer_closes_compiled_programs_when_pool_is_deleted():
-    """A program held in ``CompiledProgramsPool.compiled_programs`` is closed
+def test_pool_finalizer_finalizes_compiled_programs_when_pool_is_deleted():
+    """A program held in ``CompiledProgramsPool.compiled_programs`` is finalized
     when the pool is garbage-collected, so backends that own external
     resources release them."""
     # ``CompiledProgramsPool.__post_init__`` validates its (heavy)
@@ -372,9 +372,9 @@ def test_pool_finalizer_closes_compiled_programs_when_pool_is_deleted():
     # helper production uses.
     pool = compiled_program.CompiledProgramsPool.__new__(compiled_program.CompiledProgramsPool)
     pool.compiled_programs = {}
-    weakref.finalize(pool, compiled_program._close_compiled_programs, pool.compiled_programs)
+    weakref.finalize(pool, compiled_program._finalize_compiled_programs, pool.compiled_programs)
 
-    program = _CloseableProgram()
+    program = _FinalizableProgram()
     pool.compiled_programs[("only",)] = program
 
     pool_ref = weakref.ref(pool)
@@ -382,4 +382,4 @@ def test_pool_finalizer_closes_compiled_programs_when_pool_is_deleted():
     gc.collect()
 
     assert pool_ref() is None
-    assert program.close_count == 1
+    assert program.finalize_count == 1

--- a/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
@@ -314,3 +314,72 @@ def test_metrics_source_key_finalizer_removes_cache_entry_when_pool_is_deleted()
             compiled_program._pools_per_root = _pools_per_root
 
     ctx.run(test_f)
+
+
+class _CloseableProgram:
+    """Minimal stand-in for a backend compiled program exposing ``close()``."""
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+class _FailingCloseProgram:
+    def close(self) -> None:
+        raise RuntimeError("teardown blew up")
+
+
+def test_close_compiled_programs_calls_close_on_each_value():
+    a = _CloseableProgram()
+    b = _CloseableProgram()
+    programs = {("a",): a, ("b",): b}
+
+    compiled_program._close_compiled_programs(programs)
+
+    assert a.close_count == 1
+    assert b.close_count == 1
+
+
+def test_close_compiled_programs_skips_programs_without_close():
+    class _NoClose:
+        pass
+
+    programs = {("a",): _NoClose(), ("b",): _CloseableProgram()}
+    compiled_program._close_compiled_programs(programs)  # must not raise on _NoClose
+
+
+def test_close_compiled_programs_surfaces_close_failures_as_warnings():
+    programs = {("a",): _FailingCloseProgram(), ("b",): _CloseableProgram()}
+    ok = programs[("b",)]
+
+    with pytest.warns(UserWarning, match="raised during pool teardown"):
+        compiled_program._close_compiled_programs(programs)
+
+    # A failing program does not stop teardown of the rest.
+    assert ok.close_count == 1
+
+
+def test_pool_finalizer_closes_compiled_programs_when_pool_is_deleted():
+    """A program held in ``CompiledProgramsPool.compiled_programs`` is closed
+    when the pool is garbage-collected, so backends that own external
+    resources release them."""
+    # ``CompiledProgramsPool.__post_init__`` validates its (heavy)
+    # constructor arguments, which is irrelevant to teardown. Install the
+    # live ``compiled_programs`` dict by hand and register the same
+    # finalizer ``__post_init__`` would -- this is exactly the field and
+    # helper production uses.
+    pool = compiled_program.CompiledProgramsPool.__new__(compiled_program.CompiledProgramsPool)
+    pool.compiled_programs = {}
+    weakref.finalize(pool, compiled_program._close_compiled_programs, pool.compiled_programs)
+
+    program = _CloseableProgram()
+    pool.compiled_programs[("only",)] = program
+
+    pool_ref = weakref.ref(pool)
+    del pool
+    gc.collect()
+
+    assert pool_ref() is None
+    assert program.close_count == 1

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
@@ -9,29 +9,28 @@
 """Test the bindings stage of the dace backend workflow."""
 
 import re
+import unittest.mock as mock
 
 import numpy as np
 import pytest
-import unittest.mock as mock
+
 
 dace = pytest.importorskip("dace")
 
 from gt4py import next as gtx
 from gt4py._core import definitions as core_defs
+from gt4py.next import config
 from gt4py.next.otf import runners
 from gt4py.next.program_processors.runners.dace import transformations as gtx_transformations
-from gt4py.next.program_processors.runners.dace.workflow import (
-    backend as dace_wf_backend,
-)
-from gt4py.next.program_processors.runners.dace.workflow import (
-    translation as gtx_dace_translation,
-)
 from gt4py.next.program_processors.runners.dace.transformations import (
     auto_optimize as gtx_auto_optimize,
 )
+from gt4py.next.program_processors.runners.dace.workflow import (
+    backend as dace_wf_backend,
+    translation as gtx_dace_translation,
+)
 
-from next_tests.integration_tests import cases
-from next_tests.integration_tests import cases_utils
+from next_tests.integration_tests import cases, cases_utils
 from next_tests.integration_tests.cases_utils import KDim
 
 
@@ -160,8 +159,23 @@ def test_make_backend(auto_optimize, device_type, monkeypatch):
         mock_top_level_dataflow_hook2.assert_not_called()
 
 
+class _RecordingAllocator:
+    """Minimal `ExternalMemoryAllocator` for backend-wiring tests.
+
+    Only the identity of the allocator matters here (it is threaded through
+    to ``executor.compilation.external_memory_allocator``); ``allocate`` is
+    never called by these tests.
+    """
+
+    def allocate(self, request: gtx_auto_optimize.AllocationRequest):
+        raise AssertionError("backend-wiring tests must not call allocate")
+
+    def deallocate(self, buffer) -> None:
+        raise AssertionError("backend-wiring tests must not call deallocate")
+
+
 def test_make_backend_accepts_external_allocator_with_external_mode():
-    external_memory_allocator = lambda size, storage: bytearray(size)
+    external_memory_allocator = _RecordingAllocator()
 
     backend = dace_wf_backend.make_dace_backend(
         gpu=False,
@@ -177,7 +191,7 @@ def test_make_backend_accepts_external_allocator_with_external_mode():
 
 
 def test_make_backend_infers_external_mode_when_allocator_is_provided():
-    external_memory_allocator = lambda size, storage: bytearray(size)
+    external_memory_allocator = _RecordingAllocator()
 
     backend = dace_wf_backend.make_dace_backend(
         gpu=False,
@@ -194,7 +208,7 @@ def test_make_backend_infers_external_mode_when_allocator_is_provided():
 
 
 def test_make_backend_warns_external_allocator_without_external_mode():
-    external_memory_allocator = lambda size, storage: bytearray(size)
+    external_memory_allocator = _RecordingAllocator()
 
     with pytest.warns(UserWarning, match="External memory allocator provided"):
         backend = dace_wf_backend.make_dace_backend(
@@ -213,6 +227,29 @@ def test_make_backend_warns_external_allocator_without_external_mode():
         == gtx_transformations.TransientMemoryMode.POOL
     )
     assert backend.executor.compilation.external_memory_allocator is external_memory_allocator
+
+
+class _WorkspaceRecordingAllocator:
+    """Minimal picklable `ExternalMemoryAllocator` that records every request.
+
+    Allocations are recorded as ``(nbytes, device)`` tuples in ``requests``;
+    ``deallocate`` is a no-op. Defined at module scope so the allocator can
+    be pickled when compilation is dispatched to a worker process.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[int, core_defs.DeviceType]] = []
+
+    def allocate(self, request: gtx_auto_optimize.AllocationRequest):
+        self.requests.append((request.nbytes, request.device))
+        if request.device == core_defs.CUPY_DEVICE_TYPE:
+            import cupy as cp
+
+            return cp.empty((request.nbytes,), dtype=cp.uint8)
+        return np.empty((request.nbytes,), dtype=np.uint8)
+
+    def deallocate(self, buffer) -> None:
+        pass
 
 
 def _parse_generated_code_from_sdfg(sdfg: dace.SDFG, gpu_api_prefix: str) -> str:
@@ -252,15 +289,14 @@ def test_transient_memory_mode(device_type, transient_memory_mode, monkeypatch):
     gpu_malloc_async_marker = f"{gpu_api_prefix}MallocAsync("
     gpu_free_marker = f"{gpu_api_prefix}Free("
     gpu_free_async_marker = f"{gpu_api_prefix}FreeAsync("
-    workspace_requests: list[tuple[int, core_defs.DeviceType]] = []
+    external_memory_allocator = _WorkspaceRecordingAllocator()
+    workspace_requests = external_memory_allocator.requests
 
-    def external_memory_allocator(required_nbytes: int, device: core_defs.DeviceType):
-        workspace_requests.append((required_nbytes, device))
-        if device == core_defs.CUPY_DEVICE_TYPE:
-            import cupy as cp
-
-            return cp.empty((required_nbytes,), dtype=cp.uint8)
-        return np.empty((required_nbytes,), dtype=np.uint8)
+    # ``_WorkspaceRecordingAllocator`` is picklable (a module-level class),
+    # so compilation would otherwise be dispatched to a worker process where
+    # the ``DaCeTranslator.generate_sdfg`` monkeypatch below does not apply.
+    # Force in-process compilation so the patched translator is observed.
+    monkeypatch.setattr(config, "BUILD_JOBS_MODE", config.BuildJobsMode.SERIAL)
 
     @gtx.field_operator
     def testee_op(a: cases.IField, b: cases.IField) -> cases.IField:

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
@@ -241,12 +241,22 @@ class _WorkspaceRecordingAllocator:
         self.requests: list[tuple[int, core_defs.DeviceType]] = []
 
     def allocate(self, request: gtx_auto_optimize.AllocationRequest):
+        # Overallocate by `request.alignment - 1` bytes and slices forward to the
+        # nearest aligned boundary, using `request.alignment` directly. This makes
+        # the returned buffer deterministically aligned to the requested value
+        # (256 by default) for any workspace size — both host (`__array_interface__`)
+        # and device (`__cuda_array_interface__`) paths.
         self.requests.append((request.nbytes, request.device))
         if request.device == core_defs.CUPY_DEVICE_TYPE:
             import cupy as cp
 
-            return cp.empty((request.nbytes,), dtype=cp.uint8)
-        return np.empty((request.nbytes,), dtype=np.uint8)
+            raw = cp.empty(request.nbytes + request.alignment - 1, dtype=cp.uint8)
+            offset = (-raw.__cuda_array_interface__["data"][0]) % request.alignment
+            return raw[offset : offset + request.nbytes]
+
+        raw = np.empty(request.nbytes + request.alignment - 1, dtype=np.uint8)
+        offset = (-raw.__array_interface__["data"][0]) % request.alignment
+        return raw[offset : offset + request.nbytes]
 
     def deallocate(self, buffer) -> None:
         pass

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -21,6 +21,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+
 dace = pytest.importorskip("dace")
 
 from dace.sdfg import nodes as dace_nodes
@@ -29,6 +30,9 @@ from gt4py._core import definitions as core_defs
 from gt4py.next import config
 from gt4py.next.otf import code_specs, stages
 from gt4py.next.otf.binding import interface
+from gt4py.next.program_processors.runners.dace.transformations import (
+    auto_optimize as gtx_auto_optimize,
+)
 from gt4py.next.program_processors.runners.dace.workflow import compilation as dace_wf_compilation
 
 
@@ -260,7 +264,8 @@ def _make_compiled_program(
 
 
 def test_construct_arguments_installs_external_workspaces_once():
-    allocator = mock.MagicMock(side_effect=[np.empty((128,), dtype=np.uint8)])
+    allocator = mock.MagicMock()
+    allocator.allocate.side_effect = [np.empty((128,), dtype=np.uint8)]
     program = _make_compiled_program(
         external_memory_allocator=allocator,
         workspace_sizes={dace.StorageType.CPU_Heap: 128},
@@ -272,8 +277,11 @@ def test_construct_arguments_installs_external_workspaces_once():
     # Workspace configuration is done exactly once and reused afterwards.
     assert program.sdfg_program.initialize.call_count == 1
     assert program.sdfg_program.get_workspace_sizes.call_count == 1
-    assert allocator.call_count == 1
-    allocator.assert_called_once_with(128, core_defs.DeviceType.CPU)
+    assert allocator.allocate.call_count == 1
+    allocate_request = allocator.allocate.call_args.args[0]
+    assert isinstance(allocate_request, gtx_auto_optimize.AllocationRequest)
+    assert allocate_request.nbytes == 128
+    assert allocate_request.device == core_defs.DeviceType.CPU
     assert program.sdfg_program.set_workspace.call_count == 1
     assert program.sdfg_program.construct_arguments.call_count == 2
 
@@ -284,7 +292,8 @@ def test_construct_arguments_installs_external_workspaces_once():
 
 
 def test_construct_arguments_propagates_allocator_error_for_invalid_size_request():
-    allocator = mock.MagicMock(side_effect=ValueError("invalid workspace size request"))
+    allocator = mock.MagicMock()
+    allocator.allocate.side_effect = ValueError("invalid workspace size request")
     program = _make_compiled_program(
         external_memory_allocator=allocator,
         workspace_sizes={dace.StorageType.CPU_Heap: -1},
@@ -293,12 +302,15 @@ def test_construct_arguments_propagates_allocator_error_for_invalid_size_request
     with pytest.raises(ValueError, match="invalid workspace size request"):
         program.construct_arguments(alpha=1)
 
-    allocator.assert_called_once_with(-1, core_defs.DeviceType.CPU)
+    allocator.allocate.assert_called_once()
+    assert allocator.allocate.call_args.args[0].nbytes == -1
+    assert allocator.allocate.call_args.args[0].device == core_defs.DeviceType.CPU
     program.sdfg_program.set_workspace.assert_not_called()
 
 
 def test_construct_arguments_propagates_allocator_error_for_invalid_storage_request():
-    allocator = mock.MagicMock(side_effect=TypeError("invalid storage type request"))
+    allocator = mock.MagicMock()
+    allocator.allocate.side_effect = TypeError("invalid storage type request")
     program = _make_compiled_program(
         external_memory_allocator=allocator,
         workspace_sizes={dace.StorageType.CPU_Heap: 16},
@@ -307,5 +319,52 @@ def test_construct_arguments_propagates_allocator_error_for_invalid_storage_requ
     with pytest.raises(TypeError, match="invalid storage type request"):
         program.construct_arguments(alpha=1)
 
-    allocator.assert_called_once_with(16, core_defs.DeviceType.CPU)
+    allocator.allocate.assert_called_once()
+    assert allocator.allocate.call_args.args[0].nbytes == 16
+    assert allocator.allocate.call_args.args[0].device == core_defs.DeviceType.CPU
     program.sdfg_program.set_workspace.assert_not_called()
+
+
+def test_construct_arguments_rejects_buffer_without_array_interface():
+    """The allocator must return something ``set_workspace`` can consume."""
+    allocator = mock.MagicMock()
+    allocator.allocate.side_effect = ["not-an-array"]  # str exposes no array interface
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={dace.StorageType.CPU_Heap: 64},
+    )
+
+    with pytest.raises(TypeError, match="does not expose `__array_interface__`"):
+        program.construct_arguments(alpha=1)
+
+    program.sdfg_program.set_workspace.assert_not_called()
+
+
+def test_close_calls_deallocate_once_per_storage():
+    """``close()`` releases each workspace exactly once and is idempotent."""
+    allocator = mock.MagicMock()
+    workspace = np.empty((128,), dtype=np.uint8)
+    allocator.allocate.side_effect = [workspace]
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={dace.StorageType.CPU_Heap: 128},
+    )
+
+    program.construct_arguments(alpha=1)
+
+    program.close()
+    assert allocator.deallocate.call_count == 1
+    assert allocator.deallocate.call_args.args[0] is workspace
+    assert program.external_workspaces == {}
+    # close() is idempotent.
+    program.close()
+    assert allocator.deallocate.call_count == 1
+
+
+def test_close_with_no_allocator_is_a_safe_noop():
+    """A ``None`` allocator performs no work but still clears workspaces."""
+    program = _make_compiled_program(external_memory_allocator=None)
+
+    # close() must not raise even though no allocator is configured.
+    program.close()
+    assert program.external_workspaces == {}

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -265,7 +265,7 @@ def _make_compiled_program(
 
 def test_construct_arguments_installs_external_workspaces_once():
     allocator = mock.MagicMock()
-    allocator.allocate.side_effect = [np.empty((128,), dtype=np.uint8)]
+    allocator.allocate.side_effect = [_make_array_buffer(nbytes=128, address=256)]
     program = _make_compiled_program(
         external_memory_allocator=allocator,
         workspace_sizes={dace.StorageType.CPU_Heap: 128},
@@ -325,6 +325,21 @@ def test_construct_arguments_propagates_allocator_error_for_invalid_storage_requ
     program.sdfg_program.set_workspace.assert_not_called()
 
 
+def _make_array_buffer(*, nbytes: int, address: int, cuda: bool = False) -> mock.MagicMock:
+    """A minimal array-like buffer with a configurable base pointer.
+
+    Exposes ``__array_interface__`` (host) or ``__cuda_array_interface__``
+    (device) so it is accepted by ``_validate_external_workspace``; the
+    ``data`` tuple carries the address that DaCe's ``array_interface_ptr``
+    would hand to the SDFG.
+    """
+    buffer = mock.MagicMock()
+    buffer.nbytes = nbytes
+    interface = {"data": (address, False), "shape": (nbytes,), "typestr": "|u1", "version": 3}
+    setattr(buffer, "__cuda_array_interface__" if cuda else "__array_interface__", interface)
+    return buffer
+
+
 def test_construct_arguments_rejects_buffer_without_array_interface():
     """The allocator must return something ``set_workspace`` can consume."""
     allocator = mock.MagicMock()
@@ -340,10 +355,80 @@ def test_construct_arguments_rejects_buffer_without_array_interface():
     program.sdfg_program.set_workspace.assert_not_called()
 
 
+def test_construct_arguments_rejects_misaligned_buffer():
+    """A host buffer whose base pointer is not aligned is rejected."""
+    allocator = mock.MagicMock()
+    allocator.allocate.side_effect = [_make_array_buffer(nbytes=128, address=100)]  # 100 % 256
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={dace.StorageType.CPU_Heap: 128},
+    )
+
+    with pytest.raises(ValueError, match="not aligned to the required 256 bytes"):
+        program.construct_arguments(alpha=1)
+
+    program.sdfg_program.set_workspace.assert_not_called()
+
+
+def test_construct_arguments_accepts_aligned_buffer():
+    """A host buffer whose base pointer is aligned is accepted."""
+    allocator = mock.MagicMock()
+    workspace = _make_array_buffer(nbytes=128, address=1024)  # 1024 % 256 == 0
+    allocator.allocate.side_effect = [workspace]
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={dace.StorageType.CPU_Heap: 128},
+    )
+
+    program.construct_arguments(alpha=1)
+
+    program.sdfg_program.set_workspace.assert_called_once()
+    assert program.external_workspaces[dace.StorageType.CPU_Heap] is workspace
+
+
+def test_construct_arguments_rejects_misaligned_gpu_buffer():
+    """A device buffer whose base pointer is not aligned is rejected."""
+    allocator = mock.MagicMock()
+    allocator.allocate.side_effect = [_make_array_buffer(nbytes=128, address=100, cuda=True)]
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={dace.StorageType.GPU_Global: 128},
+    )
+
+    with (
+        mock.patch.object(
+            dace_wf_compilation.core_defs, "CUPY_DEVICE_TYPE", core_defs.DeviceType.CUDA
+        ),
+        pytest.raises(ValueError, match="not aligned to the required 256 bytes"),
+    ):
+        program.construct_arguments(alpha=1)
+
+    program.sdfg_program.set_workspace.assert_not_called()
+
+
+def test_construct_arguments_skips_alignment_when_data_missing():
+    """When the array interface omits ``data`` alignment is trust-based."""
+    allocator = mock.MagicMock()
+    buffer = mock.MagicMock()
+    buffer.nbytes = 64
+    # ``data`` is optional on the host array interface.
+    buffer.__array_interface__ = {"shape": (64,), "typestr": "|u1", "version": 3}
+    allocator.allocate.side_effect = [buffer]
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={dace.StorageType.CPU_Heap: 64},
+    )
+
+    # Must not raise even though alignment can't be verified.
+    program.construct_arguments(alpha=1)
+
+    program.sdfg_program.set_workspace.assert_called_once()
+
+
 def test_close_calls_deallocate_once_per_storage():
     """``close()`` releases each workspace exactly once and is idempotent."""
     allocator = mock.MagicMock()
-    workspace = np.empty((128,), dtype=np.uint8)
+    workspace = _make_array_buffer(nbytes=128, address=256)
     allocator.allocate.side_effect = [workspace]
     program = _make_compiled_program(
         external_memory_allocator=allocator,
@@ -359,6 +444,42 @@ def test_close_calls_deallocate_once_per_storage():
     # close() is idempotent.
     program.close()
     assert allocator.deallocate.call_count == 1
+
+
+def test_close_continues_and_is_idempotent_when_deallocate_fails():
+    """If one ``deallocate`` raises, the remaining workspaces are still released.
+
+    A failing buffer must not prevent the others from being deallocated, and
+    ``external_workspaces`` must still be cleared so a subsequent ``close()``
+    (e.g. the pool finalizer) is a no-op rather than re-deallocating the
+    buffers that already succeeded.
+    """
+    allocator = mock.MagicMock()
+    workspace_a = _make_array_buffer(nbytes=16, address=256)  # aligned for CPU
+    workspace_b = _make_array_buffer(nbytes=32, address=512, cuda=True)  # aligned for GPU
+    allocator.allocate.side_effect = [workspace_a, workspace_b]
+    program = _make_compiled_program(
+        external_memory_allocator=allocator,
+        workspace_sizes={
+            dace.StorageType.CPU_Heap: 16,
+            dace.StorageType.GPU_Global: 32,
+        },
+    )
+    with mock.patch.object(
+        dace_wf_compilation.core_defs, "CUPY_DEVICE_TYPE", core_defs.DeviceType.CUDA
+    ):
+        program.construct_arguments(alpha=1)
+    # The first deallocate raises; the second must still be called.
+    allocator.deallocate.side_effect = [RuntimeError("boom"), None]
+
+    with pytest.warns(UserWarning, match="Failed to deallocate"):
+        program.close()
+
+    assert allocator.deallocate.call_count == 2
+    assert program.external_workspaces == {}
+    # close() is idempotent even after partial failures.
+    program.close()
+    assert allocator.deallocate.call_count == 2
 
 
 def test_close_with_no_allocator_is_a_safe_noop():

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -13,6 +13,7 @@ Covers the GPU TX-marker instrumentation and the picklability of
 """
 
 import contextlib
+import dataclasses
 import pathlib
 import pickle
 import unittest.mock as mock
@@ -489,3 +490,92 @@ def test_close_with_no_allocator_is_a_safe_noop():
     # close() must not raise even though no allocator is configured.
     program.close()
     assert program.external_workspaces == {}
+
+
+# --- Phase 5: allocator pickleability -------------------------------------
+#
+# ``DaCeCompiler`` is the step that gets pickled when the OTF runner offloads
+# compilation to a ``ProcessPoolExecutor`` (``otf/runners.py``), and it carries
+# the ``external_memory_allocator``. A non-picklable allocator (closure,
+# lambda, local class) must fail fast at construction with
+# ``AllocatorNotPicklableError`` rather than silently degrading to in-process
+# compilation via a generic runner warning.
+
+
+@dataclasses.dataclass(frozen=True)
+class _ModuleLevelPicklableAllocator:
+    """A picklable allocator defined at module scope.
+
+    ``allocate``/``deallocate`` are never called by the tests below; only the
+    type's picklability and identity through a round-trip matter. Defined at
+    module scope (not inside a test) so ``pickle`` can locate it by qualname.
+    Frozen with no fields so two instances are structurally equal, mirroring
+    a stateless allocator and the frozenness of ``DaCeCompilationArtifact``.
+    """
+
+    def allocate(self, request: gtx_auto_optimize.AllocationRequest):
+        raise AssertionError("pickleability tests must not call allocate")
+
+    def deallocate(self, buffer) -> None:
+        raise AssertionError("pickleability tests must not call deallocate")
+
+
+def _make_compiler(allocator=None) -> dace_wf_compilation.DaCeCompiler:
+    return dace_wf_compilation.DaCeCompiler(
+        bind_func_name="bind",
+        cache_lifetime=config.BuildCacheLifetime.SESSION,
+        device_type=core_defs.DeviceType.CPU,
+        external_memory_allocator=allocator,
+    )
+
+
+def test_dace_compiler_rejects_non_picklable_allocator():
+    """An allocator that can not be pickled fails fast at construction."""
+
+    class _LocalAllocator:  # local class -> not picklable by qualname
+        def allocate(self, request): ...
+
+        def deallocate(self, buffer) -> None: ...
+
+    with pytest.raises(
+        dace_wf_compilation.AllocatorNotPicklableError,
+        match="external_memory_allocator .* is not picklable",
+    ) as excinfo:
+        _make_compiler(allocator=_LocalAllocator())
+
+    # The original pickle error is chained so the user can see *why*.
+    assert isinstance(excinfo.value.__cause__, Exception)
+    assert "Can't pickle" in str(excinfo.value.__cause__)
+
+
+def test_dace_compiler_accepts_picklable_allocator():
+    """A module-level allocator (and the ``None`` default) pass the gate."""
+    # ``None`` default: no probe, no raise.
+    _make_compiler(allocator=None)
+
+    # Module-level class: picklable, no raise.
+    _make_compiler(allocator=_ModuleLevelPicklableAllocator())
+
+
+def test_dace_compilation_artifact_pickle_round_trip_with_allocator(tmp_path: pathlib.Path):
+    """The allocator round-trips through the pickled compilation artifact.
+
+    The existing ``test_dace_compilation_artifact_pickle_round_trip`` covers the
+    no-allocator default; this ensures a real allocator is carried through
+    serialization with identity of intent preserved (structural equality,
+    since the allocator class defines no per-instance state).
+    """
+    allocator = _ModuleLevelPicklableAllocator()
+    artifact = dace_wf_compilation.DaCeCompilationArtifact(
+        library_path=tmp_path / "build" / "libprogram.so",
+        sdfg_json="{}",
+        binding_source_code="def update_sdfg_args(*a, **k): ...",
+        bind_func_name="update_sdfg_args",
+        device_type=core_defs.DeviceType.CPU,
+        external_memory_allocator=allocator,
+    )
+
+    restored = pickle.loads(pickle.dumps(artifact))
+
+    assert restored == artifact
+    assert isinstance(restored.external_memory_allocator, _ModuleLevelPicklableAllocator)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -426,8 +426,8 @@ def test_construct_arguments_skips_alignment_when_data_missing():
     program.sdfg_program.set_workspace.assert_called_once()
 
 
-def test_close_calls_deallocate_once_per_storage():
-    """``close()`` releases each workspace exactly once and is idempotent."""
+def test_finalize_calls_deallocate_once_per_storage():
+    """``finalize()`` releases each workspace exactly once and is idempotent."""
     allocator = mock.MagicMock()
     workspace = _make_array_buffer(nbytes=128, address=256)
     allocator.allocate.side_effect = [workspace]
@@ -438,20 +438,20 @@ def test_close_calls_deallocate_once_per_storage():
 
     program.construct_arguments(alpha=1)
 
-    program.close()
+    program.finalize()
     assert allocator.deallocate.call_count == 1
     assert allocator.deallocate.call_args.args[0] is workspace
     assert program.external_workspaces == {}
-    # close() is idempotent.
-    program.close()
+    # finalize() is idempotent.
+    program.finalize()
     assert allocator.deallocate.call_count == 1
 
 
-def test_close_continues_and_is_idempotent_when_deallocate_fails():
+def test_finalize_continues_and_is_idempotent_when_deallocate_fails():
     """If one ``deallocate`` raises, the remaining workspaces are still released.
 
     A failing buffer must not prevent the others from being deallocated, and
-    ``external_workspaces`` must still be cleared so a subsequent ``close()``
+    ``external_workspaces`` must still be cleared so a subsequent ``finalize()``
     (e.g. the pool finalizer) is a no-op rather than re-deallocating the
     buffers that already succeeded.
     """
@@ -474,21 +474,21 @@ def test_close_continues_and_is_idempotent_when_deallocate_fails():
     allocator.deallocate.side_effect = [RuntimeError("boom"), None]
 
     with pytest.warns(UserWarning, match="Failed to deallocate"):
-        program.close()
+        program.finalize()
 
     assert allocator.deallocate.call_count == 2
     assert program.external_workspaces == {}
-    # close() is idempotent even after partial failures.
-    program.close()
+    # finalize() is idempotent even after partial failures.
+    program.finalize()
     assert allocator.deallocate.call_count == 2
 
 
-def test_close_with_no_allocator_is_a_safe_noop():
+def test_finalize_with_no_allocator_is_a_safe_noop():
     """A ``None`` allocator performs no work but still clears workspaces."""
     program = _make_compiled_program(external_memory_allocator=None)
 
-    # close() must not raise even though no allocator is configured.
-    program.close()
+    # finalize() must not raise even though no allocator is configured.
+    program.finalize()
     assert program.external_workspaces == {}
 
 


### PR DESCRIPTION
This pull request introduces a new "External Memory Allocator" mode for DaCe transients in the `gt4py.next` backend, allowing explicit, caller-managed workspace allocation and teardown. This enables reusing a single workspace buffer across multiple SDFGs, removing per-call allocation overhead and providing more control over memory lifetime. The public API now exposes a typed allocator protocol, and the backend enforces that allocators are picklable to ensure compatibility with process-based compilation. The changes also include explicit pool-driven teardown of resources and improved error handling for allocator pickling.

**External Memory Allocator for DaCe Transients**

*Design and API additions:*
- Added an explicit `EXTERNAL` mode to `TransientMemoryMode`, backed by a caller-supplied `ExternalMemoryAllocator` protocol. This protocol is defined with typed `allocate` and `deallocate` methods and requires picklability. (`[[1]](diffhunk://#diff-b86bd892b20495d184cedc1d9057e4b1ef0e837d723e998628332943d900aa74R1-R147)`, `[[2]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706R117-R178)`, `[[3]](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706L133-R202)`)
- Introduced `AllocationRequest` and `Buffer` type alias to formalize the workspace allocation contract. (`[src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.pyR117-R178](diffhunk://#diff-ddbc0e8ab1d5b89929dfbd12477936ae3acad531911fa9afb125066b6fe74706R117-R178)`)
- Re-exported `AllocationRequest`, `Buffer`, and `ExternalMemoryAllocator` from the `transformations` package for public use. (`[[1]](diffhunk://#diff-c7967b0fa16e0de89cb43f3c81e9aee884122772946f031d50fb31d1cb16215bL16-R19)`, `[[2]](diffhunk://#diff-c7967b0fa16e0de89cb43f3c81e9aee884122772946f031d50fb31d1cb16215bR95-R99)`)

*Backend and resource management:*
- Updated the DaCe backend to accept an `ExternalMemoryAllocator` instance, with improved documentation and type safety. (`[[1]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbL67-R66)`, `[[2]](diffhunk://#diff-04258cb5c4aa36c40ab7da9246c27d69866a707135824bba4f76d46e93de72fbL82-R85)`)
- Added a check to ensure the allocator is picklable at backend construction, raising a clear error if not. (`[src/gt4py/next/program_processors/runners/dace/workflow/compilation.pyR43-R75](diffhunk://#diff-89b749ff9b80be5fdb8a7e0d05411d2b992b6a5892f819c7a3e001c4241a6c0dR43-R75)`)
- Implemented explicit resource teardown: when a `CompiledProgramsPool` is deleted, any compiled programs with a `finalize()` method have it called to release external resources, with warnings on failure. (`[[1]](diffhunk://#diff-cae915aa5b7a62aa4a6eb295978c894fc43270cf6e08e82fca56414bf37d7cdeR88-R113)`, `[[2]](diffhunk://#diff-cae915aa5b7a62aa4a6eb295978c894fc43270cf6e08e82fca56414bf37d7cdeR404-R417)`)

*Documentation:*
- Added ADR 0026 documenting the rationale, design, and consequences of the external memory allocator feature. (`[docs/development/ADRs/next/0026-External_Memory_Allocator.mdR1-R147](diffhunk://#diff-b86bd892b20495d184cedc1d9057e4b1ef0e837d723e998628332943d900aa74R1-R147)`)

These changes provide a robust, explicit, and user-extensible mechanism for managing transient workspace memory in DaCe-based workflows, improving performance and resource control for advanced use cases.