### PR TITLE
fix[next]: unique sys.modules key per compiled program variant

### DIFF
--- a/src/gt4py/next/otf/compilation/compiler.py
+++ b/src/gt4py/next/otf/compilation/compiler.py
@@ -66,14 +66,12 @@ class CPPCompilationArtifact:
     def load(self) -> stages.ExecutableProgram:
         """Import the .so and return the raw entry point.
 
-        Must run in the process that will call the returned program: the
-        module is registered in that process's ``sys.modules`` under the
-        ``gt4py.__compiled_programs__.`` prefix.
+        Must run in the process that will call the returned program:
+        ``import_from_path`` keeps a reference to the imported module alive for
+        the lifetime of the process, since nanobind requires the module to
+        outlive its functions (see PR #2431).
         """
-        m = importer.import_from_path(
-            self.src_dir / self.module,
-            sys_modules_prefix="gt4py.__compiled_programs__.",
-        )
+        m = importer.import_from_path(self.src_dir / self.module, keep_reference=True)
         return getattr(m, self.entry_point_name)
 
 

--- a/src/gt4py/next/otf/compilation/importer.py
+++ b/src/gt4py/next/otf/compilation/importer.py
@@ -12,8 +12,7 @@ from types import ModuleType
 
 
 #: Keeps references to dynamically loaded modules alive for the lifetime of the
-#: process. Required for nanobind extension modules, which must outlive the
-#: functions imported from them (see PR #2431). Append-only.
+#: process.
 _loaded_modules: list[ModuleType] = []
 
 

--- a/src/gt4py/next/otf/compilation/importer.py
+++ b/src/gt4py/next/otf/compilation/importer.py
@@ -8,28 +8,29 @@
 
 import importlib.util
 import pathlib
-import sys
 from types import ModuleType
 
 
-def import_from_path(
-    module_file: pathlib.Path, *, add_to_sys_modules: bool = True, sys_modules_prefix: str = ""
-) -> ModuleType:
+#: Keeps references to dynamically loaded modules alive for the lifetime of the
+#: process. Required for nanobind extension modules, which must outlive the
+#: functions imported from them (see PR #2431). Append-only.
+_loaded_modules: list[ModuleType] = []
+
+
+def import_from_path(module_file: pathlib.Path, *, keep_reference: bool = False) -> ModuleType:
     """
     Load dynamically a python module from a given file path.
 
     Args:
         module_file: The path to the python file to load as a module.
-        add_to_sys_modules: Whether to add the loaded module to 'sys.modules'.
-        sys_modules_prefix: If 'add_to_sys_modules' is `True`, the prefix to use
-            for the module name in 'sys.modules'. If empty, the module name will be
-            the file name without extension.
+        keep_reference: If `True`, keep a reference to the loaded module alive
+            for the lifetime of the process (required for nanobind extension
+            modules, which must outlive their functions, see PR #2431).
 
     Returns:
         The loaded module.
     """
     module_name = module_file.name.split(".")[0]
-
     error_msg = f"Could not load module named {module_name} from {module_file}"
     spec = importlib.util.spec_from_file_location(module_name, module_file)
     if not spec or not spec.loader:
@@ -40,11 +41,7 @@ def import_from_path(
     except ImportError as ex:
         raise ModuleNotFoundError(error_msg) from ex
 
-    if add_to_sys_modules:
-        if not sys_modules_prefix.endswith("."):
-            sys_modules_prefix += "."
-        sys.modules[sys_modules_prefix + module_name] = module
-    elif sys_modules_prefix:
-        raise ValueError("Cannot use 'sys_modules_prefix' if 'add_to_sys_modules' is False")
+    if keep_reference:
+        _loaded_modules.append(module)
 
     return module

--- a/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_importer.py
+++ b/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_importer.py
@@ -6,10 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import sys
 import textwrap
-
-import pytest
 
 from gt4py.next.otf.compilation import importer
 
@@ -24,22 +21,14 @@ def test_import_from_path(tmp_path):
     file = tmp_path / "module.py"
     file.write_text(src_module, "utf-8")
 
-    imported_modules = set(sys.modules.keys())
-    module = importer.import_from_path(file, add_to_sys_modules=False)
+    # Without keeping a reference, the module is loaded but not retained.
+    n_before = len(importer._loaded_modules)
+    module = importer.import_from_path(file, keep_reference=False)
     assert hasattr(module, "function")
-    assert "module" not in sys.modules
-    assert set(sys.modules.keys()) == imported_modules
+    assert len(importer._loaded_modules) == n_before
 
-    module = importer.import_from_path(
-        file, add_to_sys_modules=True, sys_modules_prefix="_temp_test_prefix_"
-    )
-    assert hasattr(module, "function")
-    assert len(sys.modules.keys()) == len(imported_modules) + 1
-    assert "_temp_test_prefix_.module" in sys.modules
-
-    with pytest.raises(
-        ValueError, match="Cannot use 'sys_modules_prefix' if 'add_to_sys_modules' is False"
-    ):
-        importer.import_from_path(
-            file, add_to_sys_modules=False, sys_modules_prefix="_temp_test_prefix_"
-        )
+    # Keeping a reference retains the loaded module for the process lifetime.
+    kept = importer.import_from_path(file, keep_reference=True)
+    assert hasattr(kept, "function")
+    assert kept in importer._loaded_modules
+    assert len(importer._loaded_modules) == n_before + 1


### PR DESCRIPTION
#2431 keeps a nanobind module alive by registering it in `sys.modules`, but the key was just the `entry_point_name`. Static variants of the same program share that name (and the `.so` base name), so they collided and evicted one another:

```python
# variant_a / variant_b: same program, different static args
variant_a: CompilationArtifact
variant_b: CompilationArtifact
func_a = variant_a.load()  # sys.modules["gt4py.__compiled_programs__.my_fo"] = module_a
func_b = variant_b.load()  # overwrites the key; module_a now only reachable via func_a

del variant_a
# on nanobind >=2.10 module_a can be GC'd (nb_module_clear) while func_a
# is still in use -> segfault when func_a is called
```

Solution here is to not rely on `sys.modules`, but just keep a reference to the module in a global variable.

Text and code generated with the help of LLMs and then verified by me.