### PR TITLE
feat[cartesian]: allow data dimensions with any integer type, not just plain `int`

### DIFF
--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -8,6 +8,7 @@
 
 import enum
 import functools
+import numbers
 import os
 import platform
 from dataclasses import dataclass
@@ -66,7 +67,7 @@ class FieldInfo:
     access: AccessKind
     boundary: Boundary
     axes: Tuple[str, ...]
-    data_dims: Tuple[int, ...]
+    data_dims: Tuple[numbers.Integral, ...]
     dtype: numpy.dtype
 
     def __repr__(self):

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -137,6 +137,7 @@ storing a reference to the piece of source code which originated the node.
 from __future__ import annotations
 
 import enum
+import numbers
 import operator
 import sys
 from abc import ABC
@@ -356,7 +357,7 @@ class Ref(Expr):
 @attribclass
 class VarRef(Ref):
     name = attribute(of=str)
-    index = attribute(of=int, optional=True)
+    index = attribute(of=numbers.Integral, optional=True)
     loc = attribute(of=Location, optional=True)
 
 
@@ -378,7 +379,7 @@ class IteratorAccess(Ref):
 @attribclass
 class FieldRef(Ref):
     name = attribute(of=str)
-    offset = attribute(of=DictOf[str, UnionOf[int, Expr, AbsoluteKIndex]])
+    offset = attribute(of=DictOf[str, UnionOf[numbers.Integral, Expr, AbsoluteKIndex]])
     data_index = attribute(of=ListOf[Expr], factory=list)
     loc = attribute(of=Location, optional=True)
 
@@ -412,7 +413,7 @@ class AxisPosition(Expr):
 class AxisIndex(Expr):
     axis = attribute(of=str)
     endpt = attribute(of=LevelMarker)
-    offset = attribute(of=int)
+    offset = attribute(of=numbers.Integral)
     data_type = attribute(of=DataType, default=DataType.INT32)
 
 
@@ -652,7 +653,7 @@ class FieldDecl(Decl):
     data_type = attribute(of=DataType)
     axes = attribute(of=ListOf[str])
     is_api = attribute(of=bool)
-    data_dims = attribute(of=ListOf[int], factory=list)
+    data_dims = attribute(of=ListOf[numbers.Integral], factory=list)
     layout_id = attribute(of=str, default="_default_")
     loc = attribute(of=Location, optional=True)
 
@@ -661,7 +662,7 @@ class FieldDecl(Decl):
 class VarDecl(Decl):
     name = attribute(of=str)
     data_type = attribute(of=DataType)
-    length = attribute(of=int)
+    length = attribute(of=numbers.Integral)
     is_api = attribute(of=bool)
     init = attribute(of=Literal, optional=True)
     loc = attribute(of=Location, optional=True)
@@ -731,7 +732,7 @@ class BaseAxisBound(Node, ABC):
 @attribclass
 class AxisBound(BaseAxisBound):
     level = attribute(of=LevelMarker)
-    offset = attribute(of=int, default=0)
+    offset = attribute(of=numbers.Integral, default=0)
     loc = attribute(of=Location, optional=True)
 
 

--- a/src/gt4py/cartesian/gtc/gtcpp/gtcpp.py
+++ b/src/gt4py/cartesian/gtc/gtcpp/gtcpp.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import enum
+import numbers
 from typing import Any, List, Tuple, Union
 
 from gt4py import eve
@@ -196,7 +197,7 @@ class ApiParamDecl(LocNode):
 
 class FieldDecl(ApiParamDecl):
     dimensions: Tuple[bool, bool, bool]
-    data_dims: Tuple[int, ...] = eve.field(default_factory=tuple)
+    data_dims: Tuple[numbers.Integral, ...] = eve.field(default_factory=tuple)
 
 
 class GlobalParamDecl(ApiParamDecl):

--- a/src/gt4py/cartesian/gtc/gtir.py
+++ b/src/gt4py/cartesian/gtc/gtir.py
@@ -21,6 +21,7 @@ Analysis is required to generate valid code (complying with the parallel model)
 
 from __future__ import annotations
 
+import numbers
 from typing import Any, Dict, List, Set, Tuple, Type
 
 from gt4py import eve
@@ -197,7 +198,7 @@ class Decl(LocNode):  # TODO probably Stmt
 
 class FieldDecl(Decl):
     dimensions: Tuple[bool, bool, bool]
