### PR TITLE
fix[next]: stop KeyError from masking compiled-program failures

### DIFF
--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -598,6 +598,9 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
 
         artifact_future = self._compilation_jobs.pop(key)
         assert key not in self.compiled_programs
+        # A failing 'result()' keeps the future alive through its traceback, so the
+        # weak entry would survive until the next GC pass and be reported twice.
+        _ongoing_compilations.pop(artifact_future, None)
         self.compiled_programs[key] = self._load_artifact(artifact_future)
         return True
 

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -432,10 +432,10 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             arg_specialization_key,
         )
 
-        try:
-            compiled_program = self.compiled_programs[key]
+        # Note: no `KeyError` handler, as anything raised inside one gets chained to it.
+        compiled_program = self.compiled_programs.get(key)
 
-        except KeyError as e:
+        if compiled_program is None:
             if self._finish_compilation_job(key):
                 compiled_program = self.compiled_programs[key]
             elif enable_jit:
@@ -458,13 +458,24 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
                     offset_provider=offset_provider,
                     enable_jit=False,
                     **canonical_kwargs,
-                )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call`
+                )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
 
             else:
-                raise RuntimeError("No program compiled for this set of static arguments.") from e
+                raise RuntimeError("No program compiled for this set of static arguments.")
 
         with compiled_program_call_context(self, key, args, kwargs, offset_provider):
             compiled_program(*args, **kwargs, offset_provider=offset_provider)
+
+    def _load_artifact(
+        self, artifact_future: concurrent.futures.Future[stages.CompilationArtifact]
+    ) -> stages.ExecutableProgram:
+        artifact = artifact_future.result()  # re-raises errors from the compilation worker
+        try:
+            return self.backend.load_artifact(artifact)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load the compiled program '{self.definition.__name__}'."
+            ) from e
 
     @functools.cached_property
     def _primitive_values_extractor(self) -> Callable | None:
@@ -586,9 +597,8 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             return False
 
         artifact_future = self._compilation_jobs.pop(key)
-        assert isinstance(artifact_future, concurrent.futures.Future)
         assert key not in self.compiled_programs
-        self.compiled_programs[key] = self.backend.load_artifact(artifact_future.result())
+        self.compiled_programs[key] = self._load_artifact(artifact_future)
         return True
 
     def _compile_variant(
@@ -665,7 +675,7 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
         if future.done():
             # Eager so compile() raises now; otherwise the error stays in the
             # already-resolved future until the next call touches this key.
-            self.compiled_programs[key] = self.backend.load_artifact(future.result())
+            self.compiled_programs[key] = self._load_artifact(future)
         else:
             self._compilation_jobs[key] = future
             _ongoing_compilations[future] = (

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -427,10 +427,12 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             arg_specialization_key,
         )
 
-        try:
-            compiled_program = self.compiled_programs[key]
+        # Note: a plain lookup, without a `KeyError` handler: everything raised while such a
+        # handler is active gets chained to it, and the dispatch miss with its opaque key then
+        # dominates the traceback and hides the actual failure.
+        compiled_program = self.compiled_programs.get(key)
 
-        except KeyError as e:
+        if compiled_program is None:
             if self._finish_compilation_job(key):
                 compiled_program = self.compiled_programs[key]
             elif enable_jit:
@@ -453,13 +455,24 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
                     offset_provider=offset_provider,
                     enable_jit=False,
                     **canonical_kwargs,
-                )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call`
+                )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
 
             else:
-                raise RuntimeError("No program compiled for this set of static arguments.") from e
+                raise RuntimeError("No program compiled for this set of static arguments.")
 
         with compiled_program_call_context(self, key, args, kwargs, offset_provider):
             compiled_program(*args, **kwargs, offset_provider=offset_provider)
+
+    def _load_artifact(
+        self, artifact_future: concurrent.futures.Future[stages.CompilationArtifact]
+    ) -> stages.ExecutableProgram:
+        artifact = artifact_future.result()  # re-raises errors from the compilation worker
+        try:
+            return artifact.load()
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load the compiled program '{self.definition.__name__}'."
+            ) from e
 
     @functools.cached_property
     def _primitive_values_extractor(self) -> Callable | None:
@@ -581,9 +594,8 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             return False
 
         artifact_future = self._compilation_jobs.pop(key)
-        assert isinstance(artifact_future, concurrent.futures.Future)
         assert key not in self.compiled_programs
