### PR TITLE
fix[next]: add missing side condition to EtaReduction

### DIFF
--- a/src/gt4py/next/iterator/transforms/eta_reduction.py
+++ b/src/gt4py/next/iterator/transforms/eta_reduction.py
@@ -8,10 +8,11 @@
 
 from gt4py.eve import NodeTranslator, PreserveLocationVisitor
 from gt4py.next.iterator import ir
+from gt4py.next.iterator.transforms.symbol_ref_utils import collect_symbol_refs
 
 
 class EtaReduction(PreserveLocationVisitor, NodeTranslator):
-    """Eta reduction: simplifies `λ(args...) → f(args...)` to `f`."""
+    """Eta reduction: simplifies `λ(args...) → f(args...)` to `f`, if `args` do not occur in `f`."""
 
     def visit_Lambda(self, node: ir.Lambda) -> ir.Node:
         if (
@@ -21,6 +22,7 @@ class EtaReduction(PreserveLocationVisitor, NodeTranslator):
                 isinstance(a, ir.SymRef) and p.id == a.id
                 for p, a in zip(node.params, node.expr.args)
             )
+            and not collect_symbol_refs(node.expr.fun, [p.id for p in node.params])
         ):
             return self.visit(node.expr.fun)
 

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_eta_reduction.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_eta_reduction.py
@@ -18,3 +18,17 @@ def test_simple():
     expected = ir.SymRef(id="deref")
     actual = EtaReduction().visit(testee)
     assert actual == expected
+
+
+def test_param_referenced_in_fun():
+    # `λ(x) → (λ(y) → x)(x)` must not be reduced: `x` occurs free in the called function.
+    testee = ir.Lambda(
+        params=[ir.Sym(id="x")],
+        expr=ir.FunCall(
+            fun=ir.Lambda(params=[ir.Sym(id="y")], expr=ir.SymRef(id="x")),
+            args=[ir.SymRef(id="x")],
+        ),
+    )
+    expected = testee
+    actual = EtaReduction().visit(testee)
+    assert actual == expected


### PR DESCRIPTION
`EtaReduction` can turn a well-formed expression into one with a free (escaped)
symbol, which `gt4py.eve`'s symbol-reference validator then rejects with
`EveValueError: Symbols {...} not found.`
