### PR TITLE
fix[next]: make MergeLet alpha-invariant

### DIFF
--- a/src/gt4py/next/iterator/transforms/merge_let.py
+++ b/src/gt4py/next/iterator/transforms/merge_let.py
@@ -9,6 +9,8 @@ from typing import ClassVar
 
 import gt4py.eve as eve
 from gt4py.next.iterator import ir as itir
+from gt4py.next.iterator.ir_utils import misc as ir_misc
+from gt4py.next.iterator.transforms.remap_symbols import RenameSymbols
 from gt4py.next.iterator.transforms.symbol_ref_utils import CountSymbolRefs
 
 
@@ -25,6 +27,12 @@ class MergeLet(eve.PreserveLocationVisitor, eve.NodeTranslator):
         (λ(a, b) → a+b)(arg1, arg2)
 
     This can significantly reduce the depth of the tree and its readability.
+
+    Parameters of the inner lambda that clash with a name bound or referenced by the outer
+    call are renamed apart, such that the result only depends on the program up to renaming
+    of its bound symbols. The merge is skipped only when an argument of the inner call
+    references a parameter of the outer lambda, as hoisting it would move that argument out
+    of the binder it refers to.
     """
 
     PRESERVED_ANNEX_ATTRS: ClassVar[tuple[str, ...]] = ("domain",)
@@ -40,22 +48,32 @@ class MergeLet(eve.PreserveLocationVisitor, eve.NodeTranslator):
             outer_lambda_args = node.args
             inner_lambda = node.fun.expr.fun
             inner_lambda_args = node.fun.expr.args
-            # skip if we have a collision
-            if set(outer_lambda.params) & set(inner_lambda.params):
-                return node
-            # check if the arguments to the outer lambda call use a symbol of the inner lambda
-            # e.g. (λ(a) → (λ(b) → b)(a))(b)
-            ref_counts_outer = CountSymbolRefs.apply(
-                outer_lambda_args, [param.id for param in inner_lambda.params]
-            )
-            if any(ref_count != 0 for ref_count in ref_counts_outer.values()):
-                return node
-            # check if the argument to the inner lambda call depend on an argument to the outer lambda
+            # check if the argument to the inner lambda call depend on an argument to the outer
+            # lambda; hoisting such an argument would move it out of the binder it refers to
             ref_counts = CountSymbolRefs.apply(
                 inner_lambda_args, [param.id for param in outer_lambda.params]
             )
             if any(ref_count != 0 for ref_count in ref_counts.values()):
                 return node
+            # Rename inner parameters that clash with a name bound by the outer lambda or
+            # spelled by one of its arguments, instead of skipping the merge. Merging only
+            # when the binders happen to be spelled apart would make the result depend on
+            # the choice of names rather than on the alpha-equivalence class of the program.
+            reserved = {param.id for param in outer_lambda.params} | {
+                ref.id for ref in eve.walk_values(outer_lambda_args).if_isinstance(itir.SymRef)
+            }
+            clashes = {param.id for param in inner_lambda.params} & reserved
+            if clashes:
+                taken = reserved | (
+                    eve.walk_values(inner_lambda)
+                    .if_isinstance(itir.Sym, itir.SymRef)
+                    .getattr("id")
+                    .to_set()
+                )
+                name_map: dict[str, str] = {}
+                for sym in sorted(clashes):
+                    name_map[sym] = ir_misc.unique_symbol(sym, taken | {*name_map.values()})
+                inner_lambda = RenameSymbols().visit(inner_lambda, name_map=name_map)
             return itir.FunCall(
                 fun=itir.Lambda(
                     params=outer_lambda.params + inner_lambda.params, expr=inner_lambda.expr

--- a/src/gt4py/next/iterator/transforms/remap_symbols.py
+++ b/src/gt4py/next/iterator/transforms/remap_symbols.py
@@ -40,7 +40,7 @@ class RenameSymbols(PreserveLocationVisitor, NodeTranslator):
         self, node: ir.Sym, *, name_map: Dict[str, str], active: Optional[Set[str]] = None
     ):
         if active and node.id in active:
-            return ir.Sym(id=name_map.get(node.id, node.id))
+            return ir.Sym(id=name_map.get(node.id, node.id), type=node.type)
         return node
 
     def visit_SymRef(

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py
@@ -1,0 +1,36 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms.merge_let import MergeLet
+
+
+def test_merge_nested_let():
+    testee = im.let("a", "arg2")(im.let("b", "arg1")(im.plus("a", "b")))
+    expected = im.call(im.lambda_("a", "b")(im.plus("a", "b")))("arg2", "arg1")
+
+    assert MergeLet().visit(testee) == expected
+
+
+def test_alpha_equivalent_lets_merge_differently():
+    """Characterization test: `MergeLet` is sensitive to the spelling of the bound symbols.
+
+    The two testees below are α-equivalent (the inner binder is named ``a`` in one and
+    ``b`` in the other, and it is not referenced from anywhere outside the inner lambda).
+    The pass merges only the second one, because its collision guard compares parameter
+    *names* rather than binding structure. Both results are semantically correct; what
+    this test pins down is that the result is not a function of the α-equivalence class,
+    i.e. a renaming by an earlier pass changes what `MergeLet` does.
+    """
+    # (λ(a) → (λ(a) → a)(1))(i) — inner binder shadows the outer one, merge is skipped
+    colliding = im.let("a", "i")(im.let("a", 1)("a"))
+    assert MergeLet().visit(colliding) == colliding
+
+    # (λ(a) → (λ(b) → b)(1))(i) — same program up to renaming, but merged
+    renamed = im.let("a", "i")(im.let("b", 1)("b"))
+    assert MergeLet().visit(renamed) == im.call(im.lambda_("a", "b")("b"))("i", 1)

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py
@@ -6,8 +6,10 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.iterator.transforms.merge_let import MergeLet
+from gt4py.next.type_system import type_specifications as ts
 
 
 def test_merge_nested_let():
@@ -17,20 +19,89 @@ def test_merge_nested_let():
     assert MergeLet().visit(testee) == expected
 
 
-def test_alpha_equivalent_lets_merge_differently():
-    """Characterization test: `MergeLet` is sensitive to the spelling of the bound symbols.
+def test_merge_renames_colliding_inner_param():
+    # (λ(a) → (λ(a) → a)(1))(i); the inner binder shadows the outer one and is renamed apart
+    testee = im.let("a", "i")(im.let("a", 1)("a"))
+    expected = im.call(im.lambda_("a", "a_")("a_"))("i", 1)
 
