### PR TITLE
test[next]: isolate the global compilation registry between tests

### DIFF
--- a/tests/next_tests/conftest.py
+++ b/tests/next_tests/conftest.py
@@ -7,3 +7,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .fixtures.common import uids
+from .fixtures.compilation import isolate_ongoing_compilations

--- a/tests/next_tests/fixtures/compilation.py
+++ b/tests/next_tests/fixtures/compilation.py
@@ -1,0 +1,41 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Fixtures keeping the process-global compilation state from leaking between tests."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from gt4py.next.otf import compiled_program
+
+
+def reset_ongoing_compilations() -> None:
+    """Forget every in-flight compilation tracked for `gtx.wait_for_compilation()`.
+
+    `compiled_program._ongoing_compilations` is process-global, and
+    `wait_for_compilation()` drains *all* of it, which is the documented
+    behaviour. A compiled program keeps its own reference to the future in
+    `CompiledProgramsPool._compilation_jobs`, so dropping the entry here only
+    removes the program from that global drain; a failed variant still raises
+    its original error when it is called.
+    """
+    compiled_program._ongoing_compilations.clear()
+
+
+@pytest.fixture(autouse=True)
+def isolate_ongoing_compilations() -> Iterator[None]:
+    """Stop a test from inheriting compilations left behind by an earlier one.
+
+    Without this, a compilation that fails in one test stays tracked until the
+    next `gtx.wait_for_compilation()` anywhere in the process, so an unrelated
+    test drains it and fails with a foreign error. Which test is hit depends on
+    ordering, so the failures look non-deterministic. See GitHub issue #2800.
+    """
+    yield
+    reset_ongoing_compilations()

--- a/tests/next_tests/fixtures/compilation.py
+++ b/tests/next_tests/fixtures/compilation.py
@@ -23,7 +23,9 @@ def reset_ongoing_compilations() -> None:
     behaviour. A compiled program keeps its own reference to the future in
     `CompiledProgramsPool._compilation_jobs`, so dropping the entry here only
     removes the program from that global drain; a failed variant still raises
-    its original error when it is called.
+    its original error the next time it is called. Only the next one: the pool
+    pops the job before re-raising and never reaches `compiled_programs`, so a
+    further call reports a plain cache miss instead.
     """
     compiled_program._ongoing_compilations.clear()
 
@@ -36,6 +38,14 @@ def isolate_ongoing_compilations() -> Iterator[None]:
     next `gtx.wait_for_compilation()` anywhere in the process, so an unrelated
     test drains it and fails with a foreign error. Which test is hit depends on
     ordering, so the failures look non-deterministic. See GitHub issue #2800.
+
+    Note: being function-scoped, this also drops the failure of a compilation
+    that is never awaited within the test that submitted it. That is harmless
+    while every compiling fixture is function-scoped too, as it is today, but a
+    module- or session-scoped one would have its failures silently swallowed by
+    any later `wait_for_compilation()`. Give such a fixture its own explicit
+    wait instead of relying on the global drain.
     """
+    reset_ongoing_compilations()
     yield
     reset_ongoing_compilations()

--- a/tests/next_tests/unit_tests/otf_tests/test_runners.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_runners.py
@@ -237,8 +237,12 @@ def test_wait_for_compilation_groups_multiple_failures():
     compiled_program.wait_for_compilation()
 
 
-def test_wait_for_compilation_inherits_failures_left_by_other_code():
-    """Document the leak the `isolate_ongoing_compilations` fixture exists to contain."""
+def test_wait_for_compilation_drains_foreign_entries():
+    """Pin the leak the `isolate_ongoing_compilations` fixture exists to contain.
+
+    The drain is process-global, so it reports entries this test never created.
+    Across tests that is what makes one test fail with another one's error.
+    """
     # The future has to stay referenced: tracking is weak, so a collected future
     # is not reported at all.
     foreign = concurrent.futures.Future()

