### PR TITLE
feat[next]: name program and static args in "no program compiled" error

### DIFF
--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -458,10 +458,30 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
                 )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
 
             else:
-                raise RuntimeError("No program compiled for this set of static arguments.")
+                raise RuntimeError(
+                    f"No program compiled for this set of static arguments of "
+                    f"'{self.definition.__name__}'{self._describe_argument_descriptors(key[0])}."
+                    " Note that a variant is also selected by the identity of the"
+                    " 'offset_provider' entries and, for generic programs, by the argument types."
+                )
 
         with compiled_program_call_context(self, key, args, kwargs, offset_provider):
             compiled_program(*args, **kwargs, offset_provider=offset_provider)
+
+    def _describe_argument_descriptors(self, descriptor_values: tuple[Hashable, ...]) -> str:
+        # Note: not `zip(..., strict=True)`: this runs while building an error message, so a
+        # mismatch must degrade to a shorter description instead of replacing the error.
+        exprs = [
+            expr
+            for descriptor_cls, arg_exprs in (self.argument_descriptor_mapping or {}).items()
+            for arg_expr in arg_exprs
+            for expr in descriptor_cls.attribute_extractor_exprs(arg_expr).values()
+        ]
+        if not exprs:
+            return ""
+        return ": " + ", ".join(
+            f"{expr}={value!r}" for expr, value in zip(exprs, descriptor_values)
+        )
 
     def _load_artifact(
         self, artifact_future: concurrent.futures.Future[stages.CompilationArtifact]

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -461,10 +461,30 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
                 )  # passing `enable_jit=False` because a cache miss should be a hard-error in this call
 
             else:
-                raise RuntimeError("No program compiled for this set of static arguments.")
+                raise RuntimeError(
+                    f"No program compiled for this set of static arguments of "
+                    f"'{self.definition.__name__}'{self._describe_argument_descriptors(key[0])}."
+                    " Note that a variant is also selected by the identity of the"
+                    " 'offset_provider' entries and, for generic programs, by the argument types."
+                )
 
         with compiled_program_call_context(self, key, args, kwargs, offset_provider):
             compiled_program(*args, **kwargs, offset_provider=offset_provider)
+
+    def _describe_argument_descriptors(self, descriptor_values: tuple[Hashable, ...]) -> str:
+        # Note: not `zip(..., strict=True)`: this runs while building an error message, so a
+        # mismatch must degrade to a shorter description instead of replacing the error.
+        exprs = [
+            expr
+            for descriptor_cls, arg_exprs in (self.argument_descriptor_mapping or {}).items()
+            for arg_expr in arg_exprs
+            for expr in descriptor_cls.attribute_extractor_exprs(arg_expr).values()
+        ]
+        if not exprs:
+            return ""
+        return ": " + ", ".join(
+            f"{expr}={value!r}" for expr, value in zip(exprs, descriptor_values)
+        )
 
     def _load_artifact(
         self, artifact_future: concurrent.futures.Future[stages.CompilationArtifact]

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -472,8 +472,6 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
             compiled_program(*args, **kwargs, offset_provider=offset_provider)
 
     def _describe_argument_descriptors(self, descriptor_values: tuple[Hashable, ...]) -> str:
-        # Note: not `zip(..., strict=True)`: this runs while building an error message, so a
-        # mismatch must degrade to a shorter description instead of replacing the error.
         exprs = [
             expr
             for descriptor_cls, arg_exprs in (self.argument_descriptor_mapping or {}).items()
@@ -482,6 +480,8 @@ class CompiledProgramsPool(Generic[ffront_stages.DSLDefinitionT]):
         ]
         if not exprs:
             return ""
+        # A length mismatch shortens the description; raising here would replace the
+        # error being built.
         return ": " + ", ".join(
             f"{expr}={value!r}" for expr, value in zip(exprs, descriptor_values)
         )

--- a/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_compiled_program.py
@@ -198,6 +198,29 @@ def deferred_runner(monkeypatch):
     return runner
 
 
+class _NoOpRunner:
+    """A runner whose artifacts load to a no-op callable, i.e. nothing is really compiled."""
+
+    class _Artifact:
+        def load(self):
+            return lambda *args, **kwargs: None
+
+    def submit(self, task):
+        future = concurrent.futures.Future()
+        future.set_result(self._Artifact())
+        return future
+
+    def shutdown(self, wait: bool = True) -> None:
+        pass
+
+
+@pytest.fixture
+def noop_runner(monkeypatch):
+    runner = _NoOpRunner()
+    monkeypatch.setattr(compiled_program.runners, "get_default_runner", lambda: runner)
+    return runner
+
+
 def _formatted_traceback(error: BaseException) -> str:
     return "".join(traceback.format_exception(type(error), error, error.__traceback__))
 
@@ -235,15 +258,32 @@ def test_dispatch_miss_propagates_compilation_error(testee_prog, deferred_runner
     assert "KeyError" not in _formatted_traceback(exc_info.value)
 
 
-def test_dispatch_miss_without_jit_does_not_show_key_error(testee_prog, deferred_runner):
+def test_dispatch_miss_without_jit_names_static_args(testee_prog, deferred_runner):
     testee = testee_prog.with_compilation_options(enable_jit=False).compile(
         cond=[True], offset_provider={}
     )
 
-    with pytest.raises(RuntimeError, match="No program compiled") as exc_info:
+    with pytest.raises(RuntimeError, match=r"No program compiled.*'prog': cond=False") as exc_info:
         testee(cond=False, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
 
     assert "KeyError" not in _formatted_traceback(exc_info.value)
+
+
+def test_dispatch_miss_without_jit_names_static_domain(testee_prog, noop_runner):
+    testee = testee_prog.with_compilation_options(static_domains=True, enable_jit=True)
+    testee(cond=True, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
+
+    object.__setattr__(testee.compilation_options, "enable_jit", False)
+
+    with pytest.raises(RuntimeError, match=r"'prog': \(out\)\.domain=Domain"):
+        testee(cond=True, out=gtx.zeros(domain={TDim: 2}, dtype=bool), offset_provider={})
+
+
+def test_dispatch_miss_without_argument_descriptors(testee_prog):
+    testee = testee_prog.with_compilation_options(enable_jit=False)
+
+    with pytest.raises(RuntimeError, match=r"arguments of 'prog'\. Note that"):
+        testee(cond=True, out=gtx.zeros(domain={TDim: 1}, dtype=bool), offset_provider={})
 
 
 def _verify_program_has_expected_domain(


### PR DESCRIPTION
Before:

    RuntimeError: No program compiled for this set of static arguments.

After:

    RuntimeError: No program compiled for this set of static arguments of 'prog': cond=False.
    Note that a variant is also selected by the identity of the 'offset_provider' entries and,
    for generic programs, by the argument types.

Neither the program nor the offending arguments were named, and the offset provider taking part
in the selection was not mentioned at all, which is the other common cause of an unexpected miss.