-    The two testees below are α-equivalent (the inner binder is named ``a`` in one and
-    ``b`` in the other, and it is not referenced from anywhere outside the inner lambda).
-    The pass merges only the second one, because its collision guard compares parameter
-    *names* rather than binding structure. Both results are semantically correct; what
-    this test pins down is that the result is not a function of the α-equivalence class,
-    i.e. a renaming by an earlier pass changes what `MergeLet` does.
+    assert MergeLet().visit(testee) == expected
+
+
+def test_merge_renames_inner_param_spelled_by_outer_arg():
+    # (λ(x) → (λ(b) → b)(1))(b); `b` is free in the outer argument, so the inner binder is
+    # renamed rather than left to shadow it in the merged parameter list
+    testee = im.let("x", "b")(im.let("b", 1)("b"))
+    expected = im.call(im.lambda_("x", "b_")("b_"))("b", 1)
+
+    assert MergeLet().visit(testee) == expected
+
+
+def test_merge_is_alpha_invariant():
+    """Renaming a bound symbol must not change whether, or how, the pass merges.
+
+    The two testees differ only in the name of the inner binder, which is not visible
+    outside the inner lambda. Both merge, and the results agree up to that same renaming,
+    i.e. the rewrite is a function of the program's alpha-equivalence class rather than of
+    the chosen spelling.
     """
-    # (λ(a) → (λ(a) → a)(1))(i) — inner binder shadows the outer one, merge is skipped
-    colliding = im.let("a", "i")(im.let("a", 1)("a"))
-    assert MergeLet().visit(colliding) == colliding
+    colliding = MergeLet().visit(im.let("a", "i")(im.let("a", 1)("a")))
+    apart = MergeLet().visit(im.let("a", "i")(im.let("b", 1)("b")))
 
