### PR TITLE
fix[eve]: support type aliases recursing through a container

### DIFF
--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -187,19 +187,14 @@ class ArgsOnlyCallable(Protocol[_A, _R]):
 
 _T_co = TypeVar("_T_co", covariant=True)
 
-# Note: these recursive aliases have to be defined with the PEP 695 `type` statement. Written as
-# plain assignments (`NestedTuple = tuple[Union[_T_co, "NestedTuple[_T_co]"], ...]`), subscription
-# does not substitute the type parameter inside the string annotation, so `NestedTuple[int]` keeps
-# an unparametrized `ForwardRef("NestedTuple[_T_co]")` which cannot be resolved in the namespace
-# of the annotated object (see `get_partial_type_hints`).
-type NestedSequence[T] = Sequence[T | NestedSequence[T]]
-type NestedList[T] = list[T | NestedList[T]]
-type NestedTuple[T] = tuple[T | NestedTuple[T], ...]
+type NestedSequence[_T_co] = Sequence[_T_co | NestedSequence[_T_co]]
+type NestedList[_T_co] = list[_T_co | NestedList[_T_co]]
+type NestedTuple[_T_co] = tuple[_T_co | NestedTuple[_T_co], ...]
 
-type MaybeNested[T] = T | NestedSequence[T]
-type MaybeNestedInSequence[T] = T | NestedSequence[T]
-type MaybeNestedInList[T] = T | NestedList[T]
-type MaybeNestedInTuple[T] = T | NestedTuple[T]
+type MaybeNested[_T_co] = _T_co | NestedSequence[_T_co]
+type MaybeNestedInSequence[_T_co] = _T_co | NestedSequence[_T_co]
+type MaybeNestedInList[_T_co] = _T_co | NestedList[_T_co]
+type MaybeNestedInTuple[_T_co] = _T_co | NestedTuple[_T_co]
 
 
 def is_nested_tuple_of(value: object, type_: type[_T_co]) -> TypeIs[NestedTuple[_T_co]]:

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -186,14 +186,20 @@ class ArgsOnlyCallable(Protocol[_A, _R]):
 
 
 _T_co = TypeVar("_T_co", covariant=True)
-NestedSequence = Sequence[Union[_T_co, "NestedSequence[_T_co]"]]
-NestedList = list[Union[_T_co, "NestedList[_T_co]"]]
-NestedTuple = tuple[Union[_T_co, "NestedTuple[_T_co]"], ...]
 
-MaybeNested = Union[_T_co, NestedSequence[_T_co]]
-MaybeNestedInSequence = Union[_T_co, NestedSequence[_T_co]]
-MaybeNestedInList = Union[_T_co, NestedList[_T_co]]
-MaybeNestedInTuple = Union[_T_co, NestedTuple[_T_co]]
+# Note: these recursive aliases have to be defined with the PEP 695 `type` statement. Written as
+# plain assignments (`NestedTuple = tuple[Union[_T_co, "NestedTuple[_T_co]"], ...]`), subscription
+# does not substitute the type parameter inside the string annotation, so `NestedTuple[int]` keeps
+# an unparametrized `ForwardRef("NestedTuple[_T_co]")` which cannot be resolved in the namespace
+# of the annotated object (see `get_partial_type_hints`).
+type NestedSequence[T] = Sequence[T | NestedSequence[T]]
+type NestedList[T] = list[T | NestedList[T]]
+type NestedTuple[T] = tuple[T | NestedTuple[T], ...]
+
+type MaybeNested[T] = T | NestedSequence[T]
+type MaybeNestedInSequence[T] = T | NestedSequence[T]
+type MaybeNestedInList[T] = T | NestedList[T]
+type MaybeNestedInTuple[T] = T | NestedTuple[T]
 
 
 def is_nested_tuple_of(value: object, type_: type[_T_co]) -> TypeIs[NestedTuple[_T_co]]:

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -135,6 +135,26 @@ class TypeValidatorFactory(Protocol):
 
 
 # Implementations
