### PR TITLE
refactor[next]: give the build caches one home too

### DIFF
--- a/scripts/python/dace_determinism.py
+++ b/scripts/python/dace_determinism.py
@@ -389,11 +389,14 @@ def check_determinism(
     cache2: Path,
     *,
     folder_pattern: str,
+    build_cache_dir: str,
     runs_healthy: bool | None = None,
     diffs_dir: Path | None = None,
     report_path: Path | None = None,
 ) -> list[ComparisonResult]:
     folder_re = _compile_folder_pattern(folder_pattern)
+    # `cache1`/`cache2` are cache bases; program folders live one level down.
+    cache1, cache2 = cache1 / build_cache_dir, cache2 / build_cache_dir
     bags1, n_folders1 = _scan(cache1, folder_re)
     bags2, n_folders2 = _scan(cache2, folder_re)
     results = compare(bags1, bags2)
@@ -456,44 +459,53 @@ def check_determinism(
 CACHE_SUBDIR = ".gt4py_cache"
 PYTEST_TOLERATED_EXIT_CODES = frozenset({0, 1, 5})  # ok, tests failed, no tests collected
 
-_PATTERN_PROBE_SNIPPET = (
-    "from gt4py.next.otf.compilation import cache; print(cache.CACHE_FOLDER_NAME_PATTERN)"
+_LAYOUT_PROBE_SNIPPET = (
+    "from gt4py.next.otf.compilation import cache;"
+    " print(cache.CACHE_FOLDER_NAME_PATTERN); print(cache.BUILD_CACHE_DIR_NAME)"
 )
 
 
-def fetch_cache_folder_pattern(python: str) -> str:
-    """Read the cache folder-name pattern from a gt4py-capable interpreter.
+def fetch_cache_layout(python: str) -> tuple[str, str]:
+    """Read the build cache layout from a gt4py-capable interpreter.
 
-    The pattern is owned by gt4py (`CACHE_FOLDER_NAME_PATTERN`, defined next to
-    `get_cache_folder` and held in sync with it by a round-trip unit test), so
-    reading it from the interpreter under test keeps this script correct across
-    folder-naming changes without edits here. Raises `CacheFolderPatternError`
-    when the pattern cannot be read (no or too-old gt4py in that interpreter)
-    or is unusable — deliberately no fallback, failing beats guessing.
+    Returns the folder-name pattern and the name of the directory holding the
+    program folders. Both are owned by gt4py (`CACHE_FOLDER_NAME_PATTERN` and
+    `BUILD_CACHE_DIR_NAME`, defined next to `get_cache_folder` and held in sync
+    with it by unit tests), so reading them from the interpreter under test keeps
+    this script correct across layout changes without edits here. Raises
+    `CacheFolderPatternError` when they cannot be read (no or too-old gt4py in
+    that interpreter) or are unusable — deliberately no fallback, failing beats
+    guessing.
     """
     try:
         result = subprocess.run(
-            [python, "-c", _PATTERN_PROBE_SNIPPET], capture_output=True, text=True, timeout=120
+            [python, "-c", _LAYOUT_PROBE_SNIPPET], capture_output=True, text=True, timeout=120
         )
     except (OSError, subprocess.TimeoutExpired) as e:
         raise CacheFolderPatternError(
-            f"could not run `{python}` to read gt4py's cache folder-name pattern: {e}"
+            f"could not run `{python}` to read gt4py's build cache layout: {e}"
         ) from e
     if result.returncode != 0:
         detail = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "no output"
         raise CacheFolderPatternError(
-            f"`{python}` could not provide gt4py's cache folder-name pattern "
+            f"`{python}` could not provide gt4py's build cache layout "
             f"(exit {result.returncode}: {detail}). The interpreter must have a gt4py "
-            f"recent enough to define `CACHE_FOLDER_NAME_PATTERN`."
+            f"recent enough to define `CACHE_FOLDER_NAME_PATTERN` and `BUILD_CACHE_DIR_NAME`."
         )
-    pattern = result.stdout.strip()
+    match result.stdout.split():
+        case [pattern, build_cache_dir]:
+            pass
+        case _:
+            raise CacheFolderPatternError(
+                f"`{python}` reported an unreadable build cache layout: `{result.stdout.strip()}`"
+            )
     try:
         _compile_folder_pattern(pattern)
     except (re.error, ValueError) as e:
         raise CacheFolderPatternError(
             f"`{python}` reported an unusable cache folder-name pattern `{pattern}`: {e}"
         ) from e
-    return pattern
+    return pattern, build_cache_dir
 
 
 def _run_is_healthy(junit_xml: Path) -> bool:
@@ -569,10 +581,10 @@ def run_determinism_check(
     workdir = workdir.expanduser().resolve()
     dacecache = (dacecache or Path.cwd() / ".dacecache").expanduser().resolve()
 
-    # The folder-name pattern comes from the gt4py under test — no fallback —
-    # so a gt4py-side change to the cache folder naming can never silently turn
+    # The cache layout comes from the gt4py under test — no fallback — so a
+    # gt4py-side change to the folder naming or location can never silently turn
     # every run into "no programs observed".
-    folder_pattern = fetch_cache_folder_pattern(python)
+    folder_pattern, build_cache_dir = fetch_cache_layout(python)
 
     # Self-check the comparator first: a broken script aborts here, before the
     # two expensive test-suite runs.
@@ -616,6 +628,7 @@ def run_determinism_check(
             run1_dir / CACHE_SUBDIR,
             run2_dir / CACHE_SUBDIR,
             folder_pattern=folder_pattern,
+            build_cache_dir=build_cache_dir,
             runs_healthy=runs_healthy,
             diffs_dir=workdir / "diffs",
             report_path=workdir / "report.txt",
@@ -681,10 +694,12 @@ def check(
     installed (e.g. run via `uv run python scripts/python/dace_determinism.py`).
     """
     try:
+        folder_pattern, build_cache_dir = fetch_cache_layout(sys.executable)
         results = check_determinism(
             run1.expanduser().resolve(),
             run2.expanduser().resolve(),
-            folder_pattern=fetch_cache_folder_pattern(sys.executable),
+            folder_pattern=folder_pattern,
+            build_cache_dir=build_cache_dir,
             runs_healthy=runs_healthy,
             diffs_dir=diffs_dir.expanduser().resolve() if diffs_dir else None,
             report_path=report.expanduser().resolve() if report else None,

--- a/scripts/tests/python/test_dace_determinism.py
+++ b/scripts/tests/python/test_dace_determinism.py
@@ -31,7 +31,7 @@ from dace_determinism import (
     check_determinism,
     cli,
     compare,
-    fetch_cache_folder_pattern,
+    fetch_cache_layout,
     render_report,
     run_determinism_check,
 )
@@ -48,9 +48,12 @@ _FOLDER_PATTERN = (
 )
 _FOLDER_RE = _compile_folder_pattern(_FOLDER_PATTERN)
 
+# Deliberately not gt4py's own name: the script must use whatever it is told.
+_STUB_BUILD_CACHE_DIR = "builds"
+
 
 def _bags(cache: pathlib.Path):
-    return _scan(cache, _FOLDER_RE)[0]
+    return _scan(cache / _STUB_BUILD_CACHE_DIR, _FOLDER_RE)[0]
 
 
 def _hex16(salt: str) -> str:
@@ -63,7 +66,7 @@ def _folder_name(name: str, salt: str) -> str:
 
 
 def _program(cache: pathlib.Path, name: str, salt: str, sources: dict[str, str]) -> None:
-    folder = cache / _folder_name(name, salt)
+    folder = cache / _STUB_BUILD_CACHE_DIR / _folder_name(name, salt)
     for rel, content in sources.items():
         path = folder / rel
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -79,7 +82,7 @@ def test_collect_groups_by_logical_name(tmp_path):
 def test_collect_ignores_non_program_dirs(tmp_path):
     cache = tmp_path / ".gt4py_cache"
     _program(cache, "p", "a", {"src/cpu/k.cpp": "x"})
-    (cache / "translation_cache").mkdir(parents=True)
+    (cache / _STUB_BUILD_CACHE_DIR / "not-a-program-folder").mkdir(parents=True)
     assert set(_bags(cache)) == {"p"}
 
 
@@ -92,7 +95,7 @@ def test_collect_unsupported_backend_raises(tmp_path):
 
 def test_empty_src_program_excluded(tmp_path):
     cache = tmp_path / ".gt4py_cache"
-    (cache / _folder_name("p", "a") / "src").mkdir(parents=True)
+    (cache / _STUB_BUILD_CACHE_DIR / _folder_name("p", "a") / "src").mkdir(parents=True)
     assert "p" not in _bags(cache)
 
 
@@ -148,7 +151,9 @@ def test_equal_count_source_mismatch_differs(tmp_path):
     (r,) = compare(_bags(c1), _bags(c2))
     assert r.comparable and r.differs
     with pytest.raises(DeterminismError):
-        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
+        check_determinism(
+            c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+        )
 
 
 def test_count_mismatch_skipped_but_others_compared(tmp_path):
@@ -164,7 +169,9 @@ def test_count_mismatch_skipped_but_others_compared(tmp_path):
     by_name = {r.name: r for r in compare(_bags(c1), _bags(c2))}
     assert by_name["ok"].match
     assert by_name["flaky"].skipped and not by_name["flaky"].match
-    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)  # passes: the comparable name matched
+    check_determinism(
+        c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+    )  # passes: the comparable name matched
 
 
 def test_missing_on_one_side_skipped(tmp_path):
@@ -175,7 +182,7 @@ def test_missing_on_one_side_skipped(tmp_path):
     _program(c1, "only1", "a", {"src/cpu/k.cpp": "x"})
     by_name = {r.name: r for r in compare(_bags(c1), _bags(c2))}
     assert by_name["only1"].skipped and not by_name["only1"].match
-    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
+    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR)
 
 
 def test_nothing_comparable_raises(tmp_path):
@@ -186,7 +193,9 @@ def test_nothing_comparable_raises(tmp_path):
     _program(c1, "a", "2", {"src/cpu/k.cpp": "A2"})
     _program(c2, "a", "1", {"src/cpu/k.cpp": "A1"})
     with pytest.raises(NoComparableProgramsError):
-        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
+        check_determinism(
+            c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+        )
 
 
 def test_one_empty_run_raises_not_green(tmp_path):
@@ -196,7 +205,9 @@ def test_one_empty_run_raises_not_green(tmp_path):
     _program(c1, "p", "a", {"src/cpu/k.cpp": "S1"})
     c2.mkdir(parents=True)
     with pytest.raises(NoComparableProgramsError):
-        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
+        check_determinism(
+            c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+        )
 
 
 def test_check_determinism_pass_writes_report(tmp_path):
@@ -205,7 +216,13 @@ def test_check_determinism_pass_writes_report(tmp_path):
     _program(c1, "copy", "a", {"src/cpu/k.cpp": "stable"})
     _program(c2, "copy", "a", {"src/cpu/k.cpp": "stable"})
     report = tmp_path / "report.txt"
-    results = check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, report_path=report)
+    results = check_determinism(
+        c1,
+        c2,
+        folder_pattern=_FOLDER_PATTERN,
+        build_cache_dir=_STUB_BUILD_CACHE_DIR,
+        report_path=report,
+    )
     assert all(r.match for r in results)
     assert "deterministic" in report.read_text()
 
