### PR TITLE
fix[next-dace]: Do not cut GPU block size down to symbolic map sizes

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -757,9 +757,15 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
         # TODO(phimuell): Also think of how to connect this with the loop blocking.
         assert dims_to_inspect <= 3
         for i in range(dims_to_inspect):
-            map_dim_idx_to_inspect = len(gpu_map.params) - 1 - i
-            if (map_size[map_dim_idx_to_inspect] < block_size[i]) == True:  # noqa: E712 [true-false-comparison]  # SymPy Fancy comparison.
-                block_size[i] = map_size[map_dim_idx_to_inspect]
+            map_dim_size = map_size[len(gpu_map.params) - 1 - i]
+            # Note that the comparison can be provably true for a symbolic map size, e.g.
+            #  `5 - Max(0, N)` for a statically bounded domain with a runtime scalar `N`,
+            #  but a block size must be a compile-time integer, so only cut down to
+            #  concrete sizes.
+            if not dace.symbolic.issymbolic(map_dim_size) and (
+                (map_dim_size < block_size[i]) == True  # noqa: E712 [true-false-comparison]  # SymPy Fancy comparison.
+            ):
+                block_size[i] = map_dim_size
 
         gpu_map.gpu_block_size = tuple(block_size)
         # Only set `gpu_maxnreg` if it has not been set already (default is 0),

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -15,7 +15,6 @@ import warnings
 from typing import Any, Callable, Final, Optional, Sequence, Union
 
 import dace