--- a/tests/next_tests/unit_tests/otf_tests/test_runners.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_runners.py
@@ -22,6 +22,8 @@ import gt4py.next as gtx
 from gt4py.next import backend as next_backend, config
 from gt4py.next.otf import arguments, compilation_tasks, compiled_program, runners
 
+from next_tests.fixtures import compilation as fixtures_compilation
+
 
 @pytest.fixture
 def process_runner(tmp_path):
@@ -233,6 +235,31 @@ def test_wait_for_compilation_groups_multiple_failures():
 
     # each failure is reported only once
     compiled_program.wait_for_compilation()
+
+
+def test_wait_for_compilation_inherits_failures_left_by_other_code():
+    """Document the leak the `isolate_ongoing_compilations` fixture exists to contain."""
+    # The future has to stay referenced: tracking is weak, so a collected future
+    # is not reported at all.
+    foreign = concurrent.futures.Future()
+    foreign.set_exception(ValueError("foreign boom"))
+    compiled_program._ongoing_compilations[foreign] = "testee (run_gtfn_gpu)"
+
+    # Nothing in this test compiled anything, yet it drains someone else's failure.
+    with pytest.raises(ValueError, match="foreign boom"):
+        compiled_program.wait_for_compilation()
+
+
+def test_reset_ongoing_compilations_untracks_pending_failures():
+    """A reset test must not see a failure a previous one left behind."""
+    foreign = concurrent.futures.Future()
+    foreign.set_exception(ValueError("foreign boom"))
+    compiled_program._ongoing_compilations[foreign] = "testee (run_gtfn_gpu)"
+
+    fixtures_compilation.reset_ongoing_compilations()
+
+    assert foreign not in compiled_program._ongoing_compilations
+    compiled_program.wait_for_compilation()  # must not raise
 
 
 def test_detect_cuda_archs_prefers_cudaarchs_env():


### PR DESCRIPTION
Closes the test-isolation half of #2800. Tests-only: 3 files, +83 lines, no `src/` changes.

## Problem

`compiled_program._ongoing_compilations` is process-global and `gtx.wait_for_compilation()` drains **all** of it. A compilation that fails in one test therefore stays tracked until some later test calls `wait_for_compilation()` and inherits the foreign failure.

This is not a local-invocation artefact — it has already broken CI. On #2733's `11b2802b` the [CSCS pipeline went red](https://cicd-ext-mw.cscs.ch/ci/pipeline/results/4525297225819146/42923301/2775636266?iid=22612&type=gitlab) with the correct marker filter on a properly configured runner, two tests back to back on the same xdist worker (excerpt via @havogt):

```
[gw9] PASSED  test_compiled_program.py::test_dispatch_miss_propagates_compilation_error
[gw9] FAILED  test_runners.py::test_wait_for_compilation_groups_multiple_failures
              At index 0 diff: _WorkerError('compilation failed in the worker') != ValueError('first boom')
```

`_WorkerError` is defined inside the *first* test.

The same mechanism produces the noisier local symptom that motivated #2800 — an unrelated pure-CPU parametrization drowning in another test's GPU failures:

```
ExceptionGroup: Multiple compilations failed: 'testee (run_gtfn_gpu)',
'testee (run_dace_gpu_opt)', ... (36 sub-exceptions)
```

Which test gets hit depends on which one drains first, so the failure set looks non-deterministic on top of being misattributed.

## Why this is still needed now that #2733 has merged

#2733 (`dfed778d`) fixed the **consumed** future: `_finish_compilation_job` now calls `_ongoing_compilations.pop(...)` instead of relying on the weak key, which on the failure path was defeated by the traceback keeping the future alive through a reference cycle.

That is a different path from the one here. This PR covers the **never-consumed** future — a variant that is compiled, fails, and is simply never called. Nothing pops it, the weak key never fires while the pool holds its reference, and it sits in the global registry waiting for whichever test next calls `wait_for_compilation()`. No production-side change reaches that case, because from the library's point of view nothing has gone wrong yet: the failure is still pending delivery to a caller that never arrives. Only the test harness knows the test is over.