-        self.compiled_programs[key] = artifact_future.result().load()
+        self.compiled_programs[key] = self._load_artifact(artifact_future)
         return True
 
     def _compile_variant(
@@ -660,7 +672,7 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
         if future.done():
             # Eager so compile() raises now; otherwise the error stays in the
             # already-resolved future until the next call touches this key.
-            self.compiled_programs[key] = future.result().load()
+            self.compiled_programs[key] = self._load_artifact(future)
         else:
             self._compilation_jobs[key] = future
             _ongoing_compilations[future] = (

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_infer_domain_ops.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_infer_domain_ops.py
@@ -17,7 +17,7 @@ from gt4py.next.iterator.transforms.constant_folding import ConstantFolding
 from next_tests.integration_tests.cases import IDim, JDim, KDim
 
 
-def test_data():
+def _testcases():
     return [
         (
             im.less(im.axis_literal(IDim), 1),
@@ -62,7 +62,7 @@ def test_data():
     ]
 
 
-@pytest.mark.parametrize("testee,expected", test_data())
+@pytest.mark.parametrize("testee,expected", _testcases())
 def test_trivial(testee, expected):
     actual = InferDomainOps(grid_type=common.GridType.CARTESIAN).visit(testee, recurse=True)
     actual = ConstantFolding.apply(actual)  # simplify expr to get simpler expected expressions

--- a/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
@@ -7,8 +7,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import dataclasses
 import collections
+import concurrent.futures
 import contextvars
 import gc
+import traceback
 import weakref
 
 import pytest
@@ -173,6 +175,75 @@ def test_different_static_args_break_same_prg_after_static_params_change(testee_
         match="Argument descriptor StaticArg must be the same for all compiled programs",
     ):
         prg.compile(cond=[True], offset_provider={})
+
+
+@dataclasses.dataclass
+class _DeferredRunner:
+    """A runner handing out futures that the test resolves by hand."""
+
+    futures: list[concurrent.futures.Future] = dataclasses.field(default_factory=list)
+
+    def submit(self, task):
+        self.futures.append(concurrent.futures.Future())
+        return self.futures[-1]
+
+    def shutdown(self, wait: bool = True) -> None:
+        pass
+
+
+@pytest.fixture
+def deferred_runner(monkeypatch):
+    runner = _DeferredRunner()
+    monkeypatch.setattr(compiled_program.runners, "get_default_runner", lambda: runner)
+    return runner
+
+
+def _formatted_traceback(error: BaseException) -> str:
+    return "".join(traceback.format_exception(type(error), error, error.__traceback__))
+
+
+def test_dispatch_miss_reports_load_error_as_cause(testee_prog, deferred_runner):
+    class _StaleArtifact:
+        def load(self):
+            raise OSError(116, "Stale file handle")
+
+    testee = testee_prog.compile(cond=[True], offset_provider={})
+    (future,) = deferred_runner.futures
+    future.set_result(_StaleArtifact())
+
+    with pytest.raises(
+        RuntimeError, match="Failed to load the compiled program 'prog'"
+    ) as exc_info:
+        testee(cond=True, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert "KeyError" not in _formatted_traceback(exc_info.value)
+
+
+def test_dispatch_miss_propagates_compilation_error(testee_prog, deferred_runner):
+    class _WorkerError(Exception):
+        pass
+
+    testee = testee_prog.compile(cond=[True], offset_provider={})
+    (future,) = deferred_runner.futures
+    future.set_exception(_WorkerError("compilation failed in the worker"))
+
+    with pytest.raises(_WorkerError) as exc_info:
+        testee(cond=True, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    assert exc_info.value.__context__ is None
+    assert "KeyError" not in _formatted_traceback(exc_info.value)
+
+
+def test_dispatch_miss_without_jit_does_not_show_key_error(testee_prog, deferred_runner):
+    testee = testee_prog.with_compilation_options(enable_jit=False).compile(
+        cond=[True], offset_provider={}
+    )
+
+    with pytest.raises(RuntimeError, match="No program compiled") as exc_info:
+        testee(cond=False, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    assert "KeyError" not in _formatted_traceback(exc_info.value)
 
 
 def _verify_program_has_expected_domain(


### PR DESCRIPTION
When a compiled program cannot be obtained, the traceback leads with a KeyError on the dispatch
dict, even though the actual cause is something else. 

The reason is that `CompiledProgramsPool.__call__` did all cache-miss handling inside the
except KeyError handler of the dispatch lookup, so everything raised there was chained to the
KeyError.

The dispatch lookup now uses compiled_programs.get(key) and an is-None check, so a miss raises
nothing and there is no exception context left to chain to. The miss branch itself is unchanged.
A new _load_artifact wraps load failures as
`<SomeError> from <cause>`, so `<SomeError>` is
what the reader sees. Worker exceptions from `future.result()` are deliberately not wrapped and
propagate as themselves.