### PR TITLE
fix[next-dace]: lower `as_offset` applied to a staggered access

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -1525,7 +1525,7 @@ class LambdaToDataflow(eve.NodeVisitor):
                     name="dynamic_offset",
                     inputs={"index"},
                     outputs={new_index_connector},
-                    code=f"{new_index_connector} = index + {offset_expr}",
+                    code=f"{new_index_connector} = index + {offset_expr.value}",
                 )
             else:
                 dynamic_offset_tasklet, connector_mapping = self._add_tasklet(

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
@@ -157,17 +157,12 @@ def test_cartesian_half_shift_as_offset(cartesian_case):
     ) -> cases.IKField:
         return a(KDim - 0.5)(as_offset(Koff, offset_field))
 
-    isize = cartesian_case.default_sizes[IDim]
     ksize = cartesian_case.default_sizes[KDim]
-    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: isize, KHalfDim: ksize + 1})()
+    a = cases.allocate(cartesian_case, testee, "a", sizes={KHalfDim: ksize + 1})()
     offset_field = cases.allocate(
-        cartesian_case,
-        testee,
-        "offset_field",
-        sizes={IDim: isize, KDim: ksize},
-        strategy=cases.ConstInitializer(1),
+        cartesian_case, testee, "offset_field", strategy=cases.ConstInitializer(1)
     )()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IDim: isize, KDim: ksize})()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
 
     cases.verify(
         cartesian_case, testee, a, offset_field, out=out, ref=a.asnumpy()[:, 1:], offset_provider={}
@@ -186,17 +181,12 @@ def test_cartesian_half_shift_as_offset_of_chained_ops(cartesian_case):
         b = a + 1
         return b(KDim - 0.5)(as_offset(Koff, offset_field))
 
-    isize = cartesian_case.default_sizes[IDim]
     ksize = cartesian_case.default_sizes[KDim]
-    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: isize, KHalfDim: ksize + 1})()
+    a = cases.allocate(cartesian_case, testee, "a", sizes={KHalfDim: ksize + 1})()
     offset_field = cases.allocate(
-        cartesian_case,
-        testee,
-        "offset_field",
-        sizes={IDim: isize, KDim: ksize},
-        strategy=cases.ConstInitializer(1),
+        cartesian_case, testee, "offset_field", strategy=cases.ConstInitializer(1)
     )()
-    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IDim: isize, KDim: ksize})()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN)()
 
     cases.verify(
         cartesian_case,

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_staggered.py
@@ -9,17 +9,23 @@ import numpy as np
 import pytest
 
 import gt4py.next as gtx
+from gt4py.next.ffront.experimental import as_offset
 
 from next_tests.integration_tests import cases
 from next_tests.integration_tests.cases import (
+    E2V,
+    Edge,
     IDim,
     IHalfDim,
     JDim,
     KDim,
     KHalfDim,
+    Vertex,
     cartesian_case,
+    unstructured_case,
+    unstructured_case_3d,
 )
-from next_tests.integration_tests.cases_utils import exec_alloc_descriptor
+from next_tests.integration_tests.cases_utils import Koff, exec_alloc_descriptor, mesh_descriptor
 
 
 @pytest.mark.uses_cartesian_shift
@@ -140,3 +146,98 @@ def test_cartesian_half_shift_multi_dim(cartesian_case):
     )()
 
     cases.verify(cartesian_case, testee, a, out=out, ref=a, offset_provider={})
