### PR TITLE
fix[next]: support module-qualified offsets in unstructured shifts

### DIFF
--- a/src/gt4py/next/ffront/foast_to_gtir.py
+++ b/src/gt4py/next/ffront/foast_to_gtir.py
@@ -322,8 +322,8 @@ class FieldOperatorLowering(eve.PreserveLocationVisitor, eve.NodeTranslator):
                             )
                         )
                     )(current_expr)
-                # `field(Off)`
-                case foast.Name(id=offset_name):
+                # `field(Off)` or `field(mod.Off)`
+                case foast.Name(id=offset_name) | foast.Attribute(attr=offset_name):
                     # only a single unstructured shift is supported so returning here is fine even though we
                     # are in a loop.
                     assert len(node.args) == 1 and len(arg.type.target) > 1  # type: ignore[attr-defined] # ensured by pattern

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_import_from_mod.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_import_from_mod.py
@@ -10,11 +10,17 @@ import pytest
 import numpy as np
 
 import gt4py.next as gtx
-from gt4py.next import broadcast, astype, int32
+from gt4py.next import broadcast, astype, common, int32, neighbor_sum
 
 from next_tests import integration_tests
 from next_tests.integration_tests import cases
-from next_tests.integration_tests.cases import cartesian_case, IDim, KDim
+from next_tests.integration_tests.cases import (
+    cartesian_case,
+    unstructured_case,
+    IDim,
+    IHalfDim,
+    KDim,
+)
 
 from next_tests.integration_tests.cases_utils import (
     exec_alloc_descriptor,
@@ -52,6 +58,46 @@ def test_import_dims_module(cartesian_case):
     )[0:isize, 0:ksize]
 
     cases.verify(cartesian_case, mod_prog, f, isize, ksize, out=out, ref=expected)
+
+
+@pytest.mark.uses_cartesian_shift
+def test_import_dims_module_cartesian_shift(cartesian_case):
+    @gtx.field_operator
+    def testee(a: cases.IField) -> cases.IField:
+        return a(cases.IDim + 1)
+
+    size = cartesian_case.default_sizes[IDim]
+    a = cases.allocate(cartesian_case, testee, "a", domain={IDim: (1, size + 1)})()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN, domain={IDim: (0, size)})()
+
+    cases.verify(cartesian_case, testee, a, out=out, ref=a[:], offset_provider={})
+
+
+@pytest.mark.uses_cartesian_shift
+def test_import_dims_module_staggered_shift(cartesian_case):
+    @gtx.field_operator
+    def testee(a: cases.IField) -> cases.IHalfField:
+        return a(cases.IHalfDim + 0.5)
+
+    size = cartesian_case.default_sizes[IDim]
+    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: size})()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IHalfDim: size})()
+
+    cases.verify(cartesian_case, testee, a, out=out, ref=a, offset_provider={})
+
+
+@pytest.mark.uses_unstructured_shift
+def test_import_offset_module_unstructured_shift(unstructured_case):
+    @gtx.field_operator
+    def testee(a: cases.EField) -> cases.VField:
+        return neighbor_sum(a(cases.V2E), axis=cases.V2EDim)
+
+    v2e_table = unstructured_case.offset_provider["V2E"].asnumpy()
+    cases.verify_with_default_data(
+        unstructured_case,
+        testee,
+        ref=lambda a: np.sum(a[v2e_table], axis=1, where=v2e_table != common._DEFAULT_SKIP_VALUE),
+    )
 
 
 # TODO: these set of features should be allowed as module imports in a later PR


### PR DESCRIPTION
## Description

`field(mod.Off)` raised `FieldOperatorLoweringError: Unexpected shift arguments!`, while `neighbor_sum(..., axis=mod.LocalDim)` worked. The `field(Off)` arm of `_visit_shift` matched `foast.Name` only, so a module-qualified offset (a `foast.Attribute`) fell through to `case _`. Extended to also match `foast.Attribute`.

Only the unstructured arm was affected. The Cartesian arm matches on `left=foast.LocatedNode(type=ts.DimensionType(dim=...))`, which is node-shape agnostic and carries the `Dimension` in the type — so `field(mod.Dim + 1)` already worked. (It was broken the same way until #2667, which changed that pattern from `foast.Name` to the type-driven form as a side effect of the staggered-shift work.)

The asymmetry is that `ts.OffsetType` carries only `source`/`target`, not the connectivity name, so the unstructured lowering has to fall back on the source-level identifier and therefore must match node shape.

## Tests

Added to `test_import_from_mod.py`, all across the backend matrix:

- `test_import_dims_module_cartesian_shift` — `a(cases.IDim + 1)`
- `test_import_dims_module_staggered_shift` — `a(cases.IHalfDim + 0.5)`
- `test_import_offset_module_unstructured_shift` — `neighbor_sum(a(cases.V2E), axis=cases.V2EDim)`

The first two pass without the fix; the third is the regression test.

## Known remaining gap (not fixed here)

Because the tag comes from the identifier, an offset renamed on import lowers to the wrong tag:

```python
from next_tests.integration_tests.cases import V2E as W2E

@gtx.field_operator
def testee(a: cases.EField) -> cases.VField:
    return neighbor_sum(a(W2E), axis=V2EDim)
```

```
embedded: [1 3]
gtfn:     KeyError: "Offset 'W2E' not found in offset provider."
```

Embedded resolves through `FieldOffset.value` (`fbuiltins.py:485-488`), the compiled path through the AST identifier. This dates back to the first FOAST shift lowering (#625, 2022-01-26) and became observable when embedded remap landed (#1309). Fixing it properly means carrying the name in `OffsetType` / `ConnectivityType` (cf. the existing `TODO(havogt)` on `OffsetType`), which would also make this arm type-driven and let the shape match go away entirely. Left for a follow-up since it touches `OffsetType` equality.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR.