### PR TITLE
fix[eve]: handle all modern typing spellings at annotation dispatch sites

### DIFF
--- a/src/gt4py/eve/datamodels/core.py
+++ b/src/gt4py/eve/datamodels/core.py
@@ -997,8 +997,12 @@ class DeferredTypeConverter:
 def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConverter[_T]:
     # TODO(egparedes): if a "typing tree" structure is implemented, refactor this code
     # as a tree traversal.
+    type_annotation = xtyping.normalize_union(type_annotation)
+
     try:
-        resolved_annotation = xtyping.eval_type_alias(type_annotation)
+        # Aliases and 'Annotated' metadata are resolved together: applied in separate
+        # branches they recurse forever on an annotation where each wraps the other.
+        resolved_annotation = xtyping.resolve_annotation(type_annotation)
     except NameError:
         # Deferral signal, as in 'field_type_validator_factory' above.
         return cast(TypeConverter[_T], DeferredTypeConverter(type_annotation, name))
@@ -1037,10 +1041,21 @@ def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConv
         and type(None) in (args := xtyping.get_args(type_annotation))
         and len(args) == 2
     ):
-        # Optional type
-        _inner_type_converter: TypeConverter[_T] = _make_type_converter(args[0], name)
+        # Optional type. 'typing' preserves the order the arguments were written in,
+        # so 'Union[None, int]' is as valid a spelling as 'Optional[int]' and the
+        # wrapped type cannot be assumed to be the first one.
+        inner_annotation = next(arg for arg in args if arg is not type(None))
+        _inner_type_converter: TypeConverter[_T] = _make_type_converter(inner_annotation, name)
 
         return cast(TypeConverter[_T], lambda x: x if x is None else _inner_type_converter(x))
+
+    if origin_type is xtyping.Union:
+        # No single type to coerce to. Explicit because on 3.14 'typing.Union' *is*
+        # 'types.UnionType', a real class, which the 'is_actual_type(origin_type)'
+        # fallback below would accept and turn into a 'types.UnionType(value)' call.
+        raise exceptions.EveTypeError(
+            f"Automatic type coercion for {type_annotation} types is not supported."
+        )
 
     if xtyping.is_actual_type(origin_type):
         return _make_type_converter(origin_type, name)
@@ -1088,12 +1103,13 @@ def _is_strictly_immutable_type(
         ``True`` if every value admitted by the annotation is strictly immutable.
     """
     if xtyping.is_type_alias(type_annotation) or xtyping.get_origin(type_annotation) is not None:
-        # A PEP 695 alias stands for the annotation it resolves to, so check that
-        # instead; an alias whose value cannot be evaluated (undefined name, recursive,
-        # ...) proves nothing and is rejected below like any other unresolved
-        # annotation. Non-aliases are returned unchanged, as the identical object.
+        # A PEP 695 alias stands for the annotation it resolves to, and 'Annotated'
+        # metadata is not part of the type, so check what is left once both are gone.
+        # An annotation that cannot be resolved (undefined name, recursive, ...) proves
+        # nothing and is rejected below like any other unresolved one; anything else is
+        # returned unchanged, as the identical object.
         try:
-            resolved_alias = xtyping.eval_type_alias(type_annotation)
+            resolved_alias = xtyping.resolve_annotation(type_annotation)
         except (NameError, TypeError):
             return False
         if resolved_alias is not type_annotation:

--- a/src/gt4py/eve/extended_typing.py
+++ b/src/gt4py/eve/extended_typing.py
@@ -456,6 +456,63 @@ def is_actual_type(obj: Any) -> TypeGuard[type[Any]]:
     )
 
 
+# -- PEP 604 unions (``X | Y``) --
+
+
+def normalize_union(annotation: Any) -> Any:
+    """Rewrite a PEP 604 union (``X | Y``) as the equivalent ``typing.Union[X, Y]``.
+
+    Before 3.14 the two are different runtime objects: ``get_origin(int | None)`` is
+    ``types.UnionType``, ``get_origin(Optional[int])`` is ``typing.Union``. A site
+    comparing against only one does not raise on the other, it falls through to a
+    no-match branch -- so call this at the head of any funnel dispatching on
+    union-ness. Anything already normalized, and anything that is not a union at all,
+    is returned as the identical object.
+
+    See https://github.com/python/cpython/issues/105499.
+
+    Examples:
+        >>> normalize_union(int | None) == Optional[int]
+        True
+
+        >>> normalize_union(int) is int
+        True
+    """
+    if isinstance(annotation, _types.UnionType) and get_origin(annotation) is not _typing.Union:
+        # The second test matters only on 3.14, where 'typing.Union' *is*
+        # 'types.UnionType': every union passes the 'isinstance' there, so without it
+        # an already-normalized annotation would be rebuilt into an equal but not
+        # identical object, breaking the ``is`` check this function promises.
+        return _typing.Union[annotation.__args__]
+    return annotation
+
+
+def strip_annotated(annotation: Any) -> Any:
+    """Return the type wrapped by ``Annotated[X, ...]``, or ``annotation`` unchanged.
+
+    ``Annotated`` metadata is not part of the type, so every funnel dispatching on an
+    annotation has to see through it -- and none of them fails loudly otherwise. On
+    3.12 ``typing.Annotated`` is a class, so a funnel testing "is this a class" claims
+    it and builds nonsense: a ``typing.Annotated(value)`` call, an ``isinstance``
+    check nothing satisfies, a mutability verdict read off the metadata. From 3.13 it
+    is a special form again and falls through to a no-match branch instead.
+
+    ``typing`` flattens nested ``Annotated``, so one step is enough. Anything else is
+    returned as the identical object, so callers can detect the no-op with ``is``.
+
+    Examples:
+        >>> strip_annotated(Annotated[int, "meta"]) is int
+        True
+
+        >>> strip_annotated(Annotated[Optional[int], "meta"]) == Optional[int]
+        True
+
+        >>> strip_annotated(int) is int
+        True
+    """
+    return get_args(annotation)[0] if get_origin(annotation) is Annotated else annotation
+
+
 # -- PEP 695 type aliases (``type X = ...``) --
 #
 # Resolved at the annotation-dispatch funnels (`type_validation`,
@@ -466,8 +523,11 @@ def is_actual_type(obj: Any) -> TypeGuard[type[Any]]:
 # no-match branch (``()`` for `get_represented_types`), silently making every
 # `isinstance()` against the result `False`.
 #
-# Not supported: `ClassVar` behind an alias, and aliases used as runtime values (base
-# class, constructor, `isinstance()` argument) -- the reason ruff's `UP040` stays off.
+# Not supported: `ClassVar` behind an alias, aliases used as runtime values (base
+# class, constructor, `isinstance()` argument) -- the reason ruff's `UP040` stays off --
+# and the `Coerced`/`Unchecked` tag lookup in `datamodels.core`, which reads the
+# `Annotated` metadata off the raw annotation: `type MyCoerced = Coerced[int]` loses
+# the tag rather than raising.
 
 #: Both PEP 695 alias implementations: they are distinct classes and neither is an
 #: instance of the other, so both have to be checked. ``hasattr(obj, "__value__")`` is
@@ -563,6 +623,58 @@ def eval_type_alias(annotation: Any) -> Any:
     )
 
 
+def resolve_annotation(annotation: Any) -> Any:
+    """Resolve PEP 695 aliases and strip ``Annotated`` metadata until neither applies.
+
+    The two wrappers nest into each other any number of times
+    (``type A = Annotated[B, ...]``, ``type B = Annotated[int, ...]``), so neither
+    `eval_type_alias` nor `strip_annotated` alone reaches the underlying type -- and a
+    funnel applying them in separate branches recurses forever when the two wrap each
+    other in a cycle. Anything else is returned as the identical object, so callers
+    can detect the no-op with ``is``.
+
+    Args:
+        annotation: Any type annotation.
+
+    Returns:
+        The annotation left once every alias and ``Annotated`` layer is gone, or
+        `annotation` itself.
+
+    Raises:
+        NameError: As `eval_type_alias`, so that consumers can still defer.
+        TypeError: If the layers cycle (``type R = Annotated[R, ...]``) or nest too
+            deeply, plus everything `eval_type_alias` reports.
+
+    Examples:
+        >>> type MyInt = Annotated[int, "meta"]
+        >>> resolve_annotation(MyInt)
+        <class 'int'>
+
+        >>> resolve_annotation(float) is float
+        True
+    """
+    original_annotation = annotation
+    # Identity, not equality: '__eq__' on arbitrary annotation objects is not
+    # guaranteed to be usable here.
+    seen: list[Any] = []
+    for _ in range(_MAX_TYPE_ALIAS_DEPTH):
+        unaliased = eval_type_alias(annotation)
+        stripped = strip_annotated(unaliased)
+        if unaliased is annotation and stripped is annotation:
+            return annotation
+        if any(stripped is s for s in seen):
+            raise TypeError(
+                f"Type annotation '{original_annotation}' cannot be resolved "
+                "(recursive definition)."
+            )
+        seen.append(annotation)
+        annotation = stripped
+
+    raise TypeError(
+        f"Type annotation '{original_annotation}' cannot be resolved (nested too deeply)."
+    )
+
+
 def is_Any(obj: Any) -> bool:
     """Check if an object is the ``Any`` special form."""
     # 'typing_extensions' re-exports 'typing.Any' on every supported version, so the
@@ -593,9 +705,10 @@ def get_represented_types(
         return _functools.reduce(lambda acc, c: acc + recurse(c), annotations, ())
 
     # PEP 695 aliases are opaque objects which no other branch below matches, so an
-    # unresolved one would silently yield an empty tuple. Nested aliases are covered
+    # unresolved one would silently yield an empty tuple, and the 'Annotated' special
+    # form is not a represented type either. Nested occurrences of both are covered
     # for free, since the generic branches recurse through this same function.
-    type_annotation = eval_type_alias(type_annotation)
+    type_annotation = resolve_annotation(type_annotation)
 
     if type_annotation is Ellipsis:
         return ()
@@ -618,7 +731,12 @@ def get_represented_types(
     origin_type = get_origin(type_annotation)
     type_args = get_args(type_annotation)
 
-    if origin_type in [Literal, Union, _types.UnionType]:
+    if origin_type is Literal:
+        # 'Literal' arguments are values, not types, so they cannot be recursed
+        # into: the type each one represents is its own type.
+        return tuple(dict.fromkeys(type(arg) for arg in type_args))
+
+    if origin_type in [Union, _types.UnionType]:
         return recurse_all(t for t in type_args)
 
     if origin_type is not None:
@@ -940,7 +1058,15 @@ def infer_type(
     """
     _infer = _functools.partial(infer_type, annotate_callable_kwargs=annotate_callable_kwargs)
 
-    if isinstance(value, (StdGenericAliasType, _TypingSpecialFormType)):
+    # Annotations are returned unchanged rather than described: PEP 585 generics,
+    # bare special forms, parametrized 'typing' aliases ('Optional[int]'), PEP 604
+    # unions and PEP 695 aliases. Otherwise the 'type(value)' fallback below reports
+    # the CPython-internal class implementing them ('typing._GenericAlias', ...).
+    if (
+        isinstance(value, (StdGenericAliasType, _TypingSpecialFormType))
+        or is_type_alias(value)
+        or get_origin(value) is not None
+    ):
         return value
 
     # note: identity check instead of `in`, which would use `__eq__` and fail

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -14,7 +14,6 @@ import abc
 import collections.abc
 import dataclasses
 import functools
-import types
 import typing
 
 from . import exceptions, extended_typing as xtyping, utils
@@ -225,10 +224,7 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
             if type_annotation is None:
                 type_annotation = type(None)
 
-            if isinstance(
-                type_annotation, types.UnionType
-            ):  # see https://github.com/python/cpython/issues/105499
-                type_annotation = typing.Union[type_annotation.__args__]
+            type_annotation = xtyping.normalize_union(type_annotation)
 
             # A 'NameError' is deliberately left to propagate here, so that 'datamodels'
             # can defer; see 'xtyping.eval_type_alias' for both failure modes.
@@ -246,6 +242,15 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                     return deferred
                 _alias_memo[type_annotation] = deferred = _DeferredTypeValidator(name)
                 deferred.validator = validator = make_recursive(resolved_annotation)
+                if validator is deferred:
+                    # 'type R = Annotated[R, ...]' resolves to nothing but itself, so
+                    # the placeholder would become its own validator: it builds cleanly
+                    # and recurses forever on the first value. A real recursive alias
+                    # ('type Tree = list[Tree]') has a container in between and is fine.
+                    raise exceptions.EveValueError(
+                        f"{type_annotation} type annotation is not supported: "
+                        "the alias resolves only to itself."
+                    )
                 return validator
 
             # Non-generic types
@@ -273,6 +278,9 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
             # Generic and parametrized type hints
             origin_type = xtyping.get_origin(type_annotation)
             type_args = xtyping.get_args(type_annotation)
+
+            if (stripped := xtyping.strip_annotated(type_annotation)) is not type_annotation:
+                return make_recursive(stripped)
 
             if origin_type in {typing.Literal, xtyping.Literal}:
                 if len(type_args) == 1:
@@ -310,15 +318,18 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                     # bare `type` / `typing.Type`
                     return self.make_is_instance_of(name, type)
 
-                # A PEP 695 alias nested inside `type[...]` is not resolved by the
-                # whole-annotation pass at the top of this function, so resolve it here.
+                # The pass at the top of this function does not reach inside
+                # `type[...]`, so the alias and the `Annotated` are still here. Either
+                # can wrap the other repeatedly, so both are resolved together; an
+                # annotation that does not resolve keeps the loose check below.
                 try:
-                    arg = xtyping.eval_type_alias(type_args[0])
+                    arg = xtyping.resolve_annotation(type_args[0])
                 except TypeError:
                     return self.make_is_instance_of(name, type)
 
-                if isinstance(arg, types.UnionType):  # `type[A | B]`
-                    arg = typing.Union[arg.__args__]
+                # After the metadata is gone, not before: `type[Annotated[A | B, ...]]`
+                # only reaches the union handling below if it is stripped first.
+                arg = xtyping.normalize_union(arg)  # `type[A | B]`
 
                 # `issubclass()` is not generally usable with protocol classes: it is
                 # rejected outright unless the protocol is `@runtime_checkable`, and also
@@ -375,7 +386,6 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
 
                 if issubclass(origin_type, (collections.abc.Sequence, collections.abc.Set)):
                     assert len(type_args) == 1
-                    make_recursive(type_args[0])
                     if (member_validator := make_recursive(type_args[0])) is None:
                         raise exceptions.EveValueError(
                             f"{type_args[0]} type annotation is not supported."

--- a/tests/eve_tests/unit_tests/test_annotation_spelling.py
+++ b/tests/eve_tests/unit_tests/test_annotation_spelling.py
@@ -1,0 +1,668 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Conformance matrix: equivalent annotation spellings must behave identically.
+
+Python offers several spellings for the same type -- ``Optional[int]`` and
+``int | None``, ``List[int]`` and ``list[int]``, ``X: TypeAlias = ...`` and
+``type X = ...``, a live object and the string naming it. ``eve`` builds field
+validators and converters from live annotation objects and dispatches on their
+*identity*, at several independent sites (the "funnels" below).
+
+A funnel that has not been taught a spelling does not raise: it falls through to
+its no-match branch and silently produces a wrong validator, a wrong converter,
+or a wrong answer. Every test here therefore compares two spellings of the *same*
+logical type against each other rather than against a hard-coded expectation --
+the property being asserted is agreement, so a funnel that is uniformly wrong for
+both spellings is caught elsewhere, and one that is wrong for only the new
+spelling is caught here.
+
+Adding a funnel to ``eve`` means adding an observer to ``FUNNELS``.
+
+Note on annotation-evaluation regimes: the ``str`` entries in ``SPELLINGS`` cover
+PEP 563 (``from __future__ import annotations``), which stores annotations as
+strings. PEP 649 (the Python 3.14 default) evaluates them lazily but hands back
+live objects, so it is covered by the non-string entries when the suite runs on
+3.14.
+"""
+
+# NOTE: this module deliberately does *not* use 'from __future__ import annotations'.
+# The observers below build datamodels whose field annotation is a local variable
+# ('value: annotation'). Under PEP 563 that is stored as the literal string
+# "annotation" instead of the type under test, and every assertion below silently
+# compares nothing. The PEP 563 regime is covered explicitly by
+# 'test_string_annotations_agree_with_live_objects' instead.
+
+import collections.abc
+import dataclasses
+import sys
+import types
+import typing
+from typing import (  # noqa: UP035 [deprecated-import] deliberately exercising the legacy spellings
+    Annotated,
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+import pytest
+
+from gt4py.eve import (
+    datamodels,
+    exceptions,
+    extended_typing as xtyping,
+    type_validation as type_val,
+)
+
+# Imported directly on purpose: reaching these two through a datamodel is not enough.
+# 'get_partial_type_hints' strips 'Annotated' before a field annotation gets this far,
+# so a datamodel-mediated observer compares 'X' against 'X' and cannot see a missing
+# 'Annotated' branch in either function.
+from gt4py.eve.datamodels.core import _is_strictly_immutable_type, _make_type_converter
+
+
+# -- The spellings under test --
+
+
+@dataclasses.dataclass(frozen=True)
+class Spelling:
+    """Two spellings of one logical type, plus values to probe the funnels with."""
+
+    id: str
+    legacy: Any
+    modern: Any
+    probes: tuple[Any, ...]
+
+
+#: Probe set reused by the container cases. It has to contain at least one value that
+#: each container spelling *accepts*: a row whose every probe is rejected by both sides
+#: cannot tell a correct validator from one that rejects everything -- which is exactly
+#: the failure this file exists to catch.
+_CONTAINER_PROBES: tuple[Any, ...] = (
+    None,
+    0,
+    "x",
+    [1],
+    (1,),
+    (1, "x"),
+    ([1],),
+    {1},
+    frozenset({1}),
+    {"a": 1},
+)
+
+SPELLINGS: list[Spelling] = [
+    Spelling("optional", Optional[int], int | None, (None, 3, True, "3", 1.5, [])),
+    Spelling("optional-reversed", Optional[int], Union[None, int], (None, 3, "3", 1.5)),
+    Spelling("union", Union[int, str], int | str, (1, "a", None, 1.5, [])),
+    Spelling("union-3", Union[int, str, float], int | str | float, (1, "a", 1.5, None)),
+    Spelling("list", List[int], list[int], _CONTAINER_PROBES),
+    Spelling("dict", Dict[str, int], dict[str, int], _CONTAINER_PROBES),
+    Spelling("set", Set[int], set[int], _CONTAINER_PROBES),
+    Spelling("frozenset", FrozenSet[int], frozenset[int], _CONTAINER_PROBES),
+    Spelling("tuple-var", Tuple[int, ...], tuple[int, ...], _CONTAINER_PROBES),
+    Spelling("tuple-fixed", Tuple[int, str], tuple[int, str], _CONTAINER_PROBES),
+    Spelling("type", Type[int], type[int], (int, bool, str, "int", 3, None)),
+    # Nesting: the new spelling has to survive being an argument of another generic.
+    Spelling("optional-list", Optional[List[int]], list[int] | None, _CONTAINER_PROBES),
+    Spelling("list-optional", List[Optional[int]], list[int | None], _CONTAINER_PROBES),
+    Spelling("dict-union", Dict[str, Union[int, str]], dict[str, int | str], _CONTAINER_PROBES),
+    Spelling("tuple-of-list", Tuple[List[int], ...], tuple[list[int], ...], _CONTAINER_PROBES),
+    # 'typing.Callable' vs 'collections.abc.Callable' is a 'UP035' target of the sweep.
+    Spelling(
+        "callable",
+        Callable[[int], int],
+        collections.abc.Callable[[int], int],
+        (None, 0, "x", len, lambda x: x),
+    ),
+    Spelling("literal", Literal[1, 2], Literal[1] | Literal[2], (1, 2, 3, None, "1")),
+]
+
+#: 'X | Y' is a runtime value, so it can be stored in a plain variable; the legacy
+#: and modern spellings of an *alias* are compared the same way as the types above.
+LegacyAlias: typing.TypeAlias = Optional[int]
+
+type ModernAlias = Optional[int]
+type ModernAliasPEP604 = int | None
+type AliasedInt = int
+
+ALIAS_SPELLINGS: list[Spelling] = [
+    Spelling("alias-legacy-vs-695", LegacyAlias, ModernAlias, (None, 3, "3", 1.5)),
+    Spelling("alias-695-604", ModernAlias, ModernAliasPEP604, (None, 3, "3", 1.5)),
+]
+
+
+#: `Annotated[X, ...]` carries metadata that is not part of the type: every funnel
+#: must see straight through it to `X`. On 3.12 `typing.Annotated` is a class, so a
+#: funnel dispatching on `isinstance(origin, type)` claims it by accident.
+TRANSPARENT_WRAPPERS: list[Spelling] = [
+    Spelling("annotated-int", int, Annotated[int, "meta"], (3, "3", None, 1.5)),
+    Spelling(
+        "annotated-optional", Optional[int], Annotated[Optional[int], "meta"], (None, 3, "3", 1.5)
+    ),
+    Spelling("annotated-list", list[int], Annotated[list[int], "meta"], _CONTAINER_PROBES),
+    Spelling(
+        "annotated-tuple", tuple[int, ...], Annotated[tuple[int, ...], "meta"], _CONTAINER_PROBES
+    ),
+    # Nested inside 'type[...]': the metadata is not stripped by the whole-annotation
+    # pass, so the 'type[X]' branch has to strip it itself.
+    Spelling(
+        "annotated-inside-type",
+        type[int],
+        type[Annotated[int, "meta"]],
+        (int, bool, str, 3),
+    ),
+    # Pins the order of the two rewrites inside the 'type[...]' branch: the metadata
+    # has to come off before the union is normalized, or the union is never seen.
+    Spelling(
+        "annotated-inside-type-union",
+        type[int | str],
+        type[Annotated[int | str, "meta"]],
+        (int, str, bool, float, 3),
+    ),
+    # 'Annotated' wrapping a PEP 695 alias: resolving the alias once, before the
+    # metadata is stripped, leaves the alias unresolved underneath it.
+    Spelling(
+        "annotated-inside-type-alias",
+        type[AliasedInt],
+        type[Annotated[AliasedInt, "meta"]],
+        (int, bool, str, 3),
+    ),
+]
+
+
+# -- The funnels --
+#
+# Each observer maps an annotation to a value that is comparable with '=='. They
+# must never raise: a funnel blowing up for one spelling and not the other is
+# exactly the asymmetry under test, so exceptions are captured and compared too.
+
+
+def _outcome(fn: typing.Callable[[], Any]) -> Any:
+    """Run `fn`, returning its result or a marker naming the exception type.
+
+    Used for *values*, which must compare with '=='.
+    """
+    try:
+        result = fn()
+    # A blind `except` is the point here: the exception type *is* the observation.
+    except Exception as error:
+        return ("error", type(error).__name__)
+    # The type is part of the observation: 'True == 1' and 'True' is in the probe set,
+    # while eve's 'strict_int' handling deliberately tells bool and int apart.
+    return ("value", type(result), result)
+
+
+def _build(fn: typing.Callable[[], Any]) -> tuple[Any, Any]:
+    """Run a class-building `fn`, returning `(cls, None)` or `(None, observation)`.
+
+    Kept separate from `_outcome` because a freshly built class has a unique
+    identity: returning it as the observation would make every success/success
+    comparison fail, and folding it into a marker would hide the class from the
+    caller that still needs to instantiate it.
+    """
+    try:
+        return fn(), None
+    # A blind `except` is the point here: the exception type *is* the observation.
+    except Exception as error:
+        return None, ("error", type(error).__name__)
+
+
+def _probe_all(model: type, probes: tuple[Any, ...]) -> tuple[Any, ...]:
+    return tuple(_outcome(lambda p=p: model(value=p).value) for p in probes)
+
+
+def observe_validator(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    return (
+        "validator",
+        tuple(_outcome(lambda p=p: type_val.simple_type_validator(p, annotation)) for p in probes),
+    )
+
+
+def observe_converter(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    """Coercion requested through `field(converter="coerce")`."""
+
+    def build() -> type:
+        @datamodels.datamodel
+        class Model:
+            value: annotation = datamodels.field(converter="coerce")  # type: ignore[valid-type]  # a variable annotation is the point of the test
+
+        return Model
+
+    model, failure = _build(build)
+    return ("converter", failure if model is None else _probe_all(model, probes))
+
+
+def observe_coerced_annotation(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    """The other route to a converter: the `Coerced[...]` marker rather than `field()`."""
+
+    def build() -> type:
+        @datamodels.datamodel
+        class Model:
+            value: datamodels.Coerced[annotation]  # type: ignore[valid-type]  # idem
+
+        return Model
+
+    model, failure = _build(build)
+    return ("coerced", failure if model is None else _probe_all(model, probes))
+
+
+def observe_datamodel(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    """End-to-end: field type validation on a plain (non-coercing) datamodel."""
+
+    def build() -> type:
+        @datamodels.datamodel
+        class Model:
+            value: annotation  # type: ignore[valid-type]  # idem
+
+        return Model
+
+    model, failure = _build(build)
+    return ("datamodel", failure if model is None else _probe_all(model, probes))
+
+
+def observe_represented_types(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    # Compared as a set: the result is meant to be handed to 'isinstance()', and
+    # 'typing' preserves the order the union members were written in, so
+    # 'Optional[int]' and 'Union[None, int]' legitimately differ in order alone.
+    outcome = _outcome(lambda: xtyping.get_represented_types(annotation))
+    if outcome[0] == "value":
+        return ("represented", "value", frozenset(outcome[2]))
+    return ("represented", *outcome)
+
+
+def observe_strict_frozen(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    """Immutability analysis, reachable only through `frozen='strict'`."""
+
+    def build() -> type:
+        @datamodels.datamodel(frozen="strict")
+        class Model:
+            value: annotation  # type: ignore[valid-type]  # idem
+
+        return Model
+
+    model, failure = _build(build)
+    return ("strict-frozen", ("accepted",) if model is not None else failure)
+
+
+def observe_type_converter(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    """`_make_type_converter` called directly, bypassing the datamodel."""
+    converter, failure = _build(lambda: _make_type_converter(annotation, "<field>"))
+    if converter is None:
+        return ("type-converter", failure)
+    return ("type-converter", tuple(_outcome(lambda p=p: converter(p)) for p in probes))
+
+
+def observe_immutability(annotation: Any, probes: tuple[Any, ...]) -> Any:
+    """`_is_strictly_immutable_type` called directly, bypassing the datamodel."""
+    return ("immutability", _outcome(lambda: _is_strictly_immutable_type(annotation)))
+
+
+FUNNELS: list[typing.Callable[[Any, tuple[Any, ...]], Any]] = [
+    observe_type_converter,
+    observe_immutability,
+    observe_validator,
+    observe_converter,
+    observe_coerced_annotation,
+    observe_datamodel,
+    observe_represented_types,
+    observe_strict_frozen,
+]
+
+
+# -- The matrix --
+
+
+@pytest.mark.parametrize("funnel", FUNNELS, ids=lambda f: f.__name__.removeprefix("observe_"))
+@pytest.mark.parametrize("spelling", SPELLINGS, ids=lambda s: s.id)
+def test_funnels_agree_across_spellings(spelling: Spelling, funnel: Any) -> None:
+    """Legacy and modern spellings of one type must be indistinguishable to `eve`."""
+    assert funnel(spelling.legacy, spelling.probes) == funnel(spelling.modern, spelling.probes)
+
+
+@pytest.mark.parametrize("funnel", FUNNELS, ids=lambda f: f.__name__.removeprefix("observe_"))
+@pytest.mark.parametrize("spelling", ALIAS_SPELLINGS, ids=lambda s: s.id)
+def test_funnels_agree_across_alias_spellings(spelling: Spelling, funnel: Any) -> None:
+    """`TypeAlias` and PEP 695 `type X = ...` must resolve to the same behaviour."""
+    assert funnel(spelling.legacy, spelling.probes) == funnel(spelling.modern, spelling.probes)
+
+
+#: Rows allowed to round-trip to the very same object on *both* sides, which makes
+#: their cells compare a value with itself. 'typing' caches parametrizations, so
+#: 'eval_forward_ref(str(x))' can hand back 'x'; 'literal' is the only row where that
+#: happens on both sides, and only before 3.14.
+#:
+#: Asserted as a subset, not an equality: the cache is an LRU, so a parallel run can
+#: evict an entry and stop a row being vacuous. Only "no *other* row is vacuous" is
+#: stable.
+_IDENTITY_ROUND_TRIP_ROWS = frozenset({"literal"})
+
+
+def test_string_annotation_rows_are_not_silently_vacuous() -> None:
+    """Keep the set of vacuous string round-trips from growing.
+
+    Without this, adding a spelling whose `str()` re-evaluates to the same cached
+    object would add eight green -- and entirely vacuous -- cells to
+    `test_string_annotations_agree_with_live_objects`.
+    """
+    vacuous = {
+        spelling.id
+        for spelling in SPELLINGS
+        if all(
+            xtyping.eval_forward_ref(_as_source(annotation), globalns=globals()) is annotation
+            for annotation in (spelling.legacy, spelling.modern)
+        )
+    }
+    assert vacuous <= _IDENTITY_ROUND_TRIP_ROWS, (
+        f"Rows {sorted(vacuous - _IDENTITY_ROUND_TRIP_ROWS)} compare a value with itself "
+        "on both sides, so their cells in "
+        "'test_string_annotations_agree_with_live_objects' assert nothing."
+    )
+
+
+@pytest.mark.parametrize("funnel", FUNNELS, ids=lambda f: f.__name__.removeprefix("observe_"))
+@pytest.mark.parametrize("spelling", SPELLINGS, ids=lambda s: s.id)
+def test_string_annotations_agree_with_live_objects(spelling: Spelling, funnel: Any) -> None:
+    """A PEP 563 string annotation must be indistinguishable from the object it names.
+
+    This is the regime `from __future__ import annotations` puts a module in, and the
+    one `get_partial_type_hints` has to reconstruct. Comparing only the represented
+    types would not say much -- that collapses every container to its origin -- so the
+    resolved annotation is pushed through the whole funnel list.
+
+    A 'typing.'-spelled side may round-trip to the identical cached object, in which
+    case that side asserts nothing; the modern side of the same row still exercises a
+    real reconstruction. `test_string_annotation_rows_are_not_silently_vacuous` pins
+    the rows where *both* sides are identities.
+    """
+    for annotation in (spelling.legacy, spelling.modern):
+        # PEP 563 resolves a string annotation against the *defining module's*
+        # globals, so that is what gets passed here -- this module imports 'typing'
+        # and 'collections.abc', exactly as a module writing those annotations would.
+        resolved = xtyping.eval_forward_ref(_as_source(annotation), globalns=globals())
+        assert funnel(resolved, spelling.probes) == funnel(annotation, spelling.probes)
+
+
+def _as_source(annotation: Any) -> str:
+    """Spell an annotation the way it would appear in source code.
+
+    `str(list[int])` is already source. `str(typing.List[int])` keeps the module
+    prefix, which is what exercises the deprecated-alias normalization; the same
+    goes for `str(collections.abc.Callable[...])`, which is why the caller has to
+    supply a namespace where those module names are bound.
+
+    This is a faithful spelling, not the original source text: `typing` normalizes
+    some forms on the way in, so `str(Union[None, int])` is `'typing.Optional[int]'`
+    and the written argument order is not recoverable.
+    """
+    return str(annotation)
+
+
+# -- Regression test for the specific defect the matrix was written to catch --
+
+
+def test_pep604_union_builds_the_same_converter_as_optional() -> None:
+    """'int | None' must coerce exactly like 'Optional[int]'.
+
+    'get_origin(int | None)' is 'types.UnionType', not 'typing.Union', so a funnel
+    comparing against 'typing.Union' alone skips the Optional branch and falls
+    through to a wrong one instead of raising.
+    """
+
+    @datamodels.datamodel
+    class Legacy:
+        value: Optional[int] = datamodels.field(converter="coerce")
+
+    @datamodels.datamodel
+    class Modern:
+        value: int | None = datamodels.field(converter="coerce")
+
+    for model in (Legacy, Modern):
+        assert model(value=None).value is None
+        assert model(value=3).value == 3
+        assert model(value="3").value == 3
+
+
+@pytest.mark.parametrize("funnel", FUNNELS, ids=lambda f: f.__name__.removeprefix("observe_"))
+@pytest.mark.parametrize("spelling", TRANSPARENT_WRAPPERS, ids=lambda s: s.id)
+def test_funnels_see_through_annotated(spelling: Spelling, funnel: Any) -> None:
+    """`Annotated[X, meta]` must be indistinguishable from `X` to every funnel."""
+    assert funnel(spelling.legacy, spelling.probes) == funnel(spelling.modern, spelling.probes)
+
+
+#: Funnels observed *through* a datamodel field, and those called directly.
+#:
+#: `get_partial_type_hints` strips `Annotated` recursively, so a datamodel-mediated
+#: funnel never sees the metadata: for every `TRANSPARENT_WRAPPERS` row it compares
+#: `X` with `X` and passes whatever the funnel does. Those rows are really tested by
+#: the directly-called funnels, which is why those observers exist.
+#:
+#: Both sets are pinned so that adding a funnel is a deliberate act. Without this, a
+#: new datamodel-mediated observer would quietly join the tautological set while
+#: appearing to add four green cells per wrapper row.
+_DATAMODEL_MEDIATED_FUNNELS = frozenset(
+    {"converter", "coerced_annotation", "datamodel", "strict_frozen"}
+)
+_DIRECTLY_CALLED_FUNNELS = frozenset(
+    {"validator", "represented_types", "type_converter", "immutability"}
+)
+
+
+def test_every_funnel_is_classified() -> None:
+    """Adding a funnel must force a decision about whether it can see `Annotated`."""
+    observed = {funnel.__name__.removeprefix("observe_") for funnel in FUNNELS}
+    assert observed == _DATAMODEL_MEDIATED_FUNNELS | _DIRECTLY_CALLED_FUNNELS
+
+
+def test_get_partial_type_hints_strips_annotated_recursively() -> None:
+    """The reason the directly-called observers exist.
+
+    This is what makes the `TRANSPARENT_WRAPPERS` rows vacuous for every funnel
+    reached through a datamodel: the metadata is gone before the funnel runs, at any
+    depth. If this ever stopped being true, the compensation would no longer be
+    needed -- and, more to the point, the funnels would start seeing `Annotated`
+    where they currently never do.
+    """
+
+    class _Holder:
+        plain: Annotated[int, "meta"]
+        nested: list[Annotated[int, "meta"]]
+        in_value: dict[str, Annotated[int, "meta"]]
+
+    hints = xtyping.get_partial_type_hints(_Holder)
+
+    assert hints["plain"] is int
+    assert hints["nested"] == list[int]
+    assert hints["in_value"] == dict[str, int]
+
+
+def test_represented_types_of_literal_are_the_types_of_its_values() -> None:
+    """`Literal` arguments are values, so their types cannot be found by recursion.
+
+    Recursing into them matches no branch and yields an empty tuple, which callers
+    turn into an `isinstance()` argument -- making every check against it `False`.
+    """
+    assert xtyping.get_represented_types(Literal[1, 2]) == (int,)
+    assert xtyping.get_represented_types(Literal["a", 1]) == (str, int)
+    assert xtyping.get_represented_types(Union[Literal["a"], int]) == (str, int)
+
+
+def test_represented_types_sees_through_annotated() -> None:
+    """The metadata of an `Annotated` is not a represented type, and neither is the form."""
+    assert xtyping.get_represented_types(Annotated[int, "meta"]) == (int,)
+    assert xtyping.get_represented_types(Annotated[Optional[int], "meta"]) == (int, type(None))
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [*SPELLINGS, *ALIAS_SPELLINGS, *TRANSPARENT_WRAPPERS],
+    ids=lambda s: s.id,
+)
+def test_spelling_pairs_are_distinct(spelling: Spelling) -> None:
+    """Guard against a row silently degenerating into `f(x) == f(x)`.
+
+    Every assertion in this file compares two spellings of one type. If a row's two
+    entries are the same object, the comparison is a tautology that passes whatever
+    the funnels do -- and nothing else in the file would notice.
+
+    Python 3.14 makes `typing.Union` *be* `types.UnionType`, so on that version the
+    union rows legitimately collapse: the bug they guard against cannot exist there.
+    That case is allowed through, but only there.
+    """
+    if spelling.legacy is spelling.modern:
+        unified_by_interpreter = sys.version_info >= (3, 14) and typing.get_origin(
+            spelling.legacy
+        ) in (typing.Union, types.UnionType)
+        assert unified_by_interpreter, (
+            f"Spelling row '{spelling.id}' compares an object with itself, so it asserts nothing."
+        )
+
+
+def test_infer_type_passes_annotations_through_unchanged() -> None:
+    """`infer_type` documents annotations as valid input, and must not type() them.
+
+    Only the PEP 585 spelling used to be recognized; every other one fell through to
+    the `type(value)` fallback and came back as the CPython-internal class that
+    implements it (`typing._GenericAlias`, `types.UnionType`, ...).
+    """
+    for annotation in (
+        list[int],
+        List[int],
+        Dict[str, int],
+        Optional[int],
+        int | None,
+        Union[int, str],
+        int | str,
+        Literal[1, 2],
+        Annotated[int, "meta"],
+        Callable[[int], int],
+        ModernAlias,
+    ):
+        assert xtyping.infer_type(annotation) is annotation
+
+
+def test_infer_type_still_infers_the_type_of_runtime_values() -> None:
+    """The pass-through above must not swallow ordinary values.
+
+    `get_origin` is part of the test for "is this an annotation", so anything it
+    reports an origin for would be handed back as-is rather than described.
+    """
+
+    class Generic_(typing.Generic[typing.TypeVar("_T")]): ...
+
+    assert xtyping.infer_type(3) is int
+    assert xtyping.infer_type("x") is str
+    assert xtyping.infer_type(None) is type(None)
+    assert xtyping.infer_type([1, 2]) == list[int]
+    assert xtyping.infer_type({"a": 1}) == dict[str, int]
+    assert xtyping.infer_type(Generic_()) is Generic_
+
+
+# -- Regressions from unwrapping transparent wrappers --
+
+type _SelfWrappingAlias = Annotated[_SelfWrappingAlias, "meta"]
+type _AliasOfInt = Annotated[int, "inner"]
+type _AliasOfAliasOfInt = Annotated[_AliasOfInt, "outer"]
+
+
+def test_self_referential_alias_is_reported_not_recursed() -> None:
+    """An alias that resolves only to itself must fail loudly, while building.
+
+    `Annotated` carries no structure of its own, so `type R = Annotated[R, ...]` hands
+    the recursion nothing to descend through. The cycle-breaker for genuine recursive
+    aliases makes this worse rather than better if left alone: the placeholder becomes
+    its own validator, the annotation builds cleanly, and the stack runs out on the
+    first value checked.
+    """
+    with pytest.raises(exceptions.EveValueError, match="resolves only to itself"):
+        type_val.simple_type_validator(1, _SelfWrappingAlias)
+
+
+type _MutuallyWrappingA = Annotated[_MutuallyWrappingB, "a"]
+type _MutuallyWrappingB = Annotated[_MutuallyWrappingA, "b"]
+
+
+@pytest.mark.parametrize("alias", [_SelfWrappingAlias, _MutuallyWrappingA], ids=["self", "mutual"])
+@pytest.mark.parametrize(
+    "funnel",
+    [
+        xtyping.get_represented_types,
+        _is_strictly_immutable_type,
+        lambda annotation: _make_type_converter(annotation, "<field>"),
+    ],
+    ids=["represented_types", "immutability", "type_converter"],
+)
+def test_alias_annotated_cycles_terminate_in_every_funnel(funnel: Any, alias: Any) -> None:
+    """A cycle of alias and `Annotated` layers must be reported, not recursed into.
+
+    Neither wrapper carries structure the recursion can descend through, so a funnel
+    resolving the alias in one branch and stripping the metadata in another walks the
+    same two annotations forever. The stack then runs out at whichever call site is
+    deepest, so the observed failure is not even stable.
+    """
+    try:
+        result = funnel(alias)
+    except TypeError as error:
+        # Specifically the cycle being recognized. Walking the layers until a depth
+        # bound trips, or until the interpreter stack runs out, also raises 'TypeError'
+        # -- 'eval_type_alias' converts the 'RecursionError' into one -- so a looser
+        # assertion here passes against the very behaviour this test exists to catch.
+        assert "(recursive definition)" in str(error), str(error)
+    else:
+        # Reporting the annotation as unresolvable is also a valid answer, as long as
+        # it is an answer: `_is_strictly_immutable_type` proves nothing about an
+        # annotation it cannot resolve, and says so with `False`.
+        assert result in (False, ())
+
+
+def test_normalize_union_returns_identical_objects_for_normalized_input() -> None:
+    """The ``is`` contract must not depend on the interpreter.
+
+    On 3.14 `typing.Union` *is* `types.UnionType`, so an `isinstance` test alone
+    matches annotations that are already normalized and rebuilds them into equal but
+    distinct objects. A caller detecting the no-op with `is` -- which the docstring
+    invites -- would then see a spelling change that did not happen.
+    """
+    for annotation in (Optional[int], Union[int, str], int, None, list[int]):
+        assert xtyping.normalize_union(annotation) is annotation
+
+    # Genuine PEP 604 unions are rewritten before 3.14, and are already 'typing.Union'
+    # from 3.14 on, so this is the one row whose identity legitimately varies.
+    assert xtyping.normalize_union(int | None) == Optional[int]
+
+
+def test_genuine_recursive_aliases_still_build() -> None:
+    """The guard above must not catch an alias with real structure between the two
+    occurrences."""
+
+    type Tree = list[Tree]
+
+    type_val.simple_type_validator([[], [[]]], Tree)
+    with pytest.raises(TypeError):
+        type_val.simple_type_validator("not-a-list", Tree)
+
+
+def test_type_arg_unwraps_alias_and_annotated_to_a_fixpoint() -> None:
+    """`type[X]` must reach `X` however many alias/`Annotated` layers wrap it.
+
+    Resolving once and stripping once covers `type[Annotated[Alias, ...]]` but not
+    `Alias -> Annotated -> Alias -> Annotated -> int`, which then falls through to the
+    loose "is any class at all" check and silently accepts everything.
+    """
+    for annotation in (type[int], type[_AliasOfInt], type[_AliasOfAliasOfInt]):
+        type_val.simple_type_validator(int, annotation)
+        with pytest.raises(TypeError):
+            type_val.simple_type_validator(str, annotation)


### PR DESCRIPTION
`eve` builds datamodel validators and converters at run time from live annotation
objects, dispatching on annotation identity. Python spells the same type more than one
way, and a dispatch site that has not been taught a spelling does not raise — it falls
through to a no-match branch and silently builds the wrong validator or converter.

Fixed across `_make_type_converter`, `type_validation`, `_is_strictly_immutable_type`,
`get_represented_types` and `infer_type`:

- **PEP 604 unions.** `origin_type is Union` missed `types.UnionType`, so `int | None`
  reached `is_actual_type()` — which accepts it, being a real class — and built a
  converter calling `types.UnionType(value)`: the class built, every instantiation
  raised. On 3.14 `typing.Union` *is* `types.UnionType`, so non-optional unions reach
  that same fallback; they are now rejected explicitly, at class creation.
- **`Optional` argument order.** `typing` preserves the written order, so
  `Union[None, int]` recursed into `NoneType` and raised.
- **`Annotated`.** No funnel saw through it. On 3.12 `typing.Annotated` is a class, so
  two of them took it for an ordinary type — building a `typing.Annotated(value)` call,
  and an `isinstance` check nothing can satisfy; the immutability check tested the
  metadata and called immutable fields mutable; `get_represented_types` reported the
  special form itself. Inside `type[...]` neither the metadata nor a nested PEP 695
  alias was resolved, so `type[Annotated[int, "meta"]]` accepted `str`.
- **`Literal`.** `get_represented_types` returned `()`, and callers pass the result to
  `isinstance()`, making every such check `False`.
- **`infer_type`** recognized only PEP 585 generics, so `typing.List[int]`,
  `Optional[int]`, `int | str` and PEP 695 aliases came back as the CPython-internal
  class implementing them.
- **Cycles of aliases and `Annotated`.** `type R = Annotated[R, ...]`, or a mutually
  wrapping pair, resolves only to itself. In `type_validation` the placeholder became
  its own validator, so the annotation built cleanly and exhausted the stack on the
  first value checked; the other funnels walked the two wrappers until the interpreter
  stack ran out. Both are now reported as unresolvable while building.

`normalize_union`, `strip_annotated` and `resolve_annotation` carry the reasoning the
funnels would otherwise each repeat. Each returns the identical object when it has
nothing to do, so a caller can detect the no-op with `is` -- which `normalize_union`
has to check for explicitly, since from 3.14 `typing.Union` *is* `types.UnionType` and
an `isinstance` test alone also matches annotations that are already normalized. The last resolves aliases and `Annotated` together
as a bounded fixpoint with cycle detection, which is what keeps the cycles above from
recursing: applied in separate branches the two wrappers walk each other forever. Also removed: a discarded duplicate `make_recursive()` call that built
every `Sequence`/`Set` member validator twice.

Behaviour change: `x: int | str = field(converter="coerce")` now raises `EveTypeError`
at class creation instead of building a converter that fails on every value. No in-tree
`Coerced[...]` site is affected.

`tests/eve_tests/unit_tests/test_annotation_spelling.py` is a conformance matrix
crossing each spelling with each dispatch site, asserting that two spellings of one
type agree rather than checking fixed expectations, so it keeps working as sites are
added. Every fix above was verified by reverting it alone and confirming the matrix
fails. Three ways the matrix could quietly stop asserting anything are themselves
tested: PEP 563 string annotations, `typing`'s parametrization cache turning a string
round-trip into an identity, and `get_partial_type_hints` stripping `Annotated` before
datamodel-mediated funnels ever see it.

Not fixed here: 13 further gaps found auditing the dispatch sites. Eight need a PEP 695
alias to trigger and `src/` has none — the worst is `eve/traits.py:118`, where a
`SymbolRef` behind an alias is never collected and dangling-symbol validation becomes a
no-op; fixing them means normalizing annotations where they are stored, which is an ADR
decision. The other four activate with the upcoming annotation sweep and must land in
the same commit as the rewrite that triggers them, notably `next/otf/workflow.py:159`,
where `issubclass(get_origin(X | None), ...)` is `False` and an optional pipeline step
is silently dropped from `step_order`.

Verified on 3.12, 3.13 and 3.14: 858 passed + 57 doctests each. `next` / `storage` /
`cartesian` unit tests: 3057 passed, 108 skipped, 13 xfailed. `pre-commit run
--all-files` clean, including mypy and tach. Not run locally: the backend matrix.