+
+
+@pytest.mark.uses_cartesian_shift
+@pytest.mark.uses_dynamic_offsets
+def test_cartesian_half_shift_as_offset(cartesian_case):
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[IDim, KHalfDim], np.int32], offset_field: cases.IKField
+    ) -> cases.IKField:
+        return a(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    isize = cartesian_case.default_sizes[IDim]
+    ksize = cartesian_case.default_sizes[KDim]
+    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: isize, KHalfDim: ksize + 1})()
+    offset_field = cases.allocate(
+        cartesian_case,
+        testee,
+        "offset_field",
+        sizes={IDim: isize, KDim: ksize},
+        strategy=cases.ConstInitializer(1),
+    )()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IDim: isize, KDim: ksize})()
+
+    cases.verify(
+        cartesian_case, testee, a, offset_field, out=out, ref=a.asnumpy()[:, 1:], offset_provider={}
+    )
+
+
+@pytest.mark.uses_cartesian_shift
+@pytest.mark.uses_dynamic_offsets
+def test_cartesian_half_shift_as_offset_of_chained_ops(cartesian_case):
+    """The staggered shift and the dynamic offset are separated by a further operation."""
+
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[IDim, KHalfDim], np.int32], offset_field: cases.IKField
+    ) -> cases.IKField:
+        b = a + 1
+        return b(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    isize = cartesian_case.default_sizes[IDim]
+    ksize = cartesian_case.default_sizes[KDim]
+    a = cases.allocate(cartesian_case, testee, "a", sizes={IDim: isize, KHalfDim: ksize + 1})()
+    offset_field = cases.allocate(
+        cartesian_case,
+        testee,
+        "offset_field",
+        sizes={IDim: isize, KDim: ksize},
+        strategy=cases.ConstInitializer(1),
+    )()
+    out = cases.allocate(cartesian_case, testee, cases.RETURN, sizes={IDim: isize, KDim: ksize})()
+
+    cases.verify(
+        cartesian_case,
+        testee,
+        a,
+        offset_field,
+        out=out,
+        ref=a.asnumpy()[:, 1:] + 1,
+        offset_provider={},
+    )
+
+
+@pytest.mark.uses_unstructured_shift
+@pytest.mark.uses_dynamic_offsets
+def test_unstructured_shift_half_shift_as_offset(unstructured_case_3d):
+    @gtx.field_operator
+    def testee(
+        a: gtx.Field[[Vertex, KHalfDim], np.int32],
+        offset_field: gtx.Field[[Edge, KDim], np.int32],
+    ) -> gtx.Field[[Edge, KDim], np.int32]:
+        return a(E2V[0])(KDim - 0.5)(as_offset(Koff, offset_field))
+
+    nvertices = unstructured_case_3d.default_sizes[Vertex]
+    ksize = unstructured_case_3d.default_sizes[KDim]
+    a = cases.allocate(
+        unstructured_case_3d,
+        testee,
+        "a",
+        domain={Vertex: (0, nvertices), KHalfDim: (0, ksize + 1)},
+    )()
+    offset_field = cases.allocate(
+        unstructured_case_3d, testee, "offset_field", strategy=cases.ConstInitializer(1)
+    )()
+    out = cases.allocate(unstructured_case_3d, testee, cases.RETURN)()
+
+    e2v_table = unstructured_case_3d.offset_provider["E2V"].asnumpy()
+    cases.verify(
+        unstructured_case_3d,
+        testee,
+        a,
+        offset_field,
+        out=out,
+        ref=a.asnumpy()[e2v_table[:, 0], 1:],
+    )


### PR DESCRIPTION
The dace lowering of a dynamic offset — a shift whose distance is only known at runtime, i.e. `as_offset(Koff, offset_field)` in the frontend — interpolated the whole `SymbolExpr` dataclass into the tasklet code instead of its `value`, emitting `shifted_index = index + SymbolExpr(value=0, dc_dtype=int)`. dace then picks up `int` as a free symbol and `sdfg.arglist()` fails with `KeyError: 'int'`.

The affected branch of `_make_cartesian_shift` is the one where the offset is a compile-time constant but the index it is added to is not, i.e. a static shift on top of an already dynamically shifted iterator. Nothing produced that combination before: the only integration test using `as_offset`, `test_offset_field`, shifts dynamically twice but in two different dimensions, and since the shift is lowered per dimension each of them still sees a symbolic index and takes the branch where only the offset arrives through a connector; a static shift alone is constant-folded and never reaches a tasklet. Staggering makes the combination the normal case, because a half-integer shift always lowers to a static cartesian shift — so `field(KDim - 0.5)(as_offset(Koff, offset_field))` hits it every time.

Tests: three `as_offset`-on-staggered-access tests, value-verified across the backend matrix. `test_cartesian_half_shift_as_offset` isolates the defect fixed here. The other two put a further operation between the staggered shift and the dynamic offset, which additionally runs into the unrelated fixpoint defect of the PR below, so those need the whole stack to go green.

**AI disclaimer**: This PR was written with the help of AI tools. Code was reviewed in detail, PR description briefly.

---

Stacked on-top of: #2829

Extracted from https://github.com/havogt/gt4py/pull/77, which additionally turns the domain `assert` in `translate_as_fieldop` into an explicit error; that part is left out here.
