### PR TITLE
fix[next]: lower `as_offset` applied to a staggered access

### DIFF
--- a/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
+++ b/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
@@ -64,19 +64,26 @@ class InlineDynamicShifts(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
                     node, eligible_params=list(inline_let_params.values())
                 )
 
-        if dynamic_shift_args := _dynamic_shift_args(node):
-            assert len(node.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args
+        # Fusing one producer can expose another one behind it (e.g. a chain of shifts split
+        # across multiple `as_fieldop`s), so repeat until no dynamically shifted argument is left.
+        # This terminates: `fuse_as_fieldop` replaces every fused argument by the arguments of the
+        # producer it inlines, i.e. by strict subterms of that argument, so the combined size of
+        # the arguments strictly decreases in each iteration.
+        expr: itir.Expr = node
+        while dynamic_shift_args := _dynamic_shift_args(expr):
+            assert isinstance(expr, itir.FunCall) and len(expr.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args
             fuse_args = [
                 not isinstance(inp, itir.SymRef) and dynamic_shift_arg
-                for inp, dynamic_shift_arg in zip(node.args, dynamic_shift_args, strict=True)
+                for inp, dynamic_shift_arg in zip(expr.args, dynamic_shift_args, strict=True)
             ]
-            if any(fuse_args):
-                return fuse_as_fieldop.fuse_as_fieldop(
-                    node,
-                    fuse_args,
-                    uids=self.uids,
-                    offset_provider_type=self.offset_provider_type,
-                    enable_cse=True,
-                )
+            if not any(fuse_args):
+                break
+            expr = fuse_as_fieldop.fuse_as_fieldop(
+                expr,
+                fuse_args,
+                uids=self.uids,
+                offset_provider_type=self.offset_provider_type,
+                enable_cse=True,
+            )
 
-        return node
+        return expr

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -1525,7 +1525,7 @@ class LambdaToDataflow(eve.NodeVisitor):
                     name="dynamic_offset",
                     inputs={"index"},
                     outputs={new_index_connector},
-                    code=f"{new_index_connector} = index + {offset_expr}",
+                    code=f"{new_index_connector} = index + {offset_expr.value}",
                 )
             else:
                 dynamic_offset_tasklet, connector_mapping = self._add_tasklet(

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
@@ -9,17 +9,23 @@ import numpy as np
 import pytest
 
 import gt4py.next as gtx
+from gt4py.next.ffront.experimental import as_offset
 
 from next_tests.integration_tests import cases
 from next_tests.integration_tests.cases import (
+    E2V,
+    Edge,
     IDim,
     IHalfDim,
     JDim,
     KDim,
     KHalfDim,
+    Vertex,
     cartesian_case,
+    unstructured_case,
+    unstructured_case_3d,
 )
-from next_tests.integration_tests.cases_utils import exec_alloc_descriptor
+from next_tests.integration_tests.cases_utils import exec_alloc_descriptor, mesh_descriptor
 
 
 @pytest.mark.uses_cartesian_shift
@@ -140,3 +146,67 @@ def test_cartesian_half_shift_multi_dim(cartesian_case):
     )()
 
     cases.verify(cartesian_case, testee, a, out=out, ref=a, offset_provider={})
+
+
+@pytest.mark.uses_cartesian_shift
+@pytest.mark.uses_dynamic_offsets
+def test_cartesian_half_shift_as_offset(cartesian_case):
+    Koff = gtx.FieldOffset("Koff", source=KDim, target=(KDim,))
+
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[IDim, KHalfDim], np.int32], offset_field: cases.IKField
+    ) -> cases.IKField:
+        return a(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    isize = cartesian_case.default_sizes[IDim]
+    ksize = cartesian_case.default_sizes[KDim]
+    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: isize, KHalfDim: ksize + 1})()
+    offset_field = cases.allocate(
+        cartesian_case,
+        testee,
+        "offset_field",
+        sizes={IDim: isize, KDim: ksize},
+        strategy=cases.ConstInitializer(1),
+    )()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IDim: isize, KDim: ksize})()
+
+    cases.verify(
+        cartesian_case, testee, a, offset_field, out=out, ref=a.asnumpy()[:, 1:], offset_provider={}
+    )
+
+
+@pytest.mark.uses_unstructured_shift
+@pytest.mark.uses_dynamic_offsets
+def test_unstructured_shift_half_shift_as_offset(unstructured_case_3d):
+    Koff = gtx.FieldOffset("Koff", source=KDim, target=(KDim,))
+
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[Vertex, KHalfDim], np.int32],
+        offset_field: gtx.Field[[Edge, KDim], np.int32],
+    ) -> gtx.Field[[Edge, KDim], np.int32]:
+        return a(E2V[0])(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    nvertices = unstructured_case_3d.default_sizes[Vertex]
+    ksize = unstructured_case_3d.default_sizes[KDim]
+    a = cases.allocate(
+        unstructured_case_3d,
+        testee,
+        "a",
+        domain={Vertex: (0, nvertices), KHalfDim: (0, ksize + 1)},
+    )()
+    offset_field = cases.allocate(
+        unstructured_case_3d, testee, "offset_field", strategy=cases.ConstInitializer(1)
+    )()
+    out = cases.allocate(unstructured_case_3d, testee, cases.RETURN)()
+
+    e2v_table = unstructured_case_3d.offset_provider["E2V"].asnumpy()
+    cases.verify(
+        unstructured_case_3d,
+        testee,
+        a,
+        offset_field,
+        out=out,
+        ref=a.asnumpy()[e2v_table[:, 0], 1:],
+    )

--- a/tests/next_tests/unit_tests/iterator_tests/test_inline_dynamic_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_inline_dynamic_shifts.py
@@ -30,6 +30,25 @@ def test_inline_dynamic_shift_as_fieldop_arg(uids):
     assert actual == expected
 
 
+def test_inline_dynamic_shift_nested_as_fieldop_args(uids):
+    testee = im.as_fieldop(im.lambda_("a", "b")(im.deref(im.shift(IOff, im.deref("b"))("a"))))(
+        im.as_fieldop(im.lambda_("a")(im.deref(im.shift(IOff, 1)("a"))))(
+            im.as_fieldop("deref")("inp")
+        ),
+        "offset_field",
+    )
+    expected = im.as_fieldop(
+        im.lambda_("inp", "offset_field")(
+            im.deref(im.shift(IOff, 1)(im.shift(IOff, im.deref("offset_field"))("inp")))
+        )
+    )("inp", "offset_field")
+
+    actual = inline_dynamic_shifts.InlineDynamicShifts.apply(
+        testee, offset_provider_type={}, uids=uids
+    )
+    assert actual == expected
+
+
 def test_inline_dynamic_shift_let_var(uids):
     testee = im.let("tmp", im.as_fieldop("deref")("inp"))(
         im.as_fieldop(im.lambda_("a", "b")(im.deref(im.shift(IOff, im.deref("b"))("a"))))(


### PR DESCRIPTION
Applying `as_offset` to a staggered (half-integer) access — e.g. `theta_v_ic(E2C[0])(KDim - 0.5)(as_offset(Koff, ikoffset))`, reduced from icon4py's `compute_hydrostatic_correction_term` — hits two independent defects. The composition order is forced, since `as_offset` requires the offset field to carry the dimension being shifted, so the half-integer shift has to come first.

**`InlineDynamicShifts` did not fuse to a fixpoint.** The pass fused a single producer per `as_fieldop` node and returned. When an `as_fieldop` is nested more than one level deep behind a dynamic shift, the remaining producer is still hidden behind that shift after one fusion step, so `infer_domain` marks it `UNKNOWN` and emits it without a domain. This is not dace-specific — it affects every pipeline ending at `infer_domain` (`apply_fieldview_transforms`), and `roundtrip.gtir` fails the new test on `main` too; `apply_common_transforms` masked it via its later `fuse_as_fieldop` loop, which is why gtfn was unaffected. Now fuses until no dynamically shifted argument is left. This terminates because `fuse_as_fieldop` replaces every fused argument by the arguments of the producer it inlines, i.e. by strict subterms of that argument.

**The dace lowering leaked a `SymbolExpr` into tasklet code.** `_make_cartesian_shift` interpolated the whole dataclass instead of its `value` when a static cartesian shift landed on an already dynamically shifted iterator, emitting `shifted_index = index + SymbolExpr(value=0, dc_dtype=int)`. dace then picks up `int` as a free symbol and `sdfg.arglist()` fails with `KeyError: 'int'`. The branch is reachable without staggering, but a half-integer shift always lowers to a static cartesian shift, so staggering turns a corner case into the normal path.

Tests: a backend-free unit test for the fusion fixpoint, plus cartesian and unstructured `as_offset`-on-staggered-access tests, value-verified across the backend matrix. Each fails on `main`. GPU is unverified — no working GPU in my environment — but the changed code paths are not device-specific.

---

Extracted from https://github.com/havogt/gt4py/pull/77, which additionally turns the domain `assert` in `translate_as_fieldop` into an explicit error; that part is left out here.
