### PR TITLE
fix[next]: stop KeyError from masking compiled-program failures

### DIFF
--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -427,64 +427,46 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             arg_specialization_key,
         )
 
-        try:
-            compiled_program = self.compiled_programs[key]
-        except KeyError:
-            # The handler is empty on purpose: everything that could raise while it is active
-            # would be chained to this `KeyError`, whose opaque key then dominates the traceback
-            # and hides the actual failure. Leaving the handler clears the exception context.
-            pass
-        else:
-            with compiled_program_call_context(self, key, args, kwargs, offset_provider):
-                compiled_program(*args, **kwargs, offset_provider=offset_provider)
-            return
+        # Note: a plain lookup, without a `KeyError` handler: everything raised while such a
+        # handler is active gets chained to it, and the dispatch miss with its opaque key then
+        # dominates the traceback and hides the actual failure.
+        compiled_program = self.compiled_programs.get(key)
 
-        self._dispatch_miss(
-            key, args, kwargs, canonical_args, canonical_kwargs, offset_provider, enable_jit
-        )
+        if compiled_program is None:
+            if self._finish_compilation_job(key):
+                compiled_program = self.compiled_programs[key]
+            elif enable_jit:
+                assert self.argument_descriptor_mapping is not None
+                self._compile_variant(
+                    argument_descriptors=_make_argument_descriptors(
+                        self.program_type, self.argument_descriptor_mapping, args, kwargs
+                    ),
+                    # note: it is important to use the args before named collections are extracted
+                    #  as otherwise the implicit program generation from an operator fails
+                    arg_specialization_info=(
+                        tuple(type_translation.from_value(arg) for arg in canonical_args),
+                        {k: type_translation.from_value(v) for k, v in canonical_kwargs.items()},
+                    ),
+                    offset_provider=offset_provider,
+                    call_key=key,
+                )
+                return self(
+                    *canonical_args,
+                    offset_provider=offset_provider,
+                    enable_jit=False,
+                    **canonical_kwargs,
+                )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
 
-    def _dispatch_miss(
-        self,
-        key: CompiledProgramsKey,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-        canonical_args: tuple[Any, ...],
-        canonical_kwargs: dict[str, Any],
-        offset_provider: common.OffsetProvider,
-        enable_jit: bool,
-    ) -> None:
-        """
-        Make the variant for `key` available and call it, or report why that is not possible.
-
-        Must be called outside of the `except KeyError` handler of `__call__`, such that failures
-        here are not chained to the dispatch miss.
-        """
-        if not self._finish_compilation_job(key):
-            if not enable_jit:
+            else:
                 raise RuntimeError(
                     f"No program compiled for this set of static arguments of "
                     f"'{self.definition.__name__}'{self._describe_argument_descriptors(key[0])}."
                     " Note that a variant is also selected by the identity of the"
                     " 'offset_provider' entries and, for generic programs, by the argument types."
                 )
-            assert self.argument_descriptor_mapping is not None
-            self._compile_variant(
-                argument_descriptors=_make_argument_descriptors(
-                    self.program_type, self.argument_descriptor_mapping, args, kwargs
-                ),
-                # note: it is important to use the args before named collections are extracted
-                #  as otherwise the implicit program generation from an operator fails
-                arg_specialization_info=(
-                    tuple(type_translation.from_value(arg) for arg in canonical_args),
-                    {k: type_translation.from_value(v) for k, v in canonical_kwargs.items()},
-                ),
-                offset_provider=offset_provider,
-                call_key=key,
-            )
 
