### PR TITLE
refactor[next]: name the cache layout and give the translation caches one home

### DIFF
--- a/src/gt4py/next/otf/compilation/build_systems/compiledb.py
+++ b/src/gt4py/next/otf/compilation/build_systems/compiledb.py
@@ -14,7 +14,7 @@ import pathlib
 import re
 import shutil
 import subprocess
-from typing import Optional, TypeVar
+from typing import Final, Optional, TypeVar
 
 from gt4py._core import file_utils, locking
 from gt4py.next import config, errors, fingerprinting
@@ -25,6 +25,11 @@ from gt4py.next.otf.compilation.build_systems import cmake
 
 
 CPPLikeCodeSpecT = TypeVar("CPPLikeCodeSpecT", bound=code_specs.CPPLikeCodeSpec)
+
+#: Name prefix of the synthetic program under which the shared compiledb is cached.
+#: Its cache folder sits next to the folders of real programs, so tools that scan
+#: the build cache use this to tell the two apart.
+COMPILEDB_PROTOTYPE_NAME_PREFIX: Final[str] = "compile_commands_cache"
 
 
 @dataclasses.dataclass
@@ -240,7 +245,7 @@ class CompiledbProject(stages.BuildSystemProject[CPPLikeCodeSpecT, code_specs.Py
 def _cc_prototype_program_name(
     deps: tuple[interface.LibraryDependency, ...], build_type: str, flags: list[str]
 ) -> str:
-    base_name = "compile_commands_cache"
+    base_name = COMPILEDB_PROTOTYPE_NAME_PREFIX
     deps_str = "_".join(f"{dep.name}_{dep.version}" for dep in deps)
     flags_str = "_".join(re.sub(r"\W+", "", f) for f in flags)
     return "_".join([base_name, deps_str, build_type, flags_str]).replace(".", "_")

--- a/src/gt4py/next/otf/compilation/cache.py
+++ b/src/gt4py/next/otf/compilation/cache.py
@@ -31,9 +31,35 @@ CACHE_FOLDER_NAME_PATTERN: Final[str] = (
     r"(?:_(?P<build_context_id>[0-9a-f]{16}))?"
 )
 
+#: Suffix appended by `get_cache_folder` to the program name when the cached
+#: artifact includes bindings. It is part of the pattern's `name` group, so
+#: recovering the plain program name means stripping this suffix.
+BINDINGS_NAME_SUFFIX: Final[str] = "_pyext"
+
+#: Directory under the cache base holding the translation caches, one
+#: sub-directory per backend. Unlike a build cache folder, which holds the
+#: artifacts of one compiled program variant, these hold the output of the
+#: translation step: an optimized SDFG or generated source per translated
+#: program.
+TRANSLATION_CACHE_DIR_NAME: Final[str] = "translation_cache"
+
+#: Backends that persist the output of their translation step, i.e. those whose
+#: workflow factory enables the `cached_translation` trait.
+TRANSLATION_CACHE_BACKENDS: Final[tuple[str, ...]] = ("dace", "gtfn")
+
 _session_cache_dir = tempfile.TemporaryDirectory(prefix="gt4py_session_")
 
 _session_cache_dir_path = pathlib.Path(_session_cache_dir.name)
+
+
+def get_translation_cache_folder(cache_base: pathlib.Path, backend: str) -> pathlib.Path:
+    """Return the folder under `cache_base` where `backend` caches its translations.
+
+    Unlike `get_cache_folder`, this only computes a path. The folder is created by
+    the cache that writes into it, so that asking where a cache would be does not
+    create it — which tools that only inspect a cache rely on.
+    """
+    return cache_base / TRANSLATION_CACHE_DIR_NAME / backend
 
 
 def get_cache_base_path(lifetime: config.BuildCacheLifetime) -> pathlib.Path:
@@ -70,7 +96,7 @@ def get_cache_folder(
     fingerprinter = fingerprinting.strict_fingerprinter
     slug = ext_source.program_source.entry_point.name
     if ext_source.binding_source:
-        slug = f"{slug}_pyext"
+        slug = f"{slug}{BINDINGS_NAME_SUFFIX}"
     folder_name = f"{slug}_{fingerprinter(ext_source)}_{config.BUILD_CACHE_VERSION_ID}"
     if build_context_id:
         folder_name = f"{folder_name}_{build_context_id}"

--- a/src/gt4py/next/program_processors/runners/dace/workflow/factory.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/factory.py
@@ -46,9 +46,8 @@ class DaCeWorkflowFactory(factory.Factory):
                     o.bare_translation,
                     input_fingerprinter=stages.compilable_program_fingerprinter,
                     cache=filecache.FileCache(
-                        str(
-                            cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME)
-                            / "translation_cache"
+                        cache.get_translation_cache_folder(
+                            cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME), "dace"
                         )
                     ),
                 )

--- a/src/gt4py/next/program_processors/runners/gtfn.py
+++ b/src/gt4py/next/program_processors/runners/gtfn.py
@@ -150,7 +150,9 @@ class GTFNCompileWorkflowFactory(factory.Factory):
                     o.bare_translation,
                     input_fingerprinter=stages.compilable_program_fingerprinter,
                     cache=filecache.FileCache(
-                        str(cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME) / "gtfn_cache")
+                        cache.get_translation_cache_folder(
+                            cache.get_cache_base_path(config.BUILD_CACHE_LIFETIME), "gtfn"
+                        )
                     ),
                 )
             ),