-    # (λ(a) → (λ(b) → b)(1))(i) — same program up to renaming, but merged
-    renamed = im.let("a", "i")(im.let("b", 1)("b"))
-    assert MergeLet().visit(renamed) == im.call(im.lambda_("a", "b")("b"))("i", 1)
+    assert apart == im.call(im.lambda_("a", "b")("b"))("i", 1)
+    assert colliding.args == apart.args
+    assert colliding.fun.expr == im.ref(colliding.fun.params[1].id)
+    assert apart.fun.expr == im.ref(apart.fun.params[1].id)
+
+
+def test_no_merge_if_inner_arg_uses_outer_param():
+    # the one genuine obstacle: hoisting `a` would move it out of the binder it refers to
+    testee = im.let("a", "i")(im.let("b", "a")("b"))
+
+    assert MergeLet().visit(testee) == testee
+
+
+def test_no_merge_if_inner_arg_uses_outer_param_under_collision():
+    # same obstacle, but with the inner binder spelled like the outer one
+    testee = im.let("a", "i")(im.let("a", "a")("a"))
+
+    assert MergeLet().visit(testee) == testee
+
+
+def test_rename_avoids_capture_by_nested_binder():
+    # the fresh name must dodge a binder occurring inside the inner lambda's body, even one
+    # that is never referenced, otherwise the renamed parameter gets captured by it
+    inner = itir.Lambda(
+        params=[itir.Sym(id="a")],
+        expr=im.as_fieldop(itir.Lambda(params=[itir.Sym(id="a_")], expr=im.deref("a")))(),
+    )
+    testee = itir.FunCall(
+        fun=itir.Lambda(
+            params=[itir.Sym(id="a")], expr=itir.FunCall(fun=inner, args=[im.ref("q")])
+        ),
+        args=[im.ref("i")],
+    )
+
+    actual = MergeLet().visit(testee)
+
+    renamed = actual.fun.params[1].id
+    assert renamed != "a_"
+    assert (
+        actual.fun.expr
+        == im.as_fieldop(itir.Lambda(params=[itir.Sym(id="a_")], expr=im.deref(renamed)))()
+    )
+
+
+def test_merge_preserves_type_of_renamed_param():
+    dtype = ts.ScalarType(kind=ts.ScalarKind.FLOAT32)
+    inner = itir.Lambda(params=[itir.Sym(id="a", type=dtype)], expr=im.ref("a"))
+    testee = itir.FunCall(
+        fun=itir.Lambda(
+            params=[itir.Sym(id="a", type=dtype)],
+            expr=itir.FunCall(fun=inner, args=[im.literal_from_value(1)]),
+        ),
+        args=[im.ref("i")],
+    )
+
+    actual = MergeLet().visit(testee)
+
+    assert [param.type for param in actual.fun.params] == [dtype, dtype]


### PR DESCRIPTION

## Summary

`MergeLet` is not α-invariant: its guards compare binder **spellings**, so two
α-equivalent programs are optimised differently. This PR makes the pass α-invariant
by renaming colliding inner binders apart instead of skipping the merge, and adds
the unit tests the pass was missing.

An earlier revision of this PR only characterised the behaviour and asked which fix
you wanted. It now implements one of the options that were listed — the α-renaming
one — because the objection raised against it turned out not to apply (see
"No uids pool needed"). Whether you want this at all is still open; see
"What we would like you to decide".

## The problem

```python
from gt4py.next.iterator.ir_utils import ir_makers as im
from gt4py.next.iterator.transforms.merge_let import MergeLet

MergeLet().visit(im.let("a", "i")(im.let("a", 1)("a")))
# before: (λ(a) → (λ(a) → a)(1))(i)      -- unchanged
# after:  (λ(a, a_) → a_)(i, 1)

MergeLet().visit(im.let("a", "i")(im.let("b", 1)("b")))
# before: (λ(a, b) → b)(i, 1)            -- merged
# after:  (λ(a, b) → b)(i, 1)            -- unchanged by this PR
```

The two inputs are α-equivalent: the inner binder is not referenced from outside the
inner lambda, so renaming it `a` → `b` is a pure renaming. Before this PR only the
second merged, because the collision guard was a set intersection of parameter names:

https://github.com/GridTools/gt4py/blob/1eda83a791ae84f1c6f9861b6e4a9c564e6728d0/src/gt4py/next/iterator/transforms/merge_let.py#L43-L45

The second guard (the ref-count over `inner_lambda.params`) was name-keyed the same
way: `(λ(x) → (λ(b) → b)(1))(b)` was skipped while the α-equivalent
`(λ(x) → (λ(c) → c)(1))(b)` merged.

