### PR TITLE
fix[next]: MergeLet guard blind to builtin-named params

### DIFF
--- a/src/gt4py/next/iterator/transforms/merge_let.py
+++ b/src/gt4py/next/iterator/transforms/merge_let.py
@@ -51,8 +51,12 @@ class MergeLet(eve.PreserveLocationVisitor, eve.NodeTranslator):
             if any(ref_count != 0 for ref_count in ref_counts_outer.values()):
                 return node
             # check if the argument to the inner lambda call depend on an argument to the outer lambda
+            # note: `ignore_builtins=False` since a param may shadow a builtin, in which case
+            # references to it are ordinary references to that param
             ref_counts = CountSymbolRefs.apply(
-                inner_lambda_args, [param.id for param in outer_lambda.params]
+                inner_lambda_args,
+                [param.id for param in outer_lambda.params],
+                ignore_builtins=False,
             )
             if any(ref_count != 0 for ref_count in ref_counts.values()):
                 return node

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py
@@ -1,0 +1,37 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from gt4py.next.iterator.ir_utils import ir_makers as im
+from gt4py.next.iterator.transforms.merge_let import MergeLet
+
+
+def test_simple():
+    testee = im.let("a", "arg1")(im.let("b", "arg2")(im.plus("a", "b")))
+    expected = im.call(im.lambda_("a", "b")(im.plus("a", "b")))("arg1", "arg2")
+    assert MergeLet().visit(testee) == expected
+
+
+def test_no_merge_on_param_collision():
+    testee = im.let("a", "arg1")(im.let("a", "arg2")(im.plus("a", "a")))
+    assert MergeLet().visit(testee) == testee
+
+
+def test_no_merge_outer_arg_refs_inner_param():
+    testee = im.let("a", im.deref("b"))(im.let("b", "arg2")(im.plus("a", "b")))
+    assert MergeLet().visit(testee) == testee
+
+
+@pytest.mark.parametrize("outer_param", ["s", "shift"])
+def test_no_merge_inner_arg_refs_outer_param(outer_param):
+    # `shift` is the name of a builtin. Renaming the binder is semantics-preserving and
+    # must not change whether the merge happens, otherwise `·shift` ends up outside of
+    # the lambda that binds `shift`.
+    testee = im.let(outer_param, "it")(im.let("b", im.deref(outer_param))("b"))
+    assert MergeLet().visit(testee) == testee


### PR DESCRIPTION
## Symptom

`MergeLet` merges `(λ(a) → (λ(b) → body)(arg1))(arg2)` into `(λ(a, b) → body)(arg2, arg1)`. One of its guards checks that the inner lambda's arguments do not reference a parameter of the outer lambda — merging would move those references out of the binder that binds them.

That check is defeated whenever the outer parameter's name coincides with a builtin name.

## Reproduction

```python
from gt4py.next.iterator.ir_utils import ir_makers as im
from gt4py.next.iterator.transforms.merge_let import MergeLet

for name in ("s", "shift"):
    testee = im.let(name, "it")(im.let("b", im.deref(name))("b"))
    print(f"{testee}  =>  {MergeLet().visit(testee)}")
```

On `main`:

```
(λ(s) → (λ(b) → b)(·s))(it)          =>  (λ(s) → (λ(b) → b)(·s))(it)
(λ(shift) → (λ(b) → b)(·shift))(it)  =>  (λ(shift, b) → b)(it, ·shift)
```

The two inputs differ only in the name of the outer binder.

## Why this is a defect

- The merged result `(λ(shift, b) → b)(it, ·shift)` has `·shift` as an argument of the very lambda that binds `shift`, i.e. the reference has been moved out of the scope of its binder. The occurrence now resolves to the `shift` builtin (or to whatever `shift` is in the enclosing scope) instead of to the parameter bound to `it`.
- The decision of the pass is not invariant under alpha-renaming: renaming `s` to `shift` — a semantics-preserving change — flips it from "do not merge" to "merge".

## Cause and fix

The guard uses

```python
ref_counts = CountSymbolRefs.apply(inner_lambda_args, [param.id for param in outer_lambda.params])
```

and `CountSymbolRefs.apply` defaults to `ignore_builtins=True`, so `SymRef`s whose name is a builtin are never counted. Here the names come from `outer_lambda.params`, so a parameter shadowing a builtin makes the guard count zero references and let the merge through.

The fix passes `ignore_builtins=False` for this check: within this lambda a reference to such a name is an ordinary reference to the parameter, not to the builtin.

## Tests

`merge_let` had no unit tests upstream; this PR adds the first ones in `tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_merge_let.py`, covering the plain merge, the two existing "do not merge" guards, and the A/B pair above (parametrized over `s` / `shift`) so the alpha-invariance is visible. The `shift` case fails before the fix and passes after. `tests/next_tests/unit_tests/iterator_tests/` is green (502 passed, 1 skipped, 2 xfailed).