+@dataclasses.dataclass
+class _DeferredTypeValidator:
+    """A :class:`FixedTypeValidator` forwarding to a validator which is not known yet.
+
+    This indirection is what makes recursive type aliases work: the validator of
+    ``type NestedTuple[T] = tuple[T | NestedTuple[T], ...]`` cannot be built before the
+    alias occurring inside its own definition has one, so the inner occurrence gets this
+    placeholder and the real validator is filled in once the definition is processed.
+    """
+
+    name: str
+    validator: Optional[FixedTypeValidator] = None
+
+    def __call__(self, value: Any, **kwargs: Any) -> None:
+        assert self.validator is not None, (
+            f"Validator for '{self.name}' has not been completely defined yet."
+        )
+        self.validator(value, **kwargs)
+
+
 @dataclasses.dataclass(frozen=True)
 class SimpleTypeValidatorFactory(TypeValidatorFactory):
     """A simple :class:`TypeValidatorFactory` implementation.
@@ -177,15 +197,25 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
         required: bool = True,
         globalns: Optional[dict[str, Any]] = None,
         localns: Optional[dict[str, Any]] = None,
+        _alias_memo: Optional[dict[Any, _DeferredTypeValidator]] = None,
         **kwargs: Any,
     ) -> Optional[FixedTypeValidator]:
         # TODO(egparedes): if a "typing tree" structure is implemented, refactor this code as a tree traversal.
         #
         if name is None:
             name = "<value>"
+        if _alias_memo is None:
+            # Type aliases whose validator is currently being built, used to break the
+            # cycles introduced by recursive aliases.
+            _alias_memo = {}
 
         make_recursive = functools.partial(
-            self.__call__, name=name, globalns=globalns, localns=localns, **kwargs
+            self.__call__,
+            name=name,
+            globalns=globalns,
+            localns=localns,
+            _alias_memo=_alias_memo,
+            **kwargs,
         )
 
         try:
@@ -205,7 +235,15 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                 # Keep its message: it names the alias and the cause.
                 raise exceptions.EveValueError(str(error)) from error
             if resolved_annotation is not type_annotation:
-                return make_recursive(resolved_annotation)
+                # A recursive alias reaches this point again, with the very same annotation,
+                # while its own validator is still being built. Handing the inner occurrence
+                # a placeholder breaks that cycle; it is filled in right below, before any
+                # value can be validated.
+                if (deferred := _alias_memo.get(type_annotation, None)) is not None:
+                    return deferred
+                _alias_memo[type_annotation] = deferred = _DeferredTypeValidator(name)
+                deferred.validator = validator = make_recursive(resolved_annotation)
+                return validator
 
             # Non-generic types
             if xtyping.is_actual_type(type_annotation):

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -143,6 +143,9 @@ class _DeferredTypeValidator:
     ``type NestedTuple[T] = tuple[T | NestedTuple[T], ...]`` cannot be built before the
     alias occurring inside its own definition has one, so the inner occurrence gets this
     placeholder and the real validator is filled in once the definition is processed.
+
+    Unlike ``datamodels.ForwardRefValidator``, which resolves itself lazily on its first
+    call, this one is always completed by its creator before any value reaches it.
     """
 
     name: str

--- a/tests/eve_tests/unit_tests/test_concepts.py
+++ b/tests/eve_tests/unit_tests/test_concepts.py
@@ -107,6 +107,26 @@ class TestNode:
 
         assert set(sample_node.annex.keys()) >= {"an_int", "a_str"}
 
+    def test_nested_tuple_of_nodes_field(self):
+        # A node holding an arbitrarily nested tuple of other nodes (e.g. the targets of
+        # a tuple comprehension) is annotated with the recursive 'NestedTuple' alias.
+        class Target(eve.Node):
+            name: str
+
+        class Parent(eve.Node):
+            targets: eve.extended_typing.NestedTuple[Target]
+
+        node = Parent(targets=(Target(name="a"), (Target(name="b"), (Target(name="c"),))))
+
+        assert [target.name for target in eve.walk_values(node).if_isinstance(Target)] == [
+            "a",
+            "b",
+            "c",
+        ]
+
+        with pytest.raises((TypeError, ValueError)):
+            Parent(targets=(Target(name="a"), ("b",)))
+
     def test_children(self, sample_node):
         children_names = set(name for name, _ in sample_node.iter_children_items())
 

