### PR TITLE
fix[next-dace]: reject state fusion when a transient is written in both states

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
@@ -163,6 +163,16 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
         if len(common_write_data) == 0:
             return False
 
+        # Transients are assumed to be written only once (ADR-18), in a single
+        #  state. If a transient is written to in both states — e.g. partial
+        #  writes on disjoint subsets, as produced for `concat_where` — merging
+        #  the states would leave one of the writer AccessNodes unconnected to
+        #  any reader (the consumer rewiring in `apply` only handles
+        #  second-state source nodes), leading to dangling dead writes or
+        #  uninitialized reads. Reject the fusion in this case.
+        if any(sdfg.arrays[data].transient for data in common_write_data):
+            return True
+
         for state, ac_nodes in [
             (first_state, first_state_writes),
             (second_state, second_state_writes),

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_state_fusion.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_state_fusion.py
@@ -172,6 +172,68 @@ def _make_global_both_state_write() -> tuple[dace.SDFG, dace.SDFGState, dace.SDF
     return sdfg, state1, state2
 
 
+def _make_transient_both_states_write() -> tuple[dace.SDFG, dace.SDFGState, dace.SDFGState]:
+    """In both states the same transient is written and it is read in the second one.
+
+    The two states write disjoint subsets of the transient `t` and the second
+    state also fully reads it. This is, in essence, the pattern that is emitted
+    by the stree lowering of `concat_where`.
+
+    Note that the fusion is not allowed, because after it the write to `t` in
+    the first state would no longer be connected to the read in the second
+    state (ADR-018 requires that a transient is written within a single state).
+    """
+    sdfg = dace.SDFG(util.unique_name("transient_write_in_both_states"))
+    state1 = sdfg.add_state(is_start_block=True)
+    state2 = sdfg.add_state_after(state1)
+
+    for name in ["a", "b", "o"]:
+        sdfg.add_array(
+            name,
+            shape=(20,),
+            dtype=dace.float64,
+            transient=False,
+        )
+    sdfg.add_array(
+        "t",
+        shape=(20,),
+        dtype=dace.float64,
+        transient=True,
+    )
+
+    state1.add_mapped_tasklet(
+        "comp1",
+        map_ranges={"__i": "0:10"},
+        inputs={"__in1": dace.Memlet("a[__i]")},
+        code="__out = __in1 + 10.",
+        outputs={"__out": dace.Memlet("t[__i]")},
+        external_edges=True,
+    )
+
+    t2 = state2.add_access("t")
+    state2.add_mapped_tasklet(
+        "comp2_1",
+        map_ranges={"__i": "10:20"},
+        inputs={"__in1": dace.Memlet("b[__i]")},
+        code="__out = __in1 + 12.",
+        outputs={"__out": dace.Memlet("t[__i]")},
+        external_edges=True,
+        output_nodes={t2},
+    )
+    state2.add_mapped_tasklet(
+        "comp2_2",
+        map_ranges={"__i": "0:20"},
+        inputs={"__in1": dace.Memlet("t[__i]")},
+        code="__out = __in1 * 2.",
+        outputs={"__out": dace.Memlet("o[__i]")},
+        external_edges=True,
+        input_nodes={t2},
+    )
+    sdfg.validate()
+
+    return sdfg, state1, state2
+
+
 def _make_empty_state(
     first_state_empty: bool,
 ) -> tuple[dace.SDFG, dace.SDFGState, dace.SDFGState]:
@@ -587,6 +649,22 @@ def test_global_in_both_states_write():
         for ac in ac_nodes
         if ac.data != "a"
     )
+
+
+def test_transient_in_both_states_write():
+    sdfg, state1, state2 = _make_transient_both_states_write()
+
+    # The transient is written in both states and read in the second one. Fusing
+    #  the states would disconnect the write to `t` in the first state from the
+    #  read in the second state, so the transformation must not apply.
+    nb_applied = sdfg.apply_transformations_repeated(gtx_transformations.GT4PyStateFusion)
+    sdfg.validate()
+
+    assert nb_applied == 0
+    assert sdfg.start_block is state1
+    assert sdfg.number_of_nodes() == 2
+    assert util.count_nodes(state1, dace_nodes.AccessNode) == 2
+    assert util.count_nodes(state2, dace_nodes.AccessNode) == 3
 
 
 def test_empty_first_state():


### PR DESCRIPTION
## Problem

The stree lowering of `concat_where` emits a transient array that is partially written in two consecutive SDFG states: each state writes a disjoint subset of the transient, with symbolic `Max`/`Min` bounds, and the second state also reads it. DaCe's own `SimplifyPass` cannot reason about those subsets, so it does not rewrite anything. `GT4PyStateFusion` then merged the two states anyway.

After the merge, the consumer rewiring in `apply()` only reconnects source nodes of the second state, so the first state's write to the transient was left disconnected from the second state's read. `DeadDataflowElimination` subsequently deleted the dangling write, leaving the output partially uninitialized at runtime.

Per ADR-018, a transient must be written within a single state, so such a configuration is invalid input for fusion.

## Fix

`GT4PyStateFusion._check_for_wcr_conflicts` now checks the `common_write_data` (the arrays written by both states) and reports a conflict — refusing the merge — when any commonly-written array is transient, in line with ADR-018's "a transient must be written in a single state" rule. The two states are left separate, preserving the dataflow edge from the first write to the second state's read.

## Tests

- Added regression test `test_transient_in_both_states_write` (with factory `_make_transient_both_states_write`) reproducing the `concat_where` pattern: two states writing disjoint slices of a transient `t`, the second state also reading it. It asserts that `apply_transformations_repeated(GT4PyStateFusion)` applies 0 times and that both states survive intact.
- The full `transformation_tests/test_state_fusion.py` suite passes (15 passed).
