### PR TITLE
refactor[next]: delete dead OTF workflow code (SkippableStep, BindingStep, fast fingerprinter)

### DIFF
--- a/docs/user/next/advanced/WorkflowPatterns.md
+++ b/docs/user/next/advanced/WorkflowPatterns.md
@@ -193,10 +193,6 @@ gtx.backend.DEFAULT_PROG_TRANSFORMS.past_lint??
 
 Though we execute the workflow three times we only get the debug print once, it worked! Btw, hashing is rarely that easy in the wild...
 
-#### Conditionally skipping steps
-
-The `SkippableStep` pattern can be used to skip a step under a given condition. A main use case is when you might want to run a workflow either from the start or from further along (with the same interface).
-
 Let's say we want to make our calculation workflow compatible with string input. We can add a conversion step (which only works with strings).
 
 <!-- #endregion -->
@@ -214,74 +210,6 @@ to_int_step = gtx.otf.workflow.make_step(to_int)
 str_calc = to_int_step.chain(add_3_times_2)
 
 str_calc("1")
-```
-
-<!-- #region editable=true slideshow={"slide_type": ""} -->
-
-Now we can start from a string that contains an int. But if we already have an int, it will fail.
-
-<!-- #endregion -->
-
-```python editable=true slideshow={"slide_type": ""}
-try:
-    str_calc(1)
-except AssertionError as err:
-    print(err)
-```
-
-<!-- #region editable=true slideshow={"slide_type": ""} tags=["skip-execution"] -->
-
-What to do? What we want is a to conditionally skip the first step, so we replace it with a `SkippableStep`:
-
-```python
-class OptionalStrToInt(SkippableStep[str | int, int]):
-    step: Workflow[str, int]
-
-    def skip_condition(
-        self, inp: str | int
-    ) -> (
-        bool
-    ): ...  # return True to skip (if we get an int) or False to run the conversion (str case)
-```
-
-```mermaid
-graph LR
-
-int(A: int = 1) --> calc{{"add_3_times_2(1)"}} --> result(8)
-int --> ski{{"skip_condition(1)"}} -->|True| calc
-str("B: str = '1'") --> sks{{"skip_condition('1')"}} -->|False| conv{{to_int}} --> b2("int(B) = 1") --> calc
-```
-
-<!-- #endregion -->
-
-```python editable=true slideshow={"slide_type": ""}
-@dataclasses.dataclass(frozen=True)
-class OptionalStrToInt(gtx.otf.workflow.SkippableStep[str | int, int]):
-    step: gtx.otf.workflow.Workflow[str, int] = to_int
-
-    def skip_condition(self, inp: str | int) -> bool:
-        match inp:
-            case int():
-                return True
-            case str():
-                return False
-            case _:
-                # optionally raise an error with good advice
-                return False
-
-
-strint_calc = OptionalStrToInt().chain(add_3_times_2)
-strint_calc(1) == strint_calc("1")
-```
-
-<!-- #region editable=true slideshow={"slide_type": ""} -->
-
-### Example in the Wild
-
-<!-- #endregion -->
-
-```python editable=true slideshow={"slide_type": ""}
-gtx.backend.DEFAULT_PROG_TRANSFORMS.func_to_past??
 ```
 
 <!-- #region editable=true slideshow={"slide_type": ""} -->
@@ -307,26 +235,20 @@ class StrToIntFactory(factory.Factory):
 
     class Params:
         default_step = to_int
-        optional: bool = False
-        optional_or_not = factory.LazyAttribute(
-            lambda o: OptionalStrToInt(step=o.default_step) if o.optional else o.default_step
-        )
         cached = factory.Trait(
             inner_step=factory.LazyAttribute(
                 lambda o: gtx.otf.workflow.CachedStep.in_memory(
-                    step=o.optional_or_not, input_fingerprinter=str
+                    step=o.default_step, input_fingerprinter=str
                 )
             )
         )
 
-    inner_step = factory.LazyAttribute(lambda o: o.optional_or_not)
+    inner_step = factory.LazyAttribute(lambda o: o.default_step)
 
 
 cached = StrToIntFactory(cached=True)
-optional = StrToIntFactory(optional=True)
-both = StrToIntFactory(cached=True, optional=True)
-neither = StrToIntFactory()
-neither.inner_step
+uncached = StrToIntFactory()
+uncached.inner_step
 ```
 
 ### Example in the Wild

