### PR TITLE
fix[next-dace]: deterministic GT4PyStateFusion global sink merging

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
@@ -12,6 +12,7 @@ from typing import Any
 import dace
 from dace import transformation as dace_transformation
 from dace.sdfg import nodes as dace_nodes, utils as dace_sdutils
+from ordered_set import OrderedSet
 
 
 # Conditional import because `gt4py.cartesian` uses an older DaCe version without
@@ -424,23 +425,25 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
         #  node for any global data in the combined state. The transients are handled
         #  naturally because we maintain the SSA invariant, furthermore, the inputs
         #  are already merged.
-        # TODO(phimuell): Improve this merging.
-        global_sink_nodes: dict[str, set[dace_nodes.AccessNode]] = {}
+        global_sink_nodes: dict[str, OrderedSet[dace_nodes.AccessNode]] = {}
         for sink_node in first_state.sink_nodes():
             if not isinstance(sink_node, dace_nodes.AccessNode):
                 continue
             if sink_node.desc(sdfg).transient:
                 continue
             if sink_node.data not in global_sink_nodes:
-                global_sink_nodes[sink_node.data] = set()
+                global_sink_nodes[sink_node.data] = OrderedSet()
             global_sink_nodes[sink_node.data].add(sink_node)
 
         for sink_nodes in global_sink_nodes.values():
             if len(sink_nodes) <= 1:
                 continue
-            # We now select one node and redirect all writes to it.
-            final_sink_node = sink_nodes.pop()
+            # We now select one node, in the order they appear in the state, and
+            #  redirect all writes to it.
+            final_sink_node = next(iter(sink_nodes))
             for sink_node in sink_nodes:
+                if sink_node is final_sink_node:
+                    continue
                 for iedge in first_state.in_edges(sink_node):
                     first_state.add_edge(
                         iedge.src, iedge.src_conn, final_sink_node, iedge.dst_conn, iedge.data


### PR DESCRIPTION
Closes #2784 

With this fix, the selection of the sink node is stable, because it relies on the order of nodes in the state, which in turns follows the order of the IR representation.

As commented in the issue report, this is currently not an issue because no debug information is attached to the access nodes, so the serialization of any of the access nodes (to a given data) in the state produces the same result. However, this is a potential source of nondeterminism in case the lowering changes, and each node gets some unique debug information.