--- a/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_cache.py
+++ b/tests/next_tests/unit_tests/otf_tests/compilation_tests/test_cache.py
@@ -44,13 +44,25 @@ def test_pyext_marker_only_when_bindings_present(extension_source_example):
     with_bindings = cache.get_cache_folder(
         extension_source_example, config.BuildCacheLifetime.SESSION
     )
-    assert "_pyext" in with_bindings.name
+    assert cache.BINDINGS_NAME_SUFFIX in with_bindings.name
 
     without_bindings = cache.get_cache_folder(
         dataclasses.replace(extension_source_example, binding_source=None),
         config.BuildCacheLifetime.SESSION,
     )
-    assert "_pyext" not in without_bindings.name
+    assert cache.BINDINGS_NAME_SUFFIX not in without_bindings.name
+
+
+def test_translation_caches_share_one_parent(tmp_path):
+    folders = [
+        cache.get_translation_cache_folder(tmp_path, backend)
+        for backend in cache.TRANSLATION_CACHE_BACKENDS
+    ]
+
+    assert len(folders) == len(set(folders))
+    assert {folder.parent for folder in folders} == {tmp_path / cache.TRANSLATION_CACHE_DIR_NAME}
+    # a translation cache is never mistaken for a build folder of a program
+    assert not any(re.fullmatch(cache.CACHE_FOLDER_NAME_PATTERN, f.parent.name) for f in folders)
 
 
 def test_build_context_id_busts_cache_folder(extension_source_example):


### PR DESCRIPTION
The layout of the generated-code cache was spelled out as string literals at the
places that happen to write it:

| Literal | Written in |
| --- | --- |
| `"translation_cache"` / `"gtfn_cache"` | each backend's workflow factory |
| `"_pyext"` | `cache.get_cache_folder` |
| `"compile_commands_cache"` | the compiledb build system, as a function-local |

Nothing named these, so reading a cache directory meant recognizing conventions
rather than looking them up, and anything outside the writer had to re-spell
them.

```
.gt4py_cache/
├── translation_cache/                    <- DaCe translation payloads only
├── gtfn_cache/                           <- gtfn translation payloads only
├── lap_program_pyext_<fp>_<version>/     <- build: liblap_program.so, program.sdfgz
└── compile_commands_cache_..._pyext_.../ <- shared compiledb
```

Each literal becomes a name in the module that owns it: `BINDINGS_NAME_SUFFIX`,
`TRANSLATION_CACHE_DIR_NAME` and `TRANSLATION_CACHE_BACKENDS` in
`otf/compilation/cache.py`, and `COMPILEDB_PROTOTYPE_NAME_PREFIX` in the
compiledb build system.

The inconsistent pair gets one home, stage first and backend second, reached
through `get_translation_cache_folder(cache_base, backend)` so callers no longer
assemble the path:

```
.gt4py_cache/
└── translation_cache/
    ├── dace/   <hash>.pkl
    └── gtfn/   <hash>.pkl
```