### PR TITLE
fix[next]: `concat_where(Dim != value, ...)` gives wrong results

### DIFF
--- a/src/gt4py/next/iterator/transforms/infer_domain_ops.py
+++ b/src/gt4py/next/iterator/transforms/infer_domain_ops.py
@@ -89,9 +89,9 @@ class InferDomainOps(PreserveLocationVisitor, NodeTranslator):
 
                 return domain.as_expr()
             elif cpm.is_call_to(node, "not_eq"):
-                # `IDim != a` -> `IDim < a & IDim > a`
+                # `IDim != a` -> `IDim < a | IDim > a`
                 return self.visit(
-                    im.call("and_")(
+                    im.call("or_")(
                         self.visit(
                             im.less(im.axis_literal(dim), value), **(kwargs | {"recurse": False})
                         ),

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_concat_where.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_concat_where.py
@@ -31,13 +31,12 @@ def test_concat_where_simple(cartesian_case, static_domains: bool):
     def testee(ground: cases.IJKField, air: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim > 0, air, ground)
 
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-    ground = cases.allocate(cartesian_case, testee, "ground")()
-    air = cases.allocate(cartesian_case, testee, "air")()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref = np.where(k[np.newaxis, np.newaxis, :] == 0, ground.asnumpy(), air.asnumpy())
-    cases.verify(cartesian_case, testee, ground, air, out=out, ref=ref)
+    cases.verify_with_default_data(
+        cartesian_case,
+        testee,
+        lambda ground, air: np.where(k[np.newaxis, np.newaxis, :] == 0, ground, air),
+    )
 
 
 def test_concat_where(cartesian_case, static_domains: bool):
@@ -45,13 +44,12 @@ def test_concat_where(cartesian_case, static_domains: bool):
     def testee(ground: cases.IJKField, air: cases.IJKField) -> cases.IJKField:
         return concat_where(KDim == 0, ground, air)
 
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-    ground = cases.allocate(cartesian_case, testee, "ground")()
-    air = cases.allocate(cartesian_case, testee, "air")()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref = np.where(k[np.newaxis, np.newaxis, :] == 0, ground.asnumpy(), air.asnumpy())
-    cases.verify(cartesian_case, testee, ground, air, out=out, ref=ref)
+    cases.verify_with_default_data(
+        cartesian_case,
+        testee,
+        lambda ground, air: np.where(k[np.newaxis, np.newaxis, :] == 0, ground, air),
+    )
 
 
 def test_concat_where_non_overlapping(cartesian_case, static_domains: bool):
@@ -187,18 +185,14 @@ def test_boundary_single_layer_2d_bc(cartesian_case, static_domains: bool):
     def testee(interior: cases.IJKField, boundary: cases.IJField) -> cases.IJKField:
         return concat_where(KDim == 0, boundary, interior)
 
-    interior = cases.allocate(cartesian_case, testee, "interior")()
-    boundary = cases.allocate(cartesian_case, testee, "boundary")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref = np.where(
-        k[np.newaxis, np.newaxis, :] == 0,
-        boundary.asnumpy()[:, :, np.newaxis],
-        interior.asnumpy(),
+    cases.verify_with_default_data(
+        cartesian_case,
+        testee,
+        lambda interior, boundary: np.where(
+            k[np.newaxis, np.newaxis, :] == 0, boundary[:, :, np.newaxis], interior
+        ),
     )
-
-    cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
 def test_boundary_single_layer_2d_bc_on_empty_branch(cartesian_case, static_domains: bool):
@@ -221,17 +215,16 @@ def test_dimension_two_nested_conditions(cartesian_case, static_domains: bool):
     def testee(interior: cases.IJKField, boundary: cases.IJKField) -> cases.IJKField:
         return concat_where((KDim < 2), boundary, concat_where((KDim >= 5), boundary, interior))
 
-    interior = cases.allocate(cartesian_case, testee, "interior")()
-    boundary = cases.allocate(cartesian_case, testee, "boundary")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref = np.where(
-        (k[np.newaxis, np.newaxis, :] < 2) | (k[np.newaxis, np.newaxis, :] >= 5),
-        boundary.asnumpy(),
-        interior.asnumpy(),
+    cases.verify_with_default_data(
+        cartesian_case,
+        testee,
+        lambda interior, boundary: np.where(
+            (k[np.newaxis, np.newaxis, :] < 2) | (k[np.newaxis, np.newaxis, :] >= 5),
+            boundary,
+            interior,
+        ),
     )
-    cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
 
 
 def test_dimension_two_conditions_and(cartesian_case, static_domains: bool):
@@ -254,13 +247,10 @@ def test_dimension_eq_in_middle_of_domain(cartesian_case, static_domains: bool):
     def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
         return concat_where((KDim == 2), interior, boundary)
 
-    interior = cases.allocate(cartesian_case, testee, "interior")()
-    boundary = cases.allocate(cartesian_case, testee, "boundary")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref = np.where(k == 2, interior.asnumpy(), boundary.asnumpy())
-    cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(k == 2, interior, boundary)
+    )
 
 
 @pytest.mark.embedded_concat_where_non_contiguous_domain
@@ -337,13 +327,12 @@ def test_dimension_two_conditions_or(cartesian_case, static_domains: bool):
     def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
         return concat_where(((KDim < 2) | (KDim >= 5)), boundary, interior)
 
-    interior = cases.allocate(cartesian_case, testee, "interior")()
-    boundary = cases.allocate(cartesian_case, testee, "boundary")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref = np.where((k < 2) | (k >= 5), boundary.asnumpy(), interior.asnumpy())
-    cases.verify(cartesian_case, testee, interior, boundary, out=out, ref=ref)
+    cases.verify_with_default_data(
+        cartesian_case,
+        testee,
+        lambda interior, boundary: np.where((k < 2) | (k >= 5), boundary, interior),
+    )
 
 
 def test_lap_like(cartesian_case, static_domains: bool):
@@ -390,34 +379,15 @@ def test_with_tuples(cartesian_case, static_domains: bool):
     ) -> tuple[cases.IJKField, cases.IJKField]:
         return concat_where(KDim == 0, (boundary0, boundary1), (interior0, interior1))
 
-    interior0 = cases.allocate(cartesian_case, testee, "interior0")()
-    boundary0 = cases.allocate(cartesian_case, testee, "boundary0")()
-    interior1 = cases.allocate(cartesian_case, testee, "interior1")()
-    boundary1 = cases.allocate(cartesian_case, testee, "boundary1")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref0 = np.where(
-        k[np.newaxis, np.newaxis, :] == 0,
-        boundary0.asnumpy()[:, :, np.newaxis],
-        interior0.asnumpy(),
-    )
-    ref1 = np.where(
-        k[np.newaxis, np.newaxis, :] == 0,
-        boundary1.asnumpy()[:, :, np.newaxis],
-        interior1.asnumpy(),
-    )
 
-    cases.verify(
-        cartesian_case,
-        testee,
-        interior0,
-        boundary0,
-        interior1,
-        boundary1,
-        out=out,
-        ref=(ref0, ref1),
-    )
+    def ref(interior0, boundary0, interior1, boundary1):
+        return (
+            np.where(k[np.newaxis, np.newaxis, :] == 0, boundary0[:, :, np.newaxis], interior0),
+            np.where(k[np.newaxis, np.newaxis, :] == 0, boundary1[:, :, np.newaxis], interior1),
+        )
+
+    cases.verify_with_default_data(cartesian_case, testee, ref)
 
 
 def test_nested_conditions_with_empty_branches(cartesian_case, static_domains: bool):
@@ -455,34 +425,15 @@ def test_with_tuples_different_domain(cartesian_case, static_domains: bool):
         # the broadcast is only needed since we can not return fields on different domains yet
         return a, broadcast(b, (IDim, JDim, KDim))
 
-    interior0 = cases.allocate(cartesian_case, testee, "interior0")()
-    boundary0 = cases.allocate(cartesian_case, testee, "boundary0")()
-    interior1 = cases.allocate(cartesian_case, testee, "interior1")()
-    boundary1 = cases.allocate(cartesian_case, testee, "boundary1")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
     k = np.arange(0, cartesian_case.default_sizes[KDim])
-    ref0 = np.where(
-        k[np.newaxis, np.newaxis, :] == 0,
-        boundary0.asnumpy(),
-        interior0.asnumpy(),
-    )
-    ref1 = np.where(
-        k == 0,
-        boundary1.asnumpy(),
-        interior1.asnumpy(),
-    )
 
-    cases.verify(
-        cartesian_case,
-        testee,
-        interior0,
-        boundary0,
-        interior1,
-        boundary1,
-        out=out,
-        ref=(ref0, ref1),
-    )
+    def ref(interior0, boundary0, interior1, boundary1):
+        return (
+            np.where(k[np.newaxis, np.newaxis, :] == 0, boundary0, interior0),
+            np.where(k == 0, boundary1, interior1),
+        )
+
+    cases.verify_with_default_data(cartesian_case, testee, ref)
 
 
 def test_concat_where_field_broadcast_on_empty_branch(cartesian_case, static_domains: bool):
@@ -500,9 +451,8 @@ def test_concat_where_field_broadcast_on_empty_branch(cartesian_case, static_dom
     def testee(a: cases.IJKField, b: cases.KField) -> cases.IJKField:
         return concat_where(KDim < 0, a, b)
 
-    a = cases.allocate(cartesian_case, testee, "a")()
-    b = cases.allocate(cartesian_case, testee, "b")()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
-
-    ref = np.broadcast_to(b.asnumpy()[np.newaxis, np.newaxis, :], out.domain.shape)
-    cases.verify(cartesian_case, testee, a, b, out=out, ref=ref)
+    cases.verify_with_default_data(
+        cartesian_case,
+        testee,
+        lambda a, b: np.broadcast_to(b[np.newaxis, np.newaxis, :], a.shape),
+    )

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_concat_where.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_concat_where.py
@@ -264,6 +264,74 @@ def test_dimension_eq_in_middle_of_domain(cartesian_case, static_domains: bool):
 
 
 @pytest.mark.embedded_concat_where_non_contiguous_domain
+def test_dimension_not_eq_in_middle_of_domain(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
+    def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
+        return concat_where((KDim != 2), boundary, interior)
+
+    k = np.arange(0, cartesian_case.default_sizes[KDim])
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(k != 2, boundary, interior)
+    )
+
+
+def test_dimension_less_equal(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
+    def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
+        return concat_where((KDim <= 2), boundary, interior)
+
+    k = np.arange(0, cartesian_case.default_sizes[KDim])
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(k <= 2, boundary, interior)
+    )
+
+
+def test_dimension_reverse_greater(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
+    def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
+        return concat_where((2 > KDim), boundary, interior)
+
+    k = np.arange(0, cartesian_case.default_sizes[KDim])
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(2 > k, boundary, interior)
+    )
+
+
+def test_dimension_reverse_greater_equal(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
+    def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
+        return concat_where((2 >= KDim), boundary, interior)
+
+    k = np.arange(0, cartesian_case.default_sizes[KDim])
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(2 >= k, boundary, interior)
+    )
+
+
+def test_dimension_reverse_eq(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
+    def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
+        return concat_where((2 == KDim), interior, boundary)
+
+    k = np.arange(0, cartesian_case.default_sizes[KDim])
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(2 == k, interior, boundary)
+    )
+
+
+@pytest.mark.embedded_concat_where_non_contiguous_domain
+def test_dimension_reverse_not_eq(cartesian_case, static_domains: bool):
+    @gtx.field_operator(static_domains=static_domains)
+    def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:
+        return concat_where((2 != KDim), boundary, interior)
+
+    k = np.arange(0, cartesian_case.default_sizes[KDim])
+    cases.verify_with_default_data(
+        cartesian_case, testee, lambda interior, boundary: np.where(2 != k, boundary, interior)
+    )
+
+
+@pytest.mark.embedded_concat_where_non_contiguous_domain
 def test_dimension_two_conditions_or(cartesian_case, static_domains: bool):
     @gtx.field_operator(static_domains=static_domains)
     def testee(interior: cases.KField, boundary: cases.KField) -> cases.KField:

--- a/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_infer_domain_ops.py
+++ b/tests/next_tests/unit_tests/iterator_tests/transforms_tests/test_infer_domain_ops.py
@@ -51,10 +51,18 @@ def _testcases():
             im.greater_equal(1, im.axis_literal(IDim)),
             im.domain(common.GridType.CARTESIAN, {IDim: (itir.InfinityLiteral.NEGATIVE, 2)}),
         ),
+        (im.eq(im.axis_literal(IDim), 1), im.domain(common.GridType.CARTESIAN, {IDim: (1, 2)})),
         (im.eq(1, im.axis_literal(IDim)), im.domain(common.GridType.CARTESIAN, {IDim: (1, 2)})),
         (
+            im.not_eq(im.axis_literal(IDim), 1),
+            im.or_(
+                im.domain(common.GridType.CARTESIAN, {IDim: (itir.InfinityLiteral.NEGATIVE, 1)}),
+                im.domain(common.GridType.CARTESIAN, {IDim: (2, itir.InfinityLiteral.POSITIVE)}),
+            ),
+        ),
+        (
             im.not_eq(1, im.axis_literal(IDim)),
-            im.and_(
+            im.or_(
                 im.domain(common.GridType.CARTESIAN, {IDim: (itir.InfinityLiteral.NEGATIVE, 1)}),
                 im.domain(common.GridType.CARTESIAN, {IDim: (2, itir.InfinityLiteral.POSITIVE)}),
             ),


### PR DESCRIPTION
Noticed while reviewing #2795, see https://github.com/GridTools/gt4py/pull/2795\#issuecomment-5395705263. Independent of that PR — the bug predates it and reproduces identically on `main`.

## Problem

`InferDomainOps` rewrote `IDim != a` into `IDim < a & IDim > a`. The two half-open ranges are disjoint, so the intersection is empty and the true branch of a `concat_where` with such a condition can never be selected: `concat_where(IDim != a, x, y)` silently evaluates to `y` everywhere.

With `a = ones`, `b = zeros` on `I: [0, 6)`:

```
concat_where(I != 2, a, b)      -> [0. 0. 0. 0. 0. 0.]
concat_where((I<2)|(I>2), a, b) -> [1. 1. 0. 1. 1. 1.]   # expected
concat_where(I == 2, b, a)      -> [1. 1. 0. 1. 1. 1.]   # expected
```

Only the compiled path is affected; in embedded execution `Dimension.__ne__` with an integer raises `NotImplementedError` (ADR 22).

## Fix

Lower to `IDim < a | IDim > a`. `canonicalize_domain_argument` already expands the union into a nested `concat_where` — it is the same form it produces for the equivalent `IDim == a` condition with swapped branches, so no new machinery is involved.

## Why this was not caught

- `test_infer_domain_ops.py` asserted the `and_` shape: the expected value was transcribed from the implementation rather than derived from the semantics, so the test pinned the bug instead of catching it.
- No integration test used `!=` at all. The construct reads as unsupported per ADR 22, but that is only enforced in embedded execution, where the field operator body runs as Python — a traced field operator never calls `Dimension.__ne__`.

## Tests

For the bug itself: the unit test that pinned the `and_` shape now asserts the union, and an integration test for `concat_where(Dim != n, ...)` is added.

Independently of the bug, integration tests were added for the remaining comparison operator and operand-order combinations that had no coverage, and the existing `concat_where` tests were simplified.

**AI disclaimer**: This PR was written with the help of AI tools. I reviewed the fix in detail and the respective unit tests in detail. The test refactoring was a simple precise prompt, should be alright, but I only browsed through the changes.