-        return self(
-            *canonical_args, offset_provider=offset_provider, enable_jit=False, **canonical_kwargs
-        )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
+        with compiled_program_call_context(self, key, args, kwargs, offset_provider):
+            compiled_program(*args, **kwargs, offset_provider=offset_provider)
 
     def _describe_argument_descriptors(self, descriptor_values: tuple[Hashable, ...]) -> str:
         exprs = [

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -429,37 +429,86 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
 
         try:
             compiled_program = self.compiled_programs[key]
+        except KeyError:
+            # The handler is empty on purpose: everything that could raise while it is active
+            # would be chained to this `KeyError`, whose opaque key then dominates the traceback
+            # and hides the actual failure. Leaving the handler clears the exception context.
+            pass
+        else:
+            with compiled_program_call_context(self, key, args, kwargs, offset_provider):
+                compiled_program(*args, **kwargs, offset_provider=offset_provider)
+            return
 
-        except KeyError as e:
-            if self._finish_compilation_job(key):
-                compiled_program = self.compiled_programs[key]
-            elif enable_jit:
-                assert self.argument_descriptor_mapping is not None
-                self._compile_variant(
-                    argument_descriptors=_make_argument_descriptors(
-                        self.program_type, self.argument_descriptor_mapping, args, kwargs
-                    ),
-                    # note: it is important to use the args before named collections are extracted
-                    #  as otherwise the implicit program generation from an operator fails
-                    arg_specialization_info=(
-                        tuple(type_translation.from_value(arg) for arg in canonical_args),
-                        {k: type_translation.from_value(v) for k, v in canonical_kwargs.items()},
-                    ),
-                    offset_provider=offset_provider,
-                    call_key=key,
+        self._dispatch_miss(
+            key, args, kwargs, canonical_args, canonical_kwargs, offset_provider, enable_jit
+        )
+
+    def _dispatch_miss(
+        self,
+        key: CompiledProgramsKey,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        canonical_args: tuple[Any, ...],
+        canonical_kwargs: dict[str, Any],
+        offset_provider: common.OffsetProvider,
+        enable_jit: bool,
+    ) -> None:
+        """
+        Make the variant for `key` available and call it, or report why that is not possible.
+
+        Must be called outside of the `except KeyError` handler of `__call__`, such that failures
+        here are not chained to the dispatch miss.
+        """
+        if not self._finish_compilation_job(key):
+            if not enable_jit:
+                raise RuntimeError(
+                    f"No program compiled for this set of static arguments of "
+                    f"'{self.definition.__name__}'{self._describe_argument_descriptors(key[0])}."
+                    " Note that a variant is also selected by the identity of the"
+                    " 'offset_provider' entries and, for generic programs, by the argument types."
                 )
-                return self(
-                    *canonical_args,
-                    offset_provider=offset_provider,
-                    enable_jit=False,
-                    **canonical_kwargs,
-                )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call`
+            assert self.argument_descriptor_mapping is not None
+            self._compile_variant(
+                argument_descriptors=_make_argument_descriptors(
+                    self.program_type, self.argument_descriptor_mapping, args, kwargs
+                ),
+                # note: it is important to use the args before named collections are extracted
+                #  as otherwise the implicit program generation from an operator fails
+                arg_specialization_info=(
+                    tuple(type_translation.from_value(arg) for arg in canonical_args),
+                    {k: type_translation.from_value(v) for k, v in canonical_kwargs.items()},
+                ),
+                offset_provider=offset_provider,
+                call_key=key,
+            )
 
-            else:
-                raise RuntimeError("No program compiled for this set of static arguments.") from e
+        return self(
+            *canonical_args, offset_provider=offset_provider, enable_jit=False, **canonical_kwargs
+        )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
 
-        with compiled_program_call_context(self, key, args, kwargs, offset_provider):
-            compiled_program(*args, **kwargs, offset_provider=offset_provider)
+    def _describe_argument_descriptors(self, descriptor_values: tuple[Hashable, ...]) -> str:
+        exprs = [
+            expr
+            for descriptor_cls, arg_exprs in (self.argument_descriptor_mapping or {}).items()
+            for arg_expr in arg_exprs
+            for expr in descriptor_cls.attribute_extractor_exprs(arg_expr).values()
+        ]
+        if not exprs:
+            return ""
+        return ": " + ", ".join(
+            f"{expr}={value!r}" for expr, value in zip(exprs, descriptor_values, strict=True)
+        )
+
+    def _load_artifact(
+        self, artifact_future: concurrent.futures.Future[stages.CompilationArtifact]
+    ) -> stages.ExecutableProgram:
+        artifact = artifact_future.result()  # re-raises errors from the compilation worker
+        try:
+            return artifact.load()
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load the compiled program '{self.definition.__name__}'."
+            ) from e
 
     @functools.cached_property
     def _primitive_values_extractor(self) -> Callable | None:
@@ -581,9 +630,8 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             return False
 
         artifact_future = self._compilation_jobs.pop(key)
-        assert isinstance(artifact_future, concurrent.futures.Future)
         assert key not in self.compiled_programs
-        self.compiled_programs[key] = artifact_future.result().load()
+        self.compiled_programs[key] = self._load_artifact(artifact_future)
         return True
 
     def _compile_variant(
@@ -660,7 +708,7 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
         if future.done():
             # Eager so compile() raises now; otherwise the error stays in the
             # already-resolved future until the next call touches this key.
-            self.compiled_programs[key] = future.result().load()
+            self.compiled_programs[key] = self._load_artifact(future)
         else:
             self._compilation_jobs[key] = future
             _ongoing_compilations[future] = (

--- a/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
@@ -7,8 +7,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import dataclasses
 import collections
+import concurrent.futures
 import contextvars
 import gc
+import traceback
 import weakref
 
 import pytest
@@ -173,6 +175,75 @@ def test_different_static_args_break_same_prg_after_static_params_change(testee_
         match="Argument descriptor StaticArg must be the same for all compiled programs",
     ):
         prg.compile(cond=[True], offset_provider={})
+
+
+@dataclasses.dataclass
+class _DeferredRunner:
+    """A runner handing out futures that the test resolves by hand."""
+
+    futures: list[concurrent.futures.Future] = dataclasses.field(default_factory=list)
+
+    def submit(self, task):
+        self.futures.append(concurrent.futures.Future())
+        return self.futures[-1]
+
+    def shutdown(self, wait: bool = True) -> None:
+        pass
+
+
+@pytest.fixture
+def deferred_runner(monkeypatch):
+    runner = _DeferredRunner()
+    monkeypatch.setattr(compiled_program.runners, "get_default_runner", lambda: runner)
+    return runner
+
+
+def _formatted_traceback(error: BaseException) -> str:
+    return "".join(traceback.format_exception(type(error), error, error.__traceback__))
+
+
+def test_dispatch_miss_reports_load_error_as_cause(testee_prog, deferred_runner):
+    class _StaleArtifact:
+        def load(self):
+            raise OSError(116, "Stale file handle")
+
+    testee = testee_prog.compile(cond=[True], offset_provider={})
+    (future,) = deferred_runner.futures
+    future.set_result(_StaleArtifact())
+
+    with pytest.raises(
+        RuntimeError, match="Failed to load the compiled program 'prog'"
+    ) as exc_info:
+        testee(cond=True, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert "KeyError" not in _formatted_traceback(exc_info.value)
+
+
+def test_dispatch_miss_propagates_compilation_error(testee_prog, deferred_runner):
+    class _WorkerError(Exception):
+        pass
+
+    testee = testee_prog.compile(cond=[True], offset_provider={})
+    (future,) = deferred_runner.futures
+    future.set_exception(_WorkerError("compilation failed in the worker"))
+
+    with pytest.raises(_WorkerError) as exc_info:
+        testee(cond=True, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    assert exc_info.value.__context__ is None
+    assert "KeyError" not in _formatted_traceback(exc_info.value)
+
+
+def test_dispatch_miss_without_jit_names_static_args(testee_prog, deferred_runner):
+    testee = testee_prog.with_compilation_options(enable_jit=False).compile(
+        cond=[True], offset_provider={}
+    )
+
+    with pytest.raises(RuntimeError, match=r"No program compiled.*'prog'.*cond=False") as exc_info:
+        testee(cond=False, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    assert "KeyError" not in _formatted_traceback(exc_info.value)
 
 
 def _verify_program_has_expected_domain(


### PR DESCRIPTION
## Description

Draft — opening early to discuss the trade-offs below.

When a compiled program cannot be obtained, the traceback leads with a `KeyError` on the
dispatch dict even though the actual cause is something else. Real incident (ICON/icon4py,
10 MPI ranks, shared OTF cache on Lustre scratch):

```
ERROR - A Python error occurred: [Errno 116] Stale file handle
Traceback (most recent call last):
  File ".../gt4py/next/otf/compiled_program.py", line 419, in __call__
    compiled_program = self.compiled_programs[key]
KeyError: ((np.int32(557), np.int32(72619), np.int32(0), np.int32(80)), -5810085652480803948, None)
During handling of the above exception, another exception occurred:
...
```

The genuine cause was `OSError: [Errno 116] Stale file handle` while loading the artifact, but
the `KeyError` with its opaque key tuple is what everyone reads first — it looks like a
cache-key/dispatch bug, and it is not. That cost hours of misdirected debugging.

`CompiledProgramsPool.__call__` did all cache-miss handling *inside* the `except KeyError`
handler, so everything raised there — `future.result()` re-raising a worker exception,
`artifact.load()` doing I/O — was chained to the `KeyError`.

## Changes

- The dispatch lookup is now `self.compiled_programs.get(key)` plus an `if ... is None`. No
  exception is raised on a miss, so there is no context for the real failure to be chained to.
  The miss branch itself is unchanged.
- `_load_artifact` wraps `artifact.load()` failures as
  `RuntimeError("Failed to load the compiled program '<name>'.") from <cause>`, so the `OSError`
  is what the reader sees. Worker exceptions from `future.result()` are deliberately *not*
  wrapped — they propagate as themselves.
- The genuine-miss error now names the program and the static arguments
  (`... of 'diffusion_run': scalar_int=3`) and notes that a variant is also selected by the
  identity of the `offset_provider` entries.

## Hot path

`__call__` runs per program invocation (thousands per second in ICON), so the cost of the
successful lookup matters. Isolated dict lookup, key present:

|                                | 3.10    | 3.12    | 3.13    |
| ------------------------------ | ------- | ------- | ------- |
| `try: d[key] except KeyError:` | 30.0 ns | 15.7 ns | 16.1 ns |
| `d.get(key)`                   | 30.6 ns | 21.7 ns | 20.1 ns |
| `key in d` + `d[key]`          | 43.1 ns | —       | —       |

So `.get()` costs ~5 ns on ≥3.11, where the non-raising `try` became free, and nothing on 3.10.
That is 0.2 % of the ~2800 ns a full dispatch takes; a whole-dispatch microbenchmark (program
call with the executable replaced by a no-op, under `-O`) cannot resolve it above run-to-run
noise. Taken deliberately in exchange for a much smaller, non-convoluted diff
([review thread](https://github.com/GridTools/gt4py/pull/2731#discussion_r3675680905)).

An earlier revision kept the `try/except` and restructured `__call__` so the handler was left
before any miss handling (identical hit-path bytecode, zero cost). That version is in the
history of this branch if we ever want the ns back.

Note that just adding `raise ... from e` at the raise sites does **not** fix this: `from e` sets
`__suppress_context__` on the outer exception, but the intermediate `OSError` still carries
`__context__ = KeyError` and is printed as the cause, so the `KeyError` still leads the
traceback. Hiding it that way would require setting `inner.__context__ = None` at every site.

## Open for discussion

- **Naming the static arguments** in the miss error is ~12 of the ~30 net-new lines and is a
  message improvement, not part of the fix. Drop it?
- A dedicated exception type (`CompiledProgramNotAvailableError`) carrying the key and the cause
  kind was considered and skipped — nothing catches these today.
- `_finish_compilation_job` still has `assert key not in self.compiled_programs`, which never
  runs under icon4py's `PYTHONOPTIMIZE=2`. Left as an assert: it is only reachable right after a
  confirmed dict miss, so it cannot be violated by user input.

Out of scope: the underlying Lustre `ESTALE`, which belongs with the OTF cache write/replace
logic (#2691). This is only about which error the user is shown.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Three unit tests in `tests/next_tests/unit_tests/otf_tests/test_compiled_program.py`
  (load `OSError`, worker exception, genuine miss); all three fail on `main` and pass here.
- [ ] Important design decisions have been documented in the appropriate ADR.
