### PR TITLE
fix[next]: deterministic declaration order in gtfn codegen

### DIFF
--- a/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
@@ -77,10 +77,15 @@ def _is_tuple_of_ref_or_literal(expr: itir.Expr) -> bool:
 
 
 def _get_domains(nodes: Iterable[itir.Stmt]) -> Iterable[itir.FunCall]:
-    result = set()
+    # The order the domains are returned in fixes the order of the generated dimension
+    # tag declarations, so it has to be derived from the IR rather than from set
+    # iteration, which varies with `PYTHONHASHSEED` across processes.
+    result: dict[itir.FunCall, None] = {}
     for node in nodes:
-        result |= node.walk_values().if_isinstance(itir.SetAt).getattr("domain").to_set()
-    return result
+        result.update(
+            dict.fromkeys(node.walk_values().if_isinstance(itir.SetAt).getattr("domain").to_list())
+        )
+    return result.keys()
 
 
 def _name_from_named_range(named_range_call: itir.FunCall) -> str:
@@ -154,9 +159,11 @@ def _collect_offset_definitions(
     offset_definitions = {}
     offset_provider_type = {**offset_provider_type}
 
-    cartesian_offsets: set[itir.CartesianOffset] = (
-        node.walk_values().if_isinstance(itir.CartesianOffset)
-    ).to_set()
+    # Traversal order, not set order: these feed `offset_definitions` below, whose
+    # insertion order becomes the order of the generated tag declarations.
+    cartesian_offsets: Iterable[itir.CartesianOffset] = (
+        node.walk_values().if_isinstance(itir.CartesianOffset).unique().to_list()
+    )
     for cart_offset in cartesian_offsets:
         dims = [
             ir_utils_misc.dim_from_axis_literal(v)
@@ -424,19 +431,23 @@ class GTFN_lowering(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
     @staticmethod
     def _collect_offset_or_axis_node(
         node_type: Type, tree: eve.Node | Iterable[eve.Node]
-    ) -> set[str]:
+    ) -> list[str]:
+        # Ordered by traversal: callers build generated-code lists (e.g. `connectivities`)
+        # from this, so a `set` here would make the emitted order hash-seed dependent.
         if not isinstance(tree, Iterable):
             tree = [tree]
-        result = set()
+        result: dict[str, None] = {}
         for n in tree:
             result.update(
-                n.pre_walk_values()
-                .if_isinstance(node_type)
-                .getattr("value")
-                .if_isinstance(str)
-                .to_set()
+                dict.fromkeys(
+                    n.pre_walk_values()
+                    .if_isinstance(node_type)
+                    .getattr("value")
+                    .if_isinstance(str)
+                    .to_list()
+                )
             )
-        return result
+        return list(result)
 
     def _visit_if_(self, node: itir.FunCall, **kwargs: Any) -> Node:
         assert len(node.args) == 3

--- a/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
@@ -79,9 +79,7 @@ def _is_tuple_of_ref_or_literal(expr: itir.Expr) -> bool:
 
 
 def _get_domains(nodes: Iterable[itir.Stmt]) -> Iterable[itir.FunCall]:
-    # Ordered set, here and in the other collectors below: the order the collected
-    # elements are returned in ends up in the generated code, so it must not be left to
-    # set iteration order.
+    # Ordered, here and in the collectors below: this order ends up in the generated code.
     result: OrderedSet[itir.FunCall] = OrderedSet()
     for node in nodes:
         result.update(node.walk_values().if_isinstance(itir.SetAt).getattr("domain").to_list())

--- a/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
@@ -10,6 +10,8 @@ import dataclasses
 import functools
 from typing import Any, Callable, ClassVar, Iterable, Optional, Type, TypeGuard, Union
 
+from ordered_set import OrderedSet
+
 import gt4py.eve as eve
 from gt4py.eve.concepts import SymbolName
 from gt4py.next import common, utils
@@ -77,15 +79,13 @@ def _is_tuple_of_ref_or_literal(expr: itir.Expr) -> bool:
 
 
 def _get_domains(nodes: Iterable[itir.Stmt]) -> Iterable[itir.FunCall]:
-    # The order the domains are returned in fixes the order of the generated dimension
-    # tag declarations, so it has to be derived from the IR rather than from set
-    # iteration, which varies with `PYTHONHASHSEED` across processes.
-    result: dict[itir.FunCall, None] = {}
+    # Ordered, because the order the domains are returned in fixes the order of the
+    # generated dimension tag declarations. A plain `set` would make that order depend
+    # on `PYTHONHASHSEED` and so differ between processes.
+    result: OrderedSet[itir.FunCall] = OrderedSet()
     for node in nodes:
-        result.update(
-            dict.fromkeys(node.walk_values().if_isinstance(itir.SetAt).getattr("domain").to_list())
-        )
-    return result.keys()
+        result.update(node.walk_values().if_isinstance(itir.SetAt).getattr("domain").to_list())
+    return result
 
 
 def _name_from_named_range(named_range_call: itir.FunCall) -> str:
@@ -159,10 +159,10 @@ def _collect_offset_definitions(
     offset_definitions = {}
     offset_provider_type = {**offset_provider_type}
 
-    # Traversal order, not set order: these feed `offset_definitions` below, whose
-    # insertion order becomes the order of the generated tag declarations.
-    cartesian_offsets: Iterable[itir.CartesianOffset] = (
-        node.walk_values().if_isinstance(itir.CartesianOffset).unique().to_list()
+    # Ordered, because these feed `offset_definitions` below, whose insertion order
+    # becomes the order of the generated tag declarations.
+    cartesian_offsets: OrderedSet[itir.CartesianOffset] = OrderedSet(
+        node.walk_values().if_isinstance(itir.CartesianOffset).to_list()
     )
     for cart_offset in cartesian_offsets:
         dims = [
@@ -431,23 +431,21 @@ class GTFN_lowering(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
     @staticmethod
     def _collect_offset_or_axis_node(
         node_type: Type, tree: eve.Node | Iterable[eve.Node]
-    ) -> list[str]:
-        # Ordered by traversal: callers build generated-code lists (e.g. `connectivities`)
-        # from this, so a `set` here would make the emitted order hash-seed dependent.
+    ) -> OrderedSet[str]:
+        # Ordered, because callers build generated-code lists (e.g. `connectivities`)
+        # from this, so a plain `set` would make the emitted order hash-seed dependent.
         if not isinstance(tree, Iterable):
             tree = [tree]
-        result: dict[str, None] = {}
+        result: OrderedSet[str] = OrderedSet()
         for n in tree:
             result.update(
-                dict.fromkeys(
-                    n.pre_walk_values()
-                    .if_isinstance(node_type)
-                    .getattr("value")
-                    .if_isinstance(str)
-                    .to_list()
-                )
+                n.pre_walk_values()
+                .if_isinstance(node_type)
+                .getattr("value")
+                .if_isinstance(str)
+                .to_list()
             )
-        return list(result)
+        return result
 
     def _visit_if_(self, node: itir.FunCall, **kwargs: Any) -> Node:
         assert len(node.args) == 3

--- a/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
+++ b/src/gt4py/next/program_processors/codegens/gtfn/itir_to_gtfn_ir.py
@@ -79,9 +79,9 @@ def _is_tuple_of_ref_or_literal(expr: itir.Expr) -> bool:
 
 
 def _get_domains(nodes: Iterable[itir.Stmt]) -> Iterable[itir.FunCall]:
-    # Ordered, because the order the domains are returned in fixes the order of the
-    # generated dimension tag declarations. A plain `set` would make that order depend
-    # on `PYTHONHASHSEED` and so differ between processes.
+    # Ordered set, here and in the other collectors below: the order the collected
+    # elements are returned in ends up in the generated code, so it must not be left to
+    # set iteration order.
     result: OrderedSet[itir.FunCall] = OrderedSet()
     for node in nodes:
         result.update(node.walk_values().if_isinstance(itir.SetAt).getattr("domain").to_list())
@@ -159,8 +159,6 @@ def _collect_offset_definitions(
     offset_definitions = {}
     offset_provider_type = {**offset_provider_type}
 
-    # Ordered, because these feed `offset_definitions` below, whose insertion order
-    # becomes the order of the generated tag declarations.
     cartesian_offsets: OrderedSet[itir.CartesianOffset] = OrderedSet(
         node.walk_values().if_isinstance(itir.CartesianOffset).to_list()
     )
@@ -432,8 +430,6 @@ class GTFN_lowering(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
     def _collect_offset_or_axis_node(
         node_type: Type, tree: eve.Node | Iterable[eve.Node]
     ) -> OrderedSet[str]:
-        # Ordered, because callers build generated-code lists (e.g. `connectivities`)
-        # from this, so a plain `set` would make the emitted order hash-seed dependent.
         if not isinstance(tree, Iterable):
             tree = [tree]
         result: OrderedSet[str] = OrderedSet()

--- a/tests/next_tests/unit_tests/program_processor_tests/codegens_tests/gtfn_tests/test_itir_to_gtfn_ir.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/codegens_tests/gtfn_tests/test_itir_to_gtfn_ir.py
@@ -56,3 +56,40 @@ def test_get_domains():
 
     result = list(it2gtfn._get_domains(testee.body))
     assert result == [domain]
+
+
+def _program_over_domains(domains: list[itir.FunCall]) -> itir.Program:
+    return itir.Program(
+        id="foo",
+        function_definitions=[],
+        params=[itir.Sym(id="bar")],
+        declarations=[],
+        body=[
+            itir.SetAt(expr=im.as_fieldop("deref")(), domain=domain, target=itir.SymRef(id="bar"))
+            for domain in domains
+        ],
+    )
+
+
+def test_get_domains_preserves_ir_order():
+    # The order of the domains fixes the order of the generated dimension tag
+    # declarations, so it has to follow the IR. Deriving it from a `set` instead made the
+    # generated source vary with `PYTHONHASHSEED` from one process to the next, which
+    # changed the fingerprint the build cache is keyed on.
+    domains = [
+        im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value=name), 1, 2))
+        for name in ["D", "C", "B", "A", "F", "E"]
+    ]
+
+    result = list(it2gtfn._get_domains(_program_over_domains(domains).body))
+
+    assert result == domains
+
+
+def test_get_domains_deduplicates():
+    domain = im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value="D"), 1, 2))
+    other = im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value="E"), 1, 2))
+
+    result = list(it2gtfn._get_domains(_program_over_domains([domain, other, domain]).body))
+
+    assert result == [domain, other]

