### PR TITLE
refactor[cartesian]: avoid extra boolean if we already have a boolean

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -165,7 +165,10 @@ class OIRToTreeIR(eve.NodeVisitor):
             self.visit(groups, ctx=ctx)
 
     def visit_MaskStmt(self, node: oir.MaskStmt, ctx: tir.Context) -> None:
-        condition_name, _ = self._insert_evaluation_tasklet(node, ctx)
+        if isinstance(node.mask, oir.ScalarAccess) and node.mask.dtype == common.DataType.BOOL:
+            condition_name = str(node.mask.name)
+        else:
+            condition_name, _ = self._insert_evaluation_tasklet(node, ctx)
 
         if_else = tir.IfElse(
             if_condition_code=condition_name, children=[], parent=ctx.current_scope
@@ -218,10 +221,12 @@ class OIRToTreeIR(eve.NodeVisitor):
         return " and ".join(conditions)
 
     def visit_While(self, node: oir.While, ctx: tir.Context) -> None:
-        condition_name, assignment = self._insert_evaluation_tasklet(node, ctx)
-
-        # Re-evaluate the condition as last step of the while loop
-        node.body.append(assignment)
+        if isinstance(node.cond, oir.ScalarAccess) and node.cond.dtype == common.DataType.BOOL:
+            condition_name = str(node.cond.name)
+        else:
+            condition_name, assignment = self._insert_evaluation_tasklet(node, ctx)
+            # Re-evaluate the condition as last step of the while loop
+            node.body.append(assignment)
 
         # Use the mask created for conditional check
         while_ = tir.While(

--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -6,7 +6,7 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from typing import Any, List, TypeAlias
+from typing import Any, List, TypeAlias, TypeGuard
 
 from dace import data, dtypes, symbolic
 
@@ -165,8 +165,14 @@ class OIRToTreeIR(eve.NodeVisitor):
             self.visit(groups, ctx=ctx)
 
     def visit_MaskStmt(self, node: oir.MaskStmt, ctx: tir.Context) -> None:
-        if isinstance(node.mask, oir.ScalarAccess) and node.mask.dtype == common.DataType.BOOL:
+        if _is_boolean_scalar(node.mask):
             condition_name = str(node.mask.name)
+        elif (
+            isinstance(node.mask, oir.UnaryOp)
+            and node.mask.op == common.UnaryOperator.NOT
+            and _is_boolean_scalar(node.mask.expr)
+        ):
+            condition_name = f"not {node.mask.expr.name}"
         else:
             condition_name, _ = self._insert_evaluation_tasklet(node, ctx)
 
@@ -221,8 +227,14 @@ class OIRToTreeIR(eve.NodeVisitor):
         return " and ".join(conditions)
 
     def visit_While(self, node: oir.While, ctx: tir.Context) -> None:
-        if isinstance(node.cond, oir.ScalarAccess) and node.cond.dtype == common.DataType.BOOL:
+        if _is_boolean_scalar(node.cond):
             condition_name = str(node.cond.name)
+        elif (
+            isinstance(node.cond, oir.UnaryOp)
+            and node.cond.op == common.UnaryOperator.NOT
+            and _is_boolean_scalar(node.cond.expr)
+        ):
+            condition_name = f"not {node.cond.expr.name}"
         else:
             condition_name, assignment = self._insert_evaluation_tasklet(node, ctx)
             # Re-evaluate the condition as last step of the while loop
@@ -579,3 +591,7 @@ def get_dace_strides(field: oir.FieldDecl, symbols: tir.SymbolDict) -> list[symb
         symbols[stride] = dtypes.int32
         strides.append(symbol)
     return strides
+
+
+def _is_boolean_scalar(expression: oir.Expr) -> TypeGuard[oir.ScalarAccess]:
+    return isinstance(expression, oir.ScalarAccess) and expression.dtype.isbool()

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1890,3 +1890,20 @@ def test_enum_runtime(backend):
     assert out_arr[0, 0, 0] == MyEnum.A.value
     assert out_arr[0, 0, 1] == MyEnum.B.value
     assert (out_arr[0, 0, 2:] == MyEnum.C.value).all()
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_enum_runtime(backend):
+
+    @gtscript.stencil(backend=backend)
+    def the_stencil(out_field: Field[int], done: bool):  # type: ignore
+        with computation(PARALLEL), interval(...):
+            if not done:
+                out_field = 1
+
+    domain = (5, 5, 5)
+    out_arr = gt_storage.zeros(backend=backend, shape=domain, dtype=int)
+
+    the_stencil(out_arr, done=False)
+
+    assert (out_arr[:] == 1).all()


### PR DESCRIPTION
## Description

This is little cleanup in the dace backends regarding conditionals, i.e. what is know in in the `oir` as `MaskStmt`.

Mask statements "outsource" the evaluation of conditionals to a separate tasklets to avoid DaCe issues down the line. However, most of the time, the mask is already a boolean scalar (`gtir` -> `oir`  makes such that field accesses are split out into a separate assignment ([read here](https://github.com/GridTools/gt4py/blob/ee1bb4f6a34e24e5ea0558e16463dfd195f9d224/src/gt4py/cartesian/gtc/gtir_to_oir.py#L153-L167) if you are interested)).

With this PR, we skip the step to make yet another temp boolean in `oir_to_treeir` if we detect a plain boolean scalar access (`if my_boolean`) or a negated boolean scalar (`if not my_boolean`). In the upstream case of `DelnFlux`, this changes the beginning of the generated SDFG as follows (left before, right after)

<img width="2730" height="1334" alt="image" src="https://github.com/user-attachments/assets/b3e21517-4b2e-48c9-a38c-77aa8c2ef7ef" />
left: with this PR | right: before this PR

Notice how before we have more tasklets copying one boolean into another where on the left side (after) we only have one tasklet left (which originates from the above `gtir` -> `oir` translation step).

<!--
<img width="2697" height="1315" alt="image" src="https://github.com/user-attachments/assets/6127efa7-405b-45a4-8082-cdcaf21e3356" />

Notice how before (left) we have two tasklets copying one boolean into another where on the right side (after) we only have one tasklet left (which originates from the above `gtir` -> `oir` translation step).
-->

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Assumed to be covered by the existing test suite.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. N/A
