### PR TITLE
fix[next-dace]: Include modifed SDFG with GPU TX markers in build folder fingerprint

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -17,37 +17,6 @@ from gt4py.next import config as gtx_config
 from gt4py.next.otf.compilation import common as gtx_compilation_common
 
 
-def serialize_sdfg_as_json(sdfg: dace.SDFG) -> dict[str, Any]:
-    """
-    Serialize an SDFG to JSON while removing ``guid`` keys.
-
-    `guid` is a per-element identity token: it does not affect code generation, and
-    `SDFG.from_json()` assigns fresh ids anyway. Keeping it would make the compile
-    cache key depend on element creation order, so two structurally identical
-    lowerings of the same program would not share a cached build.
-    # FIXME(edopao): remove this workaround once the SDFG lowering is stable.
-
-    Note that the recursive implementation to drop ``guid`` keys is 2-3x faster than
-    the iterative one, on a large SDFG, and it is also simpler to read.
-
-    Note that we set 'hash=True' to compute the SDFG hash and store it in the JSON
-    object. We compute the hash in order to refresh `cfg_list` on the SDFG, which
-    makes the JSON serialization stable.
-    """
-    json_obj = sdfg.to_json(hash=True)
-
-    def _drop_guids(obj: Any) -> Any:
-        if isinstance(obj, dict):
-            return {k: _drop_guids(v) for k, v in obj.items() if k != "guid"}
-        if isinstance(obj, list):
-            return [_drop_guids(v) for v in obj]
-        if isinstance(obj, tuple):
-            return tuple(_drop_guids(v) for v in obj)
-        return obj
-
-    return _drop_guids(json_obj)
-
-
 SDFG_ARG_METRIC_LEVEL: Final[str] = "gt_metrics_level"
 """Name of SDFG argument to input the GT4Py metrics level."""
 
@@ -205,3 +174,34 @@ def dace_context(**kwargs: Any) -> Generator[None, None, None]:
     with dace.config.temporary_config():
         set_dace_config(**kwargs)
         yield
+
+
+def serialize_sdfg_as_json(sdfg: dace.SDFG) -> dict[str, Any]:
+    """
+    Serialize an SDFG to JSON while removing ``guid`` keys.
+
+    `guid` is a per-element identity token: it does not affect code generation, and
+    `SDFG.from_json()` assigns fresh ids anyway. Keeping it would make the compile
+    cache key depend on element creation order, so two structurally identical
+    lowerings of the same program would not share a cached build.
+    # FIXME(edopao): remove this workaround once the SDFG lowering is stable.
+
+    Note that the recursive implementation to drop ``guid`` keys is 2-3x faster than
+    the iterative one, on a large SDFG, and it is also simpler to read.
+
+    Note that we set 'hash=True' to compute the SDFG hash and store it in the JSON
+    object. We compute the hash in order to refresh `cfg_list` on the SDFG, which
+    makes the JSON serialization stable.
+    """
+    json_obj = sdfg.to_json(hash=True)
+
+    def _drop_guids(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: _drop_guids(v) for k, v in obj.items() if k != "guid"}
+        if isinstance(obj, list):
+            return [_drop_guids(v) for v in obj]
+        if isinstance(obj, tuple):
+            return tuple(_drop_guids(v) for v in obj)
+        return obj
+
+    return _drop_guids(json_obj)

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -17,7 +17,7 @@ from gt4py.next import config as gtx_config
 from gt4py.next.otf.compilation import common as gtx_compilation_common
 
 
