### PR TITLE
refactor[cartesian]: drop support for `field[...]` assignment syntax

### DIFF
--- a/docs/development/ADRs/cartesian/archived/frontend-field-assignment-ellipsis.md
+++ b/docs/development/ADRs/cartesian/archived/frontend-field-assignment-ellipsis.md
@@ -1,0 +1,23 @@
+# field[...] assignment syntax
+
+Gt4Py version 1.2.1 was the last release to allow the following syntax:
+
+```py
+with computation(PARALLEL), interval(...):
+    field[...] = 42   # support for [...] is dropped
+    field = 42.42     # <- use this instead
+```
+
+Support for `[...]` as "the full field" has been removed because it is redundant with just `field = 42`, which is less verbose and widely adopted.
+
+## Context
+
+Both `field[...] = 42` and `field = 42` were allowed and doing the same thing. Having redundant syntax is generally a bad idea (more parsing overhead, possibility of inconsistent user code, maintenance cost). In this case we felt the maintenance cost as the syntax is - as far as we could gather - unused, yet in periodic updates had to deal with this extra syntax.
+
+## Decision
+
+The decision to use `field = 42` over `field[...] = 42` was captured in [this issue](https://github.com/GridTools/gt4py/issues/2406) and basically weighs the maintenance overhead against the usefulness/redundancy of the syntax. Since nobody was using the syntax (anymore) and we had to do maintenance work to support the syntax, it was decided to remove support for the syntax. Since we don't expect any usage, no deprecation period was chosen.
+
+## Consequences
+
+[This PR](https://github.com/GridTools/gt4py/pull/2820) drops support for the syntax in favor of just assigning to the field without any subscript. This avoids maintenance cost. We drop a custom error for any residual usage.

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1378,7 +1378,10 @@ class IRMaker(ast.NodeVisitor):
         if any(isinstance(cn, ast.Slice) for cn in index_nodes):
             raise GTScriptSyntaxError(message="Invalid target in assignment.", loc=node)
         if any(_is_ellipsis_node(cn) for cn in index_nodes):
-            return None
+            raise GTScriptSyntaxError(
+                "Field access with ellipsis has been replaced with the plain field name."
+                " Hint: Change `field[...]` to just `field`."
+            )
 
         # Determine if we are using the new-style axis syntax, or the old style.
         # If this is parsing a data index, this should be fine and will return False.

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -2491,12 +2491,20 @@ class TestEllipsisNodeDetection:
         node = ast.parse(source, mode="eval").body
         assert gt_frontend._is_ellipsis_node(node) is expected
 
-    def test_ellipsis_index_parses(self):
+    def test_ellipsis_interval_parses(self):
+        def stencil(field_a: gtscript.Field[np.float64], field_b: gtscript.Field[np.float64]):
+            with computation(PARALLEL), interval(...):  # noqa: F821 [undefined-name]
+                field_b = field_a
+
+        parse_definition(stencil, name=inspect.stack()[0][3], module=self.__class__.__name__)
+
+    def test_ellipsis_index_does_not_parses(self):
         def stencil(field_a: gtscript.Field[np.float64], field_b: gtscript.Field[np.float64]):
             with computation(PARALLEL), interval(...):  # noqa: F821 [undefined-name]
                 field_b[...] = field_a
 
-        parse_definition(stencil, name=inspect.stack()[0][3], module=self.__class__.__name__)
+        with pytest.raises(GTScriptSyntaxError):
+            parse_definition(stencil, name=inspect.stack()[0][3], module=self.__class__.__name__)
 
 
 @gtscript.enum


### PR DESCRIPTION
## Description

The `field[...]` syntax for assignment is redundant with just `field`. Drop support for the former as the later is shorter and thus more concise.

Related issue: #2406

The syntax is a remnant of the past and came up recently again (PRs #2399 and #2755 had to deal with it). As the issue shows, the syntax was deemed to be dropped some time ago. We could do an official deprecation, but given 

- how old/unused the syntax is
- how simple it is to update and
- that we are generating a specific error message with clear instructions how to update,

let's just move forward.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [x] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
