### PR TITLE
refactor[cartesian]: use standard K symbol in tree ir

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -41,9 +41,6 @@ class Context:
     tree: tir.TreeRoot
     """Schedule tree (root) in which this Tasklet will be inserted."""
 
-    scope: tir.TreeScope
-    """Schedule tree scope in which this Tasklet will be inserted."""
-
 
 class OIRToTasklet(eve.NodeVisitor):
     """
@@ -54,10 +51,10 @@ class OIRToTasklet(eve.NodeVisitor):
     """
 
     def visit_CodeBlock(
-        self, node: oir.CodeBlock, root: tir.TreeRoot, scope: tir.TreeScope
+        self, node: oir.CodeBlock, root: tir.TreeRoot
     ) -> tuple[nodes.Tasklet, dict[str, Memlet], dict[str, Memlet]]:
         """Entry point to gather all code, inputs and outputs."""
-        ctx = Context(code=[], targets=set(), inputs={}, outputs={}, tree=root, scope=scope)
+        ctx = Context(code=[], targets=set(), inputs={}, outputs={}, tree=root)
 
         self.visit(node.body, ctx=ctx)
 

--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -134,7 +134,7 @@ class OIRToTasklet(eve.NodeVisitor):
                 name_parts.append(f"[{abs_index}]")
         elif isinstance(node.offset, oir.VariableKOffset):
             # Variable K offset subscript
-            symbol = tir.k_symbol(ctx.scope)
+            symbol = tir.Axis.K.iteration_symbol()
             shift = ctx.tree.shift[node.name][tir.Axis.K]
             offset = self.visit(node.offset.k, ctx=ctx, is_target=False)
             var_index = f"{symbol} + {shift} + {offset}"
@@ -285,9 +285,6 @@ class OIRToTasklet(eve.NodeVisitor):
         return f"{function_name}({arguments})"
 
     def visit_IteratorAccess(self, node: oir.IteratorAccess, ctx: Context, **kwargs: Any) -> str:
-        if node.name == tir.Axis.K:
-            return tir.k_symbol(ctx.scope)
-
         return tir.Axis(node.name).iteration_symbol()
 
     # Not (yet) supported section