-def serialize_sdfg_as_json(sdfg: dace.SDFG) -> Any:
+def serialize_sdfg_as_json(sdfg: dace.SDFG) -> dict[str, Any]:
     """
     Serialize an SDFG to JSON while removing ``guid`` keys.
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -17,6 +17,37 @@ from gt4py.next import config as gtx_config
 from gt4py.next.otf.compilation import common as gtx_compilation_common
 
 
+def serialize_sdfg_as_json(sdfg: dace.SDFG) -> Any:
+    """
+    Serialize an SDFG to JSON while removing ``guid`` keys.
+
+    `guid` is a per-element identity token: it does not affect code generation, and
+    `SDFG.from_json()` assigns fresh ids anyway. Keeping it would make the compile
+    cache key depend on element creation order, so two structurally identical
+    lowerings of the same program would not share a cached build.
+    # FIXME(edopao): remove this workaround once the SDFG lowering is stable.
+
+    Note that the recursive implementation to drop ``guid`` keys is 2-3x faster than
+    the iterative one, on a large SDFG, and it is also simpler to read.
+
+    Note that we set 'hash=True' to compute the SDFG hash and store it in the JSON
+    object. We compute the hash in order to refresh `cfg_list` on the SDFG, which
+    makes the JSON serialization stable.
+    """
+    json_obj = sdfg.to_json(hash=True)
+
+    def _drop_guids(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: _drop_guids(v) for k, v in obj.items() if k != "guid"}
+        if isinstance(obj, list):
+            return [_drop_guids(v) for v in obj]
+        if isinstance(obj, tuple):
+            return tuple(_drop_guids(v) for v in obj)
+        return obj
+
+    return _drop_guids(json_obj)
+
+
 SDFG_ARG_METRIC_LEVEL: Final[str] = "gt_metrics_level"
 """Name of SDFG argument to input the GT4Py metrics level."""
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -38,9 +38,11 @@ SDFGExtensionSource: TypeAlias = stages.ExtensionSource[
 ]
 
 
-def _add_tx_markers(inp: SDFGExtensionSource) -> SDFGExtensionSource:
-    """Add GPU TX markers to the SDFG of the given extension source."""
-    sdfg = dace.SDFG.from_json(inp.program_source.source_code)
+def _add_tx_markers(program_source: SDFGExtensionSource) -> tuple[SDFGExtensionSource, dace.SDFG]:
+    """Add GPU TX markers to the SDFG of the given extension source.
+
+    Returns the modified extension source and the modified SDFG."""
+    sdfg = dace.SDFG.from_json(program_source.program_source.source_code)
 
     has_gpu_schedule = any(
         getattr(node, "schedule", dace.dtypes.ScheduleType.Default) in dace.dtypes.GPU_SCHEDULES
@@ -48,7 +50,7 @@ def _add_tx_markers(inp: SDFGExtensionSource) -> SDFGExtensionSource:
     )
 
     if not has_gpu_schedule:
-        return inp  # No GPU schedule, no need to add TX markers.
+        return program_source, sdfg  # No GPU schedule, no need to add TX markers.
 
     sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
     for node, _ in sdfg.all_nodes_recursive():
@@ -56,12 +58,14 @@ def _add_tx_markers(inp: SDFGExtensionSource) -> SDFGExtensionSource:
         if isinstance(node, (dace.nodes.MapEntry, dace.sdfg.SDFGState)):
             node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
 
-    json = gtx_wfdcommon.serialize_sdfg_as_json(sdfg)
+    sdfg_json = gtx_wfdcommon.serialize_sdfg_as_json(sdfg)
 
-    return dataclasses.replace(
-        inp,
-        program_source=dataclasses.replace(inp.program_source, source_code=json),
+    new_program_source = dataclasses.replace(
+        program_source,
+        program_source=dataclasses.replace(program_source.program_source, source_code=sdfg_json),  # type: ignore[arg-type] # The source code is typed as a `str`, but we assign a JSON dictionary.
     )
+
+    return new_program_source, sdfg
 
 
 class CompiledDaceProgram:
@@ -221,7 +225,9 @@ class DaCeCompiler(
         ):
             # Add TX markers to the generated GPU code for trace visualization tools.
             if self.add_gpu_trace_markers and self.device_type == core_defs.CUPY_DEVICE_TYPE:
-                inp = _add_tx_markers(inp)
+                inp, sdfg = _add_tx_markers(inp)
+            else:
+                sdfg = dace.SDFG.from_json(inp.program_source.source_code)
 
             # Fingerprint the non-default ``dace.Config`` so the SDFG rebuilds when the
             # user changes the backend configuration (PR #2650).
@@ -233,7 +239,6 @@ class DaCeCompiler(
             sdfg_build_folder.mkdir(parents=True, exist_ok=True)
 
             # Configure the SDFG build folder
-            sdfg = dace.SDFG.from_json(inp.program_source.source_code)
             sdfg.build_folder = sdfg_build_folder
 
             # ``build_folder_mode`` is set by ``dace_context``; resolve the library

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -39,9 +39,11 @@ SDFGExtensionSource: TypeAlias = stages.ExtensionSource[
 
 
 def _add_tx_markers(program_source: SDFGExtensionSource) -> tuple[SDFGExtensionSource, dace.SDFG]:
-    """Add GPU TX markers to the SDFG of the given extension source.
+    """
+    Add GPU TX markers to the SDFG of the given extension source.
 
-    Returns the modified extension source and the modified SDFG."""
+    Returns the modified extension source and the modified SDFG.
+    """
     sdfg = dace.SDFG.from_json(program_source.program_source.source_code)
 
     has_gpu_schedule = any(

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -14,7 +14,7 @@ import os
 import pathlib
 import warnings
 from collections.abc import Callable, MutableSequence, Sequence
-from typing import Any, Final
+from typing import Any, Final, TypeAlias
 
 import dace
 import dace.codegen.compiler as dace_compiler
@@ -33,18 +33,33 @@ from gt4py.next.program_processors.runners.dace.workflow import (
 _COMPILE_COMPLETE_MARKER: Final = ".gt4py_compile_complete"
 
 
-def _add_tx_markers(sdfg: dace.SDFG) -> None:
+SDFGExtensionSource: TypeAlias = stages.ExtensionSource[
+    code_specs.SDFGCodeSpec, code_specs.PythonCodeSpec
+]
+
+
+def _add_tx_markers(inp: SDFGExtensionSource) -> SDFGExtensionSource:
+    """Add GPU TX markers to the SDFG of the given extension source."""
+    sdfg = dace.SDFG.from_json(inp.program_source.source_code)
+
     has_gpu_schedule = any(
         getattr(node, "schedule", dace.dtypes.ScheduleType.Default) in dace.dtypes.GPU_SCHEDULES
         for node, _ in sdfg.all_nodes_recursive()
     )
 
-    if has_gpu_schedule:
-        sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
-        for node, _ in sdfg.all_nodes_recursive():
-            # Also adds markers to map scopes that are NOT scheduled on GPU
-            if isinstance(node, (dace.nodes.MapEntry, dace.sdfg.SDFGState)):
-                node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+    if not has_gpu_schedule:
+        return inp  # No GPU schedule, no need to add TX markers.
+
+    sdfg.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+    for node, _ in sdfg.all_nodes_recursive():
+        # Also adds markers to map scopes that are NOT scheduled on GPU
+        if isinstance(node, (dace.nodes.MapEntry, dace.sdfg.SDFGState)):
+            node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
+
+    return dataclasses.replace(
+        inp,
+        program_source=dataclasses.replace(inp.program_source, source_code=sdfg.to_json(hash=True)),
+    )
 
 
 class CompiledDaceProgram:
@@ -197,15 +212,14 @@ class DaCeCompiler(
         ):
             object.__setattr__(self, "dace_config_nondefaults", dace.Config._data.nondefaults())
 
-    def __call__(
-        self,
-        inp: stages.ExtensionSource[code_specs.SDFGCodeSpec, code_specs.PythonCodeSpec],
-    ) -> DaCeCompilationArtifact:
+    def __call__(self, inp: SDFGExtensionSource) -> DaCeCompilationArtifact:
         with gtx_wfdcommon.dace_context(
             device_type=self.device_type,
             cmake_build_type=self.cmake_build_type,
         ):
-            sdfg = dace.SDFG.from_json(inp.program_source.source_code)
+            # Add TX markers to the generated GPU code for trace visualization tools.
+            if self.add_gpu_trace_markers and self.device_type == core_defs.CUPY_DEVICE_TYPE:
+                inp = _add_tx_markers(inp)
 
             # Fingerprint the non-default ``dace.Config`` so the SDFG rebuilds when the
             # user changes the backend configuration (PR #2650).
@@ -215,11 +229,10 @@ class DaCeCompiler(
                 build_context_id=fingerprinting.strict_fingerprinter(self.dace_config_nondefaults),
             )
             sdfg_build_folder.mkdir(parents=True, exist_ok=True)
-            sdfg.build_folder = sdfg_build_folder
 
-            # Add TX markers to the generated GPU code for trace visualization tools.
-            if self.add_gpu_trace_markers and self.device_type == core_defs.CUPY_DEVICE_TYPE:
-                _add_tx_markers(sdfg)
+            # Configure the SDFG build folder
+            sdfg = dace.SDFG.from_json(inp.program_source.source_code)
+            sdfg.build_folder = sdfg_build_folder
 
             # ``build_folder_mode`` is set by ``dace_context``; resolve the library
             # path here so ``get_binary_name`` sees the same mode dace built under.

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -56,9 +56,11 @@ def _add_tx_markers(inp: SDFGExtensionSource) -> SDFGExtensionSource:
         if isinstance(node, (dace.nodes.MapEntry, dace.sdfg.SDFGState)):
             node.instrument = dace.dtypes.InstrumentationType.GPU_TX_MARKERS
 
+    json = gtx_wfdcommon.serialize_sdfg_as_json(sdfg)
+
     return dataclasses.replace(
         inp,
-        program_source=dataclasses.replace(inp.program_source, source_code=sdfg.to_json(hash=True)),
+        program_source=dataclasses.replace(inp.program_source, source_code=json),
     )
 
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -169,6 +169,13 @@ class DaCeCompilationArtifact:
     (``get_program_handle``) needs an SDFG instance to wrap into the
     returned ``CompiledSDFG``, and the build folder may not contain a
     ``program.sdfg(z)`` dump under the upcoming minimal-build-dir mode.
+
+    The SDFG we store here is the one on which we called `SDFG.compile(return_program_handle=False)`.
+    Note that the `compile()` call has side effects, because it applies transformations
+    to the SDFG, in order to enable code generation for the target platform.
+    Since we pass `return_program_handle=False`, the `compile()` method does not
+    return a `CompiledSDFG` instance, therefore we cannot access `CompiledSDFG.sdfg`,
+    which would be the modified SDFG from which DaCe generates the C++/CUDA/HIP code.
     """
 
     library_path: pathlib.Path

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -459,39 +459,11 @@ class DaCeTranslator(
 
         module: stages.ProgramSource[code_specs.SDFGCodeSpec] = stages.ProgramSource(
             entry_point=interface.Function(program.id, program_parameters),
-            # Set 'hash=True' to compute the SDFG hash and store it in the JSON.
-            #   We compute the hash in order to refresh `cfg_list` on the SDFG,
-            #   which makes the JSON serialization stable.
-            # `guid` is a per-element identity token: it does not affect code generation, and
-            #   `SDFG.from_json()` assigns fresh ids anyway. Keeping it would make the compile
-            #   cache key depend on element creation order, so two structurally identical
-            #   lowerings of the same program would not share a cached build.
-            source_code=_drop_element_ids(sdfg.to_json(hash=True)),
+            source_code=gtx_wfdcommon.serialize_sdfg_as_json(sdfg),
             library_deps=tuple(),
             code_spec=code_specs.SDFGCodeSpec(),
         )
         return module
-
-
-def _drop_element_ids(json_obj: Any) -> Any:
-    """
-    Remove ``guid`` keys from a serialized SDFG with recursion.
-
-    We remove ``guid`` keys because of indeterminism of the ``guid`` values, which
-    would cause two identical programs to result in different compiled SDFGs, since
-    the cache key contains the hash of the serialized SDFG (a JSON string).
-    # FIXME(edopao): remove this workaround once the SDFG lowering is stable.
-
-    Note that this recursive implementation is 2-3x faster than the iterative one,
-    on a large SDFG, and it is also simpler to read.
-    """
-    if isinstance(json_obj, dict):
-        return {k: _drop_element_ids(v) for k, v in json_obj.items() if k != "guid"}
-    if isinstance(json_obj, list):
-        return [_drop_element_ids(v) for v in json_obj]
-    if isinstance(json_obj, tuple):
-        return tuple(_drop_element_ids(v) for v in json_obj)
-    return json_obj
 
 
 class DaCeTranslationStepFactory(factory.Factory):

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -459,7 +459,7 @@ class DaCeTranslator(
 
         module: stages.ProgramSource[code_specs.SDFGCodeSpec] = stages.ProgramSource(
             entry_point=interface.Function(program.id, program_parameters),
-            source_code=gtx_wfdcommon.serialize_sdfg_as_json(sdfg),
+            source_code=gtx_wfdcommon.serialize_sdfg_as_json(sdfg),  # type: ignore[arg-type] # The source code is typed as a `str`, but we assign a JSON dictionary.
             library_deps=tuple(),
             code_spec=code_specs.SDFGCodeSpec(),
         )

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_backend.py
@@ -28,8 +28,9 @@ from next_tests.integration_tests.cases_utils import KDim
 @pytest.fixture(
     params=[
         pytest.param(core_defs.DeviceType.CPU),
-        pytest.param(core_defs.DeviceType.CUDA, marks=pytest.mark.requires_gpu),
-    ]
+        pytest.param(core_defs.CUPY_DEVICE_TYPE, marks=pytest.mark.requires_gpu),
+    ],
+    ids=["CPU", "GPU"],
 )
 def device_type(request) -> str:
     return request.param

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -178,10 +178,24 @@ def test_dace_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
     assert restored == artifact
 
 
-def test_same_artifact(program_source):
-    """Same SDFG and compile settings must produce the same artifact."""
-    artifact_1, sdfg_1 = _run_compiler(program_source)
-    artifact_2, sdfg_2 = _run_compiler(program_source)
+@pytest.mark.parametrize("add_gpu_trace_markers", [False, True])
+def test_same_artifact(add_gpu_trace_markers, program_source):
+    """Same SDFG and compile settings must produce the same artifact.
+
+    We also test the case ``add_gpu_trace_markers=True`` to verify that the modified
+    SDFG has the same fingerprint, for the same input SDFG and compilation settings.
+    This way, we verify that the GUIDs elements are removed from the JSON source code.
+    """
+    artifact_1, sdfg_1 = _run_compiler(
+        program_source,
+        add_gpu_trace_markers=add_gpu_trace_markers,
+        device_type=core_defs.DeviceType.CUDA,
+    )
+    artifact_2, sdfg_2 = _run_compiler(
+        program_source,
+        add_gpu_trace_markers=add_gpu_trace_markers,
+        device_type=core_defs.DeviceType.CUDA,
+    )
 
     assert artifact_1.library_path == artifact_2.library_path
     assert (

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_compilation.py
@@ -79,7 +79,8 @@ def _make_sdfg_with_gpu_map() -> dace.SDFG:
     return sdfg
 
 
-def _make_extension_source() -> stages.ExtensionSource:
+@pytest.fixture
+def program_source() -> dace_wf_compilation.SDFGExtensionSource:
     """A real `ExtensionSource` wrapping the GPU SDFG, as the dace translation step emits.
 
     Using a real source (rather than a `MagicMock`) lets the unmocked `get_cache_folder`
@@ -96,17 +97,16 @@ def _make_extension_source() -> stages.ExtensionSource:
 
 
 def _run_compiler(
+    inp: stages.ExtensionSource,
     *,
     add_gpu_trace_markers: bool = False,
     cmake_build_type: config.CMakeBuildType = config.CMakeBuildType.RELEASE,
     device_type: core_defs.DeviceType = core_defs.DeviceType.CPU,
-) -> tuple[dace_wf_compilation.DaCeCompilationArtifact, dace.SDFG, mock.MagicMock]:
-    """Run `DaCeCompiler` on a GPU SDFG with compilation stubbed out.
+) -> tuple[dace_wf_compilation.DaCeCompilationArtifact, dace.SDFG]:
+    """Run `DaCeCompiler` on the provided `program_source` with compilation stubbed out.
 
-    Returns the compilation artifact, the SDFG which was compiled, and the spy wrapping `_add_tx_markers`.
+    Returns the compilation artifact and the SDFG which was compiled.
     """
-    inp = _make_extension_source()
-
     compiler = dace_wf_compilation.DaCeCompiler(
         bind_func_name="bind",
         cache_lifetime=config.BuildCacheLifetime.SESSION,
@@ -116,11 +116,6 @@ def _run_compiler(
     )
 
     with (
-        mock.patch.object(
-            dace_wf_compilation,
-            "_add_tx_markers",
-            wraps=dace_wf_compilation._add_tx_markers,
-        ) as spy_add_tx_markers,
         mock.patch.object(dace.SDFG, "compile", autospec=True) as compile_mock,
         mock.patch.object(
             dace_wf_compilation.locking, "lock", lambda *args, **kwargs: contextlib.nullcontext()
@@ -135,18 +130,15 @@ def _run_compiler(
         artifact = compiler(inp)
         compile_input = compile_mock.call_args.args[0]
 
-    return artifact, compile_input, spy_add_tx_markers
+    return artifact, compile_input
 
 
-def test_compiler_applies_tx_markers_for_gpu():
+def test_compiler_applies_tx_markers_for_gpu(program_source):
     """On a CUDA target with the flag on, the compiler applies the markers to the SDFG."""
-    _, compile_input, spy = _run_compiler(
-        add_gpu_trace_markers=True, device_type=core_defs.DeviceType.CUDA
+    _, compile_input = _run_compiler(
+        program_source, add_gpu_trace_markers=True, device_type=core_defs.DeviceType.CUDA
     )
 
-    spy.assert_called_once()
-    # The SDFG that was marked is the very one passed on to compilation.
-    assert spy.call_args.args[0] is compile_input
     assert compile_input.instrument == _TX
     map_entries = [
         n for n, _ in compile_input.all_nodes_recursive() if isinstance(n, dace_nodes.MapEntry)
@@ -154,23 +146,21 @@ def test_compiler_applies_tx_markers_for_gpu():
     assert map_entries and all(me.instrument == _TX for me in map_entries)
 
 
-def test_compiler_skips_tx_markers_when_flag_disabled():
+def test_compiler_skips_tx_markers_when_flag_disabled(program_source):
     """With the flag off the compiler must not touch instrumentation, even on CUDA."""
-    _, compile_input, spy = _run_compiler(
-        add_gpu_trace_markers=False, device_type=core_defs.DeviceType.CUDA
+    _, compile_input = _run_compiler(
+        program_source, add_gpu_trace_markers=False, device_type=core_defs.DeviceType.CUDA
     )
 
-    spy.assert_not_called()
     assert compile_input.instrument == _NONE
 
 
-def test_compiler_skips_tx_markers_for_non_gpu_device():
+def test_compiler_skips_tx_markers_for_non_gpu_device(program_source):
     """On a CPU target the markers must not be applied even with the flag on."""
-    _, compile_input, spy = _run_compiler(
-        add_gpu_trace_markers=True, device_type=core_defs.DeviceType.CPU
+    _, compile_input = _run_compiler(
+        program_source, add_gpu_trace_markers=True, device_type=core_defs.DeviceType.CPU
     )
 
-    spy.assert_not_called()
     assert compile_input.instrument == _NONE
 
 
@@ -188,6 +178,29 @@ def test_dace_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
     assert restored == artifact
 
 
+def test_same_artifact(program_source):
+    """Same SDFG and compile settings must produce the same artifact."""
+    artifact_1, sdfg_1 = _run_compiler(program_source)
+    artifact_2, sdfg_2 = _run_compiler(program_source)
+
+    assert artifact_1.library_path == artifact_2.library_path
+    assert (
+        sdfg_1.hash_sdfg() == sdfg_2.hash_sdfg()
+    )  # might contain different GUIDs, `hash_sdfg()` ignores them
+
+
+def test_apply_tx_markers_changes_artifact(program_source):
+    """Different instrumentation settings must produce a different artifact."""
+    artifact_base, _ = _run_compiler(
+        program_source, device_type=core_defs.DeviceType.CUDA, add_gpu_trace_markers=False
+    )
+    artifact_with_markers, _ = _run_compiler(
+        program_source, device_type=core_defs.DeviceType.CUDA, add_gpu_trace_markers=True
+    )
+
+    assert artifact_base.library_path != artifact_with_markers.library_path
+
+
 # `CXXFLAGS`, `CUDAFLAGS` and `HIPFLAGS` feed `compiler.cpu.args`, `compiler.cuda.args`
 # and `compiler.cuda.hip_args` respectively (see `set_dace_config`).
 @pytest.mark.parametrize(
@@ -197,9 +210,12 @@ def test_dace_compilation_artifact_pickle_round_trip(tmp_path: pathlib.Path):
         (core_defs.DeviceType.CUDA, "CUDAFLAGS"),
         (core_defs.DeviceType.ROCM, "HIPFLAGS"),
     ],
+    ids=["CPU", "CUDA", "HIP"],
 )
-def test_compiler_flags_change_build_folder(monkeypatch, device_type, compiler_flags_env):
-    """Different compiler flags must produce a different build folder.
+def test_compiler_flags_change_artifact(
+    device_type, compiler_flags_env, program_source, monkeypatch
+):
+    """Different compiler flags must produce a different artifact.
 
     The flags are captured in `dace_config_nondefaults`, whose fingerprint the compiler
     passes to `get_cache_folder` as the `build_context_id`. That id is appended to the
@@ -207,18 +223,18 @@ def test_compiler_flags_change_build_folder(monkeypatch, device_type, compiler_f
     build cache.
     """
     monkeypatch.delenv(compiler_flags_env, raising=False)
-    artifact_default, _, _ = _run_compiler(device_type=device_type)
+    artifact_default, _ = _run_compiler(program_source, device_type=device_type)
 
     monkeypatch.setenv(compiler_flags_env, "-O0 -some-custom-flag")
-    artifact_custom, _, _ = _run_compiler(device_type=device_type)
+    artifact_custom, _ = _run_compiler(program_source, device_type=device_type)
 
     # The differing `dace_config_nondefaults` make the two compilers fingerprint differently,
-    # so `get_cache_folder` names two distinct build folders.
+    # so `get_cache_folder` names two distinct artifacts.
     assert artifact_default.library_path != artifact_custom.library_path
 
 
-def test_cmake_build_type_changes_build_folder():
-    """Different cmake build types must produce a different SDFG build folder.
+def test_cmake_build_type_changes_artifact(program_source):
+    """Different cmake build types must produce a different SDFG artifact.
 
     The cmake build type is part of the DaCe configuration captured in
     `dace_config_nondefaults`, whose fingerprint is passed to `get_cache_folder`
@@ -226,7 +242,9 @@ def test_cmake_build_type_changes_build_folder():
     changing the build type lands the SDFG build in a different folder of the
     build cache.
     """
-    artifact_release, _, _ = _run_compiler(cmake_build_type=config.CMakeBuildType.RELEASE)
-    artifact_debug, _, _ = _run_compiler(cmake_build_type=config.CMakeBuildType.DEBUG)
+    artifact_release, _ = _run_compiler(
+        program_source, cmake_build_type=config.CMakeBuildType.RELEASE
+    )
+    artifact_debug, _ = _run_compiler(program_source, cmake_build_type=config.CMakeBuildType.DEBUG)
 
     assert artifact_release.library_path != artifact_debug.library_path

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -51,7 +51,8 @@ VFTYPE = ts.FieldType(dims=[Vertex], dtype=FLOAT_TYPE)
         pytest.param(core_defs.DeviceType.CPU),
         pytest.param(core_defs.DeviceType.CUDA, marks=[pytest.mark.requires_gpu]),
         pytest.param(core_defs.DeviceType.ROCM, marks=[pytest.mark.requires_gpu]),
-    ]
+    ],
+    ids=["CPU", "CUDA", "ROCM"],
 )
 def device_type(request) -> str:
     return request.param

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/test_dace_translation.py
@@ -18,7 +18,7 @@ from unittest import mock
 dace = pytest.importorskip("dace")
 
 from gt4py._core import definitions as core_defs
-from gt4py.next import common as gtx_common
+from gt4py.next import common as gtx_common, fingerprinting
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import ir_makers as im
 from gt4py.next.otf import arguments as otf_arguments, toolchain as otf_toolchain
@@ -474,8 +474,8 @@ def _increment_sdfg_guids(sdfg: dace.SDFG) -> None:
 def test_translation_source_code_invariant_under_guid_change():
     """SDFG `guid` changes must not alter the translation cache key.
 
-    `DaCeTranslator.__call__` drops `guid` values via `_drop_element_ids`
-    before storing the SDFG JSON in `ProgramSource.source_code`. This test
+    `DaCeTranslator.__call__` serializes the SDFG via `serialize_sdfg_as_json`,
+    which drops `guid` values, before storing the SDFG JSON in
     mocks `build_sdfg_from_gtir` so that the second lowering returns the same
     SDFG with all `guid` values incremented by one, and verifies that the
     resulting `source_code` strings are identical.
@@ -517,4 +517,11 @@ def test_translation_source_code_invariant_under_guid_change():
         first_source = translator(compilable_program)
         second_source = translator(compilable_program)
 
+    # different object identities, same content
+    assert first_source.source_code is not second_source.source_code
     assert first_source.source_code == second_source.source_code
+
+    assert first_source is not second_source
+    first_source_fingerprint = fingerprinting.strict_fingerprinter(first_source)
+    second_source_fingerprint = fingerprinting.strict_fingerprinter(second_source)
+    assert first_source_fingerprint == second_source_fingerprint


### PR DESCRIPTION
This pull request refactors and improves the GPU trace marker logic in the DaCe compilation workflow, enhances test coverage, and clarifies test parameterization. The main functional change is to ensure that the fingerprint of the build folder includes the modified SDFG after applying the GPU transaction markers. This way, enabling or not the GPU transaction markers results in different build artifacts. Tests are updated to reflect the new marker application logic and to ensure that build artifacts change when relevant compilation settings differ.

**DaCe compilation logic improvements:**

* Refactored `_add_tx_markers` to take and return an `ExtensionSource`, only modifying the SDFG if GPU scheduling is detected, and returning a new `ExtensionSource` with updated SDFG JSON.
* Updated the main DaCe compiler logic to call `_add_tx_markers` only when GPU trace markers are requested and the device type is GPU, ensuring markers are not redundantly applied. [[1]](diffhunk://#diff-89b749ff9b80be5fdb8a7e0d05411d2b992b6a5892f819c7a3e001c4241a6c0dL200-R222) [[2]](diffhunk://#diff-89b749ff9b80be5fdb8a7e0d05411d2b992b6a5892f819c7a3e001c4241a6c0dL218-R235)

**Test suite improvements:**

* Refactored tests to use a real `program_source` fixture and removed unnecessary mocks and spies, directly verifying the presence or absence of GPU TX markers on the compiled SDFG. [[1]](diffhunk://#diff-57ff279a6de9ce815a6bde8ae126007687da1d07f6ad28626e998541fc9d89b3L82-R83) [[2]](diffhunk://#diff-57ff279a6de9ce815a6bde8ae126007687da1d07f6ad28626e998541fc9d89b3R100-L109) [[3]](diffhunk://#diff-57ff279a6de9ce815a6bde8ae126007687da1d07f6ad28626e998541fc9d89b3L119-L123) [[4]](diffhunk://#diff-57ff279a6de9ce815a6bde8ae126007687da1d07f6ad28626e998541fc9d89b3L138-L173)
* Added new tests to assert that identical compilation inputs produce the same artifact, and that changing instrumentation or compiler flags results in different artifacts. [[1]](diffhunk://#diff-57ff279a6de9ce815a6bde8ae126007687da1d07f6ad28626e998541fc9d89b3R181-R203) [[2]](diffhunk://#diff-57ff279a6de9ce815a6bde8ae126007687da1d07f6ad28626e998541fc9d89b3R213-R248)

**Test parameterization and device naming:**

* Updated device type parameterization in both compilation and translation tests to use consistent and descriptive IDs (`CPU`, `GPU`, `CUDA`, `ROCM`) and to use the correct device type constants. [[1]](diffhunk://#diff-19fed38498781ceef82337d097e43458274d2ebe7e0bae4578839e9fbed15194L31-R33) [[2]](diffhunk://#diff-8ba502dd24c52188c94e85f0bcd66c31fbe3093077168033f99c14eb19ac1cb4L54-R55)

These changes improve the correctness, maintainability, and clarity of both the DaCe compilation workflow and its associated tests.