### PR TITLE
fix[cartesian]: remove usage of deprecated `ast` types

### DIFF
--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -49,7 +49,6 @@ from gt4py.cartesian.utils import meta as gt_meta, warn_experimental_feature
 
 
 PYTHON_AST_VERSION: Final = (3, 12)
-ELLIPSIS_TYPE = getattr(ast, "Ellipsis", types.EllipsisType)
 
 
 class AssertionChecker(ast.NodeTransformer):
@@ -739,8 +738,7 @@ class CallInliner(ast.NodeTransformer):
 
     def visit_Expr(self, node: ast.Expr):
         """Ignore pure string statements in callee."""
-        pure_str_types = (ast.Constant,) + ((ast.Str,) if hasattr(ast, "Str") else ())
-        if not isinstance(node.value, pure_str_types):
+        if not (isinstance(node.value, ast.Constant) and isinstance(node.value, str)):
             return super().visit(node.value)
 
 
@@ -1359,7 +1357,7 @@ class IRMaker(ast.NodeVisitor):
 
         if any(isinstance(cn, ast.Slice) for cn in index_nodes):
             raise GTScriptSyntaxError(message="Invalid target in assignment.", loc=node)
-        if any(isinstance(cn, ELLIPSIS_TYPE) for cn in index_nodes):
+        if any(isinstance(cn, types.EllipsisType) for cn in index_nodes):
             return None
 
         # Determine if we are using the new-style axis syntax, or the old style.

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -737,9 +737,11 @@ class CallInliner(ast.NodeTransformer):
         return result_node
 
     def visit_Expr(self, node: ast.Expr):
-        """Ignore pure string statements in callee."""
-        if not (isinstance(node.value, ast.Constant) and isinstance(node.value, str)):
-            return super().visit(node.value)
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            # Ignore pure string statements in callee
+            return
+
+        return super().visit(node.value)
 
 
 class CompiledIfInliner(ast.NodeTransformer):


### PR DESCRIPTION
## Description

Python 3.14 will remove support for a couple of (long) deprecated `ast` types. Currently produces warnings like

```none
DeprecationWarning: ast.Ellipsis is deprecated and will be removed in Python 3.14; use ast.Constant instead
```

or

```none
DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
```

This PR updates the (cartesian) gtscript frontend to not use those types anymore and instead rely on things that are future proof, thus eliminating the warning messages.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing tests cases.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A