### PR TITLE
fix[next-dace]: return no successors for terminal blocks in find_successor_state

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/utils.py
@@ -634,7 +634,14 @@ def find_successor_state(state: dace.SDFGState) -> list[dace.SDFGState]:
         curr_out_edges = [oedge.dst for oedge in graph.out_edges(state)]
 
         # End recursion if we found some successor edges or we have reached the top.
-        if len(curr_out_edges) > 0 or graph.parent_graph is state.sdfg:
+        #  Note that if `graph` is the root region (e.g. for a terminal state at
+        #  the top level of the SDFG) its `parent_graph` is `None`, not the SDFG
+        #  itself, so that case must be handled explicitly.
+        if (
+            len(curr_out_edges) > 0
+            or graph.parent_graph is state.sdfg
+            or graph.parent_graph is None
+        ):
             return curr_out_edges
         elif isinstance(graph.parent_graph, dace.sdfg.state.ConditionalBlock):
             # For conditional we go two levels up, because there is nothing

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_utils.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_utils.py
@@ -1,0 +1,54 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dace
+from dace.sdfg.state import LoopRegion
+
+from gt4py.next.program_processors.runners.dace.transformations import (
+    utils as gtx_transformations_utils,
+)
+
+from . import util
+
+
+def test_find_successor_state():
+    sdfg = dace.SDFG(util.unique_name("find_successor_state"))
+    state1 = sdfg.add_state(is_start_block=True)
+    state2 = sdfg.add_state_after(state1)
+    sdfg.validate()
+
+    assert gtx_transformations_utils.find_successor_state(state1) == [state2]
+
+    # `state2` is a terminal control-flow block of the SDFG, thus it has no
+    #  successor. However, the function must not walk above the root region
+    #  (previously this crashed with an `AttributeError`).
+    assert gtx_transformations_utils.find_successor_state(state2) == []
+
+
+def test_find_successor_state_terminal_loop_region():
+    """Terminal inside a `LoopRegion` that is itself terminal.
+
+    The successor of the last state of the loop body is not expressible, thus
+    the function must return an empty list and not walk above the root region
+    (previously this crashed with an `AttributeError`).
+    """
+    sdfg = dace.SDFG(util.unique_name("find_successor_state_terminal_loop_region"))
+    loop = LoopRegion(
+        label="scan_loop",
+        condition_expr="i < 2",
+        loop_var="i",
+        initialize_expr="i = 0",
+        update_expr="i = i + 1",
+    )
+    sdfg.add_node(loop, is_start_block=True)
+    body_state1 = loop.add_state("body_state1", is_start_block=True)
+    body_state2 = loop.add_state_after(body_state1)
+    sdfg.validate()
+
+    assert gtx_transformations_utils.find_successor_state(body_state1) == [body_state2]
+    assert gtx_transformations_utils.find_successor_state(body_state2) == []


### PR DESCRIPTION
## Problem

`find_successor_state` (in `gt4py.next.program_processors.runners.dace.transformations.utils`) walks the outgoing region edges of a control-flow state, ascending into parent regions when a block has no successors locally. If the queried block and all its enclosing regions are terminal, the walk reached the SDFG root region and then recursed with the root region itself as `state`, so `graph = state.parent_graph` was `None` and the subsequent `graph.nodes()` call raised `AttributeError: 'NoneType' object has no attribute 'nodes'`.

This was hit via `MultiStateGlobalSelfCopyElimination`, which calls `find_successor_state` on transient-defining states (e.g. from OIR programs whose defining state is a terminal top-level block or inside a terminal `LoopRegion`).

## Fix

Treat the root region as the termination point of the walk: the no-successors early-return condition in the inner `_impl` of `find_successor_state` now also triggers when `graph.parent_graph is None` (i.e. `graph` is the SDFG root region), returning an empty successor list instead of recursing into `None`.

## Tests

New file `tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_utils.py` with two regression tests:

- `test_find_successor_state`: a terminal top-level state returns `[]` (previously crashed with `AttributeError`), a non-terminal state returns its successor.
- `test_find_successor_state_terminal_loop_region`: the last state of a `LoopRegion` body, where the loop itself is terminal at the top level, returns `[]` instead of crashing.
