### PR TITLE
test[cartesian]: test-tree hygiene (packaging)

### DIFF
--- a/tests/cartesian_tests/integration_tests/feature_tests/__init__.py
+++ b/tests/cartesian_tests/integration_tests/feature_tests/__init__.py
@@ -1,0 +1,8 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/tests/cartesian_tests/unit_tests/backend_tests/__init__.py
+++ b/tests/cartesian_tests/unit_tests/backend_tests/__init__.py
@@ -1,0 +1,8 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/tests/cartesian_tests/unit_tests/frontend_tests/__init__.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/__init__.py
@@ -1,0 +1,8 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -252,7 +252,7 @@ class TestInlinedExternals:
             "other_call",
             "func",
             "another_const",
-            "test_gtscript_frontend.func_nested.func_deeply_nested",
+            "cartesian_tests.unit_tests.frontend_tests.test_gtscript_frontend.func_nested.func_deeply_nested",
         }
 
     def test_decorated_freeze(self):


### PR DESCRIPTION
## Description

Adds missing `__init__.py` in cartesian test folders.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A