### PR TITLE
feat[next-dace]: let a SplitAccessNode fragment have several producers

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -397,8 +397,8 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         fragments: list[_Fragment] = []
         for fragment_id, consumer_edges in consumers_of_fragment.items():
             producers = OrderedSet(
-                producer_edges[i]
-                for i in range(len(producer_edges))
+                producer_edge
+                for i, producer_edge in enumerate(producer_edges)
                 if find_fragment(i) == fragment_id
             )
             subsets = gtx_dace_split.subset_merger(
@@ -458,56 +458,59 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
             if len(consumer_edges) == 0:
                 continue
 
-            # A fragment that is fed by several producers is only read as a whole,
-            #  so tightness can only be established for the fragment, not for the
-            #  individual producers.
-            if len(fragment.producers) > 1:
-                if not self._is_covered_by_consumers(fragment.subset, consumer_edges):
-                    return False
-
             for producer_edge in fragment.producers:
                 data_source = producer_edge.src
-
                 if isinstance(data_source, dace_nodes.AccessNode):
                     # TODO(phimuell): Should we also ensure that the domains are tight?
                     if gtx_transformations.utils.is_view(data_source, sdfg):
                         return False
+                elif not isinstance(data_source, dace_nodes.MapExit):
+                    return False
 
-                    # If the source is a global data, then we do not impose any other
-                    #  constraints.
-                    if not data_source.desc(sdfg).transient:
-                        continue
+            # The tightness requirement below, i.e. that what is computed is also
+            #  read, is a core assumption of the `CopyChainRemover`. A fragment with
+            #  several producers is only ever read as a whole, so the requirement
+            #  applies to the fragment; imposing it per producer instead would reject
+            #  a consumer that legitimately reads across a producer boundary, which
+            #  is the very case a multi producer fragment exists for.
+            if len(fragment.producers) > 1:
+                if not self._is_fully_read_by_consumers(fragment.subset, consumer_edges):
+                    return False
+                continue
 
-                    # If the source is a transient then we distinguish between two cases.
-                    #  In the first case there is only one consumer, in that case we
-                    #  require that everything is read. In the second case, more than
-                    #  one consumer, we do not impose any constraints.
-                    #  We do this to ensure the tightness of the temporaries, i.e. what
-                    #  is computed is also read, which is core assumption of the
-                    #  `CopyChainRemover`.
-                    # TODO(phimuell): Lift this limitation.
-                    if len(fragment.producers) == 1 and len(consumer_edges) == 1:
-                        if not next(iter(consumer_edges)).data.src_subset.covers(
-                            producer_edge.data.dst_subset
-                        ):
-                            return False
+            (producer_edge,) = fragment.producers
+            data_source = producer_edge.src
 
-                elif isinstance(data_source, dace_nodes.MapExit):
-                    # The source is a Map, in this case we just generate a new transient
-                    #  output and then perform some reconnection. However, we require that
-                    #  all consumer read exactly what is is written by the map. This
-                    #  is to ensure some tightness of the domains.
-                    if len(fragment.producers) == 1 and not all(
-                        consumer_edge.data.src_subset.covers(producer_edge.data.dst_subset)
-                        for consumer_edge in consumer_edges
+            if isinstance(data_source, dace_nodes.AccessNode):
+                # If the source is a global data, then we do not impose any other
+                #  constraints.
+                if not data_source.desc(sdfg).transient:
+                    continue
+
+                # If the source is a transient then we distinguish between two cases.
+                #  In the first case there is only one consumer, in that case we
+                #  require that everything is read. In the second case, more than
+                #  one consumer, we do not impose any constraints.
+                # TODO(phimuell): Lift this limitation.
+                if len(consumer_edges) == 1:
+                    if not next(iter(consumer_edges)).data.src_subset.covers(
+                        producer_edge.data.dst_subset
                     ):
                         return False
 
-                else:
+            else:
+                # The source is a Map, in this case we just generate a new transient
+                #  output and then perform some reconnection. However, we require that
+                #  all consumer read exactly what is is written by the map. This
+                #  is to ensure some tightness of the domains.
+                if not all(
+                    consumer_edge.data.src_subset.covers(producer_edge.data.dst_subset)
+                    for consumer_edge in consumer_edges
+                ):
                     return False
         return True
 
-    def _is_covered_by_consumers(
+    def _is_fully_read_by_consumers(
         self,
         subset: dace_sbs.Subset,
         consumer_edges: OrderedSet[dace_graph.MultiConnectorEdge],

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -370,14 +370,7 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         for oedge in state.out_edges(access_node):
             if oedge.data.wcr is not None:
                 return None
-            # NOTE: This must be the raw property and not `get_src_subset()`. A
-            #  Memlet that has no side associated to it has no `src_subset`, see
-            #  [issue 1703](https://github.com/spcl/dace/issues/1703), and the check
-            #  below turns that into a decline. `get_src_subset()` initializes the
-            #  Memlet, which removes that guard and makes the transformation accept
-            #  nodes whose rerouting then fails inside
-            #  `reconfigure_dataflow_after_rerouting()`.
-            consumer_subset = oedge.data.src_subset
+            consumer_subset = oedge.data.get_src_subset(oedge, state)
             if consumer_subset is None:
                 return None  # TODO(phimuell): Lift this.
 
@@ -425,7 +418,9 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         #  exactly one fragment, so a consumer must not straddle a fragment boundary.
         for fragment in fragments:
             for consumer_edge in fragment.consumers:
-                if not fragment.subset.covers(consumer_edge.data.src_subset):
+                if not fragment.subset.covers(
+                    consumer_edge.data.get_src_subset(consumer_edge, state)
+                ):
                     return None
         for i, fragment in enumerate(fragments):
             if any(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -352,8 +352,10 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 return None
             producer_edges.append(iedge)
 
-        # Every producer starts out in its own fragment, consumers that straddle
-        #  several producers merge them together.
+        # Union find over the producers: `fragment_of_producer[i]` is the id of
+        #  another producer in the same fragment as producer `i`, or `i` itself if
+        #  `i` is the representative of its fragment. Every producer starts out
+        #  alone; a consumer that straddles several producers merges them.
         fragment_of_producer = list(range(len(producer_edges)))
 
         def find_fragment(idx: int) -> int:
@@ -368,39 +370,40 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         for oedge in state.out_edges(access_node):
             if oedge.data.wcr is not None:
                 return None
-            consumer_subset = oedge.data.src_subset
+            consumer_subset = oedge.data.get_src_subset(oedge, state)
             if consumer_subset is None:
                 return None  # TODO(phimuell): Lift this.
 
             # All producers that might contribute to what this consumer reads have
             #  to be part of the same fragment. Several producers may already share a
-            #  fragment, so the ids have to be deduplicated before they are merged.
-            contributing = list(
-                dict.fromkeys(
-                    find_fragment(i)
-                    for i, producer_edge in enumerate(producer_edges)
-                    if gtx_dace_split.maybe_intersecting(
-                        producer_edge.data.dst_subset, consumer_subset
-                    )
-                )
-            )
+            #  fragment, so the ids are deduplicated before they are merged.
+            contributing = {
+                find_fragment(i)
+                for i, producer_edge in enumerate(producer_edges)
+                if gtx_dace_split.maybe_intersecting(producer_edge.data.dst_subset, consumer_subset)
+            }
             if len(contributing) == 0:
                 return None
 
             merged_id = min(contributing)
-            for fragment_id in contributing:
+            for fragment_id in sorted(contributing):
                 if fragment_id != merged_id:
                     fragment_of_producer[fragment_id] = merged_id
                     consumers_of_fragment[merged_id] |= consumers_of_fragment.pop(fragment_id)
             consumers_of_fragment[merged_id].add(oedge)
 
+        fragment_of = [find_fragment(i) for i in range(len(producer_edges))]
         fragments: list[_Fragment] = []
         for fragment_id, consumer_edges in consumers_of_fragment.items():
             producers = OrderedSet(
                 producer_edge
                 for i, producer_edge in enumerate(producer_edges)
-                if find_fragment(i) == fragment_id
+                if fragment_of[i] == fragment_id
             )
+            # NOTE: This must be the adjacency only merger. Producers that overlap
+            #  would describe the same memory twice, so they must not be merged into
+            #  one region here, unlike the consumer subsets in
+            #  `_is_fully_read_by_consumers()` which only have to cover the fragment.
             subsets = gtx_dace_split.subset_merger(
                 [producer_edge.data.dst_subset for producer_edge in producers]
             )
@@ -412,16 +415,20 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 _Fragment(producers=producers, consumers=consumer_edges, subset=subsets[0])
             )
 
-        # `split_node()` requires that every edge is fully covered by exactly one
-        #  fragment, so a consumer must not straddle a fragment boundary.
+        # `split_node()` requires that every consumer edge is fully covered by
+        #  exactly one fragment, so a consumer must not straddle a fragment boundary.
         for fragment in fragments:
             for consumer_edge in fragment.consumers:
-                if not fragment.subset.covers(consumer_edge.data.src_subset):
+                if not fragment.subset.covers(
+                    consumer_edge.data.get_src_subset(consumer_edge, state)
+                ):
                     return None
         for i, fragment in enumerate(fragments):
-            for other in fragments[i + 1 :]:
-                if gtx_dace_split.maybe_intersecting(fragment.subset, other.subset):
-                    return None
+            if any(
+                gtx_dace_split.maybe_intersecting(fragment.subset, other.subset)
+                for other in fragments[i + 1 :]
+            ):
+                return None
 
         unused_producers = [
             producer
@@ -467,12 +474,16 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 elif not isinstance(data_source, dace_nodes.MapExit):
                     return False
 
-            # The tightness requirement below, i.e. that what is computed is also
-            #  read, is a core assumption of the `CopyChainRemover`. A fragment with
-            #  several producers is only ever read as a whole, so the requirement
-            #  applies to the fragment; imposing it per producer instead would reject
-            #  a consumer that legitimately reads across a producer boundary, which
-            #  is the very case a multi producer fragment exists for.
+            # Both branches below require that what is computed is also read. They
+            #  differ only in the granularity at which that is checked. A fragment
+            #  fed by several producers is only ever read as a whole -- no consumer
+            #  is associated with an individual producer -- so the requirement is
+            #  imposed on the fragment. Imposing it per producer would reject a
+            #  consumer that reads across a producer boundary, which is the case a
+            #  multi producer fragment exists for. Note that the requirement is not
+            #  weaker: a producer writing `[0:10]` whose only consumer reads `[0:5]`
+            #  is rejected either way, by `_is_fully_read_by_consumers()` here and by
+            #  the `covers()` below.
             if len(fragment.producers) > 1:
                 if not self._is_fully_read_by_consumers(fragment.subset, consumer_edges):
                     return False

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -370,7 +370,14 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         for oedge in state.out_edges(access_node):
             if oedge.data.wcr is not None:
                 return None
-            consumer_subset = oedge.data.get_src_subset(oedge, state)
+            # NOTE: This must be the raw property and not `get_src_subset()`. A
+            #  Memlet that has no side associated to it has no `src_subset`, see
+            #  [issue 1703](https://github.com/spcl/dace/issues/1703), and the check
+            #  below turns that into a decline. `get_src_subset()` initializes the
+            #  Memlet, which removes that guard and makes the transformation accept
+            #  nodes whose rerouting then fails inside
+            #  `reconfigure_dataflow_after_rerouting()`.
+            consumer_subset = oedge.data.src_subset
             if consumer_subset is None:
                 return None  # TODO(phimuell): Lift this.
 
@@ -418,9 +425,7 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         #  exactly one fragment, so a consumer must not straddle a fragment boundary.
         for fragment in fragments:
             for consumer_edge in fragment.consumers:
-                if not fragment.subset.covers(
-                    consumer_edge.data.get_src_subset(consumer_edge, state)
-                ):
+                if not fragment.subset.covers(consumer_edge.data.src_subset):
                     return None
         for i, fragment in enumerate(fragments):
             if any(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -352,10 +352,10 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 return None
             producer_edges.append(iedge)
 
-        # Union find over the producers: `fragment_of_producer[i]` is the id of
-        #  another producer in the same fragment as producer `i`, or `i` itself if
-        #  `i` is the representative of its fragment. Every producer starts out
-        #  alone; a consumer that straddles several producers merges them.
+        # We use union find over the producers, i.e. `fragment_of_producer[i]` is
+        #  the id of another producer that is in the same fragment as producer `i`,
+        #  or `i` itself if `i` is the representative of its fragment. Every producer
+        #  starts alone and a consumer that straddles several producers merges them.
         fragment_of_producer = list(range(len(producer_edges)))
 
         def find_fragment(idx: int) -> int:
@@ -400,10 +400,9 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 for i, producer_edge in enumerate(producer_edges)
                 if fragment_of[i] == fragment_id
             )
-            # NOTE: This must be the adjacency only merger. Producers that overlap
-            #  would describe the same memory twice, so they must not be merged into
-            #  one region here, unlike the consumer subsets in
-            #  `_is_fully_read_by_consumers()` which only have to cover the fragment.
+            # NOTE: We must use the adjacency only merger here, producers that
+            #  overlap would describe the same memory twice, so we must not merge
+            #  them into one region.
             subsets = gtx_dace_split.subset_merger(
                 [producer_edge.data.dst_subset for producer_edge in producers]
             )
@@ -474,19 +473,14 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 elif not isinstance(data_source, dace_nodes.MapExit):
                     return False
 
-            # Both branches below require that what is computed is also read. They
-            #  differ only in the granularity at which that is checked. A fragment
-            #  fed by several producers is only ever read as a whole -- no consumer
-            #  is associated with an individual producer -- so the requirement is
-            #  imposed on the fragment. Imposing it per producer would reject a
-            #  consumer that reads across a producer boundary, which is the case a
-            #  multi producer fragment exists for. Note that the requirement is not
-            #  weaker: a producer writing `[0:10]` whose only consumer reads `[0:5]`
-            #  is rejected either way, by `_is_fully_read_by_consumers()` here and by
-            #  the `covers()` below.
+            # For a fragment with a single producer we require that what is computed
+            #  is also read. We can not impose that on a fragment that is fed by
+            #  several producers, no consumer is associated to an individual producer
+            #  of it, so requiring that the fragment is read in full would reject the
+            #  whole node, including the fragments that are fine. What stays unread is
+            #  dead data, which we already tolerate for a fragment without any
+            #  consumer, see the warning in `_find_edge_reassignment()`.
             if len(fragment.producers) > 1:
-                if not self._is_fully_read_by_consumers(fragment.subset, consumer_edges):
-                    return False
                 continue
 
             (producer_edge,) = fragment.producers
@@ -520,99 +514,3 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 ):
                     return False
         return True
-
-    def _is_fully_read_by_consumers(
-        self,
-        subset: dace_sbs.Subset,
-        consumer_edges: OrderedSet[dace_graph.MultiConnectorEdge],
-    ) -> bool:
-        """Checks if `subset` is fully read by `consumer_edges` taken together."""
-        merged = _merge_overlapping_subsets(
-            [consumer_edge.data.src_subset for consumer_edge in consumer_edges]
-        )
-        return any(merged_subset.covers(subset) for merged_subset in merged)
-
-
-def _merge_overlapping_subsets(subsets: list[dace_sbs.Subset]) -> list[dace_sbs.Subset]:
-    """Merges subsets that overlap, touch or contain each other.
-
-    `splitting_tools.subset_merger()` only joins subsets that are exactly adjacent,
-    which is what describing a split needs. Consumers however routinely read
-    overlapping regions, so deciding whether they read a fragment in full needs the
-    stronger version.
-    """
-    subsets = sorted(subsets, key=str)
-
-    performed_merge = True
-    while performed_merge and len(subsets) > 1:
-        performed_merge = False
-        for idx1 in range(len(subsets)):
-            for idx2 in range(idx1 + 1, len(subsets)):
-                merged_subset = _try_to_merge_overlapping_subsets(subsets[idx1], subsets[idx2])
-                if merged_subset is None:
-                    continue
-                subsets = [sbs for idx, sbs in enumerate(subsets) if idx not in (idx1, idx2)]
-                subsets.append(merged_subset)
-                performed_merge = True
-                break
-            if performed_merge:
-                break
-
-    return subsets
-
-
-def _try_to_merge_overlapping_subsets(
-    subset1: dace_sbs.Subset,
-    subset2: dace_sbs.Subset,
-) -> Optional[dace_sbs.Subset]:
-    """Tries to express two subsets as a single one, returns `None` if impossible.
-
-    Like `splitting_tools._try_to_merge_subsets()` the two subsets must have the same
-    bounds in all but one dimension, but in that dimension they may also overlap
-    instead of only touching.
-    """
-    if subset1.covers(subset2):
-        return subset1
-    if subset2.covers(subset1):
-        return subset2
-    if subset1.dims() != subset2.dims():
-        return None
-
-    merged_subset: list[Any] = []
-    has_found_merge_dim = False
-    for dim in range(subset1.dims()):
-        start1, end1, step1 = subset1[dim]
-        start2, end2, step2 = subset2[dim]
-
-        if (step1 != 1) == True or (step2 != 1) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            return None
-
-        elif (start1 == start2) == True and (end1 == end2) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            merged_subset.append((start1, end1, 1))
-            continue
-
-        if has_found_merge_dim:
-            # It is only possible to extend along one dimension.
-            return None
-
-        # Order the two ranges such that `lo` starts first, `end` is inclusive.
-        if (start1 <= start2) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            (lo_start, lo_end), (hi_start, hi_end) = (start1, end1), (start2, end2)
-        elif (start2 <= start1) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            (lo_start, lo_end), (hi_start, hi_end) = (start2, end2), (start1, end1)
-        else:
-            return None
-
-        # Unless they overlap or touch their union has a hole in it.
-        if not ((hi_start <= lo_end + 1) == True):  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            return None
-
-        if (hi_end >= lo_end) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            merged_subset.append((lo_start, hi_end, 1))
-        elif (lo_end >= hi_end) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
-            merged_subset.append((lo_start, lo_end, 1))
-        else:
-            return None
-        has_found_merge_dim = True
-
-    return dace_sbs.Range(merged_subset)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -257,7 +257,7 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
             return False
 
         # Now check if a decomposition exist.
-        fragments = self._find_edge_reassignment(graph)
+        fragments = self._find_fragments(graph)
         if fragments is None:
             return False
         if len(fragments) <= 1:
@@ -288,7 +288,7 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
     ) -> dict[dace_sbs.Subset, dace_nodes.AccessNode]:
         access_node: dace_nodes.AccessNode = self.access_node
 
-        fragments = self._find_edge_reassignment(graph)
+        fragments = self._find_fragments(graph)
         assert fragments is not None
 
         # TODO(phimuell): Make it more general that it can take the full advantage
@@ -324,7 +324,7 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         # Special extension to support certain workflows.
         return fragment_access_nodes
 
-    def _find_edge_reassignment(
+    def _find_fragments(
         self,
         state: dace.SDFGState,
     ) -> list[_Fragment] | None:
@@ -456,7 +456,7 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         """Checks if the decomposition results in a valid SDFG.
 
         This function is used to validate the decomposition computed by
-        `self._find_edge_reassignment()`.
+        `self._find_fragments()`.
         """
 
         for fragment in fragments:
@@ -477,9 +477,12 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
             #  is also read. We can not impose that on a fragment that is fed by
             #  several producers, no consumer is associated to an individual producer
             #  of it, so requiring that the fragment is read in full would reject the
-            #  whole node, including the fragments that are fine. What stays unread is
-            #  dead data, which we already tolerate for a fragment without any
-            #  consumer, see the warning in `_find_edge_reassignment()`.
+            #  whole node, including the fragments that are fine.
+            # NOTE: What stays unread is computed and stored for nothing, and unlike a
+            #   fragment without any consumer, which `DeadDataflowElimination` removes,
+            #   it can not be recovered later, the fragment is read. It is not a
+            #   regression, without the split the same producer computes the same
+            #   values and they are discarded just as well.
             if len(fragment.producers) > 1:
                 continue
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -516,7 +516,92 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         consumer_edges: OrderedSet[dace_graph.MultiConnectorEdge],
     ) -> bool:
         """Checks if `subset` is fully read by `consumer_edges` taken together."""
-        merged = gtx_dace_split.subset_merger(
+        merged = _merge_overlapping_subsets(
             [consumer_edge.data.src_subset for consumer_edge in consumer_edges]
         )
         return any(merged_subset.covers(subset) for merged_subset in merged)
+
+
+def _merge_overlapping_subsets(subsets: list[dace_sbs.Subset]) -> list[dace_sbs.Subset]:
+    """Merges subsets that overlap, touch or contain each other.
+
+    `splitting_tools.subset_merger()` only joins subsets that are exactly adjacent,
+    which is what describing a split needs. Consumers however routinely read
+    overlapping regions, so deciding whether they read a fragment in full needs the
+    stronger version.
+    """
+    subsets = sorted(subsets, key=str)
+
+    performed_merge = True
+    while performed_merge and len(subsets) > 1:
+        performed_merge = False
+        for idx1 in range(len(subsets)):
+            for idx2 in range(idx1 + 1, len(subsets)):
+                merged_subset = _try_to_merge_overlapping_subsets(subsets[idx1], subsets[idx2])
+                if merged_subset is None:
+                    continue
+                subsets = [sbs for idx, sbs in enumerate(subsets) if idx not in (idx1, idx2)]
+                subsets.append(merged_subset)
+                performed_merge = True
+                break
+            if performed_merge:
+                break
+
+    return subsets
+
+
+def _try_to_merge_overlapping_subsets(
+    subset1: dace_sbs.Subset,
+    subset2: dace_sbs.Subset,
+) -> Optional[dace_sbs.Subset]:
+    """Tries to express two subsets as a single one, returns `None` if impossible.
+
+    Like `splitting_tools._try_to_merge_subsets()` the two subsets must have the same
+    bounds in all but one dimension, but in that dimension they may also overlap
+    instead of only touching.
+    """
+    if subset1.covers(subset2):
+        return subset1
+    if subset2.covers(subset1):
+        return subset2
+    if subset1.dims() != subset2.dims():
+        return None
+
+    merged_subset: list[Any] = []
+    has_found_merge_dim = False
+    for dim in range(subset1.dims()):
+        start1, end1, step1 = subset1[dim]
+        start2, end2, step2 = subset2[dim]
+
+        if (step1 != 1) == True or (step2 != 1) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            return None
+
+        elif (start1 == start2) == True and (end1 == end2) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            merged_subset.append((start1, end1, 1))
+            continue
+
+        if has_found_merge_dim:
+            # It is only possible to extend along one dimension.
+            return None
+
+        # Order the two ranges such that `lo` starts first, `end` is inclusive.
+        if (start1 <= start2) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            (lo_start, lo_end), (hi_start, hi_end) = (start1, end1), (start2, end2)
+        elif (start2 <= start1) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            (lo_start, lo_end), (hi_start, hi_end) = (start2, end2), (start1, end1)
+        else:
+            return None
+
+        # Unless they overlap or touch their union has a hole in it.
+        if not ((hi_start <= lo_end + 1) == True):  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            return None
+
+        if (hi_end >= lo_end) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            merged_subset.append((lo_start, hi_end, 1))
+        elif (lo_end >= hi_end) == True:  # noqa: E712 [true-false-comparison]  # SymPy comparison
+            merged_subset.append((lo_start, lo_end, 1))
+        else:
+            return None
+        has_found_merge_dim = True
+
+    return dace_sbs.Range(merged_subset)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/split_access_nodes.py
@@ -8,8 +8,9 @@
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 import dace
 from dace import (
@@ -25,6 +26,22 @@ from gt4py.next.program_processors.runners.dace import transformations as gtx_tr
 from gt4py.next.program_processors.runners.dace.transformations import (
     splitting_tools as gtx_dace_split,
 )
+
+
+@dataclasses.dataclass(frozen=True)
+class _Fragment:
+    """One piece into which an AccessNode is split.
+
+    Attributes:
+        producers: The incoming edges that generate the data of the fragment.
+        consumers: The outgoing edges that read data of the fragment.
+        subset: The region of the original data that the fragment describes,
+            i.e. the union of what `producers` write.
+    """
+
+    producers: OrderedSet[dace_graph.MultiConnectorEdge]
+    consumers: OrderedSet[dace_graph.MultiConnectorEdge]
+    subset: dace_sbs.Subset
 
 
 def gt_split_access_nodes(
@@ -151,10 +168,10 @@ def _apply_split_access_node_non_recursive(
 class SplitAccessNode(dace_transformation.SingleStateTransformation):
     """The transformation will split an AccessNode into multiple ones.
 
-    If there is no intersection between a write and different reads,
-    i.e. if every read to the AccessNode can be satisfied by a single
-    write to the AccessNode and the AccessNode is only used at one
-    location, then the node is split.
+    The node is split into fragments, such that every read is served by a
+    single fragment and the AccessNode is only used at one location. A
+    fragment is usually defined by a single write, but if a read spans the
+    data of several writes, then those writes form one fragment together.
     This means that the reads will be satisfied directly and the node
     does not have to materialize.
 
@@ -169,8 +186,6 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
             `self.access_node` really is single use data.
 
     Todo:
-        - Made it possible to merge splits, i.e. such that a fragment can
-            be described by two producers.
         - Create a version that is able to split over multiple states. This is
             mostly useful to enable more state fusion.
 
@@ -242,13 +257,15 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
             return False
 
         # Now check if a decomposition exist.
-        edge_reassignments = self._find_edge_reassignment(graph)
-        if edge_reassignments is None:
+        fragments = self._find_edge_reassignment(graph)
+        if fragments is None:
+            return False
+        if len(fragments) <= 1:
             return False
         if not self._check_split_constraints(
             state=graph,
             sdfg=sdfg,
-            edge_reassignments=edge_reassignments,
+            fragments=fragments,
         ):
             return False
 
@@ -271,12 +288,12 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
     ) -> dict[dace_sbs.Subset, dace_nodes.AccessNode]:
         access_node: dace_nodes.AccessNode = self.access_node
 
-        edge_reassignments = self._find_edge_reassignment(graph)
-        assert edge_reassignments is not None
+        fragments = self._find_edge_reassignment(graph)
+        assert fragments is not None
 
         # TODO(phimuell): Make it more general that it can take the full advantage
         #   of the splitter functionality.
-        split_description = [e.data.dst_subset for e in edge_reassignments.keys()]
+        split_description = [fragment.subset for fragment in fragments]
 
         fragment_access_nodes = gtx_dace_split.split_node(
             state=graph,
@@ -310,56 +327,107 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
     def _find_edge_reassignment(
         self,
         state: dace.SDFGState,
-    ) -> dict[dace_graph.MultiConnectorEdge, OrderedSet[dace_graph.MultiConnectorEdge]] | None:
+    ) -> list[_Fragment] | None:
         """Determine how the edges should be distributed to the fragments.
 
-        The current implementation defines the fragments, i.e. the pieces into
-        which `self.access_node` should be split into, through the incoming edges.
-        This means that every incoming edge defines one fragment.
-        Therefor, the function returns a `dict` that maps each incoming edge to the
-        set of out going edges that are associated to it, i.e. depend on the producer
-        edge or `None` if such a distribution does not exist.
+        A fragment, i.e. one of the pieces into which `self.access_node` is split,
+        is defined by a set of incoming edges together with the outgoing edges that
+        read what those incoming edges produce. In the simplest case a fragment is
+        made up of a single producer, but if a consumer reads data that is generated
+        by several producers, then all of them end up in the same fragment.
+        The function returns the list of fragments or `None` if no such distribution
+        exists.
 
         The function does not perform any checks if the split lead to a valid
         SDFG, for that reason the result should be checked by
         `_check_split_constraints()`.
-
-        Todo:
-            Extend the function such that a fragment is not limited to a single
-            incoming edge, but can also be defined through multiple edges.
         """
         access_node: dace_nodes.AccessNode = self.access_node
 
-        # NOTE: Build the assignments based on the producers. Basing the split on
-        #  the producers has the advantages that it naturally takes "double use"
-        #  into account, i.e. one producer computes something and two different
-        #  reads it. However, it is also quite unnatural, because the consumer
-        #  should define the split (i.e. more than one producer are needed to
-        #  generate the data for a consumer). This is hard to handle, but should
-        #  be implemented at some point.
-        edge_reassignments: dict[
-            dace_graph.MultiConnectorEdge, OrderedSet[dace_graph.MultiConnectorEdge]
-        ] = {}
+        producer_edges: list[dace_graph.MultiConnectorEdge] = []
         for iedge in state.in_edges(access_node):
             if iedge.data.dst_subset is None:
                 return None  # TODO(phimuell): Lift this.
             if iedge.data.wcr is not None:
                 return None
-            edge_reassignments[iedge] = OrderedSet()
+            producer_edges.append(iedge)
 
-        # Now match the outgoing edges to their incoming producers.
+        # Every producer starts out in its own fragment, consumers that straddle
+        #  several producers merge them together.
+        fragment_of_producer = list(range(len(producer_edges)))
+
+        def find_fragment(idx: int) -> int:
+            while fragment_of_producer[idx] != idx:
+                fragment_of_producer[idx] = fragment_of_producer[fragment_of_producer[idx]]
+                idx = fragment_of_producer[idx]
+            return idx
+
+        consumers_of_fragment: dict[int, OrderedSet[dace_graph.MultiConnectorEdge]] = {
+            i: OrderedSet() for i in range(len(producer_edges))
+        }
         for oedge in state.out_edges(access_node):
             if oedge.data.wcr is not None:
                 return None
-            possible_producer = self._find_producer(oedge, edge_reassignments.keys())
-            if possible_producer is None:
+            consumer_subset = oedge.data.src_subset
+            if consumer_subset is None:
+                return None  # TODO(phimuell): Lift this.
+
+            # All producers that might contribute to what this consumer reads have
+            #  to be part of the same fragment. Several producers may already share a
+            #  fragment, so the ids have to be deduplicated before they are merged.
+            contributing = list(
+                dict.fromkeys(
+                    find_fragment(i)
+                    for i, producer_edge in enumerate(producer_edges)
+                    if gtx_dace_split.maybe_intersecting(
+                        producer_edge.data.dst_subset, consumer_subset
+                    )
+                )
+            )
+            if len(contributing) == 0:
                 return None
-            edge_reassignments[possible_producer].add(oedge)
+
+            merged_id = min(contributing)
+            for fragment_id in contributing:
+                if fragment_id != merged_id:
+                    fragment_of_producer[fragment_id] = merged_id
+                    consumers_of_fragment[merged_id] |= consumers_of_fragment.pop(fragment_id)
+            consumers_of_fragment[merged_id].add(oedge)
+
+        fragments: list[_Fragment] = []
+        for fragment_id, consumer_edges in consumers_of_fragment.items():
+            producers = OrderedSet(
+                producer_edges[i]
+                for i in range(len(producer_edges))
+                if find_fragment(i) == fragment_id
+            )
+            subsets = gtx_dace_split.subset_merger(
+                [producer_edge.data.dst_subset for producer_edge in producers]
+            )
+            # The producers of a fragment must describe a single contiguous region,
+            #  otherwise it can not be turned into one data descriptor.
+            if len(subsets) != 1:
+                return None
+            fragments.append(
+                _Fragment(producers=producers, consumers=consumer_edges, subset=subsets[0])
+            )
+
+        # `split_node()` requires that every edge is fully covered by exactly one
+        #  fragment, so a consumer must not straddle a fragment boundary.
+        for fragment in fragments:
+            for consumer_edge in fragment.consumers:
+                if not fragment.subset.covers(consumer_edge.data.src_subset):
+                    return None
+        for i, fragment in enumerate(fragments):
+            for other in fragments[i + 1 :]:
+                if gtx_dace_split.maybe_intersecting(fragment.subset, other.subset):
+                    return None
 
         unused_producers = [
             producer
-            for producer, assigned_consumers in edge_reassignments.items()
-            if len(assigned_consumers) == 0
+            for fragment in fragments
+            if len(fragment.consumers) == 0
+            for producer in fragment.producers
         ]
         if unused_producers:
             # This situation is generated by MapFusion, if the intermediate
@@ -371,67 +439,13 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
                 stacklevel=0,
             )
 
-        return edge_reassignments
-
-    def _find_producer(
-        self,
-        consumer_edge: dace_graph.MultiConnectorEdge,
-        producer_edges: Iterable[dace_graph.MultiConnectorEdge],
-    ) -> dace_graph.MultiConnectorEdge | None:
-        """Find the producer edge that generates what the consumer reads.
-
-        The function checks which producer covers what the consumer reads.
-        If there is not producer that does this, this function returns `None`.
-        This function does not perform any additional tests.
-
-        Args:
-            consumer_edge: The edge that reads from `self.access_node`.
-            producer_edges: List of all edges that writes to `self.access_node`.
-        """
-        consumer_subset = consumer_edge.data.src_subset
-
-        # The consumer subset does not exist, so we can not do the decomposition.
-        # TODO(phimuell): Fix this.
-        if consumer_subset is None:
-            return None
-
-        # This check only checks if that the producer really generates the data that
-        #  is consumed later. However, we also have to ensure that nothing is computed
-        #  what is not consumed later. Thus.
-        possible_producers = [
-            producer_edge
-            for producer_edge in producer_edges
-            if producer_edge.data.dst_subset.covers(consumer_subset)
-        ]
-
-        # We only allow the case that one producer covers the consumer. If we found
-        #  multiple candidates then we have an invalid SDFG, because multiple
-        #  producer writes to the same memory location.
-        if len(possible_producers) == 0:
-            return None
-        elif len(possible_producers) != 1:
-            # This might indicate an error (the same memory location is written by
-            #  multiple producer. However, there are some cases where it is not an
-            #  error. For example a Map, with two Tasklets, writes to the node,
-            #  one Tasklet writes `T[__i, 0]` the other `T[__i, 10]`, where `__i`
-            #  is the iteration index. Then Memlet propagation will set the subset
-            #  to something like `T[:, 0:10]`. So it is not an error in that case.
-            warnings.warn(
-                f"Found transient '{self.access_node.data}' that has multiple overlapping"
-                " incoming edges. Might indicate an error.",
-                stacklevel=0,
-            )
-            return None
-
-        return possible_producers[0]
+        return fragments
 
     def _check_split_constraints(
         self,
         state: dace.SDFGState,
         sdfg: dace.SDFG,
-        edge_reassignments: dict[
-            dace_graph.MultiConnectorEdge, OrderedSet[dace_graph.MultiConnectorEdge]
-        ],
+        fragments: list[_Fragment],
     ) -> bool:
         """Checks if the decomposition results in a valid SDFG.
 
@@ -439,46 +453,67 @@ class SplitAccessNode(dace_transformation.SingleStateTransformation):
         `self._find_edge_reassignment()`.
         """
 
-        for producer_edge, consumer_edges in edge_reassignments.items():
-            data_source = producer_edge.src
-
+        for fragment in fragments:
+            consumer_edges = fragment.consumers
             if len(consumer_edges) == 0:
                 continue
-            elif isinstance(data_source, dace_nodes.AccessNode):
-                # TODO(phimuell): Should we also ensure that the domains are tight?
-                if gtx_transformations.utils.is_view(data_source, sdfg):
+
+            # A fragment that is fed by several producers is only read as a whole,
+            #  so tightness can only be established for the fragment, not for the
+            #  individual producers.
+            if len(fragment.producers) > 1:
+                if not self._is_covered_by_consumers(fragment.subset, consumer_edges):
                     return False
 
-                # If the source is a global data, then we do not impose any other
-                #  constraints.
-                if not data_source.desc(sdfg).transient:
-                    continue
+            for producer_edge in fragment.producers:
+                data_source = producer_edge.src
 
-                # If the source is a transient then we distinguish between two cases.
-                #  In the first case there is only one consumer, in that case we
-                #  require that everything is read. In the second case, more than
-                #  one consumer, we do not impose any constraints.
-                #  We do this to ensure the tightness of the temporaries, i.e. what
-                #  is computed is also read, which is core assumption of the
-                #  `CopyChainRemover`.
-                # TODO(phimuell): Lift this limitation.
-                if len(consumer_edges) == 1:
-                    if not next(iter(consumer_edges)).data.src_subset.covers(
-                        producer_edge.data.dst_subset
+                if isinstance(data_source, dace_nodes.AccessNode):
+                    # TODO(phimuell): Should we also ensure that the domains are tight?
+                    if gtx_transformations.utils.is_view(data_source, sdfg):
+                        return False
+
+                    # If the source is a global data, then we do not impose any other
+                    #  constraints.
+                    if not data_source.desc(sdfg).transient:
+                        continue
+
+                    # If the source is a transient then we distinguish between two cases.
+                    #  In the first case there is only one consumer, in that case we
+                    #  require that everything is read. In the second case, more than
+                    #  one consumer, we do not impose any constraints.
+                    #  We do this to ensure the tightness of the temporaries, i.e. what
+                    #  is computed is also read, which is core assumption of the
+                    #  `CopyChainRemover`.
+                    # TODO(phimuell): Lift this limitation.
+                    if len(fragment.producers) == 1 and len(consumer_edges) == 1:
+                        if not next(iter(consumer_edges)).data.src_subset.covers(
+                            producer_edge.data.dst_subset
+                        ):
+                            return False
+
+                elif isinstance(data_source, dace_nodes.MapExit):
+                    # The source is a Map, in this case we just generate a new transient
+                    #  output and then perform some reconnection. However, we require that
+                    #  all consumer read exactly what is is written by the map. This
+                    #  is to ensure some tightness of the domains.
+                    if len(fragment.producers) == 1 and not all(
+                        consumer_edge.data.src_subset.covers(producer_edge.data.dst_subset)
+                        for consumer_edge in consumer_edges
                     ):
                         return False
 
-            elif isinstance(data_source, dace_nodes.MapExit):
-                # The source is a Map, in this case we just generate a new transient
-                #  output and then perform some reconnection. However, we require that
-                #  all consumer read exactly what is is written by the map. This
-                #  is to ensure some tightness of the domains.
-                if not all(
-                    consumer_edge.data.src_subset.covers(producer_edge.data.dst_subset)
-                    for consumer_edge in consumer_edges
-                ):
+                else:
                     return False
-
-            else:
-                return False
         return True
+
+    def _is_covered_by_consumers(
+        self,
+        subset: dace_sbs.Subset,
+        consumer_edges: OrderedSet[dace_graph.MultiConnectorEdge],
+    ) -> bool:
+        """Checks if `subset` is fully read by `consumer_edges` taken together."""
+        merged = gtx_dace_split.subset_merger(
+            [consumer_edge.data.src_subset for consumer_edge in consumer_edges]
+        )
+        return any(merged_subset.covers(subset) for merged_subset in merged)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
@@ -273,6 +273,16 @@ def split_node(
     assert not gtx_transformations.utils.is_view(desc_to_split)
     assert isinstance(desc_to_split, dace_data.Array)
 
+    # DaCe reruns Memlet propagation after every applied transformation. It rebuilds
+    #  the Memlets on the edges of a NestedSDFG from the ones inside it and carries over
+    #  which side of the connection the data is on, although inside it refers to a
+    #  different data container, which can leave a read without a `src_subset`. The
+    #  rerouting below can not repair that, it runs while the old and the new edge are
+    #  both present, so it is done here, while the graph still tells where the data is.
+    for edge in state.all_edges(node_to_split):
+        for memlet_tree in state.memlet_tree(edge).traverse_children(include_self=True):
+            memlet_tree.edge.data.try_initialize(sdfg, state, memlet_tree.edge)
+
     input_descriptions = describe_incoming_edges(state, node_to_split)
     output_descriptions = describe_outgoing_edges(state, node_to_split)
     edge_descriptions = input_descriptions + output_descriptions

--- a/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
@@ -279,6 +279,10 @@ def split_node(
     #  different data container, which can leave a read without a `src_subset`. The
     #  rerouting below can not repair that, it runs while the old and the new edge are
     #  both present, so it is done here, while the graph still tells where the data is.
+    # TODO(phimuell): Replace this with a cheaper repair. The cost is not the Memlet
+    #   tree, which is scope local, but `try_initialize()`, which calls `memlet_path()`
+    #   once per edge; that is also where the "undefined for more than one path"
+    #   caveat of `memlet_path()` applies.
     for edge in state.all_edges(node_to_split):
         for memlet_tree in state.memlet_tree(edge).traverse_children(include_self=True):
             memlet_tree.edge.data.try_initialize(sdfg, state, memlet_tree.edge)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
@@ -279,11 +279,8 @@ def split_node(
     #  different data container, which can leave a read without a `src_subset`. The
     #  rerouting below can not repair that, it runs while the old and the new edge are
     #  both present, so it is done here, while the graph still tells where the data is.
-    # TODO(phimuell): Replace this with a cheaper repair, that fixes the Memlet trees
-    #   directly instead of every single Memlet. The cost is not the Memlet tree, which
-    #   is scope local, but `try_initialize()`, which calls `memlet_path()` once per
-    #   edge; that is also where the "undefined for more than one path" caveat of
-    #   `memlet_path()` applies.
+    # TODO(phimuell): Replace this with a cheaper repair, that fixes the Memlet
+    #   trees directly instead of every single Memlet. The cost is not the Memlet.
     for edge in state.all_edges(node_to_split):
         for memlet_tree in state.memlet_tree(edge).traverse_children(include_self=True):
             memlet_tree.edge.data.try_initialize(sdfg, state, memlet_tree.edge)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/splitting_tools.py
@@ -279,10 +279,11 @@ def split_node(
     #  different data container, which can leave a read without a `src_subset`. The
     #  rerouting below can not repair that, it runs while the old and the new edge are
     #  both present, so it is done here, while the graph still tells where the data is.
-    # TODO(phimuell): Replace this with a cheaper repair. The cost is not the Memlet
-    #   tree, which is scope local, but `try_initialize()`, which calls `memlet_path()`
-    #   once per edge; that is also where the "undefined for more than one path"
-    #   caveat of `memlet_path()` applies.
+    # TODO(phimuell): Replace this with a cheaper repair, that fixes the Memlet trees
+    #   directly instead of every single Memlet. The cost is not the Memlet tree, which
+    #   is scope local, but `try_initialize()`, which calls `memlet_path()` once per
+    #   edge; that is also where the "undefined for more than one path" caveat of
+    #   `memlet_path()` applies.
     for edge in state.all_edges(node_to_split):
         for memlet_tree in state.memlet_tree(edge).traverse_children(include_self=True):
             memlet_tree.edge.data.try_initialize(sdfg, state, memlet_tree.edge)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
@@ -1052,3 +1052,76 @@ def test_consumer_spanning_already_merged_producers():
     # Everything ends up in a single fragment, so there is nothing to split -- the
     #  point of the test is that determining that does not raise.
     _perform_test(sdfg, explected_applies=0)
+
+
+def _make_multi_producer_sdfg(
+    name: str,
+    producers: list[tuple[str, int]],
+    consumers: list[tuple[str, str]],
+) -> tuple[dace.SDFG, dace.SDFGState]:
+    """Builds an SDFG where `producers` write disjoint chunks of `t` that `consumers` read."""
+    sdfg = dace.SDFG(util.unique_name(name))
+    state = sdfg.add_state(is_start_block=True)
+
+    for array in [source for source, _ in producers] + [dst for dst, _ in consumers] + ["t"]:
+        sdfg.add_array(array, shape=(20,), dtype=dace.float64, transient=(array == "t"))
+    t = state.add_access("t")
+
+    for producer, (source, start) in enumerate(producers):
+        state.add_mapped_tasklet(
+            f"producer_{producer}",
+            map_ranges={"__i": f"{start}:{start + 5}"},
+            inputs={"__in": dace.Memlet(f"{source}[__i]")},
+            code=f"__out = __in + {producer + 1}.0",
+            outputs={"__out": dace.Memlet("t[__i]")},
+            output_nodes={t},
+            external_edges=True,
+        )
+    for consumer, (destination, rng) in enumerate(consumers):
+        state.add_mapped_tasklet(
+            f"consumer_{consumer}",
+            map_ranges={"__i": rng},
+            inputs={"__in": dace.Memlet("t[__i]")},
+            code="__out = __in + 13.0",
+            outputs={"__out": dace.Memlet(f"{destination}[__i]")},
+            input_nodes={t},
+            external_edges=True,
+        )
+    sdfg.validate()
+    return sdfg, state
+
+
+def test_partially_read_multi_producer_fragment_is_rejected():
+    """A merged fragment whose data is not read in full must not be split off.
+
+    The first producer forms its own, fully read fragment, so the candidate is not
+    rejected before the merged fragment is examined. The second and third producer
+    are merged by the spanning consumer, but that consumer stops short of what the
+    third producer writes, so the fragment is not tight and splitting it would break
+    the assumption `CopyChainRemover` relies on.
+    """
+    sdfg, _ = _make_multi_producer_sdfg(
+        "partially_read_multi_producer_fragment",
+        producers=[("a", 0), ("b", 5), ("c", 10)],
+        consumers=[("d", "0:5"), ("e", "5:12")],
+    )
+    _perform_test(sdfg, explected_applies=0)
+
+
+def test_overlapping_consumers_cover_multi_producer_fragment():
+    """Consumers that read overlapping regions still cover the merged fragment.
+
+    The two reads of the merged fragment overlap rather than being adjacent, which
+    is the common case for stencils reading a halo. Their union still covers what
+    the two producers write, so the split must be performed.
+    """
+    sdfg, state = _make_multi_producer_sdfg(
+        "overlapping_consumers_cover_fragment",
+        producers=[("a", 0), ("b", 5), ("c", 10)],
+        consumers=[("d", "0:5"), ("e", "5:12"), ("f", "10:15")],
+    )
+    _perform_test(sdfg, explected_applies=1, removed_transients={"t"})
+
+    fragment_nodes = [dnode for dnode in state.data_nodes() if sdfg.arrays[dnode.data].transient]
+    assert len(fragment_nodes) == 2
+    assert {state.in_degree(dnode) for dnode in fragment_nodes} == {1, 2}

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
@@ -1091,21 +1091,24 @@ def _make_multi_producer_sdfg(
     return sdfg, state
 
 
-def test_partially_read_multi_producer_fragment_is_rejected():
-    """A merged fragment whose data is not read in full must not be split off.
+def test_partially_read_multi_producer_fragment():
+    """A fragment that is not read in full does not prevent the other ones.
 
-    The first producer forms its own, fully read fragment, so the candidate is not
-    rejected before the merged fragment is examined. The second and third producer
-    are merged by the spanning consumer, but that consumer stops short of what the
-    third producer writes, so the fragment is not tight and splitting it would break
-    the assumption `CopyChainRemover` relies on.
+    The second and third producer are merged by the spanning consumer, which stops
+    short of what the third producer writes, so that fragment keeps data that nobody
+    reads. The first producer and its consumer are unaffected by that and become an
+    independent fragment.
     """
-    sdfg, _ = _make_multi_producer_sdfg(
+    sdfg, state = _make_multi_producer_sdfg(
         "partially_read_multi_producer_fragment",
         producers=[("a", 0), ("b", 5), ("c", 10)],
         consumers=[("d", "0:5"), ("e", "5:12")],
     )
-    _perform_test(sdfg, explected_applies=0)
+    _perform_test(sdfg, explected_applies=1, removed_transients={"t"})
+
+    fragment_nodes = [dnode for dnode in state.data_nodes() if sdfg.arrays[dnode.data].transient]
+    assert len(fragment_nodes) == 2
+    assert {state.in_degree(dnode) for dnode in fragment_nodes} == {1, 2}
 
 
 def test_overlapping_consumers_cover_multi_producer_fragment():

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
@@ -948,8 +948,27 @@ def test_consumer_spanning_multiple_producers():
 
     _perform_test(sdfg, explected_applies=1, removed_transients={"t"})
 
-    # The node was split into exactly the two fragments described above.
-    assert len([desc for desc in sdfg.arrays.values() if desc.transient]) == 2
+    # The node was split into exactly the two fragments described above: one fed by
+    #  the first producer alone, the other by the second and third together.
+    fragment_nodes = [dnode for dnode in state.data_nodes() if sdfg.arrays[dnode.data].transient]
+    assert len(fragment_nodes) == 2
+    fragment_by_nb_producers = {state.in_degree(dnode): dnode for dnode in fragment_nodes}
+    assert set(fragment_by_nb_producers.keys()) == {1, 2}
+
+    # Each fragment serves exactly the consumer that reads it, i.e. the single
+    #  producer fragment feeds the consumer writing to `d` and the merged one the
+    #  consumer writing to `e`.
+    for nb_producers, expected_destination in [(1, "d"), (2, "e")]:
+        fragment_node = fragment_by_nb_producers[nb_producers]
+        assert state.out_degree(fragment_node) == 1
+        consumer_entry = next(iter(state.out_edges(fragment_node))).dst
+        assert isinstance(consumer_entry, dace_nodes.MapEntry)
+        destinations = {
+            oedge.dst.data
+            for oedge in state.out_edges(state.exit_node(consumer_entry))
+            if isinstance(oedge.dst, dace_nodes.AccessNode)
+        }
+        assert destinations == {expected_destination}
 
 
 def test_consumer_spanning_all_producers():

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_split_access_node.py
@@ -904,3 +904,132 @@ def test_unused_partial_read_from_inout_node():
     sdfg.validate()
 
     _perform_test(sdfg, explected_applies=1, removed_transients={t})
+
+
+def test_consumer_spanning_multiple_producers():
+    """A consumer that reads the data of two producers puts them in one fragment."""
+    sdfg = dace.SDFG(util.unique_name("consumer_spanning_multiple_producers"))
+    state = sdfg.add_state(is_start_block=True)
+
+    for name in "abctde":
+        sdfg.add_array(
+            name,
+            shape=(20,),
+            dtype=dace.float64,
+            transient=(name == "t"),
+        )
+    t = state.add_access("t")
+
+    for producer, (source, start) in enumerate([("a", 0), ("b", 5), ("c", 10)]):
+        state.add_mapped_tasklet(
+            f"producer_{producer}",
+            map_ranges={"__i": f"{start}:{start + 5}"},
+            inputs={"__in": dace.Memlet(f"{source}[__i]")},
+            code=f"__out = __in + {producer + 1}.0",
+            outputs={"__out": dace.Memlet("t[__i]")},
+            output_nodes={t},
+            external_edges=True,
+        )
+
+    # The first consumer is served by the first producer alone, but the second one
+    #  reads what the second and third producer generate, so those two have to end
+    #  up in the same fragment.
+    for consumer, (destination, rng) in enumerate([("d", "0:5"), ("e", "5:15")]):
+        state.add_mapped_tasklet(
+            f"consumer_{consumer}",
+            map_ranges={"__i": rng},
+            inputs={"__in": dace.Memlet("t[__i]")},
+            code="__out = __in + 13.0",
+            outputs={"__out": dace.Memlet(f"{destination}[__i]")},
+            input_nodes={t},
+            external_edges=True,
+        )
+    sdfg.validate()
+
+    _perform_test(sdfg, explected_applies=1, removed_transients={"t"})
+
+    # The node was split into exactly the two fragments described above.
+    assert len([desc for desc in sdfg.arrays.values() if desc.transient]) == 2
+
+
+def test_consumer_spanning_all_producers():
+    """If a single consumer reads everything there is only one fragment, so no split."""
+    sdfg = dace.SDFG(util.unique_name("consumer_spanning_all_producers"))
+    state = sdfg.add_state(is_start_block=True)
+
+    for name in "abtd":
+        sdfg.add_array(
+            name,
+            shape=(20,),
+            dtype=dace.float64,
+            transient=(name == "t"),
+        )
+    t = state.add_access("t")
+
+    for producer, (source, start) in enumerate([("a", 0), ("b", 5)]):
+        state.add_mapped_tasklet(
+            f"producer_{producer}",
+            map_ranges={"__i": f"{start}:{start + 5}"},
+            inputs={"__in": dace.Memlet(f"{source}[__i]")},
+            code=f"__out = __in + {producer + 1}.0",
+            outputs={"__out": dace.Memlet("t[__i]")},
+            output_nodes={t},
+            external_edges=True,
+        )
+    state.add_mapped_tasklet(
+        "consumer",
+        map_ranges={"__i": "0:10"},
+        inputs={"__in": dace.Memlet("t[__i]")},
+        code="__out = __in + 13.0",
+        outputs={"__out": dace.Memlet("d[__i]")},
+        input_nodes={t},
+        external_edges=True,
+    )
+    sdfg.validate()
+
+    _perform_test(sdfg, explected_applies=0)
+
+
+def test_consumer_spanning_already_merged_producers():
+    """A consumer spans producers that a previous consumer already merged."""
+    sdfg = dace.SDFG(util.unique_name("consumer_spanning_already_merged_producers"))
+    state = sdfg.add_state(is_start_block=True)
+
+    for name in "abctde":
+        sdfg.add_array(
+            name,
+            shape=(20,),
+            dtype=dace.float64,
+            transient=(name == "t"),
+        )
+    t = state.add_access("t")
+
+    for producer, (source, start) in enumerate([("a", 0), ("b", 5), ("c", 10)]):
+        state.add_mapped_tasklet(
+            f"producer_{producer}",
+            map_ranges={"__i": f"{start}:{start + 5}"},
+            inputs={"__in": dace.Memlet(f"{source}[__i]")},
+            code=f"__out = __in + {producer + 1}.0",
+            outputs={"__out": dace.Memlet("t[__i]")},
+            output_nodes={t},
+            external_edges=True,
+        )
+
+    # The first consumer merges producer 1 and producer 2 into one fragment. The
+    #  second one spans all three, so looking up the fragment of producer 1 and of
+    #  producer 2 now yields the same non-minimal id twice.
+    for consumer, (destination, rng) in enumerate([("d", "5:15"), ("e", "0:15")]):
+        state.add_mapped_tasklet(
+            f"consumer_{consumer}",
+            map_ranges={"__i": rng},
+            inputs={"__in": dace.Memlet("t[__i]")},
+            code="__out = __in + 13.0",
+            outputs={"__out": dace.Memlet(f"{destination}[__i]")},
+            input_nodes={t},
+            external_edges=True,
+        )
+    sdfg.validate()
+
+    # Everything ends up in a single fragment, so there is nothing to split -- the
+    #  point of the test is that determining that does not raise.
+    _perform_test(sdfg, explected_applies=0)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_vertical_map_split_fusion.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_vertical_map_split_fusion.py
@@ -388,3 +388,101 @@ def test_vertical_map_fusion_with_neighbor_access(run_map_fusion: bool):
         # to the temporary field.
         assert ret == 0
         assert util.count_nodes(sdfg, dace_nodes.MapEntry) == initial_map_entries_nb
+
+
+def _make_if_block(state: dace.SDFGState) -> dace_nodes.NestedSDFG:
+    inner_sdfg = dace.SDFG(util.unique_name("if_stmt_"))
+    for name, dtype in [
+        ("__arg1", dace.float64),
+        ("__arg2", dace.float64),
+        ("__cond", dace.bool_),
+        ("__output", dace.float64),
+    ]:
+        inner_sdfg.add_scalar(name, dtype=dtype, transient=False)
+
+    if_region = dace.sdfg.state.ConditionalBlock(util.unique_name("if"))
+    inner_sdfg.add_node(if_region, is_start_block=True)
+
+    for branch, arg in [("then_body", "__arg1"), ("else_body", "__arg2")]:
+        body = dace.sdfg.state.ControlFlowRegion(branch, sdfg=inner_sdfg)
+        bstate = body.add_state(branch, is_start_block=True)
+        bstate.add_nedge(
+            bstate.add_access(arg),
+            bstate.add_access("__output"),
+            dace.Memlet(data="__output", subset="0"),
+        )
+        cond = "__cond" if arg == "__arg1" else "not __cond"
+        if_region.add_branch(dace.sdfg.state.CodeBlock(cond), body)
+
+    return state.add_nested_sdfg(
+        sdfg=inner_sdfg,
+        inputs={"__arg1", "__arg2", "__cond"},
+        outputs={"__output"},
+    )
+
+
+def nested_sdfg_consumer_sdfg(N: int) -> dace.SDFG:
+    """The second Map consumes the intermediate through a NestedSDFG."""
+    sdfg = dace.SDFG(util.unique_name("nested_sdfg_consumer"))
+    A, _ = sdfg.add_array("A", [N], dtype=dace.float64)
+    B, _ = sdfg.add_array("B", [N], dtype=dace.float64)
+    M, _ = sdfg.add_array("M", [N], dtype=dace.bool_)
+    tmp, _ = sdfg.add_temp_transient([N], dtype=dace.float64)
+
+    st = sdfg.add_state()
+    A_node = st.add_access(A)
+    B_node = st.add_access(B)
+    M_node = st.add_access(M)
+    tmp_node = st.add_access(tmp)
+
+    st.add_mapped_tasklet(
+        "map1",
+        map_ranges={"__i": f"0:{N}"},
+        code="__out = __inp + 1",
+        inputs={"__inp": dace.Memlet(data=A, subset="__i")},
+        outputs={"__out": dace.Memlet(data=tmp, subset="__i")},
+        input_nodes={A_node},
+        output_nodes={tmp_node},
+        external_edges=True,
+    )
+
+    map_entry, map_exit = st.add_map("map2", ndrange={"__i": f"1:{N}"})
+    nsdfg = _make_if_block(st)
+    for conn, node, data, subset in [
+        ("__arg1", tmp_node, tmp, f"1:{N}"),
+        ("__arg2", A_node, A, f"1:{N}"),
+        ("__cond", M_node, M, f"1:{N}"),
+    ]:
+        map_entry.add_in_connector(f"IN_{conn}")
+        map_entry.add_out_connector(f"OUT_{conn}")
+        st.add_edge(node, None, map_entry, f"IN_{conn}", dace.Memlet(data=data, subset=subset))
+        st.add_edge(map_entry, f"OUT_{conn}", nsdfg, conn, dace.Memlet(data=data, subset="__i"))
+    map_exit.add_in_connector("IN_B")
+    map_exit.add_out_connector("OUT_B")
+    st.add_edge(nsdfg, "__output", map_exit, "IN_B", dace.Memlet(data=B, subset="__i"))
+    st.add_edge(map_exit, "OUT_B", B_node, None, dace.Memlet(data=B, subset=f"1:{N}"))
+
+    sdfg.validate()
+    return sdfg
+
+
+def test_vertical_map_fusion_with_nested_sdfg_consumer():
+    N = 80
+    sdfg = nested_sdfg_consumer_sdfg(N)
+
+    res, ref = util.make_sdfg_args(sdfg)
+    util.compile_and_run_sdfg(sdfg, **ref)
+
+    ret = gtx_transformations.gt_vertical_map_split_fusion(
+        sdfg=sdfg,
+        run_simplify=True,
+        run_map_fusion=False,
+        fuse_map_fragments=True,
+        consolidate_edges_only_if_not_extending=False,
+        validate=True,
+        validate_all=True,
+    )
+    assert ret == 1
+
+    util.compile_and_run_sdfg(sdfg, **res)
+    assert util.compare_sdfg_res(ref=ref, res=res)


### PR DESCRIPTION
Lets a `SplitAccessNode` fragment have several producers.

Before, a fragment was a single producer edge, so an AccessNode fed by several producers and read by several consumers could not be split, and the maps around it could not be fused. A fragment is now a set of producers joined by union find: a consumer that may intersect more than one producer merges them, so each fragment is a region that is written by a known set of producers and read by a known set of consumers, and the fragments are independent of each other.

Consequences worth knowing:

The check that everything a producer computes is also read applies only to a fragment with a single producer. With several producers no consumer is tied to an individual producer, so requiring the fragment to be read in full would reject the whole node, including the fragments that are fine. What stays unread is computed for nothing, but it is not a regression, without the split the same producer computes the same values and they are discarded just as well.

The producers of a fragment are merged with the adjacency only merger, since producers that overlap would describe the same memory twice.

`split_node()` now re-initializes the Memlet trees of the edges it is about to reroute. DaCe reruns Memlet propagation after every applied transformation, and it can leave a read on the edge of a NestedSDFG without a `src_subset`; the rerouting itself cannot repair that, because it runs while the old and the new edge are both present.