@@ -217,7 +234,13 @@ def test_check_determinism_differs_writes_diff(tmp_path):
     _program(c2, "abs", "b", {"src/cpu/k.cpp": "B"})
     diffs = tmp_path / "diffs"
     with pytest.raises(DeterminismError):
-        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, diffs_dir=diffs)
+        check_determinism(
+            c1,
+            c2,
+            folder_pattern=_FOLDER_PATTERN,
+            build_cache_dir=_STUB_BUILD_CACHE_DIR,
+            diffs_dir=diffs,
+        )
     body = (diffs / "abs.txt").read_text().splitlines()
     assert body[0] == "abs"
     assert "src/cpu/k.cpp" in body
@@ -229,16 +252,20 @@ def test_no_programs_raises(tmp_path):
     c1.mkdir(parents=True)
     c2.mkdir(parents=True)
     with pytest.raises(NoProgramsObservedError):
-        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
+        check_determinism(
+            c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+        )
 
 
 def test_no_source_files_raises(tmp_path):
     c1 = tmp_path / "r1" / ".gt4py_cache"
     c2 = tmp_path / "r2" / ".gt4py_cache"
-    (c1 / _folder_name("p", "a")).mkdir(parents=True)
-    (c2 / _folder_name("p", "a")).mkdir(parents=True)
+    (c1 / _STUB_BUILD_CACHE_DIR / _folder_name("p", "a")).mkdir(parents=True)
+    (c2 / _STUB_BUILD_CACHE_DIR / _folder_name("p", "a")).mkdir(parents=True)
     with pytest.raises(NoSourceFilesObservedError, match="development"):