--- a/tests/next_tests/unit_tests/program_processor_tests/codegens_tests/gtfn_tests/test_itir_to_gtfn_ir.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/codegens_tests/gtfn_tests/test_itir_to_gtfn_ir.py
@@ -72,10 +72,7 @@ def _program_over_domains(domains: list[itir.FunCall]) -> itir.Program:
 
 
 def test_get_domains_preserves_ir_order():
-    # The order of the domains fixes the order of the generated dimension tag
-    # declarations, so it has to follow the IR. Deriving it from a `set` instead made the
-    # generated source vary with `PYTHONHASHSEED` from one process to the next, which
-    # changed the fingerprint the build cache is keyed on.
+    # The order of the domains fixes the order of the generated dimension tag declarations.
     domains = [
         im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value=name), 1, 2))
         for name in ["D", "C", "B", "A", "F", "E"]

--- a/tests/next_tests/unit_tests/program_processor_tests/codegens_tests/gtfn_tests/test_itir_to_gtfn_ir.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/codegens_tests/gtfn_tests/test_itir_to_gtfn_ir.py
@@ -56,37 +56,3 @@ def test_get_domains():
 
     result = list(it2gtfn._get_domains(testee.body))
     assert result == [domain]
-
-
-def _program_over_domains(domains: list[itir.FunCall]) -> itir.Program:
-    return itir.Program(
-        id="foo",
-        function_definitions=[],
-        params=[itir.Sym(id="bar")],
-        declarations=[],
-        body=[
-            itir.SetAt(expr=im.as_fieldop("deref")(), domain=domain, target=itir.SymRef(id="bar"))
-            for domain in domains
-        ],
-    )
-
-
-def test_get_domains_preserves_ir_order():
-    # The order of the domains fixes the order of the generated dimension tag declarations.
-    domains = [
-        im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value=name), 1, 2))
-        for name in ["D", "C", "B", "A", "F", "E"]
-    ]
-
-    result = list(it2gtfn._get_domains(_program_over_domains(domains).body))
-
-    assert result == domains
-
-
-def test_get_domains_deduplicates():
-    domain = im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value="D"), 1, 2))
-    other = im.call("cartesian_domain")(im.named_range(itir.AxisLiteral(value="E"), 1, 2))
-
-    result = list(it2gtfn._get_domains(_program_over_domains([domain, other, domain]).body))
-
-    assert result == [domain, other]


### PR DESCRIPTION
The gtfn lowering collected dimensions, cartesian offsets and shift offsets into sets and iterated them while building the generated source.

The fix replaces the set by an OrderedSet at the three collectors. Only the one in _get_domains is backed by observed diffs; the other two are the same defect on inputs the test runs did not reach, namely several cartesian dimensions and more than one connectivity offset in a stencil.