### PR TITLE
fix[next-dace]: block state fusion creating a WAR hazard on global data

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
@@ -307,6 +307,15 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
                     #  dataflow is executed. We thus have to ensure that the new
                     #  component will not affect any component that is not involved
                     #  inside the merge.
+                    # Moreover, the consumer itself must not create a WAR hazard:
+                    #  the messenger only orders the producer's writes before the
+                    #  consumer's accesses, it does not order the producer's *reads*
+                    #  of the same data before the consumer's write.
+                    if any(
+                        self._has_war_hazard(first_state, second_state, data, consumed_messenger)
+                        for data in producer_dependency.intersection(consumer_influece)
+                    ):
+                        return True
                     unaffected_producers: list[int] = [
                         producer_id
                         for producer_id, data_producer in enumerate(data_producers)
@@ -335,6 +344,103 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
                 #  merge.
                 return True
 
+        return False
+
+    def _has_war_hazard(
+        self,
+        first_state: dace.SDFGState,
+        second_state: dace.SDFGState,
+        data: str,
+        messengers: set[str],
+    ) -> bool:
+        """Checks if the fusion would create a write-after-read hazard on `data`.
+
+        The data `data` is read in the first state and written to in the second
+        state, by a consumer component that consumes the `messengers` from the
+        first state. In the merged state the consumer's write is only ordered after
+        the data the write depends on, i.e. the messengers. Thus the write is
+        unordered with respect to a read in the first state - a WAR hazard - unless
+        that read is dataflow-upstream of the exchanged messages, in which case the
+        dataflow through the messenger imposes the order.
+
+        The check is performed at node level and considers the fusion safe for a
+        write of `data` in the second state if there is an exchanged messenger such
+        that:
+        - the messenger is dataflow-upstream of the write in the second state, and
+        - every read of `data` in the first state is dataflow-upstream of the
+          messenger's producing AccessNode in the first state.
+
+        Args:
+            first_state: The first state of the fusion.
+            second_state: The second state of the fusion.
+            data: The global data that is read in the first state and written to
+                in the second state.
+            messengers: The data that is produced by a component of the first state
+                and consumed by the consumer component of the second state.
+
+        Returns:
+            `True` if the fusion would create a WAR hazard on `data`.
+        """
+
+        def _has_path(state: dace.SDFGState, src, dst) -> bool:
+            if src is dst:
+                return True
+            visited = {src}
+            to_visit = [src]
+            while to_visit:
+                for edge in state.out_edges(to_visit.pop()):
+                    if edge.dst is dst:
+                        return True
+                    if edge.dst not in visited:
+                        visited.add(edge.dst)
+                        to_visit.append(edge.dst)
+            return False
+
+        # The sites where `data` is read in the first state are identified by the
+        #  destination nodes of the read edges, i.e. the MapEntries and Tasklets
+        #  that perform the read.
+        read_sites = {
+            edge.dst
+            for read_node in first_state.data_nodes()
+            if read_node.data == data and first_state.out_degree(read_node) != 0
+            for edge in first_state.out_edges(read_node)
+        }
+        write_nodes = [
+            node
+            for node in second_state.data_nodes()
+            if node.data == data and second_state.in_degree(node) != 0
+        ]
+        for write_node in write_nodes:
+            for messenger in messengers:
+                # The AccessNodes that produce the messenger in the first state.
+                messenger_producers = [
+                    node
+                    for node in first_state.data_nodes()
+                    if node.data == messenger and first_state.in_degree(node) != 0
+                ]
+                # The AccessNodes through which the messenger enters the consumer
+                #  component of the second state.
+                messenger_consumers = [
+                    node
+                    for node in second_state.data_nodes()
+                    if node.data == messenger and second_state.out_degree(node) != 0
+                ]
+                if not any(
+                    _has_path(second_state, consumer, write_node)
+                    for consumer in messenger_consumers
+                ):
+                    continue
+                if all(
+                    any(
+                        _has_path(first_state, read_site, producer)
+                        for producer in messenger_producers
+                    )
+                    for read_site in read_sites
+                ):
+                    # The write is ordered after all reads through `messenger`.
+                    break
+            else:
+                return True
         return False
 
     def _move_nodes(self, sdfg: dace.SDFG) -> None:

--- a/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/state_fusion.py
@@ -382,7 +382,9 @@ class GT4PyStateFusion(dace_transformation.MultiStateTransformation):
             `True` if the fusion would create a WAR hazard on `data`.
         """
 
-        def _has_path(state: dace.SDFGState, src, dst) -> bool:
+        def _has_path(
+            state: dace.SDFGState, src: dace_nodes.AccessNode, dst: dace_nodes.AccessNode
+        ) -> bool:
             if src is dst:
                 return True
             visited = {src}

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_state_fusion.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_state_fusion.py
@@ -780,3 +780,106 @@ def test_hidden_double_producer():
     sdfg.validate()
 
     assert nb_applied == 0
+
+
+def _make_global_read_up_and_downstream_of_messenger() -> tuple[
+    dace.SDFG, dace.SDFGState, dace.SDFGState
+]:
+    """The second state writes a global that the first state also reads downstream of the messenger.
+
+    The first state reads the global `g` twice; once to produce the transient
+    messenger `t` (`t = g + 1`) and once together with the messenger
+    (`u = t / g`). Note that both computations share the same AccessNodes and
+    therefore form a single concurrent subgraph. The second state then performs
+    the write back `g = t`.
+
+    This models in-place update field operators of the form
+
+    ```python
+    z_g = g
+    g_new = g + incr
+    o = g_new / z_g
+    ```
+
+    where the second state performs the write back of `g_new` into `g`.
+    """
+    sdfg = dace.SDFG(util.unique_name("global_read_up_and_downstream_of_messenger"))
+    state1 = sdfg.add_state(is_start_block=True)
+    state2 = sdfg.add_state_after(state1)
+
+    for name in ["g", "t", "u"]:
+        sdfg.add_array(
+            name,
+            shape=(10,),
+            dtype=dace.float64,
+            transient=name in {"t", "u"},
+        )
+
+    # The AccessNodes are shared between the two computations, such that the
+    #  dataflow of the first state forms a single concurrent subgraph.
+    g = state1.add_access("g")
+    t = state1.add_access("t")
+
+    # Upstream computation: `t = g + 1`, `t` is the messenger.
+    state1.add_mapped_tasklet(
+        "comp1",
+        map_ranges={"__i": "0:10"},
+        inputs={"__in": dace.Memlet("g[__i]")},
+        code="__out = __in + 1.",
+        outputs={"__out": dace.Memlet("t[__i]")},
+        input_nodes={g},
+        output_nodes={t},
+        external_edges=True,
+    )
+    # Downstream computation: `u = t / g`, i.e. `g` is read a second time,
+    #  downstream of the messenger `t`.
+    state1.add_mapped_tasklet(
+        "comp2",
+        map_ranges={"__i": "0:10"},
+        inputs={
+            "__in1": dace.Memlet("t[__i]"),
+            "__in2": dace.Memlet("g[__i]"),
+        },
+        code="__out = __in1 / __in2",
+        outputs={"__out": dace.Memlet("u[__i]")},
+        input_nodes={t, g},
+        external_edges=True,
+    )
+
+    # Second state: write back `g = t`.
+    state2.add_nedge(
+        state2.add_access("t"),
+        state2.add_access("g"),
+        dace.Memlet("t[0:10] -> [0:10]"),
+    )
+
+    return sdfg, state1, state2
+
+
+def test_global_read_up_and_downstream_of_messenger():
+    """Fusing the states would create a WAR hazard on `g`, so it must not happen.
+
+    In the merged state the write `g = t` is dataflow-ordered after the
+    computation of the messenger `t`, and thus after the *first* read of `g`.
+    However, it is not ordered with respect to the *second* read of `g`: the
+    computation `u = t / g` depends on the messenger as well and is therefore
+    concurrent with the write back.
+    """
+    sdfg, state1, state2 = _make_global_read_up_and_downstream_of_messenger()
+    assert sdfg.number_of_nodes() == 2
+    # Both computations of the first state form a single concurrent subgraph.
+    assert len(dace.sdfg.utils.concurrent_subgraphs(state1)) == 1
+    assert util.count_nodes(state1, dace_nodes.AccessNode) == 3
+
+    nb_applied = sdfg.apply_transformations_repeated(gtx_transformations.GT4PyStateFusion)
+    sdfg.validate()
+
+    assert nb_applied == 0
+    assert sdfg.number_of_nodes() == 2
+
+    # Ensure that the unfused SDFG computes the intended result, i.e. the write
+    #  back `g = t` happened only after all reads of `g` in the first state.
+    g_orig = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    g = g_orig.copy()
+    sdfg(g=g)
+    assert np.allclose(g, g_orig + 1.0)


### PR DESCRIPTION
## Description

`GT4PyStateFusion` merged two states whenever the consumer component of the second state exchanged a messenger with the producer component of the first state, assuming the transient dataflow imposes all necessary orderings. However, the messenger only orders the producer's *writes* before the consumer's accesses; it does not order the producer's *reads* of global data before the consumer's *writes* to the same data.

If the first state reads a global field both upstream and downstream of the messenger it produces, the merged state contains an unordered write-after-read pair on that global, and the computation result becomes undefined.

This pattern is generated by in-place update stencils, e.g. `update_theta_and_exner` in icon4py:

```python
z_theta = theta_v
theta_v = theta_v + (area * z_temp)
exner = exner * (1.0 + rd_o_cvd * (theta_v / z_theta - 1.0))
```

which the lowering turns into a compute state followed by a write-back state. The compute state reads `theta_v` twice — upstream to produce the new value (the messenger) and downstream, together with the messenger, in the `exner` update. When `GT4PyStateFusion` merged the write-back state into the compute state, the write `theta_v = theta_v_new` was dataflow-ordered after the *first* read of `theta_v` via the messenger, but **not** after the *second* read, since the reader of the messenger and the write-back are siblings downstream of it.

## Fix

Add a node-level check to `GT4PyStateFusion`: when the consumer component writes global data that the producer component reads, the fusion is rejected unless every read of the conflicting global in the first state is guaranteed to be dataflow-ordered before the consumer's write through an exchanged messenger — i.e. there is a messenger that (a) is dataflow-upstream of the write in the second state and (b) every read of the global in the first state is dataflow-upstream of that messenger's producing AccessNode.

This keeps allowing the safe patterns covered by the existing tests (`test_global_in_both_read_and_write`, `test_global_merge_2`, `test_non_concurrent_data_dependency`, `test_double_producer`), where the write is chained through the messenger.

## Tests

- New regression test `test_global_read_up_and_downstream_of_messenger`: without the fix the fusion is applied and executes with wrong results (verified numerically: `u = (g+1)/(g+1) ≡ 1` instead of `(g+1)/g`); with the fix the fusion is rejected.
- All 436 tests in `tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/` pass.
- Validated downstream against the icon4py stencil test suite (dycore + diffusion, `dace_cpu` backend, 177 tests), which was the original motivation.