-        check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)
+        check_determinism(
+            c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+        )
 
 
 def test_report_lists_mismatching_sources(tmp_path):
@@ -276,13 +303,23 @@ def test_count_mismatch_fails_when_runs_healthy(tmp_path):
     _program(c1, "wobble", "a", {"src/cpu/k.cpp": "W1"})
     _program(c1, "wobble", "b", {"src/cpu/k.cpp": "W2"})
     _program(c2, "wobble", "x", {"src/cpu/k.cpp": "W1"})
-    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN)  # health unknown -> tolerated skip
     check_determinism(
-        c1, c2, folder_pattern=_FOLDER_PATTERN, runs_healthy=False
+        c1, c2, folder_pattern=_FOLDER_PATTERN, build_cache_dir=_STUB_BUILD_CACHE_DIR
+    )  # health unknown -> tolerated skip
+    check_determinism(
+        c1,
+        c2,
+        folder_pattern=_FOLDER_PATTERN,
+        build_cache_dir=_STUB_BUILD_CACHE_DIR,
+        runs_healthy=False,
     )  # a test failed -> tolerated skip
     with pytest.raises(DeterminismError):
         check_determinism(
-            c1, c2, folder_pattern=_FOLDER_PATTERN, runs_healthy=True
+            c1,
+            c2,
+            folder_pattern=_FOLDER_PATTERN,
+            build_cache_dir=_STUB_BUILD_CACHE_DIR,
+            runs_healthy=True,
         )  # clean pair -> failure
 
 