--- a/src/gt4py/next/otf/definitions.py
+++ b/src/gt4py/next/otf/definitions.py
@@ -42,19 +42,6 @@ class TranslationStep(
     ...
 
 
-class BindingStep(Protocol[CodeSpecT, TargetCodeSpecT]):
-    """
-    Generate Bindings for program source and package both together (ProgramSource -> ExtensionSource).
-
-    In the special cases where bindings are not required, such a step could also simply construct
-    an ``ExtensionSource`` from the ``ProgramSource`` with bindings set to ``None``.
-    """
-
-    def __call__(
-        self, program_source: stages.ProgramSource[CodeSpecT]
-    ) -> stages.ExtensionSource[CodeSpecT, TargetCodeSpecT]: ...
-
-
 class CompilationStep(
     workflow.Workflow[
         stages.ExtensionSource[CodeSpecT, TargetCodeSpecT], stages.CompilationArtifact

--- a/src/gt4py/next/otf/stages.py
+++ b/src/gt4py/next/otf/stages.py
@@ -10,52 +10,11 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Callable
-from typing import (
-    TYPE_CHECKING,
-    Final,
-    Generic,
-    Optional,
-    Protocol,
-    TypeAlias,
-    TypeVar,
-    runtime_checkable,
-)
+from typing import Final, Generic, Optional, Protocol, TypeAlias, TypeVar, runtime_checkable
 
-from gt4py.next import common, fingerprinting
-from gt4py.next.iterator import ir as itir
+from gt4py.next import fingerprinting
 from gt4py.next.otf import code_specs
 from gt4py.next.otf.binding import interface
-
-
-if TYPE_CHECKING:
-    # Imported only for typing to avoid the import cycle with `otf.definitions`,
-    # which imports this module.
-    from gt4py.next.otf import definitions
-
-
-def fast_compilable_program_fingerprinter(program_def: definitions.CompilableProgramDef) -> str:
-    """
-    In-memory executor cache key: changes whenever the program needs recompilation.
-
-    The program is identified by its location- and type-agnostic semantic
-    fingerprint, while the offset providers are identified by the identity of
-    their connectivities, in iteration order. The order matters because the
-    generated bindings bake in the offset-provider order (see
-    ``extract_connectivity_args``), and the by-identity (rather than by-content)
-    comparison keeps this in-memory key cheap by not hashing the connectivity
-    tables.
-    """
-    prog_def_args = program_def.args
-    offset_provider = prog_def_args.offset_provider
-    return fingerprinting.lenient_fingerprinter(
-        (
-            itir.lenient_ir_fingerprinter(program_def.data),
-            prog_def_args.args,
-            prog_def_args.kwargs,
-            common.hash_offset_provider_items_by_id(offset_provider) if offset_provider else None,
-            prog_def_args.column_axis,
-        )
-    )
 
 
 compilable_program_fingerprinter: Final[fingerprinting.Fingerprinter] = (

--- a/src/gt4py/next/otf/workflow.py
+++ b/src/gt4py/next/otf/workflow.py
@@ -341,19 +341,3 @@ class CachedStep(
 
     def cache_key(self, inp: StartT) -> str:
         return self.step_fingerprinter((self._step_fingerprint, self.input_fingerprinter(inp)))
-
-
-@dataclasses.dataclass(frozen=True)
-class SkippableStep(
-    ChainableWorkflowMixin[StartT, EndT],
-    ReplaceEnabledWorkflowMixin[StartT, EndT],
-):
-    step: Workflow[StartT, EndT]
-
-    def __call__(self, inp: StartT) -> EndT:
-        if not self.skip_condition(inp):
-            return self.step(inp)
-        return inp  # type: ignore[return-value]  # up to the implementer to make sure StartT == EndT
-
-    def skip_condition(self, inp: StartT) -> bool:
-        raise NotImplementedError()

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -190,7 +190,6 @@ class GTFNBackendFactory(factory.Factory):
             name_device="gpu",
         )
         device_type = core_defs.DeviceType.CPU
-        key_function = stages.fast_compilable_program_fingerprinter
         otf_workflow = factory.SubFactory(
             GTFNCompileWorkflowFactory,
             cached_translation=True,

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -192,7 +192,6 @@ class GTFNBackendFactory(factory.Factory):
             name_device="gpu",
         )
         device_type = core_defs.DeviceType.CPU
-        key_function = stages.fast_compilable_program_fingerprinter
         otf_workflow = factory.SubFactory(
             GTFNCompileWorkflowFactory,
             cached_translation=True,


### PR DESCRIPTION
## Description

First PR of a stack refactoring the `gt4py.next.otf` toolchain (phases 0-4 of the `otf-toolchain-split` proposal). This one only deletes dead code, with no behavior change:

- **`workflow.SkippableStep`**: unused combinator (no subclasses, no instantiations in the repo). The corresponding section in `docs/user/next/advanced/WorkflowPatterns.md` is removed and the `StrToIntFactory` example simplified to the traits actually demonstrated.
- **`stages.fast_compilable_program_fingerprinter`** and the `key_function` helper in `runners/gtfn.py`: an unused alternative cache-key function with no remaining readers. The persistent caches (`gtfn`, dace) keep using the strict fingerprinter through the existing `stages.compilable_program_fingerprinter` alias, so cache keys are unaffected.
- **`definitions.BindingStep`** protocol (`otf/definitions.py`): never implemented by any class; binding steps are plain callables.

No public `gtx.*` API is affected. Cache keys are unchanged (fingerprints use fully-qualified class names, which none of these deletions touch).

## Requirements

- [x] All fixes and/or new features come with corresponding tests. (Deletion-only; existing suites cover the surviving code paths.)
- [x] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. (None needed for dead-code deletion; the naming/pipeline ADR lands later in this stack.)

https://claude.ai/code/session_01R8zRtFMhdJ8c96XJYCXkRk