@@ -406,12 +403,7 @@ def _memlet_subset_cartesian(
     # Handle cartesian indices
     for index, axis in enumerate(tir.Axis.dims_3d()):
         if dimensions[index]:
-            iteration_symbol = (
-                utils.get_dace_symbol(tir.k_symbol(ctx.scope))
-                if axis == tir.Axis.K
-                else axis.iteration_dace_symbol()
-            )
-            i = f"({iteration_symbol}) + ({shift[axis]}) + ({offset_dict[axis.lower()]})"
+            i = f"({axis.iteration_dace_symbol()}) + ({shift[axis]}) + ({offset_dict[axis.lower()]})"
             ranges.append((i, i, 1))
 
     # Append data dimensions

--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -73,7 +73,7 @@ class OIRToTreeIR(eve.NodeVisitor):
 
     def visit_CodeBlock(self, node: oir.CodeBlock, ctx: tir.Context) -> None:
         dace_tasklet, inputs, outputs = oir_to_tasklet.OIRToTasklet().visit_CodeBlock(
-            node, root=ctx.root, scope=ctx.current_scope
+            node, root=ctx.root
         )
 
         tasklet = tir.Tasklet(

--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -422,12 +422,9 @@ class OIRToTreeIR(eve.NodeVisitor):
         for index, axis in enumerate(tir.Axis.dims_3d()):
             if ctx.root.dimensions[field.name][index]:
                 shift_str = f" + {shift[axis]}" if shift[axis] != 0 else ""
-                iteration_symbol = (
-                    tir.k_symbol(ctx.current_scope)
-                    if axis == tir.Axis.K
-                    else axis.iteration_symbol()
+                indices.append(
+                    f"{axis.iteration_symbol()}{shift_str} + {offset_dict[axis.lower()]}"
                 )
-                indices.append(f"{iteration_symbol}{shift_str} + {offset_dict[axis.lower()]}")
 
         return ", ".join(indices)
 
@@ -442,7 +439,7 @@ class OIRToTreeIR(eve.NodeVisitor):
         return (
             f"{tir.Axis.I.iteration_symbol()}{i_shift}, "
             f"{tir.Axis.J.iteration_symbol()}{j_shift}, "
-            f"{tir.k_symbol(ctx.current_scope)}{k_shift} + {self.visit(node.k, ctx=ctx, **kwargs)}"
+            f"{tir.Axis.K.iteration_symbol()}{k_shift} + {self.visit(node.k, ctx=ctx, **kwargs)}"
         )
 
     def visit_AbsoluteKIndex(
@@ -512,9 +509,6 @@ class OIRToTreeIR(eve.NodeVisitor):
     def visit_IteratorAccess(
         self, node: oir.IteratorAccess, ctx: tir.Context, **kwargs: Any
     ) -> str:
-        if node.name == tir.Axis.K:
-            return tir.k_symbol(ctx.current_scope)
-
         return tir.Axis(node.name).iteration_symbol()
 
     # visitors that should _not_ be called

--- a/src/gt4py/cartesian/gtc/dace/treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir.py
@@ -152,13 +152,3 @@ class TreeRoot(TreeScope):
 
     symbols: SymbolDict
     """Mapping between type and symbol name."""
-
-
-def k_symbol(scope: TreeScope) -> eve.SymbolRef:
-    if scope.parent is None:
-        raise ValueError("No vertical loop found in (parents of) current scope.")
-
-    if isinstance(scope, (SequentialVerticalLoop, ParallelVerticalLoop)):
-        return scope.iteration_variable
-
-    return k_symbol(scope.parent)

--- a/tests/cartesian_tests/unit_tests/test_gtc/dace/test_oir_to_tasklet.py
+++ b/tests/cartesian_tests/unit_tests/test_gtc/dace/test_oir_to_tasklet.py
@@ -105,7 +105,7 @@ def test_integer_power_function(exponent: oir.Expr, expected_ipow_usage: bool) -
 
     visitor = oir_to_tasklet.OIRToTasklet()
     fake_context = oir_to_tasklet.Context(
-        code="asdf", targets=set(), inputs={}, outputs={}, tree=None, scope=None
+        code="asdf", targets=set(), inputs={}, outputs={}, tree=None
     )
     tasklet_code = visitor.visit_NativeFuncCall(pow_call, ctx=fake_context, is_target=False)
 
@@ -120,7 +120,7 @@ def test_integer_power_zero() -> None:
 
     visitor = oir_to_tasklet.OIRToTasklet()
     fake_context = oir_to_tasklet.Context(
-        code="asdf", targets=set(), inputs={}, outputs={}, tree=None, scope=None
+        code="asdf", targets=set(), inputs={}, outputs={}, tree=None
     )
     tasklet_code = visitor.visit_NativeFuncCall(pow_call, ctx=fake_context, is_target=False)
 
@@ -134,7 +134,7 @@ def test_integer_power_of_integer() -> None:
 
     visitor = oir_to_tasklet.OIRToTasklet()
     fake_context = oir_to_tasklet.Context(
-        code="asdf", targets=set(), inputs={}, outputs={}, tree=None, scope=None
+        code="asdf", targets=set(), inputs={}, outputs={}, tree=None
     )
     tasklet_code = visitor.visit_NativeFuncCall(pow_call, ctx=fake_context, is_target=False)
 
@@ -153,7 +153,7 @@ def test_log10_respects_floating_point_precision(arg: oir.Literal) -> None:
 
     visitor = oir_to_tasklet.OIRToTasklet()
     fake_context = oir_to_tasklet.Context(
-        code="asdf", targets=set(), inputs={}, outputs={}, tree=None, scope=None
+        code="asdf", targets=set(), inputs={}, outputs={}, tree=None
     )
     tasklet_code = visitor.visit_NativeFuncCall(log10_call, ctx=fake_context, is_target=False)
 


### PR DESCRIPTION
## Description

PR https://github.com/GridTools/gt4py/pull/2752 normalized the K axis name from a unique name (per stencil) to just `__k` everywhere. To support the different K-axis names, `treeir` had a helper function `k_symbol()`. While all K-axis names got normalized, the helper function remained. This PR cleanes that up.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
  Covered by existing cartesian / dace tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder. N/A