@@ -291,7 +328,13 @@ def test_clean_pair_all_match_passes(tmp_path):
     c2 = tmp_path / "r2" / ".gt4py_cache"
     _program(c1, "copy", "a", {"src/cpu/k.cpp": "S1"})
     _program(c2, "copy", "a", {"src/cpu/k.cpp": "S1"})
-    check_determinism(c1, c2, folder_pattern=_FOLDER_PATTERN, runs_healthy=True)
+    check_determinism(
+        c1,
+        c2,
+        folder_pattern=_FOLDER_PATTERN,
+        build_cache_dir=_STUB_BUILD_CACHE_DIR,
+        runs_healthy=True,
+    )
 
 
 def test_report_marks_count_as_failure_when_healthy(tmp_path):
@@ -329,8 +372,9 @@ _STUB_PYTEST = """\
 #!{python}
 import hashlib, os, pathlib, sys
 
-if sys.argv[1:2] == ["-c"]:  # the folder-name pattern probe
+if sys.argv[1:2] == ["-c"]:  # the cache layout probe
     print({pattern!r})
+    print({build_cache_dir!r})
     sys.exit(0)
 
 junit = next(a.split("=", 1)[1] for a in sys.argv if a.startswith("--junit-xml="))
@@ -338,7 +382,8 @@ cache = pathlib.Path(os.environ["GT4PY_BUILD_CACHE_DIR"]) / ".gt4py_cache"
 run_name = pathlib.Path(os.environ["GT4PY_BUILD_CACHE_DIR"]).name
 # Codegen differs between runs only when perturbation is requested.
 content = run_name if os.environ.get("FAKE_PERTURB") else "stable"
-folder = cache / ("prog_" + hashlib.sha256(b"prog").hexdigest()[:16]) / "src" / "cpu"
+folder = (cache / {build_cache_dir!r}
+          / ("prog_" + hashlib.sha256(b"prog").hexdigest()[:16]) / "src" / "cpu")
 folder.mkdir(parents=True, exist_ok=True)
 (folder / "k.cpp").write_text(content)
 pathlib.Path(junit).write_text('<testsuite tests="1" failures="0" errors="0" />')
@@ -347,7 +392,13 @@ pathlib.Path(junit).write_text('<testsuite tests="1" failures="0" errors="0" />'
 
 def _stub_interpreter(tmp_path: pathlib.Path) -> str:
     stub = tmp_path / "fake_pytest.py"
-    stub.write_text(_STUB_PYTEST.format(python=sys.executable, pattern=_STUB_FOLDER_PATTERN))
+    stub.write_text(
+        _STUB_PYTEST.format(
+            python=sys.executable,
+            pattern=_STUB_FOLDER_PATTERN,
+            build_cache_dir=_STUB_BUILD_CACHE_DIR,
+        )
+    )
     stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
     return str(stub)
 
@@ -397,6 +448,7 @@ def test_run_determinism_check_infra_failure_raises(tmp_path):
         "import sys\n"
         "if sys.argv[1:2] == ['-c']:\n"
         f"    print({_STUB_FOLDER_PATTERN!r})\n"
+        f"    print({_STUB_BUILD_CACHE_DIR!r})\n"
         "    sys.exit(0)\n"
         "sys.exit(2)\n"
     )
@@ -438,6 +490,7 @@ def test_run_determinism_check_env_overrides_are_set(tmp_path):
         "import os, pathlib, sys\n"
         "if sys.argv[1:2] == ['-c']:\n"
         f"    print({_STUB_FOLDER_PATTERN!r})\n"
+        f"    print({_STUB_BUILD_CACHE_DIR!r})\n"
         "    sys.exit(0)\n"
         "junit = next(a.split('=', 1)[1] for a in sys.argv if a.startswith('--junit-xml='))\n"
         "cache = pathlib.Path(os.environ['GT4PY_BUILD_CACHE_DIR']) / '.gt4py_cache'\n"
@@ -512,7 +565,12 @@ def test_ci_check_command_success_echoes_report(monkeypatch, tmp_path):
 
 def test_pattern_without_name_group_rejected(tmp_path):
     with pytest.raises(ValueError, match="name"):
-        check_determinism(tmp_path / "r1", tmp_path / "r2", folder_pattern=r".+_[0-9a-f]{16}")
+        check_determinism(
+            tmp_path / "r1",
+            tmp_path / "r2",
+            folder_pattern=r".+_[0-9a-f]{16}",
+            build_cache_dir=_STUB_BUILD_CACHE_DIR,
+        )
 
 
 def test_check_cli_uses_fetched_pattern(monkeypatch, tmp_path):
@@ -521,12 +579,13 @@ def test_check_cli_uses_fetched_pattern(monkeypatch, tmp_path):
     c1 = tmp_path / "r1" / ".gt4py_cache"
     c2 = tmp_path / "r2" / ".gt4py_cache"
     for cache in (c1, c2):
-        src = cache / "copy-ABC" / "src" / "cpu"
+        src = cache / _STUB_BUILD_CACHE_DIR / "copy-ABC" / "src" / "cpu"
         src.mkdir(parents=True)
         (src / "k.cpp").write_text("stable")
 
     monkeypatch.setattr(
-        "dace_determinism.fetch_cache_folder_pattern", lambda python: r"(?P<name>.+)-[A-Z]{3}"
+        "dace_determinism.fetch_cache_layout",
+        lambda python: (r"(?P<name>.+)-[A-Z]{3}", _STUB_BUILD_CACHE_DIR),
     )
     result = CliRunner().invoke(cli, ["check", "--run1", str(c1), "--run2", str(c2)])
     assert result.exit_code == 0
@@ -537,7 +596,7 @@ def test_check_cli_fails_without_pattern_source(monkeypatch, tmp_path):
     def boom(python):
         raise CacheFolderPatternError("no gt4py in this interpreter")
 
-    monkeypatch.setattr("dace_determinism.fetch_cache_folder_pattern", boom)
+    monkeypatch.setattr("dace_determinism.fetch_cache_layout", boom)
     (tmp_path / "r1").mkdir()
     (tmp_path / "r2").mkdir()
     result = CliRunner().invoke(
@@ -553,22 +612,33 @@ def _fake_interpreter(tmp_path: pathlib.Path, body: str) -> str:
     return str(stub)
 
 
-def test_fetch_pattern_returns_advertised_pattern(tmp_path):
-    python = _fake_interpreter(tmp_path, f"print({_STUB_FOLDER_PATTERN!r})\n")
-    assert fetch_cache_folder_pattern(python) == _STUB_FOLDER_PATTERN
+def test_fetch_layout_returns_advertised_values(tmp_path):
+    python = _fake_interpreter(
+        tmp_path, f"print({_STUB_FOLDER_PATTERN!r})\nprint({_STUB_BUILD_CACHE_DIR!r})\n"
+    )
+    assert fetch_cache_layout(python) == (_STUB_FOLDER_PATTERN, _STUB_BUILD_CACHE_DIR)
 
 
-def test_fetch_pattern_raises_on_failing_interpreter(tmp_path):
+def test_fetch_layout_raises_on_failing_interpreter(tmp_path):
     python = _fake_interpreter(tmp_path, "import sys; sys.exit(1)\n")
     with pytest.raises(CacheFolderPatternError, match="could not provide"):
-        fetch_cache_folder_pattern(python)
+        fetch_cache_layout(python)
 
 
-def test_fetch_pattern_raises_on_unusable_pattern(tmp_path):
-    for body in ("print('no name group here')\n", "print('(?P<name>unbalanced')\n", "print()\n"):
-        python = _fake_interpreter(tmp_path, body)
+def test_fetch_layout_raises_on_incomplete_output(tmp_path):
+    # only the pattern, no build cache directory name
+    python = _fake_interpreter(tmp_path, f"print({_STUB_FOLDER_PATTERN!r})\n")
+    with pytest.raises(CacheFolderPatternError, match="unreadable"):
+        fetch_cache_layout(python)
+
+
+def test_fetch_layout_raises_on_unusable_pattern(tmp_path):
+    for pattern in ("no-name-group-here", "(?P<name>unbalanced"):
+        python = _fake_interpreter(
+            tmp_path, f"print({pattern!r})\nprint({_STUB_BUILD_CACHE_DIR!r})\n"
+        )
         with pytest.raises(CacheFolderPatternError, match="unusable"):
-            fetch_cache_folder_pattern(python)
+            fetch_cache_layout(python)
 
 
 def test_run_determinism_check_aborts_without_pattern(tmp_path):

--- a/src/gt4py/next/gt_cache_manager.py
+++ b/src/gt4py/next/gt_cache_manager.py
@@ -152,12 +152,13 @@ def get_cache_base(cache_dir: pathlib.Path | None = None) -> pathlib.Path:
     if not (
         path.name == config.BUILD_CACHE_DIR.name
         or (path / cache.TRANSLATION_CACHE_DIR_NAME).is_dir()
-        or any(_BUILD_FOLDER_RE.fullmatch(child.name) for child in path.iterdir() if child.is_dir())
+        or (path / cache.BUILD_CACHE_DIR_NAME).is_dir()
     ):
         raise CacheDirError(
             f"'{path}' does not look like a gt4py.next cache base directory: it is not named"
-            f" '{config.BUILD_CACHE_DIR.name}' and contains neither a translation cache"
-            f" ('{cache.TRANSLATION_CACHE_DIR_NAME}') nor a build cache folder."
+            f" '{config.BUILD_CACHE_DIR.name}' and holds neither a translation cache"
+            f" ('{cache.TRANSLATION_CACHE_DIR_NAME}') nor a build cache"
+            f" ('{cache.BUILD_CACHE_DIR_NAME}')."
         )
     return path
 
@@ -229,10 +230,11 @@ def find_build_dirs(cache_base: pathlib.Path, *, program: str | None = None) -> 
     The shared compiledb folder is named like a program's build folder but belongs
     to no program, so it is left out and never deleted along with one.
     """