The two are complementary; #2733 is merged into this branch and both are exercised by the runs below.

## Fix

An autouse fixture in `tests/next_tests/` clears the registry around each test.

What makes it safe to drop entries: the global drain is **not** the only reference to a compilation. `CompiledProgramsPool._compile_variant()` stores `self._compilation_jobs[key] = future` right next to the `_ongoing_compilations[future] = ...` registration, so clearing the global registry loses no result — a failed variant still raises its original error the next time it is called.

Only the *next* time, and the fixture docstring says so: the pool pops the job before re-raising and never reaches `compiled_programs`, so a further call reports a cache miss instead. Measured:

```
FIRST CALL : ValueError: original boom
SECOND CALL: RuntimeError: No program compiled for this set of static arguments ...
```

`wait_for_compilation()`'s own semantics are deliberate and unchanged. Draining every ongoing compilation is documented behaviour and correct for the API's stated purpose; the defect is that tests shared one process-global registry.

Scoped to `next_tests` because the registry lives in `gt4py.next.otf.compiled_program` and nothing outside `gt4py.next` uses it.

### Known limitation, documented in the fixture

Being function-scoped, the teardown also drops the failure of a compilation that is never awaited inside the test that submitted it. That is harmless while every compiling fixture is function-scoped — as it is today, verified by AST scan — but a module- or session-scoped one would have its failures silently swallowed. The docstring says to give such a fixture its own explicit wait.

The cleaner long-term shape is to scope the registry itself (per pool, or a `contextvar`) rather than clear a global one, which would remove this limitation instead of documenting it. That is a `src/` change with an open API question — what a process-wide `gtx.wait_for_compilation()` means once the registry is not process-wide — so it is deliberately not in this PR.

## Regression tests

Two tests beside the existing `wait_for_compilation` unit tests in `test_runners.py`, both order-independent so neither can pass vacuously depending on ordering:

- `test_wait_for_compilation_drains_foreign_entries` — pins that the drain is process-global and reports entries the caller never created, which is the mechanism the fixture contains.
- `test_reset_ongoing_compilations_untracks_pending_failures` — a reset test must not see a failure a previous one left behind.

## Verification

**A/B proof that it fixes the reported contamination.** The same two-test module (test 1 leaks a failed future, test 2 calls `wait_for_compilation()`) placed once inside `next_tests` and once outside it, so the only variable is whether the fixture applies:

| Location | Fixture applies | Result |
| --- | --- | --- |
| `tests/next_tests/unit_tests/` | yes | **2 passed** |
| `tests/cartesian_tests/unit_tests/` | no | **1 failed** — test 2 inherits test 1's `ValueError` |

Fixture ordering confirmed via `--setup-show`: `isolate_ongoing_compilations` sets up *before* the compiling fixtures and tears down after them, so the pre-`yield` clear cannot wipe a registration made during setup.

**No regressions**, on the merge commit (CPU-only machine, `-m "not requires_gpu"`, since this branch does not carry #2801's auto-skip):

- `tests/next_tests/unit_tests` — 2077 passed, 6 skipped, 11 xfailed
- `test_compiled_program.py` (integration) — 250 passed, 80 skipped, 6 xfailed, exactly the baseline recorded in #2800
- `uv run pre-commit run --files <changed>` green

**Not run locally:** GPU sessions (no device available). CI covers them.

## Note on the ruff warning in `tests/next_tests/conftest.py`

The added `from .fixtures.compilation import isolate_ongoing_compilations` is an unused import by ruff's reckoning, as is the pre-existing `uids` re-export on the line above — that is the pytest idiom for exposing fixtures from a conftest. `ruff check` excludes `^(tests/|docs/|examples/)` in `.pre-commit-config.yaml`, so neither is flagged in CI, and the new line is kept consistent with its neighbour rather than carrying a `noqa` the existing one does not have.
