### PR TITLE
fix[next-dace]: normalize staggered dimensions in get_map_variable

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
@@ -45,10 +45,10 @@ def get_map_variable(dim: gtx_common.Dimension) -> str:
     """
     Format map variable name based on the naming convention for application-specific SDFG transformations.
     """
-    # A staggered dimension shares its index space with its base dimension, so both must map
-    # to the same map variable. Otherwise `split_overlapping_map_range()` compares the parameter
-    # names of two Maps, finds them different, and refuses to split ranges that do overlap,
-    # which prevents the Maps from being fused.
+    # A staggered dimension can share its index space with the base dimension, as a field can only
+    # ever carry either the staggered or the base dimension. The dace transformations for map 
+    # fusion and map splitting rely on the names of the map variables to match the field
+    # dimensions and decide whether two maps have the same iteration space.
     dim = gtx_common.as_non_staggered(dim)
     suffix = "dim" if dim.kind == gtx_common.DimensionKind.LOCAL else ""
     return f"i_{dim.value}_gtx_{dim.kind}{suffix}"

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
@@ -46,7 +46,7 @@ def get_map_variable(dim: gtx_common.Dimension) -> str:
     Format map variable name based on the naming convention for application-specific SDFG transformations.
     """
     # A staggered dimension can share its index space with the base dimension, as a field can only
-    # ever carry either the staggered or the base dimension. The dace transformations for map 
+    # ever carry either the staggered or the base dimension. The dace transformations for map
     # fusion and map splitting rely on the names of the map variables to match the field
     # dimensions and decide whether two maps have the same iteration space.
     dim = gtx_common.as_non_staggered(dim)

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
@@ -45,6 +45,11 @@ def get_map_variable(dim: gtx_common.Dimension) -> str:
     """
     Format map variable name based on the naming convention for application-specific SDFG transformations.
     """
+    # A staggered dimension shares its index space with its base dimension, so both must map
+    # to the same map variable. Otherwise `split_overlapping_map_range()` compares the parameter
+    # names of two Maps, finds them different, and refuses to split ranges that do overlap,
+    # which prevents the Maps from being fused.
+    dim = gtx_common.as_non_staggered(dim)
     suffix = "dim" if dim.kind == gtx_common.DimensionKind.LOCAL else ""
     return f"i_{dim.value}_gtx_{dim.kind}{suffix}"
 


### PR DESCRIPTION
`get_map_variable()` derives the map variable from `dim.value`, so a staggered
dimension and its base dimension are given different names — `i_K_gtx_vertical`
vs `i__StaggeredK_gtx_vertical` — even though they share an index space.

That name difference blocks Map fusion. `split_overlapping_map_range()` starts with

```python
first_map_params = set(first_map.params)
second_map_params = set(second_map.params)
if first_map_params != second_map_params:
    return None
```

so genuinely overlapping ranges are never even examined, e.g. (nlev = 20)

```
(K, 0:19)  vs (_StaggeredK, 1:19)      -> should split at k=1
(K, 8:19)  vs (_StaggeredK, 4:19)      -> should split at k=8
```