-    if not cache_base.is_dir():
+    build_cache = cache_base / cache.BUILD_CACHE_DIR_NAME
+    if not build_cache.is_dir():
         return []
     build_dirs = []
-    for path in sorted(cache_base.iterdir()):
+    for path in sorted(build_cache.iterdir()):
         if not path.is_dir() or not (match := _BUILD_FOLDER_RE.fullmatch(path.name)):
             continue
         name = match.group("name").removesuffix(cache.BINDINGS_NAME_SUFFIX)
@@ -302,8 +304,8 @@ def delete_build_dirs(build_dirs: Sequence[BuildDir], cache_base: pathlib.Path) 
         CacheDirError: If a folder is not a build cache folder of `cache_base`.
     """
     for build_dir in build_dirs:
-        if build_dir.path.parent != cache_base or not _BUILD_FOLDER_RE.fullmatch(
-            build_dir.path.name
+        if build_dir.path.parent != cache_base / cache.BUILD_CACHE_DIR_NAME or not (
+            _BUILD_FOLDER_RE.fullmatch(build_dir.path.name)
         ):
             raise CacheDirError(f"refusing to remove '{build_dir.path}': not a build cache folder.")
         with locking.lock(build_dir.path):
@@ -340,7 +342,10 @@ def _cmd_path(args: argparse.Namespace) -> int:
     rows.append(
         (
             "build folders",
-            f"{cache_base}/<program>{cache.BINDINGS_NAME_SUFFIX}_<fingerprint>_<version>",
+            (
+                f"{cache_base / cache.BUILD_CACHE_DIR_NAME}"
+                f"/<program>{cache.BINDINGS_NAME_SUFFIX}_<fingerprint>_<version>"
+            ),
         )
     )
     width = max(len(label) for label, _ in rows) + 2

--- a/src/gt4py/next/otf/compilation/cache.py
+++ b/src/gt4py/next/otf/compilation/cache.py
@@ -37,11 +37,15 @@ CACHE_FOLDER_NAME_PATTERN: Final[str] = (
 BINDINGS_NAME_SUFFIX: Final[str] = "_pyext"
 
 #: Directory under the cache base holding the translation caches, one
-#: sub-directory per backend. Unlike a build cache folder, which holds the
-#: artifacts of one compiled program variant, these hold the output of the
-#: translation step: an optimized SDFG or generated source per translated
-#: program.
+#: sub-directory per backend. These hold the output of the translation step: an
+#: optimized SDFG or generated source per translated program.
 TRANSLATION_CACHE_DIR_NAME: Final[str] = "translation_cache"
+
+#: Directory under the cache base holding the build caches, one folder per
+#: compiled program variant, named by `CACHE_FOLDER_NAME_PATTERN`. These hold
+#: build artifacts and the compiled library, so unlike a translation cache they
+#: are shared by all backends.
+BUILD_CACHE_DIR_NAME: Final[str] = "build_cache"
 
 #: Backends that persist the output of their translation step, i.e. those whose
 #: workflow factory enables the `cached_translation` trait.
@@ -101,10 +105,10 @@ def get_cache_folder(
     if build_context_id:
         folder_name = f"{folder_name}_{build_context_id}"
 
-    base_path = get_cache_base_path(lifetime)
-    base_path.mkdir(exist_ok=True)
+    build_cache_path = get_cache_base_path(lifetime) / BUILD_CACHE_DIR_NAME
+    build_cache_path.mkdir(parents=True, exist_ok=True)
 
-    complete_path = base_path / folder_name
+    complete_path = build_cache_path / folder_name
     complete_path.mkdir(exist_ok=True)
 
     # Resolve symlinks to workaround an issue on MacOS where the default tmp directory is a symlink

--- a/tests/next_tests/unit_tests/test_gt_cache_manager.py
+++ b/tests/next_tests/unit_tests/test_gt_cache_manager.py
@@ -47,7 +47,11 @@ def write_build_dir(
 ) -> pathlib.Path:
     """Create a folder named the way `cache.get_cache_folder` names them."""
     version_id = config.BUILD_CACHE_VERSION_ID if version_id is None else version_id
-    folder = cache_base / f"{name}{cache.BINDINGS_NAME_SUFFIX}_{salt * 16}_{version_id}"
+    folder = (
+        cache_base
+        / cache.BUILD_CACHE_DIR_NAME
+        / f"{name}{cache.BINDINGS_NAME_SUFFIX}_{salt * 16}_{version_id}"
+    )
     folder.mkdir(parents=True)
     (folder / "libprogram.so").write_text("not really a library")
     return folder
@@ -482,6 +486,7 @@ def test_path_command_reports_both_caches_and_the_build_folders(cache_base, caps
     # the confusion this answers: build folders are siblings of the translation
     # caches, not something inside them
     assert cache.BINDINGS_NAME_SUFFIX in out
+    assert str(cache_base.resolve() / cache.BUILD_CACHE_DIR_NAME) in out
 
 
 def test_list_json_output(cache_base, capsys):


### PR DESCRIPTION
Top of the stack: #2769 (layout names) → #2768 (cache manager CLI) → this.

## Why

#2769 gave the two translation caches one home. The build caches were left
loose in the cache base — one folder per compiled program variant, sitting
directly next to `translation_cache/`:

```
.gt4py_cache/
├── translation_cache/{dace,gtfn}/        <- a fixed directory
├── lap_program_pyext_<fp>_<version>/     <- ... next to an unbounded set of
├── laplap_program_pyext_<fp>_<version>/     program folders
└── compile_commands_cache_..._pyext_.../
```

So the base mixed the two, and nothing in the listing said which entry was
which kind of cache. That is also what invites *"is the DaCe build directory
inside `translation_cache`?"*, the question that started #2769.

## What

```
.gt4py_cache/
├── translation_cache/{dace,gtfn}/
└── build_cache/<program>_pyext_<fingerprint>_<version>/
```

The base now holds exactly the two kinds of cache gt4py.next keeps, each named
for what it is.

**No `<backend>` level here**, deliberately. Which backend produced a build
folder is not knowable where the folder is named: `get_cache_folder` is reached
from `otf/compilation/` and its build systems, which are generic over the source
language rather than aware of backends, so a backend level would mean either
threading a name through that layer or mapping language→backend. The fingerprint
already keeps variants apart, so the flat set is correct — only its location
changes.

`dace_determinism.py` scans that directory and so far learned only the
folder-name pattern from the gt4py under test. Its probe now returns the
directory name too, rather than gaining a second hardcoded literal, so a
gt4py-side move of the build cache surfaces as a fetch error instead of as "no
programs observed". The stub interpreters in its tests answer with a *different*
directory name than gt4py's own, which is what proves nothing is hardcoded.

## Migration

Not migrated — and these are the large caches. They are already discarded on any
change of `BUILD_CACHE_VERSION_ID` (every gt4py version bump, and every commit
for an editable install), so orphaned build folders are the normal state of this
cache; the stale directories can simply be removed.

## Verification

- Compiled a program with **both backends** into a fresh cache and confirmed the
  resulting tree, then read it back through `gt4py-next-cache path` and
  `list --by-program`.
- Ran `dace_determinism check` against real caches in the new layout: it reports
  `3 in run1, 3 in run2`, i.e. it locates the program folders one level down.
  Before this change that scan returns 0 and raises `NoProgramsObservedError`.
- `scripts/test python`: 46 passed. `tests/next_tests/unit_tests/test_gt_cache_manager.py`
  and `otf_tests`: 137 passed. Hooks clean.
- The delete guard in the CLI was tightened with the move: a folder with a valid
  build-folder name but the wrong parent is still refused.