--- a/tests/eve_tests/unit_tests/test_datamodels.py
+++ b/tests/eve_tests/unit_tests/test_datamodels.py
@@ -1501,6 +1501,28 @@ def test_coerced_type_alias_field():
     assert Model(value="42").value == 42
 
 
+type SampleAliasNestedTuple[T] = typing.Tuple[T | SampleAliasNestedTuple[T], ...]
+
+
+class SampleAliasSymbol(datamodels.DataModel):
+    name: str
+
+
+def test_type_alias_recursing_through_a_container_field():
+    # An arbitrarily nested tuple of datamodels (e.g. the targets of a tuple
+    # comprehension) can only be annotated with an alias which refers to itself.
+    class Model(datamodels.DataModel):
+        targets: SampleAliasNestedTuple[SampleAliasSymbol]
+
+    model = Model(targets=(SampleAliasSymbol(name="a"), (SampleAliasSymbol(name="b"),), ()))
+    assert model.targets[1][0].name == "b"
+
+    with pytest.raises(TypeError, match="Model.targets"):
+        Model(targets=(SampleAliasSymbol(name="a"), ("b",)))
+    with pytest.raises(TypeError, match="Model.targets"):
+        Model(targets=SampleAliasSymbol(name="a"))
+
+
 def test_type_alias_field_with_undefined_value_is_deferred():
     # The alias value is evaluated lazily, so the class body must not fail even
     # though 'DefinedLater' does not exist yet. Validation happens on the first

--- a/tests/eve_tests/unit_tests/test_extended_typing.py
+++ b/tests/eve_tests/unit_tests/test_extended_typing.py
@@ -500,6 +500,7 @@ type SampleRecursiveAlias = SampleRecursiveAlias
 type SampleMutualAliasA = SampleMutualAliasB
 type SampleMutualAliasB = SampleMutualAliasA
 type SampleDivergingGenericAlias[T] = SampleDivergingGenericAlias[tuple[T]]
+type SampleNestedTupleAlias[T] = tuple[T | SampleNestedTupleAlias[T], ...]
 
 
 def test_is_type_alias():
@@ -540,6 +541,21 @@ def test_eval_type_alias_with_undefined_value():
 def test_eval_type_alias_with_recursive_alias():
     with pytest.raises(TypeError, match="recursive definition"):
         xtyping.eval_type_alias(SampleRecursiveAlias)
+
+
+def test_eval_type_alias_with_alias_recursing_through_a_container():
+    # Unlike 'type A = A', an alias recursing through a container is well founded: a
+    # single resolution step already yields an annotation which is not an alias itself,
+    # so it resolves instead of being reported as a cycle. The alias is still present
+    # in the result, so consumers walking it have to break the recursion themselves.
+    assert (
+        xtyping.eval_type_alias(SampleNestedTupleAlias[int])
+        == tuple[int | SampleNestedTupleAlias[int], ...]
+    )
+    assert (
+        xtyping.eval_type_alias(xtyping.NestedTuple[int])
+        == tuple[int | xtyping.NestedTuple[int], ...]
+    )
 
 
 def test_eval_type_alias_with_mutually_recursive_aliases():
@@ -607,6 +623,15 @@ def test_get_represented_types_resolves_type_aliases():
         SampleReprB,
         int,
     )
+
+
+def test_get_represented_types_with_alias_recursing_through_a_container():
+    # The recursion stops at the container, since generic annotations are represented
+    # by their origin and are not walked any further.
+    assert xtyping.get_represented_types(SampleNestedTupleAlias[int]) == (tuple,)
+    assert xtyping.get_represented_types(xtyping.NestedTuple) == (tuple,)
+    assert xtyping.get_represented_types(xtyping.NestedTuple[int]) == (tuple,)
+    assert xtyping.get_represented_types(xtyping.MaybeNestedInTuple[int]) == (int, tuple)
 
 
 def test_get_represented_types_with_alias_nested_in_annotation():

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -158,6 +158,7 @@ type SampleIntAlias = int
 type SampleChainedAlias = SampleIntAlias
 type SampleListAlias = list[SampleIntAlias]
 type SamplePairAlias[T] = tuple[T, T]
