### PR TITLE
fix[next]: fuse dynamic shifts to a fixpoint in `InlineDynamicShifts`

### DIFF
--- a/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
+++ b/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
@@ -64,19 +64,26 @@ class InlineDynamicShifts(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
                     node, eligible_params=list(inline_let_params.values())
                 )
 
-        if dynamic_shift_args := _dynamic_shift_args(node):
-            assert len(node.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args
+        # Fusing one producer can expose another one behind it (e.g. a chain of shifts split
+        # across multiple `as_fieldop`s), so repeat until no dynamically shifted argument is left.
+        # This terminates: `fuse_as_fieldop` replaces every fused argument by the arguments of the
+        # producer it inlines, i.e. by strict subterms of that argument, so the combined size of
+        # the arguments strictly decreases in each iteration.
+        expr: itir.Expr = node
+        while dynamic_shift_args := _dynamic_shift_args(expr):
+            assert isinstance(expr, itir.FunCall) and len(expr.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args
             fuse_args = [
                 not isinstance(inp, itir.SymRef) and dynamic_shift_arg
-                for inp, dynamic_shift_arg in zip(node.args, dynamic_shift_args, strict=True)
+                for inp, dynamic_shift_arg in zip(expr.args, dynamic_shift_args, strict=True)
             ]
-            if any(fuse_args):
-                return fuse_as_fieldop.fuse_as_fieldop(
-                    node,
-                    fuse_args,
-                    uids=self.uids,
-                    offset_provider_type=self.offset_provider_type,
-                    enable_cse=True,
-                )
+            if not any(fuse_args):
+                break
+            expr = fuse_as_fieldop.fuse_as_fieldop(
+                expr,
+                fuse_args,
+                uids=self.uids,
+                offset_provider_type=self.offset_provider_type,
+                enable_cse=True,
+            )
 
-        return node
+        return expr

--- a/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
+++ b/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
@@ -65,10 +65,11 @@ class InlineDynamicShifts(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
                 )
 
         # Fusing one producer can expose another one behind it (e.g. a chain of shifts split
-        # across multiple `as_fieldop`s), so repeat until no dynamically shifted argument is left.
-        # This terminates: `fuse_as_fieldop` replaces every fused argument by the arguments of the
-        # producer it inlines, i.e. by strict subterms of that argument, so the combined size of
-        # the arguments strictly decreases in each iteration.
+        # across multiple `as_fieldop`s), so repeat until no dynamically shifted argument that is
+        # not a `SymRef` is left. A let-bound producer shared between two dynamically shifted
+        # consumers is therefore left behind, see #2839.
+        # This terminates: each iteration either replaces an `as_fieldop` or `if_` argument by
+        # strict subterms of itself, or drops a tuple-of-literals argument entirely.
         expr: itir.Expr = node
         while dynamic_shift_args := _dynamic_shift_args(expr):
             assert isinstance(expr, itir.FunCall) and len(expr.fun.args) in [1, 2]  # type: ignore[attr-defined]  # ensured by is_applied_as_fieldop in _dynamic_shift_args

--- a/tests/next_tests/integration_tests/cases_utils.py
+++ b/tests/next_tests/integration_tests/cases_utils.py
@@ -160,6 +160,9 @@ JHalfDim = common.flip_staggered(JDim)
 KDim = gtx.Dimension("KDim", kind=gtx.DimensionKind.VERTICAL)
 KHalfDim = common.flip_staggered(KDim)
 
+Ioff = gtx.FieldOffset("Ioff", source=IDim, target=(IDim,))
+Koff = gtx.FieldOffset("Koff", source=KDim, target=(KDim,))
+
 Vertex = gtx.Dimension("Vertex")
 Edge = gtx.Dimension("Edge")
 Cell = gtx.Dimension("Cell")

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_cartesian_shifts.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_cartesian_shifts.py
@@ -19,6 +19,8 @@ from next_tests.integration_tests.cases import (
     cartesian_case,
 )
 from next_tests.integration_tests.cases_utils import (
+    Ioff,
+    Koff,
     exec_alloc_descriptor,
 )
 
@@ -54,9 +56,6 @@ def test_fold_shifts(cartesian_case):
 @pytest.mark.uses_cartesian_shift
 @pytest.mark.uses_dynamic_offsets
 def test_offset_field(cartesian_case):
-    Ioff = gtx.FieldOffset("Ioff", source=IDim, target=(IDim,))
-    Koff = gtx.FieldOffset("Koff", source=KDim, target=(KDim,))
-
     ref = np.full(
         (cartesian_case.default_sizes[IDim], cartesian_case.default_sizes[KDim]), True, dtype=bool
     )
@@ -87,4 +86,30 @@ def test_offset_field(cartesian_case):
         out=out,
         ref=ref,
         comparison=lambda out, ref: np.all(out == ref),
+    )
+
+
+@pytest.mark.uses_dynamic_offsets
+def test_offset_field_of_chained_ops(cartesian_case):
+    """A dynamic offset on top of a chain of operations must be fused past all of them."""
+
+    @gtx.field_operator
+    def testee(a: cases.IKField, offset_field: cases.IKField) -> cases.IKField:
+        b = a + 1
+        c = b * 2
+        return c(as_offset(Koff, offset_field))
+
+    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
+    a = cases.allocate(cartesian_case, testee, "a").extend({KDim: (0, 1)})()
+    offset_field = cases.allocate(
+        cartesian_case, testee, "offset_field", strategy=cases.ConstInitializer(1)
+    )()
+
+    cases.verify(
+        cartesian_case,
+        testee,
+        a,
+        offset_field,
+        out=out,
+        ref=(a.asnumpy()[:, 1:] + 1) * 2,
     )

--- a/tests/next_tests/unit_tests/iterator_tests/test_inline_dynamic_shifts.py
+++ b/tests/next_tests/unit_tests/iterator_tests/test_inline_dynamic_shifts.py
@@ -30,6 +30,25 @@ def test_inline_dynamic_shift_as_fieldop_arg(uids):
     assert actual == expected
 
 
+def test_inline_dynamic_shift_nested_as_fieldop_args(uids):
+    testee = im.as_fieldop(im.lambda_("a", "b")(im.deref(im.shift(IOff, im.deref("b"))("a"))))(
+        im.as_fieldop(im.lambda_("a")(im.deref(im.shift(IOff, 1)("a"))))(
+            im.as_fieldop("deref")("inp")
+        ),
+        "offset_field",
+    )
+    expected = im.as_fieldop(
+        im.lambda_("inp", "offset_field")(
+            im.deref(im.shift(IOff, 1)(im.shift(IOff, im.deref("offset_field"))("inp")))
+        )
+    )("inp", "offset_field")
+
+    actual = inline_dynamic_shifts.InlineDynamicShifts.apply(
+        testee, offset_provider_type={}, uids=uids
+    )
+    assert actual == expected
+
+
 def test_inline_dynamic_shift_let_var(uids):
     testee = im.let("tmp", im.as_fieldop("deref")("inp"))(
         im.as_fieldop(im.lambda_("a", "b")(im.deref(im.shift(IOff, im.deref("b"))("a"))))(


### PR DESCRIPTION
`InlineDynamicShifts` fused a single producer per `as_fieldop` node and returned immediately. When an `as_fieldop` is nested more than one level deep behind a dynamic shift, the remaining producer is still hidden behind that shift after one fusion step, so `infer_domain` marks it `UNKNOWN` and emits it without a domain.

This is not backend-specific — it affects every pipeline ending at `infer_domain` (`apply_fieldview_transforms`), and shows up on `roundtrip.gtir` and dace alike. `apply_common_transforms` masked it via its later `fuse_as_fieldop` loop, which is why gtfn was unaffected.

Now fuses until no dynamically shifted argument that is not a `SymRef` is left. This terminates because `fuse_as_fieldop` replaces every fused argument by the arguments of the producer it inlines, i.e. by strict subterms of that argument. The `SymRef` exclusion means a let-bound producer shared between two dynamically shifted consumers is still not inlined; that case is pre-existing (it fails identically on `main`) and tracked in #2839.

Tests: a backend-free unit test for the fusion fixpoint, plus a minimal cartesian integration test — a dynamic offset applied on top of a chain of two operations, `(a + 1) * 2`. No staggering and no unstructured shift are needed to trigger this. Both fail on `main`.

**AI Disclaimer**: This PR was written with the help of AI tools. I reviewed the code (tests and implementation) in detail.

---

Found while extracting https://github.com/havogt/gt4py/pull/77.