-import sympy
 from dace import (
     dtypes as dace_dtypes,
     properties as dace_properties,
@@ -762,8 +761,8 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
             # Note that the comparison can be provably true for a symbolic map size, e.g.
             #  `5 - Max(0, N)` for a statically bounded domain with a runtime scalar `N`,
             #  but a block size must be a compile-time integer, so only cut down to
-            #  concrete sizes. The type check is much cheaper than
-            #  `dace.symbolic.issymbolic()`, which traverses the expression tree.
+            #  concrete sizes. The string check is much cheaper than
+            #  `dace.symbolic.issymbolic()`.
             if str(map_dim_size).isdigit() and map_dim_size < block_size[i]:
                 block_size[i] = int(map_dim_size)
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -764,7 +764,7 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
             #  but a block size must be a compile-time integer, so only cut down to
             #  concrete sizes. The type check is much cheaper than
             #  `dace.symbolic.issymbolic()`, which traverses the expression tree.
-            if isinstance(map_dim_size, (int, sympy.Integer)) and map_dim_size < block_size[i]:
+            if str(map_dim_size).isdigit() and map_dim_size < block_size[i]:
                 block_size[i] = int(map_dim_size)
 
         gpu_map.gpu_block_size = tuple(block_size)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/gpu_utils.py
@@ -15,6 +15,7 @@ import warnings
 from typing import Any, Callable, Final, Optional, Sequence, Union
 
 import dace
+import sympy
 from dace import (
     dtypes as dace_dtypes,
     properties as dace_properties,
@@ -761,11 +762,10 @@ class GPUSetBlockSize(dace_transformation.SingleStateTransformation):
             # Note that the comparison can be provably true for a symbolic map size, e.g.
             #  `5 - Max(0, N)` for a statically bounded domain with a runtime scalar `N`,
             #  but a block size must be a compile-time integer, so only cut down to
-            #  concrete sizes.
-            if not dace.symbolic.issymbolic(map_dim_size) and (
-                (map_dim_size < block_size[i]) == True  # noqa: E712 [true-false-comparison]  # SymPy Fancy comparison.
-            ):
-                block_size[i] = map_dim_size
+            #  concrete sizes. The type check is much cheaper than
+            #  `dace.symbolic.issymbolic()`, which traverses the expression tree.
+            if isinstance(map_dim_size, (int, sympy.Integer)) and map_dim_size < block_size[i]:
+                block_size[i] = int(map_dim_size)
 
         gpu_map.gpu_block_size = tuple(block_size)
         # Only set `gpu_maxnreg` if it has not been set already (default is 0),

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_compiled_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_compiled_program.py
@@ -22,7 +22,6 @@ from gt4py.next import errors, config
 from gt4py.next.otf import compiled_program, options, arguments
 from gt4py.next.otf.compilation import cache as compilation_cache
 from gt4py.next.ffront.decorator import Program
-from gt4py.next.ffront.experimental import concat_where
 from gt4py.next.ffront.fbuiltins import int32, neighbor_sum
 
 from next_tests.integration_tests import cases
@@ -1089,24 +1088,3 @@ def test_warn_on_direct_scan_operator_call(cartesian_case, scan_operator_testee)
     w = generic_warnings[0]
     assert w.filename == __file__
     assert w.lineno == call_lineno
-
-
-@pytest.mark.uses_concat_where
-def test_static_domains_with_runtime_scalar_condition(cartesian_case):
-    """With static domain bounds, a domain condition on a runtime scalar yields map extents
-    that are symbolic but provably bounded, e.g. `size - Max(0, N)`. Regression test for the
-    DaCe GPU block-size cut-down, which used such extents as (compile-time) block sizes.
-    """
-    if cartesian_case.backend is None:
-        pytest.skip("Compilation options are meaningless in embedded execution.")
-
-    @gtx.field_operator(static_domains=True)
-    def testee(a: cases.IJKField, b: cases.IJKField, N: int32) -> cases.IJKField:
-        return concat_where(cases.IDim < N, a, b * 2)
-
-    a = cases.allocate(cartesian_case, testee, "a")()
-    b = cases.allocate(cartesian_case, testee, "b")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
-    N = cartesian_case.default_sizes[cases.IDim] + 1
-    cases.verify(cartesian_case, testee, a, b, N, out=out, ref=a.asnumpy())

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_compiled_program.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_compiled_program.py
@@ -22,6 +22,7 @@ from gt4py.next import errors, config
 from gt4py.next.otf import compiled_program, options, arguments
 from gt4py.next.otf.compilation import cache as compilation_cache
 from gt4py.next.ffront.decorator import Program
+from gt4py.next.ffront.experimental import concat_where
 from gt4py.next.ffront.fbuiltins import int32, neighbor_sum
 
 from next_tests.integration_tests import cases
@@ -1088,3 +1089,24 @@ def test_warn_on_direct_scan_operator_call(cartesian_case, scan_operator_testee)
     w = generic_warnings[0]
     assert w.filename == __file__
     assert w.lineno == call_lineno
+
+
+@pytest.mark.uses_concat_where
+def test_static_domains_with_runtime_scalar_condition(cartesian_case):
+    """With static domain bounds, a domain condition on a runtime scalar yields map extents
+    that are symbolic but provably bounded, e.g. `size - Max(0, N)`. Regression test for the
+    DaCe GPU block-size cut-down, which used such extents as (compile-time) block sizes.
+    """
+    if cartesian_case.backend is None:
+        pytest.skip("Compilation options are meaningless in embedded execution.")
+
+    @gtx.field_operator(static_domains=True)
+    def testee(a: cases.IJKField, b: cases.IJKField, N: int32) -> cases.IJKField:
+        return concat_where(cases.IDim < N, a, b * 2)
+
+    a = cases.allocate(cartesian_case, testee, "a")()
+    b = cases.allocate(cartesian_case, testee, "b")()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
+
+    N = cartesian_case.default_sizes[cases.IDim] + 1
+    cases.verify(cartesian_case, testee, a, b, N, out=out, ref=a.asnumpy())

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_concat_where.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_concat_where.py
@@ -20,8 +20,14 @@ from next_tests.integration_tests.cases_utils import (
 pytestmark = pytest.mark.uses_concat_where
 
 
-def test_concat_where_simple(cartesian_case):
-    @gtx.field_operator
+@pytest.fixture(params=[False, True], ids=["dynamic_domains", "static_domains"])
+def static_domains(request) -> bool:
+    """Fixture to select compilation with dynamic or statically known domain bounds."""
+    return request.param
+
+
+def test_concat_where_simple(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(ground: cases.IJKField, air: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim > 0, air, ground)
 
@@ -34,8 +40,8 @@ def test_concat_where_simple(cartesian_case):
     cases.verify(cartesian_case, testee, ground, air, out=out, ref=ref)
 
 
-def test_concat_where(cartesian_case):
-    @gtx.field_operator
+def test_concat_where(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(ground: cases.IJKField, air: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim == 0, ground, air)
 
@@ -48,10 +54,10 @@ def test_concat_where(cartesian_case):
     cases.verify(cartesian_case, testee, ground, air, out=out, ref=ref)
 
 
-def test_concat_where_non_overlapping(cartesian_case):
+def test_concat_where_non_overlapping(cartesian_case, static_domains: bool):
     """Fields only defined in their respective region in concat_where."""
 
-    @gtx.field_operator
+    @gtx.field_operator(static_domains=static_domains)
     def testee(ground: cases.IJKField, air: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim == 0, ground, air)
 
@@ -65,8 +71,8 @@ def test_concat_where_non_overlapping(cartesian_case):
     cases.verify(cartesian_case, testee, ground, air, out=out, ref=ref)
 
 
-def test_concat_where_empty_branch(cartesian_case):
-    @gtx.field_operator
+def test_concat_where_empty_branch(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(a: cases.IJKField, b: cases.IJKField, N: np.int32) -> cases.IJKField:
         return concat_where(IDim < N, a, b * 2)
 
@@ -79,8 +85,8 @@ def test_concat_where_empty_branch(cartesian_case):
 
 
 @pytest.mark.embedded_concat_where_infinite_domain
-def test_concat_where_scalar_broadcast(cartesian_case):
-    @gtx.field_operator
+def test_concat_where_scalar_broadcast(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(a: np.int32, b: cases.IJKField, N: np.int32) -> cases.IJKField:
         return concat_where(KDim < N - 1, a, b)
 
@@ -99,10 +105,10 @@ def test_concat_where_scalar_broadcast(cartesian_case):
 
 
 @pytest.mark.embedded_concat_where_infinite_domain
-def test_concat_where_scalar_broadcast_on_empty_branch(cartesian_case):
+def test_concat_where_scalar_broadcast_on_empty_branch(cartesian_case, static_domains: bool):
     """Output domain such that the scalar branch is never active."""
 
-    @gtx.field_operator
+    @gtx.field_operator(static_domains=static_domains)
     def testee(a: np.int32, b: cases.KField, N: np.int32) -> cases.KField:
         return concat_where(KDim < N, a, b)
 
@@ -114,8 +120,8 @@ def test_concat_where_scalar_broadcast_on_empty_branch(cartesian_case):
     cases.verify(cartesian_case, testee, a, b, 1, out=out, ref=ref)
 
 
-def test_concat_where_single_level_broadcast(cartesian_case):
-    @gtx.field_operator
+def test_concat_where_single_level_broadcast(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(a: cases.KField, b: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim == 0, a, b)
 
@@ -135,8 +141,10 @@ def test_concat_where_single_level_broadcast(cartesian_case):
     cases.verify(cartesian_case, testee, a, b, out=out, ref=ref)
 
 
-def test_concat_where_single_level_restricted_domain_broadcast(cartesian_case):
-    @gtx.field_operator
+def test_concat_where_single_level_restricted_domain_broadcast(
+    cartesian_case, static_domains: bool
+):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(a: cases.KField, b: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim == 0, a, b)
 
@@ -155,8 +163,8 @@ def test_concat_where_single_level_restricted_domain_broadcast(cartesian_case):
     cases.verify(cartesian_case, testee, a, b, out=out, ref=ref)
 
 
-def test_boundary_single_layer_3d_bc(cartesian_case):
-    @gtx.field_operator
+def test_boundary_single_layer_3d_bc(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.IJKField, boundary: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim == 0, boundary, interior)
 
@@ -174,8 +182,8 @@ def test_boundary_single_layer_3d_bc(cartesian_case):
     cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
-def test_boundary_single_layer_2d_bc(cartesian_case):
-    @gtx.field_operator
+def test_boundary_single_layer_2d_bc(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.IJKField, boundary: cases.IJField) -> cases.IJKField:
         return concat_where(KDim == 0, boundary, interior)
 
@@ -193,8 +201,8 @@ def test_boundary_single_layer_2d_bc(cartesian_case):
     cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
-def test_boundary_single_layer_2d_bc_on_empty_branch(cartesian_case):
-    @gtx.field_operator
+def test_boundary_single_layer_2d_bc_on_empty_branch(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.IJKField, boundary: cases.IJField) -> cases.IJKField:
         return concat_where(KDim == 0, boundary, interior)
 
@@ -208,8 +216,8 @@ def test_boundary_single_layer_2d_bc_on_empty_branch(cartesian_case):
     cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
-def test_dimension_two_nested_conditions(cartesian_case):
-    @gtx.field_operator
+def test_dimension_two_nested_conditions(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.IJKField, boundary: cases.IJKField) -> cases.IJKField:
         return concat_where((KDim < 2), boundary, concat_where((KDim >= 5), boundary, interior))
 
@@ -226,8 +234,8 @@ def test_dimension_two_nested_conditions(cartesian_case):
     cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
-def test_dimension_two_conditions_and(cartesian_case):
-    @gtx.field_operator
+def test_dimension_two_conditions_and(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.KField, boundary: cases.KField, nlev: np.int32) -> cases.KField:
         return concat_where((0 < KDim) & (KDim < (nlev - 1)), interior, boundary)
 
@@ -241,8 +249,8 @@ def test_dimension_two_conditions_and(cartesian_case):
     cases.verify(cartesian_case, testee, interior, boundary, nlev, out=out, ref=ref)
 
 
-def test_dimension_eq_in_middle_of_domain(cartesian_case):
-    @gtx.field_operator
+def test_dimension_eq_in_middle_of_domain(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
         return concat_where((KDim == 2), interior, boundary)
 
@@ -256,8 +264,8 @@ def test_dimension_eq_in_middle_of_domain(cartesian_case):
 
 
 @pytest.mark.embedded_concat_where_non_contiguous_domain
-def test_dimension_two_conditions_or(cartesian_case):
-    @gtx.field_operator
+def test_dimension_two_conditions_or(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
         return concat_where(((KDim < 2) | (KDim >= 5)), boundary, interior)
 
@@ -270,8 +278,8 @@ def test_dimension_two_conditions_or(cartesian_case):
     cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
-def test_lap_like(cartesian_case):
-    @gtx.field_operator
+def test_lap_like(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(
         inp: cases.IJField, boundary: np.int32, shape: tuple[np.int32, np.int32]
     ) -> cases.IJField:
@@ -304,8 +312,8 @@ def test_lap_like(cartesian_case):
 
 
 @pytest.mark.uses_tuple_returns
-def test_with_tuples(cartesian_case):
-    @gtx.field_operator
+def test_with_tuples(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(
         interior0: cases.IJKField,
         boundary0: cases.IJField,
@@ -344,8 +352,8 @@ def test_with_tuples(cartesian_case):
     )
 
 
-def test_nested_conditions_with_empty_branches(cartesian_case):
-    @gtx.field_operator
+def test_nested_conditions_with_empty_branches(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.IField, boundary: cases.IField, N: gtx.int32) -> cases.IField:
         interior = concat_where(IDim == 0, boundary, interior)
         interior = concat_where((1 <= IDim) & (IDim < N - 1), interior * 2, interior)
@@ -367,8 +375,8 @@ def test_nested_conditions_with_empty_branches(cartesian_case):
 
 
 @pytest.mark.uses_tuple_returns
-def test_with_tuples_different_domain(cartesian_case):
-    @gtx.field_operator
+def test_with_tuples_different_domain(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
     def testee(
         interior0: cases.IJKField,
         boundary0: cases.IJKField,


### PR DESCRIPTION
## Description

`GPUSetBlockSize` cuts the GPU thread block size down to the map size when the map is smaller than the requested block, so no threads are wasted. The check used SymPy's fancy comparison `(map_size < block_size) == True`, which can also be *provably* true for a symbolic map size — e.g. `5 - Max(0, N)` arising from a statically bounded domain combined with a runtime scalar `N` (`concat_where` with static domains). In that case the symbolic expression was assigned as the block size, and code generation later failed with `TypeError: Cannot convert symbols to int` (see `test_static_domains_with_runtime_scalar_condition` on `main`).

A GPU block size must be a compile-time integer, so the block size is now only cut down when the map size is a concrete integer. Following review, the check is `isinstance(map_dim_size, (int, sympy.Integer))`, which is O(1) — roughly an order of magnitude faster than `dace.symbolic.issymbolic()` (traverses the expression tree) and `str(...).isdigit()` (renders it through the SymPy printer); benchmark in [this thread](https://github.com/GridTools/gt4py/pull/2797#discussion_r3793996390).

The regression is covered by parametrizing the `concat_where` tests on `static_domains`, which reproduces the failure on GPU backends.

---

**AI disclaimer**: Fully AI-generated (implementation and description).