Nothing miscompiled — each individual output was correct. The defect is that the
result of the rewrite was not a function of the program's α-equivalence class. That
matters here in particular because `MergeLet` runs directly after
`CommonSubexpressionElimination` in `pass_manager.py`, and CSE invents its binder
names from a UID pool: the names CSE happens to pick decide whether the subsequent
`MergeLet` fires. It also makes the pass hard to test, and hard to port — we hit this
while differential-testing the iterator transforms against an independent MLIR/xDSL
port of GTIR, where the IR is α-normalised, so the two programs above are literally
the same term and cannot produce two different results.

## The change

Guards 1 and 2 are replaced by renaming the offending inner parameters apart. Guard 3
is kept unchanged and is now the only reason to skip: if an argument of the inner call
references a parameter of the outer lambda, hoisting it would move it out of the binder
it refers to. Renaming uses the existing `RenameSymbols` and `ir_misc.unique_symbol`,
exactly as `inline_lambdas` already does for the same purpose.

Net effect: strictly more merging, and the result now depends only on the input up to
renaming of bound symbols.

### No uids pool needed

The obvious objection to α-renaming inside this pass is that it would need a fresh-name
source, changing `MergeLet`'s signature and all three of its call sites. It does not:
`ir_misc.unique_symbol(name, reserved)` is a pure function of the name and the reserved
set, so the pass stays stateless and no call site changes.

The reserved set is the outer parameters, the symbols referenced by the outer arguments,
and every `Sym`/`SymRef` occurring anywhere in the inner lambda. Including binder `Sym`s
and not just `SymRef`s is load-bearing: a nested lambda may *bind* the candidate name
without ever referencing it, and renaming into it would then capture. With a refs-only
reserved set,

```
(λ(a) → (λ(a) → (⇑(λ(a_) → ·a))())(q))(i)
```

merges to `(λ(a, a_) → (⇑(λ(a_) → ·a_))())(i, q)`, where `·a_` now derefs the nested
lambda's own parameter. There is a regression test for this.

### One change outside `merge_let.py`

`RenameSymbols.visit_Sym` dropped `Sym.type` when renaming, while `visit_SymRef` right
below it explicitly copies the type over. That asymmetry looks like an oversight; it
became visible here because `MergeLet` runs on typed IR inside `fuse_as_fieldop`, so
renaming a parameter would have silently discarded its type. Fixed by passing
`type=node.type` through. This also affects `inline_lambdas`, the other `RenameSymbols`
user — happy to split it into its own PR if you would rather review it separately.

## What we would like you to decide

The alternative is to keep the current behaviour and document the pass as
name-sensitive by design. If you prefer that, this PR should simply be closed and
replaced by a docstring note — we would just like the chosen semantics to be written
down somewhere.

Two things worth a maintainer's eye if you do want this:

* **New binder names appear in the output.** Unavoidable for α-renaming. The thing we
  cannot check from outside is whether any downstream consumer relies on binder names
  surviving `MergeLet` — e.g. debugging output, the DaCe lowering's name handling, or
  anything matching on specific symbol names.
* **Guard 2 could be dropped rather than turned into a rename.** Arguments are evaluated
  in the enclosing scope, so an inner binder that merely *spells* the same name as a free
  symbol in an outer argument cannot actually capture it; `(λ(x, b) → b)(b, 1)` would be
  correct as-is. We kept a rename there because it preserves the guard's evident intent
  and keeps the merged output free of confusing shadowing, but dropping it entirely is a
  defensible simplification if you prefer.

## Tests

`tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py` is new;
`merge_let` had no tests. It covers the plain merge, both renaming cases, α-invariance of
the pair above, both guard-3 skip cases, capture-avoidance against a nested binder, and
type preservation of a renamed parameter.

Local runs (Python 3.14):

* `tests/next_tests/unit_tests/iterator_tests/` — 505 passed, 1 skipped, 2 xfailed.
* `tests/next_tests/integration_tests/feature_tests/ffront_tests/ -k roundtrip` (the
  pipeline path where `MergeLet` runs after CSE) — 622 passed, 10 skipped, 70 xfailed.
* `tests/next_tests/unit_tests/` — identical pass/fail set to a clean-tree baseline
  (the failures there are local dace/cupy/sympy environment noise, unrelated).

CI will have to cover `gtfn` and `dace`, which we cannot run locally.

Related: we have a second draft PR (`fix/mergelet-builtin-names`) touching the same
file — it fixes one concrete instance of name-keyed-guard breakage in guard 3 and also
creates `test_merge_let.py`, so the two will need sequencing / a trivial merge.

Left as a draft pending your call on the direction.

🤖 Generated with [Claude Code](https://claude.ai/code)
