### PR TITLE
fix[next]: Detect ROCm device architecture instead of hard-coding gfx942

### DIFF
--- a/src/gt4py/next/otf/compilation/common.py
+++ b/src/gt4py/next/otf/compilation/common.py
@@ -38,10 +38,15 @@ def _query_device_arch() -> str | None:
             )
             return None
     elif core_defs.CUPY_DEVICE_TYPE == core_defs.DeviceType.ROCM:
-        # TODO(egparedes): Implement this properly, either parsing the output of `$ rocminfo`
-        # or using the HIP low level bindings.
-        # Check: https://rocm.docs.amd.com/projects/hip-python/en/latest/user_guide/1_usage.html
-        return "gfx942"  # MI300A
+        try:
+            arch = core_defs.cp.cuda.runtime.getDeviceProperties(0)["gcnArchName"]  # type: ignore[attr-defined]
+        except core_defs.cp.cuda.runtime.CUDARuntimeError as e:  # type: ignore[attr-defined]
+            warnings.warn(
+                UserWarning(f"Could not determine the HIP device architecture: {e}"), stacklevel=2
+            )
+            return None
+        # strip the target feature suffix, e.g. `b"gfx90a:sramecc+:xnack-"` -> `"gfx90a"`
+        return arch.decode().split(":")[0]
 
     return None
 


### PR DESCRIPTION
## Problem

`_query_device_arch()` in `otf/compilation/common.py` returns a hard-coded `"gfx942"` (MI300A) for ROCm devices — an old TODO. Every GPU binary is therefore compiled for gfx942 only (`get_device_arch()` feeds both the DaCe and the gtfn/CMake build); on any other AMD GPU the fat binary contains no matching code object and the first kernel launch segfaults inside `libamdhip64` (the stub-based `hipLaunchKernel` does not return a clean error for this case). Observed on a gfx1103 APU; setting `HIPARCHS` explicitly works around it.

## Fix

Query the architecture from the device via `cupy.cuda.runtime.getDeviceProperties(0)["gcnArchName"]`, stripping the target-feature suffix (e.g. `gfx90a:sramecc+:xnack-` → `gfx90a`), with the same error handling as the CUDA branch. The `CUDAARCHS`/`HIPARCHS` environment override precedence is unchanged. Verified on a gfx1103 APU (ROCm 7.2): detection returns `gfx1103`.

**AI disclaimer**: Description and code were developed with the help of LLMs. Code was reviewed in detail, description briefly read, too verbose, but doesn't matter.