### PR TITLE
refactor[cartesian] Normalize K axis name

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -277,7 +277,7 @@ class OIRToTreeIR(eve.NodeVisitor):
         loop: tir.SequentialVerticalLoop | tir.ParallelVerticalLoop
         if loop_order == common.LoopOrder.PARALLEL:
             loop = tir.ParallelVerticalLoop(
-                iteration_variable=eve.SymbolRef(f"{tir.Axis.K.iteration_symbol()}_{id(node)}"),
+                iteration_variable=tir.Axis.K.iteration_symbol(),
                 bounds_k=bounds,
                 schedule=_resolve_map_schedule(self._device_type),
                 children=[],
@@ -285,7 +285,7 @@ class OIRToTreeIR(eve.NodeVisitor):
             )
         else:
             loop = tir.SequentialVerticalLoop(
-                iteration_variable=eve.SymbolRef(f"{tir.Axis.K.iteration_symbol()}_{id(node)}"),
+                iteration_variable=tir.Axis.K.iteration_symbol(),
                 bounds_k=bounds,
                 loop_order=loop_order,
                 children=[],

--- a/src/gt4py/cartesian/gtc/dace/passes/push_vertical_map_down.py
+++ b/src/gt4py/cartesian/gtc/dace/passes/push_vertical_map_down.py
@@ -81,9 +81,9 @@ class PushVerticalMapDown(tn.ScheduleNodeVisitor):
     def visit_MapScope(self, node: tn.MapScope):
         if self._forscope_only:
             return
-        if node.node.map.params[0].startswith("__k"):
+        if node.node.map.params[0] == "__k":
             self._push_K_loop_in_IJ(node)
 
     def visit_ForScope(self, node: tn.ForScope):
-        if node.loop.loop_variable.startswith("__k"):
+        if node.loop.loop_variable == "__k":
             self._push_K_loop_in_IJ(node)

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_dace_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_dace_backend.py
@@ -117,7 +117,7 @@ def test_dace_cpu_loop_structure():
     state = sdfg.states()[0]
 
     loop_indices = [node.map.params for node in state.nodes() if isinstance(node, nodes.MapEntry)]
-    assert len(loop_indices[0]) == 1 and loop_indices[0][0].startswith("__k")
+    assert loop_indices[0] == ["__k"]
     assert loop_indices[1] == ["__i", "__j"]
 
 
@@ -130,7 +130,7 @@ def test_dace_cpu_kfirst_loop_structure():
 
     loop_indices = [node.map.params for node in state.nodes() if isinstance(node, nodes.MapEntry)]
     assert loop_indices[0] == ["__i", "__j"]
-    assert len(loop_indices[1]) == 1 and loop_indices[1][0].startswith("__k")
+    assert loop_indices[1] == ["__k"]
 
     builder = StencilBuilder(copy_forward_stencil, backend="dace:cpu_kfirst")
     manager = SDFGManager(builder)
@@ -151,7 +151,7 @@ def test_dace_cpu_kfirst_loop_structure():
     assert len(for_nested_nodes) == 1
     loop_region = for_nested_nodes[0]
     assert isinstance(loop_region, LoopRegion)
-    assert loop_region.loop_variable.startswith("__k")
+    assert loop_region.loop_variable == "__k"
 
 
 def test_dace_cpu_KJI_loop_structure():
@@ -168,7 +168,7 @@ def test_dace_cpu_KJI_loop_structure():
         loop_indices = [
             node.map.params for node in state.nodes() if isinstance(node, nodes.MapEntry)
         ]
-        assert len(loop_indices[0]) == 1 and loop_indices[0][0].startswith("__k")
+        assert loop_indices[0] == ["__k"]
         assert loop_indices[1] == ["__j", "__i"]
 
         builder = StencilBuilder(copy_forward_stencil, backend="dace:cpu_KJI")
@@ -178,7 +178,7 @@ def test_dace_cpu_KJI_loop_structure():
 
         # Expect LoopRegion for K outside
         loop_region: LoopRegion = list(sdfg.all_control_flow_blocks())[0]
-        assert loop_region.loop_variable.startswith("__k")
+        assert loop_region.loop_variable == "__k"
 
         # Expect JI Map and in loop_body state (#2)
         state = loop_region.start_block
@@ -212,4 +212,4 @@ def test_dace_cpu_KJI_loop_structure_parallel():
         assert len(for_nested_nodes) == 1
         loop_region = for_nested_nodes[0]
         assert isinstance(loop_region, LoopRegion)
-        assert loop_region.loop_variable.startswith("__k")
+        assert loop_region.loop_variable == "__k"

--- a/tests/cartesian_tests/unit_tests/backend_tests/test_dace_backend.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/test_dace_backend.py
@@ -117,7 +117,7 @@ def test_dace_cpu_loop_structure():
     state = sdfg.states()[0]
 
     loop_indices = [node.map.params for node in state.nodes() if isinstance(node, nodes.MapEntry)]
-    assert len(loop_indices[0]) == 1 and loop_indices[0][0].startswith("__k_")
+    assert len(loop_indices[0]) == 1 and loop_indices[0][0].startswith("__k")
     assert loop_indices[1] == ["__i", "__j"]
 
 
@@ -130,7 +130,7 @@ def test_dace_cpu_kfirst_loop_structure():
 
     loop_indices = [node.map.params for node in state.nodes() if isinstance(node, nodes.MapEntry)]
     assert loop_indices[0] == ["__i", "__j"]
-    assert len(loop_indices[1]) == 1 and loop_indices[1][0].startswith("__k_")
+    assert len(loop_indices[1]) == 1 and loop_indices[1][0].startswith("__k")
 
     builder = StencilBuilder(copy_forward_stencil, backend="dace:cpu_kfirst")
     manager = SDFGManager(builder)
@@ -168,7 +168,7 @@ def test_dace_cpu_KJI_loop_structure():
         loop_indices = [
             node.map.params for node in state.nodes() if isinstance(node, nodes.MapEntry)
         ]
-        assert len(loop_indices[0]) == 1 and loop_indices[0][0].startswith("__k_")
+        assert len(loop_indices[0]) == 1 and loop_indices[0][0].startswith("__k")
         assert loop_indices[1] == ["__j", "__i"]
 
         builder = StencilBuilder(copy_forward_stencil, backend="dace:cpu_KJI")


### PR DESCRIPTION
## Description

To ago around a series of issues with loop/conditional construction in DaCe v1.x we used a unique K axis name for each stencils. New optimizations passes are being slowed by normalization passes.

Here we propose to use the normalized `__k` and hope the CFG in DaCe v2.x as gotten rid of the previous issues

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.