+type SampleNestedTupleAlias[T] = tuple[T | SampleNestedTupleAlias[T], ...]
 
 
 SAMPLE_TYPE_DEFINITIONS.extend(
@@ -168,6 +169,36 @@ SAMPLE_TYPE_DEFINITIONS.extend(
         (list[SampleIntAlias], ([1, 2, 3], []), (1, [1.0]), None, None),
         (Optional[SampleIntAlias], [1, None], ["1"], None, None),
         (SamplePairAlias[int], [(1, 2)], [(1, "2"), (1,)], None, None),
+        # Aliases recursing through a container
+        (
+            SampleNestedTupleAlias[int],
+            ((), (1, 2), (1, (2, (3, 4)), ())),
+            (1, [1], (1, "2"), (1, [2])),
+            None,
+            None,
+        ),
+        (
+            SampleNestedTupleAlias[SampleDataClass],
+            ((), (SampleDataClass(1),), (SampleDataClass(1), ((SampleDataClass(2),), ()))),
+            (SampleDataClass(1), [SampleDataClass(1)], (1,), (SampleDataClass(1), (1,))),
+            None,
+            None,
+        ),
+        (
+            xtyping.NestedTuple[int],
+            ((), (1, 2), (1, (2, (3, 4)), ())),
+            (1, [1], (1, "2"), (1, [2])),
+            None,
+            None,
+        ),
+        (
+            xtyping.NestedList[int],
+            ([], [1, 2], [1, [2, [3, 4]], []]),
+            (1, (1,), [1, "2"], [1, (2,)]),
+            None,
+            None,
+        ),
+        (xtyping.MaybeNestedInTuple[int], (1, (), (1, (2, 3))), ("1", [1], (1, "2")), None, None),
     ]
 )
 
@@ -270,7 +301,9 @@ def test_simple_validation_particularities():
         type_val.simple_type_validator_factory(InvalidAnnotation, "value")
 
 
-def test_recursive_type_alias_is_not_supported():
+def test_cyclic_type_alias_is_not_supported():
+    # An alias standing for itself directly never reaches an actual annotation, unlike
+    # one recursing through a container (see the samples above).
     type RecursiveAlias = RecursiveAlias
 
     # The reason the alias could not be resolved is kept instead of the generic


### PR DESCRIPTION
`NestedTuple` and its siblings in `gt4py.eve.extended_typing` were defined as plain assignments holding a string forward reference to themselves:

    NestedTuple = tuple[Union[_T_co, "NestedTuple[_T_co]"], ...]

Subscripting such an alias does not substitute the type parameter inside the forward reference, so `NestedTuple[Foo]` expands to `tuple[Foo | ForwardRef('NestedTuple[_T_co]'), ...]` and `get_type_hints()` fails with `NameError: name '_T_co' is not defined` when resolving it in the namespace of the annotated object. These aliases could therefore not be used as datamodel/node field annotations at all, which is why #2487 had to fall back to `target: Any` instead of `NestedTuple[DataSymbol]` in `foast.TupleComprehensionMapper`.

Changes:

- The `Nested*` / `MaybeNested*` aliases are now defined with the PEP 695 `type` statement, which substitutes type parameters properly across the recursion.
- `SimpleTypeValidatorFactory` breaks the resulting cycle. Such an alias is well founded, unlike the `type A = A` cycle `eval_type_alias()` rejects: a single resolution step already yields an annotation which is not an alias itself. What it does not yield is a *finite* one, so the alias occurring inside its own definition is now handed a deferred validator, filled in as soon as the definition has been processed.

`test_recursive_type_alias_is_not_supported` was renamed to `test_cyclic_type_alias_is_not_supported`, since only degenerate cycles remain unsupported.

Once this is merged, the `target: Any` workaround in #2487 can be removed.

**Disclaimer**: This PR and its description were written largely with the help of AI. Code was reviewed briefly by me and in more detail by the reviewer.