### PR TITLE
fix[dace]: avoid `set` for dace node connectors, use `dict` to ensure deterministic lowering

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "setup": "uv sync"
+  }
+}

--- a/paseo.json
+++ b/paseo.json
@@ -1,5 +1,0 @@
-{
-  "worktree": {
-    "setup": "uv sync"
-  }
-}

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -266,15 +266,19 @@ def freeze_origin_domain_sdfg(
     state = wrapper_sdfg.add_state("frozen_" + inner_sdfg.name + "_state")
 
     # gather inputs & outputs (i.e. reads/writes without transients)
-    inputs, outputs = inner_sdfg.read_and_write_sets()
-    inputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, inputs))
-    outputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, outputs))
+    read_set, write_set = inner_sdfg.read_and_write_sets()
+    inputs = {
+        name: None
+        for name, desc in inner_sdfg.arrays.items()
+        if name in read_set and not desc.transient
+    }
+    outputs = {
+        name: None
+        for name, desc in inner_sdfg.arrays.items()
+        if name in write_set and not desc.transient
+    }
 
-    nsdfg = state.add_nested_sdfg(
-        inner_sdfg,
-        inputs={name: None for name in sorted(inputs)},
-        outputs={name: None for name in sorted(outputs)},
-    )
+    nsdfg = state.add_nested_sdfg(inner_sdfg, inputs, outputs)
 
     _sdfg_add_arrays_and_edges(
         field_info, wrapper_sdfg, state, inner_sdfg, nsdfg, inputs, outputs, origin, domain

--- a/src/gt4py/cartesian/backend/dace_backend.py
+++ b/src/gt4py/cartesian/backend/dace_backend.py
@@ -270,7 +270,11 @@ def freeze_origin_domain_sdfg(
     inputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, inputs))
     outputs = set(filter(lambda name: not inner_sdfg.arrays[name].transient, outputs))
 
-    nsdfg = state.add_nested_sdfg(inner_sdfg, inputs, outputs)
+    nsdfg = state.add_nested_sdfg(
+        inner_sdfg,
+        inputs={name: None for name in sorted(inputs)},
+        outputs={name: None for name in sorted(outputs)},
+    )
 
     _sdfg_add_arrays_and_edges(
         field_info, wrapper_sdfg, state, inner_sdfg, nsdfg, inputs, outputs, origin, domain

--- a/src/gt4py/next/program_processors/runners/dace/library_nodes/reduce_with_skip_values.py
+++ b/src/gt4py/next/program_processors/runners/dace/library_nodes/reduce_with_skip_values.py
@@ -141,7 +141,7 @@ class ReduceWithSkipValuesExpandInlined(dace_transform.ExpandTransformation):
         init_tasklet = st_init.add_tasklet(
             name="write",
             inputs={},
-            outputs={"__tlet_out"},
+            outputs={"__tlet_out": None},
             code=f"__tlet_out = {input_desc.dtype}({node.init})",
         )
         st_init.add_edge(

--- a/src/gt4py/next/program_processors/runners/dace/transformations/inline_fuser.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/inline_fuser.py
@@ -373,7 +373,7 @@ def _insert_nested_sdfg(
     nsdfg_node = state.add_nested_sdfg(
         sdfg=nsdfg,
         inputs=input_node_map.keys(),
-        outputs={output_name},
+        outputs={output_name: None},
         symbol_mapping=first_map_param_mapping,
     )
 

--- a/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
@@ -970,8 +970,8 @@ class LoopBlocking(dace_transformation.SingleStateTransformation):
 
                     copy_tlet = state.add_tasklet(
                         name=f"loop_blocking_copy_tlet_{independent_node.data}_{copy_tlet_counter}",
-                        inputs={"__in"},
-                        outputs={"__out"},
+                        inputs={"__in": None},
+                        outputs={"__out": None},
                         code="__out = __in",
                     )
                     copy_tlet_counter += 1

--- a/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/simplify.py
@@ -1013,7 +1013,7 @@ class GT4PyMoveTaskletIntoMap(dace_transformation.SingleStateTransformation):
         inner_tasklet: dace_nodes.Tasklet = graph.add_tasklet(
             name=next(self._uids[f"{tasklet.label}__clone"]),
             outputs=tasklet.out_connectors.keys(),
-            inputs=set(),
+            inputs={},
             code=tasklet.code,
             language=tasklet.language,
             debuginfo=tasklet.debuginfo,

--- a/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/translation.py
@@ -207,7 +207,7 @@ def add_instrumentation(sdfg: dace.SDFG, gpu: bool) -> None:
     tlet_start_timer = begin_state.add_tasklet(
         "gt_start_timer",
         inputs={},
-        outputs={"time"},
+        outputs={"time": None},
         code=f"""\
 {sync_code}
 auto now = std::chrono::high_resolution_clock::now();
@@ -239,8 +239,8 @@ time = std::chrono::duration_cast<std::chrono::nanoseconds>(
     # Populate the branch that computes the stencil time metric
     tlet_stop_timer = end_state.add_tasklet(
         "gt_stop_timer",
-        inputs={"run_cpp_start_time"},
-        outputs={"duration"},
+        inputs={"run_cpp_start_time": None},
+        outputs={"duration": None},
         code=f"""\
 {sync_code}
 auto now = std::chrono::high_resolution_clock::now();
@@ -324,8 +324,8 @@ def make_sdfg_call_sync(sdfg: dace.SDFG, gpu: bool) -> None:
     assert dace_gpu_backend in ["cuda", "hip"], f"GPU backend '{dace_gpu_backend}' is unknown."
     sync_state.add_tasklet(
         "sync_tlet",
-        inputs=set(),
-        outputs=set(),
+        inputs={},
+        outputs={},
         code=f"{dace_gpu_backend}StreamSynchronize({dace_gpu_backend}StreamDefault);",
         language=dace.dtypes.Language.CPP,
         side_effects=True,


### PR DESCRIPTION
This PR fixes the warnings:
`Using sets as inputs is discouraged as it leads to indeterministic behavior`

All warnings in GT4Py-next are false alarms, since the set is either empty or contains one element. The corresponding warning won't be emitted in dace after https://github.com/spcl/dace/pull/2511

The warning from GT4Py cartesian is real, and this PR fixes the issue.