-    data_dims: Tuple[int, ...] = eve.field(default_factory=tuple)
+    data_dims: Tuple[numbers.Integral, ...] = eve.field(default_factory=tuple)
 
 
 class ScalarDecl(Decl):

--- a/src/gt4py/cartesian/gtc/numpy/npir.py
+++ b/src/gt4py/cartesian/gtc/numpy/npir.py
@@ -6,6 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import numbers
 from typing import List, Optional, Tuple, Union
 
 from gt4py import eve
@@ -58,7 +59,7 @@ class FieldDecl(Decl):
     """General field shared across HorizontalBlocks."""
 
     dimensions: Tuple[bool, bool, bool]
-    data_dims: Tuple[int, ...] = eve.field(default_factory=tuple)
+    data_dims: Tuple[numbers.Integral, ...] = eve.field(default_factory=tuple)
     extent: Extent
 
 
@@ -74,7 +75,7 @@ class TemporaryDecl(Decl):
     padding: Buffer added to compute domain as field size.
     """
 
-    data_dims: Tuple[int, ...] = eve.field(default_factory=tuple)
+    data_dims: Tuple[numbers.Integral, ...] = eve.field(default_factory=tuple)
     dimensions: Tuple[bool, bool, bool]
     offset: Tuple[int, int]
     padding: Tuple[int, int]

--- a/src/gt4py/cartesian/gtc/oir.py
+++ b/src/gt4py/cartesian/gtc/oir.py
@@ -15,6 +15,7 @@ e.g. stage merging, staged computations to compute-on-the-fly, cache annotations
 
 from __future__ import annotations
 
+import numbers
 from typing import Any, List, Optional, Tuple, Type, Union
 
 from gt4py import eve
@@ -131,7 +132,7 @@ class Decl(LocNode):
 
 class FieldDecl(Decl):
     dimensions: Tuple[bool, bool, bool]
-    data_dims: Tuple[int, ...] = eve.field(default_factory=tuple)
+    data_dims: Tuple[numbers.Integral, ...] = eve.field(default_factory=tuple)
 
 
 class ScalarDecl(Decl):

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -731,6 +731,24 @@ def test_higher_dim_scalar_stencil(backend) -> None:
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_ddims_with_numpy_type(backend: str) -> None:
+    @gtscript.stencil(backend=backend)
+    def data_dims_with_numpy_int_type(
+        out_field: gtscript.Field[gtscript.IJK, np.int32],  # type: ignore
+        in_field: gtscript.Field[gtscript.IJK, (np.int32, (np.int32(3)))],  # type: ignore
+    ):
+        with computation(PARALLEL), interval(...):
+            out_field = in_field.A[0]
+
+    in_field = gt_storage.ones((2, 2, 4), (np.int32, (np.int32(3))), backend=backend)
+    out_field = gt_storage.zeros((2, 2, 4), np.int32, backend=backend)
+
+    data_dims_with_numpy_int_type(out_field, in_field)
+    cpu_output = storage_utils.cpu_copy(out_field)
+    np.testing.assert_allclose(cpu_output.view(np.ndarray)[:, :, :], 1)
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
 def test_native_function_call_stencil(backend) -> None:
     field_in = gt_storage.ones(
         dtype=np.float64, backend=backend, shape=(4, 4, 4), aligned_index=(0, 0, 0)

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -1924,10 +1924,6 @@ class TestGlobalTablesWithDataDimensions:
                 module=self.__class__.__name__,
             )
 
-    @pytest.mark.xfail(
-        reason="IR validation expects ddim sizes to be of type `int`",
-        raises=gt_frontend.GTScriptSyntaxError,
-    )
     def test_ddims_with_numpy_type(self) -> None:
         def data_dims_with_numpy_int_type(
             out_field: gtscript.Field[gtscript.IJK, np.int32],


### PR DESCRIPTION
## Description

NDSL issue https://github.com/NOAA-GFDL/NDSL/issues/500 showed that data dimension size validation with plain `int`  is too restrictive. As reported in the issue, it is unexpected that other integer types (i.e. ` numpy.int32`) will raise an exception at the IR validation level.

This PR proposes to change the type validation from plain `int` to `numbers.Integral` to support any integral type as size for data dimensions.

Related issue: https://github.com/GridTools/gt4py/issues/2705.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
