### PR TITLE
feat[next]: register JaxArrayField as a JAX pytree node

### DIFF
--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -1090,6 +1090,22 @@ if jnp:
     common._field.register(jnp.ndarray, JaxArrayField.from_array)
     common._connectivity.register(jnp.ndarray, JaxArrayConnectivityField.from_array)
 
+    def _flatten_jax_field(
+        field: JaxArrayField,
+    ) -> tuple[tuple[core_defs.NDArrayObject], common.Domain]:
+        return (field.ndarray,), field.domain
+
+    def _unflatten_jax_field(
+        domain: common.Domain, children: tuple[core_defs.NDArrayObject]
+    ) -> JaxArrayField:
+        return JaxArrayField(domain, children[0])  # type: ignore[abstract] # mypy does not see '__gt_builtin_func__' as implemented by 'FieldBuiltinFuncRegistry'
+
+    jax.tree_util.register_pytree_node(
+        JaxArrayField,  # type: ignore[type-abstract, unused-ignore] # only reported when 'jax' is installed, see '_unflatten_jax_field'
+        _flatten_jax_field,
+        _unflatten_jax_field,
+    )
+
 
 def _broadcast(field: common.Field, new_dimensions: Sequence[common.Dimension]) -> common.Field:
     if field.domain.dims == new_dimensions:

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -1758,3 +1758,44 @@ def test_concat(fields_data, dim, expected_data, expect_error):
 
         assert result.domain == expected_domain
         np.testing.assert_allclose(result.asnumpy(), expected_array)
+
+
+@pytest.mark.requires_jax
+def test_jax_jit_field_arguments():
+    jax = pytest.importorskip("jax")
+
+    domain = common.domain({D0: (1, 3), D1: (2, 5)})
+    a = common._field(
+        jax.numpy.asarray(np.arange(6, dtype=np.float64).reshape(2, 3)), domain=domain
+    )
+    b = common._field(jax.numpy.ones((2, 3), dtype=np.float64), domain=domain)
+
+    @jax.jit
+    def add(x, y):
+        return x + y
+
+    result = add(a, b)
+
+    assert isinstance(result, common.Field)
+    assert result.domain == domain
+    np.testing.assert_allclose(result.asnumpy(), a.asnumpy() + b.asnumpy())
+
+
+@pytest.mark.requires_jax
+def test_jax_jit_field_passthrough():
+    jax = pytest.importorskip("jax")
+
+    domain = common.domain({D0: (1, 3), D1: (2, 5)})
+    field = common._field(jax.numpy.ones((2, 3), dtype=np.float64), domain=domain)
+    traced_domains = []
+
+    @jax.jit
+    def identity(f):
+        traced_domains.append(f.domain)
+        return f
+
+    result = identity(field)
+
+    assert traced_domains == [domain]  # the domain is static metadata, not a traced value
+    assert result.domain == domain
+    np.testing.assert_allclose(result.asnumpy(), field.asnumpy())

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -1782,20 +1782,22 @@ def test_jax_jit_field_arguments():
 
 
 @pytest.mark.requires_jax
-def test_jax_jit_field_passthrough():
+def test_jax_pytree_roundtrip():
     jax = pytest.importorskip("jax")
 
     domain = common.domain({D0: (1, 3), D1: (2, 5)})
     field = common._field(jax.numpy.ones((2, 3), dtype=np.float64), domain=domain)
-    traced_domains = []
 
-    @jax.jit
-    def identity(f):
-        traced_domains.append(f.domain)
-        return f
+    children, treedef = jax.tree_util.tree_flatten(field)
 
-    result = identity(field)
+    assert len(children) == 1
+    assert children[0] is field.ndarray
 
-    assert traced_domains == [domain]  # the domain is static metadata, not a traced value
-    assert result.domain == domain
-    np.testing.assert_allclose(result.asnumpy(), field.asnumpy())
+    restored = jax.tree_util.tree_unflatten(treedef, children)
+    assert restored.domain == domain
+
+    other_field = common._field(
+        jax.numpy.ones((2, 3), dtype=np.float64), domain=common.domain({D0: (0, 2), D1: (2, 5)})
+    )
+    # the domain is part of the tree structure, hence a domain change forces a 'jax.jit' retrace
+    assert jax.tree_util.tree_structure(other_field) != treedef


### PR DESCRIPTION
Flatten a JaxArrayField into its backing array (traced child) plus its domain (static aux data), so gt4py fields can be passed to and returned from jax.jit-ed functions outside of field operators.