### PR TITLE
refactor[eve]: replace extended_typing re-exports with extra_typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,10 +241,6 @@ disable_error_code = "call-arg"
 module = 'gt4py.cartesian.frontend.defir_to_gtir'
 
 [[tool.mypy.overrides]]
-module = 'gt4py.eve.extended_typing'
-warn_unused_ignores = false
-
-[[tool.mypy.overrides]]
 # TODO: Make this false and fix errors
 disallow_untyped_defs = false
 follow_imports = 'silent'
@@ -372,7 +368,6 @@ ignore = [
 ]
 preview = true  # use only with explicit-preview-rules=true
 select = ['A', 'B', 'CPY', 'E', 'ERA', 'F', 'FA100', 'I', 'ISC', 'NPY', 'Q', 'RUF', 'T10', 'YTT']
-typing-modules = ['gt4py.eve.extended_typing']
 unfixable = []
 
 [tool.ruff.lint.flake8-builtins]

--- a/scripts/python/check.py
+++ b/scripts/python/check.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env -S uv run -q --frozen --isolated --python 3.12 --group scripts python3
+#
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Repository consistency checks."""
+
+from __future__ import annotations
+
+import ast
+import collections
+import typing
+
+import rich
+import typer
+from helpers import common
+
+
+cli = typer.Typer(no_args_is_help=True, name="check", help=__doc__)
+
+SEARCH_ROOTS: typing.Final[tuple[str, ...]] = ("src", "tests", "scripts", "typing_tests")
+
+
+def _typing_extensions_imports() -> dict[str, list[str]]:
+    """Map every name imported from `typing_extensions` to where it is imported."""
+    found: dict[str, list[str]] = collections.defaultdict(list)
+    for root in SEARCH_ROOTS:
+        for path in sorted((common.REPO_ROOT / root).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text())
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module == "typing_extensions":
+                    for alias in node.names:
+                        location = f"{path.relative_to(common.REPO_ROOT)}:{node.lineno}"
+                        found[alias.name].append(location)
+    return dict(found)
+
+
+@cli.command("typing-extensions-usage")
+def typing_extensions_usage() -> None:
+    """Report `typing_extensions` imports that the current Python floor makes redundant.
+
+    The project imports from `typing_extensions` only what the supported Python floor
+    does not provide, or where the two implementations genuinely differ. Both sets
+    shrink as the floor rises, but nothing makes that visible: run this after bumping
+    `requires-python` to find the imports that can move to `typing`.
+
+    A name is only reported when `typing` provides the very same object, so the
+    deliberate cases -- where `typing_extensions` is chosen because its implementation
+    differs -- are not flagged.
+    """
+    try:
+        import typing_extensions
+    except ModuleNotFoundError:
+        rich.print("[red]'typing_extensions' is not installed in this environment.[/red]")
+        raise typer.Exit(1) from None
+
+    floor = f"{common.PYTHON_VERSIONS[0]}"
+    graduated: list[tuple[str, list[str]]] = []
+    kept: list[str] = []
+    for name, locations in sorted(_typing_extensions_imports().items()):
+        in_typing = getattr(typing, name, None)
+        if in_typing is None:
+            kept.append(f"{name} (absent from 'typing')")
+        elif in_typing is getattr(typing_extensions, name, None):
+            graduated.append((name, locations))
+        else:
+            kept.append(f"{name} (different object in 'typing')")
+
+    rich.print(f"Python floor: [bold]{floor}[/bold] (from '.python-versions')")
+    if graduated:
+        rich.print("\n[yellow]Can move to 'typing':[/yellow]")
+        for name, locations in graduated:
+            rich.print(f"  {name}")
+            for location in locations:
+                rich.print(f"      {location}")
+    else:
+        rich.print("\n[green]No 'typing_extensions' import can move to 'typing' yet.[/green]")
+    if kept:
+        rich.print("\nStaying on 'typing_extensions':")
+        for entry in kept:
+            rich.print(f"  {entry}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/gt4py/_core/definitions.py
+++ b/src/gt4py/_core/definitions.py
@@ -14,22 +14,14 @@ import enum
 import functools
 import math
 import numbers
-
-import numpy as np
-import numpy.typing as npt
-
-import gt4py.eve as eve
-from gt4py._core import types as core_types
-from gt4py.eve.extended_typing import (
+from collections.abc import Iterator, Sequence
+from typing import (
     TYPE_CHECKING,
     Any,
     Final,
     Generic,
-    Iterator,
     Literal,
-    Protocol,
     Self,
-    Sequence,
     TypeAlias,
     TypeGuard,
     TypeVar,
@@ -37,6 +29,13 @@ from gt4py.eve.extended_typing import (
     cast,
     overload,
 )
+
+import numpy as np
+import numpy.typing as npt
+from typing_extensions import Protocol
+
+import gt4py.eve as eve
+from gt4py._core import types as core_types
 
 
 try:

--- a/src/gt4py/eve/__init__.py
+++ b/src/gt4py/eve/__init__.py
@@ -11,7 +11,7 @@
 The internal dependencies between modules are the following (each module depends
 on some of the previous ones):
 
-  0. extended_typing
+  0. extra_typing
   1. exceptions, pattern_matching, type_definitions
   2. utils
   3. type_validation

--- a/src/gt4py/eve/codegen.py
+++ b/src/gt4py/eve/codegen.py
@@ -21,28 +21,16 @@ import subprocess
 import sys
 import textwrap
 import types
+from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
+from typing import Any, ClassVar, Optional, TypeVar, Union, overload
 
 import black
 import jinja2
 from mako import template as mako_tpl
+from typing_extensions import Protocol, runtime_checkable
 
 from . import exceptions, utils
 from .concepts import CollectionNode, LeafNode, Node, RootNode
-from .extended_typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Collection,
-    Iterator,
-    Mapping,
-    Optional,
-    Protocol,
-    Sequence,
-    TypeVar,
-    Union,
-    overload,
-    runtime_checkable,
-)
 from .visitors import NodeVisitor
 
 

--- a/src/gt4py/eve/concepts.py
+++ b/src/gt4py/eve/concepts.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 
 import copy
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import Any, ClassVar, Final, Optional, TypeVar, Union
 
-from . import datamodels, exceptions, extended_typing as xtyping, trees, utils
+from . import datamodels, exceptions, extra_typing, trees, utils
 from .datamodels import validators as _validators
-from .extended_typing import Any, ClassVar, Final, Iterable, Optional, TypeVar, Union
 from .type_definitions import ConstrainedStr, IntEnum, StrEnum
 
 
@@ -105,7 +105,7 @@ class AnnexManager:
     def register_user(
         cls: type[AnnexManager],
         key: str,
-        type_hint: xtyping.TypeAnnotation,
+        type_hint: extra_typing.TypeAnnotation,
         *,
         shared: bool = False,
     ) -> Callable[[_T], _T]:

--- a/src/gt4py/eve/datamodels/core.py
+++ b/src/gt4py/eve/datamodels/core.py
@@ -32,26 +32,26 @@ except ModuleNotFoundError:
     # Fall back to pure Python toolz
     import toolz
 
-from .. import exceptions, extended_typing as xtyping, type_validation as type_val, utils
-from ..extended_typing import (
+from collections.abc import Callable, Generator, Mapping, Sequence
+from typing import (
     Any,
-    Callable,
     ClassVar,
     Final,
     ForwardRef,
-    Generator,
     Literal,
-    Mapping,
     Optional,
-    Protocol,
-    Sequence,
     TypeAlias,
-    TypeAnnotation,
     TypeVar,
     Union,
     cast,
     overload,
 )
+
+import typing_extensions
+from typing_extensions import Protocol
+
+from .. import exceptions, extra_typing, type_validation as type_val, utils
+from ..extra_typing import TypeAnnotation
 from ..type_definitions import NOTHING, NothingType
 
 
@@ -75,7 +75,7 @@ class _AttrsClassTP(Protocol):
 Attribute: TypeAlias = attr.Attribute
 
 
-class DataModelTP(_AttrsClassTP, xtyping.DevToolsPrettyPrintable, Protocol):
+class DataModelTP(_AttrsClassTP, extra_typing.DevToolsPrettyPrintable, Protocol):
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
     __datamodel_fields__: ClassVar[utils.FrozenNamespace[Attribute]] = cast(
@@ -85,7 +85,7 @@ class DataModelTP(_AttrsClassTP, xtyping.DevToolsPrettyPrintable, Protocol):
         utils.FrozenNamespace[Attribute], None
     )
     __datamodel_root_validators__: ClassVar[
-        tuple[xtyping.NonDataDescriptor[DataModelTP, BoundRootValidator], ...]
+        tuple[extra_typing.NonDataDescriptor[DataModelTP, BoundRootValidator], ...]
     ] = ()
     # Optional
     __auto_init__: ClassVar[Callable[..., None]] = cast(Callable[..., None], None)
@@ -157,11 +157,11 @@ MODEL_PARAM_DEFINITIONS_ATTR: Final = "__datamodel_params__"
 MODEL_ROOT_VALIDATORS_ATTR: Final = "__datamodel_root_validators__"
 
 
-Coerced = xtyping.Annotated[_T, _COERCED_TYPE_TAG]
+Coerced = typing.Annotated[_T, _COERCED_TYPE_TAG]
 """Type hint marker to define fields that should be coerced at initialization."""
 
 
-Unchecked = xtyping.Annotated[_T, _UNCHECKED_TYPE_TAG]
+Unchecked = typing.Annotated[_T, _UNCHECKED_TYPE_TAG]
 """Type hint marker to define fields that should NOT be type-checked at initialization."""
 
 
@@ -224,7 +224,7 @@ def field_type_validator_factory(
         try:
             simple_validator = factory(type_annotation, name, required=True)
         except NameError:
-            # Deferral signal from 'xtyping.eval_type_alias' (see its 'except NameError'
+            # Deferral signal from 'extra_typing.eval_type_alias' (see its 'except NameError'
             # branch); handled like a forward reference.
             return ForwardRefValidator(factory)
 
@@ -424,7 +424,7 @@ frozen_model = frozenmodel
 
 
 # Typing protocols are used instead of the actual classes for type checks
-if xtyping.TYPE_CHECKING:
+if typing.TYPE_CHECKING:
 
     class DataModel(DataModelTP):
         def __init__(self, *args: Any, **kwargs: Any) -> None: ...
@@ -642,7 +642,7 @@ def is_datamodel(obj: Any) -> bool:
 def is_generic_datamodel_class(cls: type[Any]) -> bool:
     """Return ``True`` if `obj` is a generic Data Model class with type parameters."""
     assert isinstance(cls, type)
-    return is_datamodel(cls) and xtyping.has_type_parameters(cls)
+    return is_datamodel(cls) and extra_typing.has_type_parameters(cls)
 
 
 def get_fields(model: Union[DataModel, type[DataModel]]) -> utils.FrozenNamespace:
@@ -759,7 +759,7 @@ def update_forward_refs(
 
             if isinstance(field_attr.type, ForwardRef):
                 try:
-                    actual_type = xtyping.eval_forward_ref(
+                    actual_type = extra_typing.eval_forward_ref(
                         field_attr.type,
                         sys.modules[model_cls.__module__].__dict__,
                         localns,
@@ -997,12 +997,12 @@ class DeferredTypeConverter:
 def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConverter[_T]:
     # TODO(egparedes): if a "typing tree" structure is implemented, refactor this code
     # as a tree traversal.
-    type_annotation = xtyping.normalize_union(type_annotation)
+    type_annotation = extra_typing.normalize_union(type_annotation)
 
     try:
         # Aliases and 'Annotated' metadata are resolved together: applied in separate
         # branches they recurse forever on an annotation where each wraps the other.
-        resolved_annotation = xtyping.resolve_annotation(type_annotation)
+        resolved_annotation = extra_typing.resolve_annotation(type_annotation)
     except NameError:
         # Deferral signal, as in 'field_type_validator_factory' above.
         return cast(TypeConverter[_T], DeferredTypeConverter(type_annotation, name))
@@ -1010,8 +1010,8 @@ def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConv
     if resolved_annotation is not type_annotation:
         return _make_type_converter(resolved_annotation, name)
 
-    if xtyping.is_actual_type(type_annotation) and not isinstance(None, type_annotation):
-        assert not xtyping.get_args(type_annotation)
+    if extra_typing.is_actual_type(type_annotation) and not isinstance(None, type_annotation):
+        assert not typing.get_args(type_annotation)
         assert isinstance(type_annotation, type)
 
         def _type_converter(value: Any) -> _T:
@@ -1034,11 +1034,11 @@ def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConv
     if type_annotation is Any:
         return toolz.identity
 
-    origin_type = xtyping.get_origin(type_annotation)
+    origin_type = typing.get_origin(type_annotation)
 
     if (
-        origin_type is xtyping.Union
-        and type(None) in (args := xtyping.get_args(type_annotation))
+        origin_type is typing.Union
+        and type(None) in (args := typing.get_args(type_annotation))
         and len(args) == 2
     ):
         # Optional type. 'typing' preserves the order the arguments were written in,
@@ -1049,7 +1049,7 @@ def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConv
 
         return cast(TypeConverter[_T], lambda x: x if x is None else _inner_type_converter(x))
 
-    if origin_type is xtyping.Union:
+    if origin_type is typing.Union:
         # No single type to coerce to. Explicit because on 3.14 'typing.Union' *is*
         # 'types.UnionType', a real class, which the 'is_actual_type(origin_type)'
         # fallback below would accept and turn into a 'types.UnionType(value)' call.
@@ -1057,7 +1057,7 @@ def _make_type_converter(type_annotation: TypeAnnotation, name: str) -> TypeConv
             f"Automatic type coercion for {type_annotation} types is not supported."
         )
 
-    if xtyping.is_actual_type(origin_type):
+    if extra_typing.is_actual_type(origin_type):
         return _make_type_converter(origin_type, name)
 
     raise exceptions.EveTypeError(
@@ -1102,14 +1102,17 @@ def _is_strictly_immutable_type(
     Returns:
         ``True`` if every value admitted by the annotation is strictly immutable.
     """
-    if xtyping.is_type_alias(type_annotation) or xtyping.get_origin(type_annotation) is not None:
+    if (
+        extra_typing.is_type_alias(type_annotation)
+        or typing.get_origin(type_annotation) is not None
+    ):
         # A PEP 695 alias stands for the annotation it resolves to, and 'Annotated'
         # metadata is not part of the type, so check what is left once both are gone.
         # An annotation that cannot be resolved (undefined name, recursive, ...) proves
         # nothing and is rejected below like any other unresolved one; anything else is
         # returned unchanged, as the identical object.
         try:
-            resolved_alias = xtyping.resolve_annotation(type_annotation)
+            resolved_alias = extra_typing.resolve_annotation(type_annotation)
         except (NameError, TypeError):
             return False
         if resolved_alias is not type_annotation:
@@ -1120,12 +1123,12 @@ def _is_strictly_immutable_type(
     if is_datamodel(type_annotation):
         return getattr(type_annotation, MODEL_PARAM_DEFINITIONS_ATTR).strict_frozen is True
 
-    origin_type = xtyping.get_origin(type_annotation)
-    type_args = xtyping.get_args(type_annotation)
+    origin_type = typing.get_origin(type_annotation)
+    type_args = typing.get_args(type_annotation)
 
     if origin_type is Literal:
         # 'Literal' arguments are values, not types.
-        return all(xtyping.is_type_with_custom_hash(type(arg)) for arg in type_args)
+        return all(extra_typing.is_type_with_custom_hash(type(arg)) for arg in type_args)
 
     if origin_type is Union or origin_type is types.UnionType:
         # 'Union[A, B]' and 'A | B' are different runtime objects before Python 3.14.
@@ -1146,13 +1149,15 @@ def _is_strictly_immutable_type(
             _is_strictly_immutable_type(arg) for arg in type_args if arg is not Ellipsis
         )
 
-    if xtyping.is_actual_type(type_annotation):  # plain type, already known not to be a datamodel
+    if extra_typing.is_actual_type(
+        type_annotation
+    ):  # plain type, already known not to be a datamodel
         if not _as_container_origin and issubclass(type_annotation, _ITEM_HASHING_CONTAINER_TYPES):
             # Unparametrized container ('tuple', 'frozenset', a 'NamedTuple', ...): its
             # hash folds in the hashes of items which nothing here proves immutable, the
             # same reason why 'tuple[Any, ...]' is rejected.
             return False
-        return xtyping.is_type_with_custom_hash(type_annotation)
+        return extra_typing.is_type_with_custom_hash(type_annotation)
 
     if isinstance(type_annotation, TypeVar):
         # Check the concrete annotations the type variable can stand for. Note that the
@@ -1170,7 +1175,7 @@ def _is_strictly_immutable_type(
         # Forward references that cannot be resolved at this point do not prove
         # anything, so they are rejected instead of propagating the resolution error.
         try:
-            resolved_annotation = xtyping.eval_forward_ref(type_annotation)
+            resolved_annotation = extra_typing.eval_forward_ref(type_annotation)
         except Exception:
             return False
         return _is_strictly_immutable_type(resolved_annotation)
@@ -1205,8 +1210,8 @@ def _make_datamodel(
     if "__annotations__" not in cls.__dict__ and "__annotate_func__" not in cls.__dict__:
         cls.__annotations__ = {}
     annotations = cls.__annotations__
-    resolved_annotations = xtyping.get_partial_type_hints(cls)
-    annotations_with_extras = xtyping.get_partial_type_hints(cls, include_extras=True)
+    resolved_annotations = extra_typing.get_partial_type_hints(cls)
+    annotations_with_extras = extra_typing.get_partial_type_hints(cls, include_extras=True)
 
     frozen, strict_frozen = (True, True) if frozen == "strict" else (frozen, False)
 
@@ -1217,11 +1222,11 @@ def _make_datamodel(
         type_hint = annotations[key] = resolved_annotations[key]
 
         # Skip members annotated as class variables
-        if type_hint is ClassVar or xtyping.get_origin(type_hint) is ClassVar:
+        if type_hint is ClassVar or typing.get_origin(type_hint) is ClassVar:
             continue
 
-        if xtyping.get_origin(annotations_with_extras[key]) == xtyping.Annotated:
-            _, *type_extras = xtyping.get_args(annotations_with_extras[key])
+        if typing.get_origin(annotations_with_extras[key]) == typing.Annotated:
+            _, *type_extras = typing.get_args(annotations_with_extras[key])
         else:
             type_extras = []
 
@@ -1293,7 +1298,7 @@ def _make_datamodel(
             num_attrs += 1
             if (
                 key not in annotations
-                and xtyping.get_origin(resolved_annotations.get(key, None)) is not ClassVar
+                and typing.get_origin(resolved_annotations.get(key, None)) is not ClassVar
             ):
                 raise TypeError(f"Missing type annotation in '{key}' field.")
 
@@ -1347,7 +1352,7 @@ def _make_datamodel(
             generic = True
         else:
             # For any other subclass, add the proper __class_getitem__ method
-            if not issubclass(cls, (typing.Generic, xtyping.Generic)):
+            if not issubclass(cls, (typing.Generic, typing.Generic)):
                 raise TypeError(
                     f"'{cls.__name__}' cannot be converted to a GenericDataModel because it is not a generic class."
                 )
@@ -1436,7 +1441,7 @@ def _make_concrete_with_cache(
         _accepted_types: tuple[type, ...] = (
             type,
             type(None),
-            xtyping.StdGenericAliasType,
+            extra_typing.StdGenericAliasType,
             types.UnionType,
         )
         if not (
@@ -1459,7 +1464,7 @@ def _make_concrete_with_cache(
     new_annotations = {}
 
     new_field_c_attrs = {}
-    for field_name, field_type in xtyping.get_type_hints(datamodel_cls).items():
+    for field_name, field_type in typing_extensions.get_type_hints(datamodel_cls).items():
         new_annotation, replaced = _substitute_typevars(field_type, type_params_map)
         if replaced:
             new_annotations[field_name] = new_annotation
@@ -1519,7 +1524,7 @@ def _make_concrete_with_cache(
     return concrete_cls
 
 
-if xtyping.TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     FrozenModel: TypeAlias = DataModel
 
 else:
@@ -1528,7 +1533,7 @@ else:
         __slots__ = ()
 
 
-if xtyping.TYPE_CHECKING:
+if typing.TYPE_CHECKING:
 
     class GenericDataModel(GenericDataModelTP):
         @classmethod

--- a/src/gt4py/eve/exceptions.py
+++ b/src/gt4py/eve/exceptions.py
@@ -10,7 +10,7 @@
 
 from __future__ import annotations
 
-from .extended_typing import Any, Optional
+from typing import Any, Optional
 
 
 class EveError:

--- a/src/gt4py/eve/extra_typing.py
+++ b/src/gt4py/eve/extra_typing.py
@@ -6,172 +6,260 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""
-Typing definitions working across different Python versions (via `typing_extensions`).
+"""Typing definitions that `typing` and `typing_extensions` do not provide.
 
-Definitions in 'typing_extensions' take priority over those in 'typing'.
+This module is **not** a replacement for `typing`: it does not re-export it.
+Import the standard names from `typing`, `typing_extensions` or
+`collections.abc` directly, and take only GT4Py's own definitions from here --
+the array and DLPack protocols, the nested-collection aliases, the descriptor
+and dataclass protocols, and the annotation utilities.
+
+Where a name lives, and why:
+
+- `collections.abc` -- the container protocols (`Sequence`, `Mapping`,
+  `Callable`, `Iterable`, `Iterator`, `Collection`, `Generator`, ...). Their
+  `typing` spellings are deprecated by PEP 585.
+- `typing` -- everything the standard library provides on the supported floor,
+  including `TypeVar`, `TypeVarTuple`, `ParamSpec` and `NamedTuple`. The
+  `typing_extensions` versions of those four differ only in PEP 696
+  `default=` support and generic/defaulted named tuples, neither of which this
+  codebase uses.
+- `typing_extensions` -- `TypeIs` and `is_protocol`, which Python 3.12 lacks
+  (both land in `typing` at 3.13, so they move when the floor rises); plus
+  `Protocol`, `runtime_checkable` and `get_type_hints`, whose implementations
+  genuinely differ from the `typing` ones. `eve` runs every annotation through
+  `get_type_hints`, and `gt4py.next` declares `@runtime_checkable` protocols
+  that are checked on hot paths, so those keep the implementation they have
+  always had.
+
+Run `./scripts/run check typing-extensions-usage` after raising the Python
+floor to find the `typing_extensions` imports that can move to `typing`.
 """
 
 from __future__ import annotations
 
-# ruff: noqa: F401, F405
 import abc as _abc
 import array as _array
-import builtins as _builtins
+import collections as _collections
 import collections.abc as _collections_abc
+import contextlib as _contextlib
 import dataclasses as _dataclasses
 import functools as _functools
 import inspect as _inspect
 import mmap as _mmap
 import pickle as _pickle
-import sys as _sys
+import re as _re
 import types as _types
 import typing as _typing
-from typing import *  # noqa: F403 [undefined-local-with-import-star]
-from typing import overload
+from collections.abc import (
+    Buffer,
+    Callable,
+    Generator,
+    Hashable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    Final,
+    ForwardRef,
+    Generic,
+    Literal,
+    Never,
+    NotRequired,
+    Optional,
+    ParamSpec,
+    Self,
+    SupportsBytes,
+    TypeAlias,
+    TypeAliasType,
+    TypedDict,
+    TypeGuard,
+    TypeVar,
+    Union,
+    final,
+    get_args,
+    get_origin,
+    overload,
+)
 
 import numpy.typing as npt
 import typing_extensions as _typing_extensions
-from typing_extensions import *  # type: ignore[assignment,no-redef]  # noqa: F403 [undefined-local-with-import-star]
+from typing_extensions import Protocol, TypeIs, get_type_hints, runtime_checkable
 
 
-# Re-export the standard collection types under the names the star imports above bind to
-# their deprecated 'typing' counterparts, so that e.g. 'Sequence' is
-# 'collections.abc.Sequence' rather than 'typing.Sequence'. This block must stay *below*
-# the star imports, since it deliberately rebinds names those imports also define; the
-# 'isort: split' marker keeps the import sorter from hoisting it. The builtin generics
-# are deliberately not re-exported under their old 'typing' spellings; see
-# '_DEPRECATED_TYPING_ALIASES' below.
-# isort: split
-from collections import (
-    ChainMap as ChainMap,
-    Counter as Counter,
-    OrderedDict as OrderedDict,
-    defaultdict as defaultdict,
-    deque as deque,
-)
-from collections.abc import (
-    AsyncGenerator as AsyncGenerator,
-    AsyncIterable as AsyncIterable,
-    AsyncIterator as AsyncIterator,
-    Awaitable as Awaitable,
-    ByteString as ByteString,
-    Callable as Callable,
-    Collection as Collection,
-    Container as Container,
-    Coroutine as Coroutine,
-    Generator as Generator,
-    ItemsView as ItemsView,
-    Iterable as Iterable,
-    Iterator as Iterator,
-    KeysView as KeysView,
-    Mapping as Mapping,
-    MappingView as MappingView,
-    MutableMapping as MutableMapping,
-    MutableSequence as MutableSequence,
-    MutableSet as MutableSet,
-    Reversible as Reversible,
-    Sequence as Sequence,
-    Set as AbstractSet,
-    ValuesView as ValuesView,
-)
-from contextlib import (
-    AbstractAsyncContextManager as AsyncContextManager,
-    AbstractContextManager as ContextManager,
-)
-from re import Match as Match, Pattern as Pattern
+#: Only this module's own definitions are exported. The names it imports for its own
+#: use stay reachable as attributes -- that is true of any module -- but they are
+#: deliberately not offered here: import them from 'typing', 'typing_extensions'
+#: or 'collections.abc' at the use site.
+__all__ = [
+    "ArgsOnlyCallable",
+    "ArrayInterface",
+    "ArrayInterfaceTypedDict",
+    "CUDAArrayInterface",
+    "CUDAArrayInterfaceTypedDict",
+    "CallableKwargsInfo",
+    "DLPackBuffer",
+    "DLPackDevice",
+    "DataDescriptor",
+    "DataclassABC",
+    "DevToolsPrettyPrintable",
+    "FrozenDataclass",
+    "HasCustomHash",
+    "HashlibAlgorithm",
+    "MaybeNested",
+    "MaybeNestedInList",
+    "MaybeNestedInSequence",
+    "MaybeNestedInTuple",
+    "MultiStreamDLPackBuffer",
+    "NestedList",
+    "NestedSequence",
+    "NestedTuple",
+    "NoArgsCallable",
+    "NonDataDescriptor",
+    "OpaqueMutableMapping",
+    "ReadOnlyBuffer",
+    "ReadableBuffer",
+    "SingleDispatchCallable",
+    "SingleStreamDLPackBuffer",
+    "SingleTypeAnnotation",
+    "SolvedTypeAnnotation",
+    "SourceTypeAnnotation",
+    "StdGenericAliasType",
+    "StrictArrayInterface",
+    "StrictCUDAArrayInterface",
+    "SupportsArray",
+    "TypeAnnotation",
+    "TypedNamedTupleABC",
+    "WriteableBuffer",
+    "annotations",
+    "eval_forward_ref",
+    "eval_type_alias",
+    "get_actual_type",
+    "get_partial_type_hints",
+    "get_represented_types",
+    "has_type_parameters",
+    "infer_type",
+    "is_Any",
+    "is_actual_type",
+    "is_maybe_nested_in_tuple_of",
+    "is_nested_tuple_of",
+    "is_single_dispatch_callable",
+    "is_type_alias",
+    "is_type_with_custom_hash",
+    "normalize_union",
+    "resolve_annotation",
+    "strip_annotated",
+    "supports_array",
+    "supports_array_interface",
+    "supports_cuda_array_interface",
+    "supports_dlpack",
+]
 
 
-# The 'typing' aliases of the builtin generics are deprecated since PEP 585 and are no
-# longer re-exported: use the builtin spelling instead. They are not simply absent from
-# this module -- the star imports above bind them, and '__getattr__' below would happily
-# forward them to 'typing' -- so they are dropped from the namespace here and rejected
-# explicitly. Without this, removing them would silently downgrade every use site from
-# the builtin to the deprecated 'typing' object. Note that this is a runtime guarantee
-# only: a type checker still resolves the names through the star imports.
-_DEPRECATED_TYPING_ALIASES: Final[Mapping[str, str]] = {
-    "Dict": "dict",
-    "FrozenSet": "frozenset",
-    "List": "list",
-    "Set": "set",
-    "Tuple": "tuple",
-    "Type": "type",
-}
+# -- Forward-reference resolution --
+#
+# A forward reference is a string, so resolving it needs a namespace to evaluate it
+# in. This module used to be that namespace: it star-imported 'typing' and
+# 'typing_extensions', so 'globals()' happened to contain every typing name and
+# 'eval_forward_ref' could fall back to it. Nothing re-exports anything now, so the
+# namespace is built explicitly below -- which is also what it always meant.
 
-for _alias in _DEPRECATED_TYPING_ALIASES:
-    globals().pop(_alias, None)
-del _alias
-
-# The names are still valid in user-written annotations, and resolving a forward
-# reference through this module has always normalized them to the builtin generic
-# ('typing.List[int]' -> 'list[int]'). Keep that mapping available to the forward-ref
-# machinery below, which would otherwise either raise or hand back the deprecated
-# 'typing' object.
+#: The 'typing' aliases of the builtin generics are deprecated by PEP 585, but they
+#: stay valid in user-written annotations, and resolving one through this module has
+#: always normalized it to the builtin generic ('typing.List[int]' -> 'list[int]').
 _DEPRECATED_ALIAS_REPLACEMENTS: Final[Mapping[str, Any]] = {
-    name: getattr(_builtins, replacement)
-    for name, replacement in _DEPRECATED_TYPING_ALIASES.items()
+    "Dict": dict,
+    "FrozenSet": frozenset,
+    "List": list,
+    "Set": set,
+    "Tuple": tuple,
+    "Type": type,
 }
+
+#: Names that a forward reference may use and that must resolve to the
+#: 'collections.abc' / 'collections' / 'contextlib' / 're' object rather than to the
+#: deprecated 'typing' alias of the same name.
+_NON_TYPING_ALIASES: Final[Mapping[str, Any]] = {
+    **{
+        name: getattr(_collections_abc, name)
+        for name in (
+            "AsyncGenerator",
+            "AsyncIterable",
+            "AsyncIterator",
+            "Awaitable",
+            "Callable",
+            "Collection",
+            "Container",
+            "Coroutine",
+            "Generator",
+            "ItemsView",
+            "Iterable",
+            "Iterator",
+            "KeysView",
+            "Mapping",
+            "MappingView",
+            "MutableMapping",
+            "MutableSequence",
+            "MutableSet",
+            "Reversible",
+            "Sequence",
+            "ValuesView",
+        )
+    },
+    "AbstractSet": _collections_abc.Set,
+    "ChainMap": _collections.ChainMap,
+    "Counter": _collections.Counter,
+    "OrderedDict": _collections.OrderedDict,
+    "defaultdict": _collections.defaultdict,
+    "deque": _collections.deque,
+    "AsyncContextManager": _contextlib.AbstractAsyncContextManager,
+    "ContextManager": _contextlib.AbstractContextManager,
+    "Match": _re.Match,
+    "Pattern": _re.Pattern,
+}
+
+
+@_functools.cache
+def _forward_ref_namespace() -> dict[str, Any]:
+    """Namespace used to resolve a forward reference when the caller provides none.
+
+    Later entries win, so the precedence is: 'typing', then 'typing_extensions',
+    then the non-'typing' spellings of the container protocols, then this module's
+    own definitions, then the builtin generics standing in for the deprecated
+    'typing' aliases.
+    """
+    namespace: dict[str, Any] = {}
+    namespace.update(vars(_typing))
+    namespace.update(vars(_typing_extensions))
+    namespace.update(_NON_TYPING_ALIASES)
+    namespace.update(globals())
+    namespace.update(_DEPRECATED_ALIAS_REPLACEMENTS)
+    return namespace
 
 
 class _ForwardRefTypingNamespace:
     """Namespace bound to the name 'typing' while evaluating forward references.
 
-    Annotations resolve through this module, so that 'typing_extensions' definitions
-    take priority and the standard collection types are used. The deprecated builtin
-    aliases are not re-exported here, but they stay valid in user-written annotations,
-    so 'typing.List[int]' resolves to 'list[int]' rather than raising.
+    A reference spelled 'typing.Sequence[int]' resolves through this object, so that
+    'typing_extensions' definitions take priority, the container protocols come from
+    'collections.abc', and the deprecated builtin aliases give back the builtin
+    generic instead of the deprecated 'typing' object.
     """
 
     def __getattr__(self, name: str) -> Any:
-        if (replacement := _DEPRECATED_ALIAS_REPLACEMENTS.get(name)) is not None:
-            return replacement
-        return getattr(_sys.modules[__name__], name)
+        namespace = _forward_ref_namespace()
+        if name in namespace:
+            return namespace[name]
+        raise AttributeError(f"Module 'typing' has no attribute '{name}'.")
 
 
 _FORWARD_REF_TYPING_NS: Final = _ForwardRefTypingNamespace()
-
-
-# These fallbacks are useful for public symbols not exported by default.
-# Again, definitions in 'typing_extensions' take priority over those in 'typing'
-def __getattr__(name: str) -> Any:
-    import sys
-
-    import typing_extensions
-
-    if (replacement := _DEPRECATED_TYPING_ALIASES.get(name)) is not None:
-        raise AttributeError(
-            f"'{name}' is a deprecated 'typing' alias (PEP 585) and is not exported by"
-            f" '{__name__}'. Use '{replacement}' instead."
-        )
-
-    result = SENTINEL = object()
-    if not (name.startswith("__") and name.endswith("__")):
-        result = getattr(typing_extensions, name, SENTINEL)
-        if result is SENTINEL:
-            import typing
-
-            result = getattr(typing, name, SENTINEL)
-
-    if result is SENTINEL:
-        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-    setattr(sys.modules[__name__], name, result)  # cache result
-
-    return result
-
-
-def __dir__() -> list[str]:
-    if not hasattr(self_func := (globals()["__dir__"]), "__cached_dir"):
-        import typing
-
-        import typing_extensions
-
-        # Everything reachable through '__getattr__' plus this module's own definitions,
-        # minus the aliases '__getattr__' explicitly rejects.
-        names = {*typing.__dir__(), *typing_extensions.__dir__(), *globals()}
-        self_func.__cached_dir = sorted(names - _DEPRECATED_TYPING_ALIASES.keys())
-
-    return self_func.__cached_dir
 
 
 # -- Common type aliases --
@@ -684,7 +772,7 @@ def is_Any(obj: Any) -> bool:
 
 def has_type_parameters(cls: type[Any]) -> bool:
     """Return ``True`` if obj is a generic class with type parameters."""
-    return issubclass(cls, Generic) and len(getattr(cls, "__parameters__", [])) > 0  # type: ignore[arg-type]  # Generic not considered as a class
+    return issubclass(cls, Generic) and len(getattr(cls, "__parameters__", [])) > 0
 
 
 def get_actual_type(obj: _T) -> type[_T]:
@@ -881,9 +969,6 @@ class OpaqueMutableMapping(Protocol[_KT, _VT]):
     def __delitem__(self, key: _KT) -> None: ...
 
 
-is_protocol = _typing_extensions.is_protocol
-
-
 def get_partial_type_hints(
     obj: Union[
         object,
@@ -969,11 +1054,11 @@ def eval_forward_ref(
     safe_localns.setdefault("NoneType", type(None))
 
     if globalns is None:
-        # Without an explicit 'globalns' the reference is resolved in this module's
-        # namespace, which used to spell the deprecated aliases as the builtin generics.
-        # They are no longer defined here, so re-add them for this evaluation only; a
-        # caller-provided 'globalns' is left untouched, exactly as before.
-        globalns = {**globals(), **_DEPRECATED_ALIAS_REPLACEMENTS}
+        # No caller-provided namespace: resolve against the explicit one, which spells
+        # the container protocols as their 'collections.abc' objects and the deprecated
+        # 'typing' aliases as the builtin generics. A caller-provided 'globalns' is left
+        # untouched.
+        globalns = _forward_ref_namespace()
 
     actual_type = get_type_hints(f, globalns, safe_localns, include_extras=include_extras)["return"]
     assert not isinstance(actual_type, ForwardRef)

--- a/src/gt4py/eve/pattern_matching.py
+++ b/src/gt4py/eve/pattern_matching.py
@@ -10,9 +10,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from functools import singledispatch
-
-from .extended_typing import Any, Iterator
+from typing import Any
 
 
 class ObjectPattern:

--- a/src/gt4py/eve/traits.py
+++ b/src/gt4py/eve/traits.py
@@ -11,9 +11,9 @@
 from __future__ import annotations
 
 import collections
+from typing import Any, no_type_check
 
 from . import concepts, datamodels, exceptions, visitors
-from .extended_typing import Any, no_type_check
 
 
 # ---  Node Traits ---

--- a/src/gt4py/eve/trees.py
+++ b/src/gt4py/eve/trees.py
@@ -13,18 +13,12 @@ from __future__ import annotations
 import abc
 import collections.abc
 import functools
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+
+from typing_extensions import Protocol
 
 from . import utils
-from .extended_typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Iterable,
-    Optional,
-    Protocol,
-    TypeVar,
-    Union,
-)
 from .type_definitions import Enum
 
 

--- a/src/gt4py/eve/type_definitions.py
+++ b/src/gt4py/eve/type_definitions.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import abc
 import re
 from enum import Enum as Enum, IntEnum as IntEnum
+from typing import Any, ClassVar, NoReturn, Optional, TypeVar, final
 
 from boltons.typeutils import classproperty as classproperty
-
-from .extended_typing import Any, ClassVar, NoReturn, Optional, TypeVar, final
 
 
 # -- Frozen collections --

--- a/src/gt4py/eve/type_validation.py
+++ b/src/gt4py/eve/type_validation.py
@@ -15,22 +15,13 @@ import collections.abc
 import dataclasses
 import functools
 import typing
+from collections.abc import Sequence
+from typing import Any, Final, ForwardRef, Literal, Optional, TypeGuard, Union, cast, overload
 
-from . import exceptions, extended_typing as xtyping, utils
-from .extended_typing import (
-    Any,
-    Final,
-    ForwardRef,
-    Literal,
-    Optional,
-    Protocol,
-    Sequence,
-    TypeAnnotation,
-    Union,
-    cast,
-    overload,
-    runtime_checkable,
-)
+from typing_extensions import Protocol, is_protocol, runtime_checkable
+
+from . import exceptions, extra_typing, utils
+from .extra_typing import TypeAnnotation
 
 
 # Protocols
@@ -224,12 +215,12 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
             if type_annotation is None:
                 type_annotation = type(None)
 
-            type_annotation = xtyping.normalize_union(type_annotation)
+            type_annotation = extra_typing.normalize_union(type_annotation)
 
             # A 'NameError' is deliberately left to propagate here, so that 'datamodels'
-            # can defer; see 'xtyping.eval_type_alias' for both failure modes.
+            # can defer; see 'extra_typing.eval_type_alias' for both failure modes.
             try:
-                resolved_annotation = xtyping.eval_type_alias(type_annotation)
+                resolved_annotation = extra_typing.eval_type_alias(type_annotation)
             except TypeError as error:
                 # Keep its message: it names the alias and the cause.
                 raise exceptions.EveValueError(str(error)) from error
@@ -254,8 +245,8 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                 return validator
 
             # Non-generic types
-            if xtyping.is_actual_type(type_annotation):
-                assert not xtyping.get_args(type_annotation)
+            if extra_typing.is_actual_type(type_annotation):
+                assert not typing.get_args(type_annotation)
                 if type_annotation is int and kwargs.get("strict_int", True):
                     return self.make_is_instance_of_int(name)
                 else:
@@ -269,20 +260,22 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
 
             if isinstance(type_annotation, ForwardRef):
                 return make_recursive(
-                    xtyping.eval_forward_ref(type_annotation, globalns=globalns, localns=localns)
+                    extra_typing.eval_forward_ref(
+                        type_annotation, globalns=globalns, localns=localns
+                    )
                 )
 
-            if xtyping.is_Any(type_annotation):
+            if extra_typing.is_Any(type_annotation):
                 return self._make_is_any(name)
 
             # Generic and parametrized type hints
-            origin_type = xtyping.get_origin(type_annotation)
-            type_args = xtyping.get_args(type_annotation)
+            origin_type = typing.get_origin(type_annotation)
+            type_args = typing.get_args(type_annotation)
 
-            if (stripped := xtyping.strip_annotated(type_annotation)) is not type_annotation:
+            if (stripped := extra_typing.strip_annotated(type_annotation)) is not type_annotation:
                 return make_recursive(stripped)
 
-            if origin_type in {typing.Literal, xtyping.Literal}:
+            if origin_type in {typing.Literal, typing.Literal}:
                 if len(type_args) == 1:
                     return self.make_is_literal(name, type_args[0])
                 else:
@@ -323,20 +316,20 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                 # can wrap the other repeatedly, so both are resolved together; an
                 # annotation that does not resolve keeps the loose check below.
                 try:
-                    arg = xtyping.resolve_annotation(type_args[0])
+                    arg = extra_typing.resolve_annotation(type_args[0])
                 except TypeError:
                     return self.make_is_instance_of(name, type)
 
                 # After the metadata is gone, not before: `type[Annotated[A | B, ...]]`
                 # only reaches the union handling below if it is stripped first.
-                arg = xtyping.normalize_union(arg)  # `type[A | B]`
+                arg = extra_typing.normalize_union(arg)  # `type[A | B]`
 
                 # `issubclass()` is not generally usable with protocol classes: it is
                 # rejected outright unless the protocol is `@runtime_checkable`, and also
                 # for `@runtime_checkable` protocols with non-method members. Protocols
                 # therefore keep the loose check, like any other unsupported shape.
-                def is_strict_arg(a: Any) -> xtyping.TypeGuard[type]:
-                    return xtyping.is_actual_type(a) and not xtyping.is_protocol(a)
+                def is_strict_arg(a: Any) -> TypeGuard[type]:
+                    return extra_typing.is_actual_type(a) and not is_protocol(a)
 
                 if isinstance(arg, typing.TypeVar):
                     # Mirror the plain-`TypeVar` branch above, which honours the bound.
@@ -347,8 +340,8 @@ class SimpleTypeValidatorFactory(TypeValidatorFactory):
                 if is_strict_arg(arg):
                     return self.make_is_subclass_of(name, arg)
 
-                if xtyping.get_origin(arg) is Union:  # `type[A | B]`, `type[Union[A, B]]`
-                    members = xtyping.get_args(arg)
+                if typing.get_origin(arg) is Union:  # `type[A | B]`, `type[Union[A, B]]`
+                    members = typing.get_args(arg)
                     if members and all(is_strict_arg(m) for m in members):
                         return self.combine_validators_as_or(
                             name, *(self.make_is_subclass_of(name, m) for m in members)

--- a/src/gt4py/eve/utils.py
+++ b/src/gt4py/eve/utils.py
@@ -24,6 +24,19 @@ import pprint
 import re
 import types
 import typing
+from collections.abc import Callable, Collection, Iterable, Iterator
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Literal,
+    Optional,
+    ParamSpec,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 import deepdiff
 import xxhash
@@ -42,24 +55,8 @@ from boltons.strutils import (
     unwrap_text as unwrap_text,
 )
 
-from . import extended_typing as xtyping
-from .extended_typing import (
-    TYPE_CHECKING,
-    Any,
-    ArgsOnlyCallable,
-    Callable,
-    Collection,
-    Generic,
-    Iterable,
-    Iterator,
-    Literal,
-    Optional,
-    ParamSpec,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from . import extra_typing
+from .extra_typing import ArgsOnlyCallable
 from .type_definitions import NOTHING, NothingType
 
 
@@ -638,7 +635,7 @@ def is_noninstantiable(cls: type[_T]) -> bool:
 
 def singledispatcher(
     default: Callable[P, T] | None = None, *, implementations: dict[type, Callable[[Any], Any]]
-) -> xtyping.SingleDispatchCallable[P, T]:
+) -> extra_typing.SingleDispatchCallable[P, T]:
     """
     Create a single-dispatch callable from a default and a registry of implementations.
 
@@ -682,7 +679,7 @@ def singledispatcher(
 
     assert callable(default)  # for mypy
 
-    if xtyping.is_single_dispatch_callable(default):
+    if extra_typing.is_single_dispatch_callable(default):
         # `default` is itself a single-dispatch callable (e.g. a dispatcher used
         # as the fallback to chain dispatchers). `functools.singledispatch`
         # copies the wrapped callable's ``__dict__`` -- which, for a dispatcher,
@@ -699,12 +696,12 @@ def singledispatcher(
     result = functools.singledispatch(default)
     for cls, func in implementations.items():
         result.register(cls)(func)
-    return cast(xtyping.SingleDispatchCallable[P, T], result)
+    return cast(extra_typing.SingleDispatchCallable[P, T], result)
 
 
 def merge_dispatchers(
-    *dispatchers: xtyping.SingleDispatchCallable[P, T], default: Callable[P, T] | None = None
-) -> xtyping.SingleDispatchCallable[P, T]:
+    *dispatchers: extra_typing.SingleDispatchCallable[P, T], default: Callable[P, T] | None = None
+) -> extra_typing.SingleDispatchCallable[P, T]:
     """
     Merge multiple single-dispatch callables into one.
 
@@ -719,7 +716,7 @@ def merge_dispatchers(
 
     merged_registry: dict[Any, Any] = {}
     for d in dispatchers:
-        if not xtyping.is_single_dispatch_callable(d):
+        if not extra_typing.is_single_dispatch_callable(d):
             raise TypeError(
                 f"Expected only single-dispatch callables, got '{d}' of type '{type(d)}'"
             )
@@ -739,7 +736,7 @@ _CONTENT_HASH_PICKLE_PROTOCOL: int = 5
 
 def content_hash(
     *args: Any,
-    hash_algorithm: xtyping.HashlibAlgorithm | None = None,
+    hash_algorithm: extra_typing.HashlibAlgorithm | None = None,
     pickler_type: type[pickle.Pickler] = pickle.Pickler,
 ) -> str:
     """Stable content-based hash function using instance serialization data.

--- a/src/gt4py/eve/visitors.py
+++ b/src/gt4py/eve/visitors.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import collections.abc
 import copy
 import enum
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from . import concepts, trees
-from .extended_typing import Any
 from .type_definitions import NOTHING
 
 

--- a/src/gt4py/next/common.py
+++ b/src/gt4py/next/common.py
@@ -16,16 +16,10 @@ import functools
 import math
 import sys
 import types
-from collections.abc import Iterable, Mapping, Sequence
-
-import numpy as np
-
-from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping, utils
-from gt4py.eve.extended_typing import (
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Final,
     Generic,
@@ -35,7 +29,6 @@ from gt4py.eve.extended_typing import (
     NoReturn,
     Optional,
     ParamSpec,
-    Protocol,
     Self,
     TypeAlias,
     TypeGuard,
@@ -44,8 +37,13 @@ from gt4py.eve.extended_typing import (
     Unpack,
     cast,
     overload,
-    runtime_checkable,
 )
+
+import numpy as np
+from typing_extensions import Protocol, runtime_checkable
+
+from gt4py._core import definitions as core_defs
+from gt4py.eve import extra_typing, utils
 from gt4py.eve.type_definitions import StrEnum
 
 
@@ -882,13 +880,13 @@ class MutableField(Field[DimsT, core_defs.ScalarT], Protocol[DimsT, core_defs.Sc
 #: Type alias for primitive numeric values (i.e. scalars or fields).
 NumericValue: TypeAlias = core_defs.Scalar | Field
 NumericValueT = TypeVar("NumericValueT", bound=NumericValue)
-NUMERIC_VALUE_TYPES: Final[tuple[type[NumericValue], ...]] = xtyping.get_represented_types(
+NUMERIC_VALUE_TYPES: Final[tuple[type[NumericValue], ...]] = extra_typing.get_represented_types(
     NumericValue
 )
 
 #: Type alias for any kind primitive value understood by GT4Py DSL.
 PrimitiveValue: TypeAlias = NumericValue  # For now, only numeric values, in the future it could include functions, enums, ...
-PRIMITIVE_VALUE_TYPES: Final[tuple[type[PrimitiveValue], ...]] = xtyping.get_represented_types(
+PRIMITIVE_VALUE_TYPES: Final[tuple[type[PrimitiveValue], ...]] = extra_typing.get_represented_types(
     PrimitiveValue
 )
 

--- a/src/gt4py/next/constructors.py
+++ b/src/gt4py/next/constructors.py
@@ -25,7 +25,7 @@ from gt4py._core import (
     ndarray_utils as core_ndarray_utils,
     types as core_types,
 )
-from gt4py.eve import extended_typing as xtyping
+from gt4py.eve import extra_typing
 
 
 """
@@ -599,7 +599,7 @@ def as_field(
         >>> gtx.as_field({IDim: range(-1, 2)}, xdata).domain.ranges[0]
         UnitRange(-1, 2)
     """
-    if allocator is None and device is None and xtyping.supports_dlpack(data):
+    if allocator is None and device is None and extra_typing.supports_dlpack(data):
         # allocate for the device of the input data if no explicit allocator or device is given
         device = core_defs.Device(*data.__dlpack_device__())
     return _field_constructor(allocator, aligned_index=aligned_index, device=device).as_field(

--- a/src/gt4py/next/custom_layout_allocators.py
+++ b/src/gt4py/next/custom_layout_allocators.py
@@ -9,22 +9,14 @@
 import abc
 import dataclasses
 import functools
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, Final, Optional, TypeAlias, cast
+
+from typing_extensions import Protocol, TypeIs
 
 import gt4py._core.definitions as core_defs
 import gt4py.next.common as common
 import gt4py.storage.allocators as core_allocators
-from gt4py.eve.extended_typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Final,
-    Optional,
-    Protocol,
-    Sequence,
-    TypeAlias,
-    TypeIs,
-    cast,
-)
 
 
 FieldLayoutMapper: TypeAlias = Callable[

--- a/src/gt4py/next/embedded/common.py
+++ b/src/gt4py/next/embedded/common.py
@@ -12,8 +12,8 @@ import functools
 import itertools
 import operator
 from collections.abc import Iterator, Sequence
+from typing import Any, Optional, cast
 
-from gt4py.eve.extended_typing import Any, Optional, cast
 from gt4py.next import common
 from gt4py.next.embedded import exceptions as embedded_exceptions
 

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -15,21 +15,12 @@ import itertools
 import math
 from collections.abc import Callable, Sequence
 from types import ModuleType
+from typing import Any, ClassVar, Never, Optional, ParamSpec, TypeAlias, TypeVar, cast
 
 import numpy as np
 from numpy import typing as npt
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve.extended_typing import (
-    Any,
-    ClassVar,
-    Never,
-    Optional,
-    ParamSpec,
-    TypeAlias,
-    TypeVar,
-    cast,
-)
 from gt4py.next import common
 from gt4py.next.embedded import (
     common as embedded_common,

--- a/src/gt4py/next/embedded/operators.py
+++ b/src/gt4py/next/embedded/operators.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Generic, Optional, ParamSpec, Sequence, TypeVa
 
 from gt4py import eve
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping
+from gt4py.eve import extra_typing
 from gt4py.next import common, errors, field_utils, named_collections, utils
 from gt4py.next.embedded import common as embedded_common, context as embedded_context
 from gt4py.next.field_utils import get_array_ns
@@ -32,9 +32,9 @@ class EmbeddedOperator(Generic[_R, _P]):
 
 
 @dataclasses.dataclass(frozen=True)
-class ScanOperator(EmbeddedOperator[xtyping.MaybeNestedInTuple[core_defs.ScalarT], _P]):
+class ScanOperator(EmbeddedOperator[extra_typing.MaybeNestedInTuple[core_defs.ScalarT], _P]):
     forward: bool
-    init: xtyping.MaybeNestedInTuple[core_defs.ScalarT]
+    init: extra_typing.MaybeNestedInTuple[core_defs.ScalarT]
     axis: common.Dimension
 
     def __call__(  # type: ignore[override]
@@ -65,7 +65,7 @@ class ScanOperator(EmbeddedOperator[xtyping.MaybeNestedInTuple[core_defs.ScalarT
         res = field_utils.field_from_typespec(init_type, out_domain, xp)
 
         def scan_loop(hpos: Sequence[common.NamedIndex]) -> None:
-            acc: xtyping.MaybeNestedInTuple[core_defs.ScalarT] = self.init
+            acc: extra_typing.MaybeNestedInTuple[core_defs.ScalarT] = self.init
             for k in scan_range.unit_range if self.forward else reversed(scan_range.unit_range):
                 pos = (*hpos, common.NamedIndex(scan_axis, k))
                 new_args = [_tuple_at(pos, arg) for arg in args]
@@ -74,8 +74,8 @@ class ScanOperator(EmbeddedOperator[xtyping.MaybeNestedInTuple[core_defs.ScalarT
                 # convert custom NamedCollections to plain tuples for assignment
                 acc_extracted = arguments.extract(acc)
                 res_extracted = arguments.extract(res)
-                assert xtyping.is_maybe_nested_in_tuple_of(acc_extracted, core_defs.Scalar)  # type: ignore[arg-type]  # Scalar is a Union
-                assert xtyping.is_maybe_nested_in_tuple_of(res_extracted, common.MutableField)  # type: ignore[type-abstract]  # MutableField is abstract/generic
+                assert extra_typing.is_maybe_nested_in_tuple_of(acc_extracted, core_defs.Scalar)  # type: ignore[arg-type]  # Scalar is a Union
+                assert extra_typing.is_maybe_nested_in_tuple_of(res_extracted, common.MutableField)  # type: ignore[type-abstract]  # MutableField is abstract/generic
                 _tuple_assign_value(pos, res_extracted, acc_extracted)
 
         if len(non_scan_domain) == 0:
@@ -88,7 +88,7 @@ class ScanOperator(EmbeddedOperator[xtyping.MaybeNestedInTuple[core_defs.ScalarT
         return res
 
 
-def _get_out_domain(out: xtyping.MaybeNestedInTuple[common.MutableField]) -> common.Domain:
+def _get_out_domain(out: extra_typing.MaybeNestedInTuple[common.MutableField]) -> common.Domain:
     return embedded_common.domain_intersection(
         *[f.domain for f in utils.flatten_nested_tuple((out,))]
     )
@@ -117,7 +117,10 @@ def field_operator_call(op: EmbeddedOperator[_R, _P], args: Any, kwargs: Any) ->
         # We currently apply the extract on both the rhs (`res`) computed by the operator and the lhs (`out`, provided by the user)
         # without checking if the types are consistent. However, these errors are caught in linting if enabled.
         container_extracted_out = arguments.extract(out)
-        assert xtyping.is_maybe_nested_in_tuple_of(container_extracted_out, common.MutableField)  # type: ignore[type-abstract]  # MutableField is abstract/generic
+        assert extra_typing.is_maybe_nested_in_tuple_of(
+            container_extracted_out,
+            common.MutableField,  # type: ignore[type-abstract]  # MutableField is abstract/generic
+        )
         out_domain = (
             utils.tree_map(common.domain)(domain)
             if domain is not None
@@ -147,9 +150,9 @@ def _get_vertical_range(domain: common.Domain) -> common.NamedRange | eve.Nothin
 
 
 def _tuple_assign_field(
-    target: xtyping.MaybeNestedInTuple[common.MutableField],
-    source: xtyping.MaybeNestedInTuple[common.Field],
-    domain: xtyping.MaybeNestedInTuple[common.Domain],
+    target: extra_typing.MaybeNestedInTuple[common.MutableField],
+    source: extra_typing.MaybeNestedInTuple[common.Field],
+    domain: extra_typing.MaybeNestedInTuple[common.Domain],
 ) -> None:
     @named_collections.tree_map_named_collection
     def impl(target: common.MutableField, source: common.Field, domain: common.Domain) -> None:
@@ -165,7 +168,7 @@ def _tuple_assign_field(
 
 
 def _intersect_scan_args(
-    *args: xtyping.MaybeNestedInTuple[core_defs.Scalar | common.Field],
+    *args: extra_typing.MaybeNestedInTuple[core_defs.Scalar | common.Field],
 ) -> common.Domain:
     return embedded_common.domain_intersection(
         *[arg.domain for arg in utils.flatten_nested_tuple(args) if isinstance(arg, common.Field)]
@@ -174,8 +177,8 @@ def _intersect_scan_args(
 
 def _tuple_assign_value(
     pos: Sequence[common.NamedIndex],
-    target: xtyping.MaybeNestedInTuple[common.MutableField],
-    source: xtyping.MaybeNestedInTuple[core_defs.Scalar],
+    target: extra_typing.MaybeNestedInTuple[common.MutableField],
+    source: extra_typing.MaybeNestedInTuple[core_defs.Scalar],
 ) -> None:
     @utils.tree_map
     def impl(target: common.MutableField, source: core_defs.Scalar) -> None:
@@ -186,7 +189,7 @@ def _tuple_assign_value(
 
 def _tuple_at(
     pos: Sequence[common.NamedIndex],
-    field: xtyping.MaybeNestedInTuple[common.Field | core_defs.Scalar],
+    field: extra_typing.MaybeNestedInTuple[common.Field | core_defs.Scalar],
 ) -> core_defs.Scalar | tuple[core_defs.ScalarT | tuple, ...]:
     @named_collections.tree_map_named_collection
     def impl(field: common.Field | core_defs.Scalar) -> core_defs.Scalar:

--- a/src/gt4py/next/ffront/decorator.py
+++ b/src/gt4py/next/ffront/decorator.py
@@ -20,12 +20,11 @@ import types
 import typing
 import warnings
 from collections.abc import Callable
-from typing import Any, Generic, Optional, Sequence, TypeAlias
+from typing import Any, Generic, Optional, Self, Sequence, TypeAlias, Unpack, override
 
 from gt4py import eve
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping
-from gt4py.eve.extended_typing import Self, Unpack, override
+from gt4py.eve import extra_typing
 from gt4py.next import (
     backend as next_backend,
     common,
@@ -164,7 +163,7 @@ class _CompilableGTEntryPointMixin(Generic[ffront_stages.DSLDefinitionT]):
         | common.OffsetProvider
         | list[common.OffsetProviderType | common.OffsetProvider]
         | None = None,
-        **static_args: list[xtyping.MaybeNestedInTuple[core_defs.Scalar]],
+        **static_args: list[extra_typing.MaybeNestedInTuple[core_defs.Scalar]],
     ) -> Self:
         """
         Compiles the program or operator for the given combination of static arguments and offset
@@ -494,7 +493,7 @@ class ProgramWithBoundArgs(Program):
         | common.OffsetProvider
         | list[common.OffsetProviderType | common.OffsetProvider]
         | None = None,
-        **static_args: list[xtyping.MaybeNestedInTuple[core_defs.Scalar]],
+        **static_args: list[extra_typing.MaybeNestedInTuple[core_defs.Scalar]],
     ) -> Self:
         raise NotImplementedError("Compilation of programs with bound arguments is not implemented")
 

--- a/src/gt4py/next/ffront/dialect_parser.py
+++ b/src/gt4py/next/ffront/dialect_parser.py
@@ -10,10 +10,9 @@ import ast
 import textwrap
 import typing
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Collection
+from typing import Any, Callable, ClassVar, Collection, Generic, TypeVar
 
 from gt4py.eve.concepts import SourceLocation
-from gt4py.eve.extended_typing import Any, Generic, TypeVar
 from gt4py.next import errors
 from gt4py.next.ffront.ast_passes.fix_missing_locations import FixMissingLocations
 from gt4py.next.ffront.ast_passes.remove_docstrings import RemoveDocstrings

--- a/src/gt4py/next/ffront/foast_to_gtir.py
+++ b/src/gt4py/next/ffront/foast_to_gtir.py
@@ -8,10 +8,9 @@
 
 
 import dataclasses
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Never, Optional
 
 from gt4py import eve
-from gt4py.eve.extended_typing import Never
 from gt4py.next import common, utils
 from gt4py.next.ffront import (
     dialect_ast_enums,

--- a/src/gt4py/next/field_utils.py
+++ b/src/gt4py/next/field_utils.py
@@ -11,7 +11,7 @@ from types import ModuleType
 import numpy as np
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve.extended_typing import NestedTuple
+from gt4py.eve.extra_typing import NestedTuple
 from gt4py.next import common, named_collections, utils
 from gt4py.next.type_system import type_specifications as ts, type_translation
 

--- a/src/gt4py/next/instrumentation/metrics.py
+++ b/src/gt4py/next/instrumentation/metrics.py
@@ -24,12 +24,11 @@ import time
 import types
 import typing
 from collections.abc import Callable, Mapping
-from typing import ClassVar, TypeAlias
+from typing import Any, ClassVar, Final, TypeAlias
 
 import numpy as np
 
-from gt4py.eve import extended_typing as xtyping, utils
-from gt4py.eve.extended_typing import Any, Final
+from gt4py.eve import extra_typing, utils
 from gt4py.next import config
 from gt4py.next.otf import arguments
 
@@ -428,7 +427,7 @@ def dumps_json(metric_sources: Mapping[str, Source] | None = None) -> str:
                 }
             case arguments.StaticArg() as arg:
                 return arg.value
-            case xtyping.DataclassABC():
+            case extra_typing.DataclassABC():
                 return dataclasses.asdict(obj)
             case numbers.Integral() as i:
                 return int(i)

--- a/src/gt4py/next/iterator/embedded.py
+++ b/src/gt4py/next/iterator/embedded.py
@@ -16,25 +16,15 @@ import dataclasses
 import itertools
 import math
 import operator
-
-import numpy as np
-import numpy.typing as npt
-
-from gt4py import eve
-from gt4py._core import definitions as core_defs, types as core_types
-from gt4py.eve import extended_typing as xtyping
-from gt4py.eve.extended_typing import (
+import typing
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import (
     Any,
-    Callable,
     Generic,
-    Iterable,
     Literal,
-    Mapping,
     NoReturn,
     Optional,
-    Protocol,
     Self,
-    Sequence,
     SupportsFloat,
     SupportsInt,
     TypeAlias,
@@ -43,8 +33,15 @@ from gt4py.eve.extended_typing import (
     Union,
     cast,
     overload,
-    runtime_checkable,
 )
+
+import numpy as np
+import numpy.typing as npt
+from typing_extensions import Protocol, runtime_checkable
+
+from gt4py import eve
+from gt4py._core import definitions as core_defs, types as core_types
+from gt4py.eve import extra_typing
 from gt4py.next import common, field_utils, utils
 from gt4py.next.embedded import (
     context as embedded_context,
@@ -120,7 +117,7 @@ class StridedConnectivityField(common.Connectivity):
         object.__setattr__(self, "_max_neighbors", max_neighbors)
 
     @property
-    def __gt_origin__(self) -> xtyping.Never:
+    def __gt_origin__(self) -> typing.Never:
         raise NotImplementedError
 
     def __gt_type__(self) -> common.NeighborConnectivityType:
@@ -166,7 +163,7 @@ class StridedConnectivityField(common.Connectivity):
         index = item[0] * self._max_neighbors + item[1]  # type: ignore[operator]
         return ConstantField(index)
 
-    def as_scalar(self) -> xtyping.Never:
+    def as_scalar(self) -> typing.Never:
         raise NotImplementedError()
 
     def __call__(
@@ -485,7 +482,7 @@ def is_dtype_like(t: Any) -> TypeGuard[npt.DTypeLike]:
 
 
 def infer_dtype_like_type(t: Any) -> npt.DTypeLike:
-    res = xtyping.infer_type(t)
+    res = extra_typing.infer_type(t)
     assert is_dtype_like(res), res
     return res
 
@@ -1668,7 +1665,7 @@ def _validate_domain(domain: Domain, offset_provider_type: common.OffsetProvider
 @runtime.set_at.register(EMBEDDED)
 def set_at(
     expr: common.Field,
-    domain_like: xtyping.MaybeNestedInTuple[common.DomainLike],
+    domain_like: extra_typing.MaybeNestedInTuple[common.DomainLike],
     target: common.MutableField,
 ) -> None:
     domain = utils.tree_map(common.domain)(domain_like)

--- a/src/gt4py/next/iterator/transforms/infer_domain.py
+++ b/src/gt4py/next/iterator/transforms/infer_domain.py
@@ -9,10 +9,11 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import Callable
+from typing import Optional, TypeAlias, TypeVar, Unpack
 
 from gt4py import eve
 from gt4py.eve import utils as eve_utils
-from gt4py.eve.extended_typing import Callable, Optional, TypeAlias, TypeVar, Unpack
 from gt4py.next import common, utils as gtx_utils
 from gt4py.next.iterator import builtins, ir as itir
 from gt4py.next.iterator.ir_utils import (

--- a/src/gt4py/next/iterator/transforms/prune_empty_concat_where.py
+++ b/src/gt4py/next/iterator/transforms/prune_empty_concat_where.py
@@ -6,10 +6,9 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 import dataclasses
-from typing import Optional, TypeVar
+from typing import Optional, Self, TypeVar
 
 from gt4py.eve import NodeTranslator, PreserveLocationVisitor
-from gt4py.eve.extended_typing import Self
 from gt4py.next import common
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import (

--- a/src/gt4py/next/iterator/transforms/replace_get_domain_range_with_constants.py
+++ b/src/gt4py/next/iterator/transforms/replace_get_domain_range_with_constants.py
@@ -10,7 +10,7 @@ import dataclasses
 
 from gt4py._core import definitions as core_defs
 from gt4py.eve import NodeTranslator, PreserveLocationVisitor
-from gt4py.eve.extended_typing import MaybeNestedInTuple
+from gt4py.eve.extra_typing import MaybeNestedInTuple
 from gt4py.next import common
 from gt4py.next.iterator import ir as itir
 from gt4py.next.iterator.ir_utils import (

--- a/src/gt4py/next/iterator/transforms/symbol_ref_utils.py
+++ b/src/gt4py/next/iterator/transforms/symbol_ref_utils.py
@@ -8,9 +8,10 @@
 
 import dataclasses
 from collections import Counter
+from collections.abc import Iterable
+from typing import Literal, Optional, cast, overload
 
 import gt4py.eve as eve
-from gt4py.eve.extended_typing import Iterable, Literal, Optional, cast, overload
 from gt4py.next.iterator import ir as itir
 
 

--- a/src/gt4py/next/iterator/type_system/inference.py
+++ b/src/gt4py/next/iterator/type_system/inference.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import copy
 import dataclasses
 import functools
+from collections.abc import Callable
+from typing import Any, Optional, TypeVar, Union
 
 from gt4py import eve
 from gt4py.eve import concepts
-from gt4py.eve.extended_typing import Any, Callable, Optional, TypeVar, Union
 from gt4py.next import common
 from gt4py.next.iterator import builtins, ir as itir
 from gt4py.next.iterator.ir_utils.common_pattern_matcher import is_applied_as_fieldop, is_call_to

--- a/src/gt4py/next/iterator/type_system/type_synthesizer.py
+++ b/src/gt4py/next/iterator/type_system/type_synthesizer.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import dataclasses
 import functools
 import inspect
-from typing import TypeVar, cast, overload
+from collections.abc import Callable, Iterable
+from typing import Optional, TypeVar, Union, cast, overload
 
 from gt4py.eve import utils as eve_utils
-from gt4py.eve.extended_typing import Callable, Iterable, Optional, Union
 from gt4py.next import common, utils
 from gt4py.next.iterator import builtins, ir as itir
 from gt4py.next.iterator.ir_utils import misc as ir_misc

--- a/src/gt4py/next/named_collections.py
+++ b/src/gt4py/next/named_collections.py
@@ -13,23 +13,18 @@ import functools
 import inspect
 import pkgutil
 import typing
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from typing import Any, Final, TypeAlias, TypeGuard, TypeVar
 
-from gt4py.eve import extended_typing as xtyping
-from gt4py.eve.extended_typing import (
-    Any,
-    Final,
-    Mapping,
-    NestedTuple,
-    TypeAlias,
-    TypeGuard,
-    TypeVar,
-)
+import typing_extensions
+
+from gt4py.eve import extra_typing
+from gt4py.eve.extra_typing import NestedTuple
 from gt4py.next import common, utils
 from gt4py.next.type_system import type_info, type_specifications as ts
 
 
-class CustomDataclassNamedCollectionABC(xtyping.DataclassABC):
+class CustomDataclassNamedCollectionABC(extra_typing.DataclassABC):
     """ABC for dataclasses satisfying the current constraints to be custom named collections."""
 
     @classmethod
@@ -49,14 +44,18 @@ class CustomDataclassNamedCollectionABC(xtyping.DataclassABC):
         return False
 
 
-CustomNamedCollection: TypeAlias = xtyping.TypedNamedTupleABC | CustomDataclassNamedCollectionABC
-CUSTOM_NAMED_COLLECTION_TYPES: Final[tuple[type, ...]] = xtyping.get_represented_types(
+CustomNamedCollection: TypeAlias = (
+    extra_typing.TypedNamedTupleABC | CustomDataclassNamedCollectionABC
+)
+CUSTOM_NAMED_COLLECTION_TYPES: Final[tuple[type, ...]] = extra_typing.get_represented_types(
     CustomNamedCollection
 )
 
 NamedCollection: TypeAlias = NestedTuple | CustomNamedCollection
 NamedCollectionT = TypeVar("NamedCollectionT", bound=NamedCollection)
-NAMED_COLLECTION_TYPES: Final[tuple[type, ...]] = xtyping.get_represented_types(NamedCollection)
+NAMED_COLLECTION_TYPES: Final[tuple[type, ...]] = extra_typing.get_represented_types(
+    NamedCollection
+)
 
 
 NamedCollectionExtractor: TypeAlias = Callable[
@@ -69,9 +68,9 @@ NamedCollectionConstructor: TypeAlias = Callable[
 NamedCollectionKey = str | int
 
 
-def named_collection_type(type_hint: xtyping.TypeAnnotation) -> type[NamedCollection] | None:
+def named_collection_type(type_hint: extra_typing.TypeAnnotation) -> type[NamedCollection] | None:
     """Get the type if the given type hint represents a supported Python named collection type."""
-    class_ = xtyping.get_origin(type_hint) or type_hint
+    class_ = typing.get_origin(type_hint) or type_hint
     if class_ is tuple or (
         isinstance(class_, type) and issubclass(class_, CUSTOM_NAMED_COLLECTION_TYPES)
     ):
@@ -79,38 +78,40 @@ def named_collection_type(type_hint: xtyping.TypeAnnotation) -> type[NamedCollec
     return None
 
 
-def is_named_collection_type(type_hint: xtyping.TypeAnnotation) -> TypeGuard[type[NamedCollection]]:
+def is_named_collection_type(
+    type_hint: extra_typing.TypeAnnotation,
+) -> TypeGuard[type[NamedCollection]]:
     """Check if a type annotation represents a supported Python named collection type."""
     return named_collection_type(type_hint) is not None
 
 
 def elements_keys(
-    named_collection_type_hint: xtyping.SingleTypeAnnotation,
+    named_collection_type_hint: extra_typing.SingleTypeAnnotation,
 ) -> tuple[NamedCollectionKey, ...]:
     """Get the keys of the elements in a named collection type."""
-    class_ = xtyping.get_origin(named_collection_type_hint) or named_collection_type_hint
+    class_ = typing.get_origin(named_collection_type_hint) or named_collection_type_hint
     if class_ is tuple:
-        return tuple(range(len(xtyping.get_args(named_collection_type_hint))))
+        return tuple(range(len(typing.get_args(named_collection_type_hint))))
 
     # TODO(egparedes): consider using "__match_args__" as general custom named collection marker
     return tuple(getattr(class_, "__annotations__", {}).keys()) if isinstance(class_, type) else ()
 
 
 def elements_types(
-    named_collection_type_hint: xtyping.SingleTypeAnnotation,
+    named_collection_type_hint: extra_typing.SingleTypeAnnotation,
     *,
     globalns: dict[str, Any] | None = None,
     localns: dict[str, Any] | None = None,
 ) -> Mapping[NamedCollectionKey, type]:
     """Get the types of the elements of a named collection type."""
 
-    if xtyping.get_origin(named_collection_type_hint) is tuple:
-        return {i: value for i, value in enumerate(xtyping.get_args(named_collection_type_hint))}
+    if typing.get_origin(named_collection_type_hint) is tuple:
+        return {i: value for i, value in enumerate(typing.get_args(named_collection_type_hint))}
 
     type_ = named_collection_type(named_collection_type_hint)
     if type_ is not None:
         keys = elements_keys(named_collection_type_hint)
-        all_hints = xtyping.get_type_hints(
+        all_hints = typing_extensions.get_type_hints(
             named_collection_type_hint, globalns=globalns, localns=localns
         )
         if not {*keys} <= all_hints.keys():
@@ -125,7 +126,7 @@ def elements_types(
 
 @functools.cache
 def make_named_collection_extractor(
-    named_collection_type_hint: xtyping.TypeAnnotation,
+    named_collection_type_hint: extra_typing.TypeAnnotation,
 ) -> NamedCollectionExtractor:
     """
     Create an extractor function for the given named collection type.
@@ -150,23 +151,25 @@ def make_named_collection_extractor_from_type_spec(
     return eval(extractor_func_src)
 
 
-def make_extractor_expr(named_collection_type_hint: xtyping.TypeAnnotation, value_expr: str) -> str:
+def make_extractor_expr(
+    named_collection_type_hint: extra_typing.TypeAnnotation, value_expr: str
+) -> str:
     """Make an expression from a type description to extract numeric values out of its instances."""
 
-    children_type_hints: dict[str, xtyping.TypeAnnotation] = {}
+    children_type_hints: dict[str, extra_typing.TypeAnnotation] = {}
     expr_parts: list[str] = []
-    actual_type = xtyping.get_origin(named_collection_type_hint) or named_collection_type_hint
+    actual_type = typing.get_origin(named_collection_type_hint) or named_collection_type_hint
 
     if isinstance(actual_type, type):
         if issubclass(actual_type, CUSTOM_NAMED_COLLECTION_TYPES):
-            children_type_hints = xtyping.get_type_hints(named_collection_type_hint)
+            children_type_hints = typing_extensions.get_type_hints(named_collection_type_hint)
             assert len(children_type_hints)
             expr_parts = [
                 make_extractor_expr(value, f"{value_expr}.{key}")
                 for key, value in children_type_hints.items()
             ]
         elif issubclass(actual_type, tuple) and (
-            tuple_arg_hints := xtyping.get_args(named_collection_type_hint)
+            tuple_arg_hints := typing.get_args(named_collection_type_hint)
         ):
             # This is a `tuple` with type arguments
             expr_parts = [
@@ -210,11 +213,11 @@ def make_extractor_expr_from_type_spec(type_: ts.TypeSpec, value_expr: str) -> s
 
 
 def _get_named_collection_constructor_args_info(
-    named_collection_type_hint: xtyping.SingleTypeAnnotation,
+    named_collection_type_hint: extra_typing.SingleTypeAnnotation,
 ) -> tuple[int, list[str]]:
-    if xtyping.get_origin(named_collection_type_hint) is tuple:
+    if typing.get_origin(named_collection_type_hint) is tuple:
         # For plain tuples, we assume all arguments are positional
-        args_count = len(xtyping.get_args(named_collection_type_hint))
+        args_count = len(typing.get_args(named_collection_type_hint))
         return args_count, []
 
     assert isinstance(named_collection_type_hint, type)
@@ -254,7 +257,7 @@ def _get_named_collection_constructor_args_info(
 
 @functools.cache
 def make_named_collection_constructor(
-    named_collection_type_hint: type[NamedCollectionT] | xtyping.TypeAnnotation,
+    named_collection_type_hint: type[NamedCollectionT] | extra_typing.TypeAnnotation,
     *,
     nested: bool = True,
 ) -> NamedCollectionConstructor[NamedCollectionT]:
@@ -287,7 +290,7 @@ def make_named_collection_constructor_from_type_spec(
 
 
 def make_constructor_expr(
-    named_collection_type_hint: xtyping.TypeAnnotation,
+    named_collection_type_hint: extra_typing.TypeAnnotation,
     value_expr: str,
     *,
     item_path: str,
@@ -311,8 +314,8 @@ def make_constructor_expr(
         global_ns: The global namespace where the unique named collection type aliases are
             stored for final evaluation of the constructor expression.
     """
-    actual_type = xtyping.get_origin(named_collection_type_hint) or named_collection_type_hint
-    nested_types: dict[int | str, xtyping.TypeAnnotation] = {}
+    actual_type = typing.get_origin(named_collection_type_hint) or named_collection_type_hint
+    nested_types: dict[int | str, extra_typing.TypeAnnotation] = {}
     if isinstance(actual_type, type):
         if issubclass(actual_type, CUSTOM_NAMED_COLLECTION_TYPES):
             # Store the named collection type alias in the global namespace for eval()
@@ -322,7 +325,7 @@ def make_constructor_expr(
             # Get the type hints of the named collection's members
             named_collection_type = typing.cast(str | type, named_collection_type_hint)
             named_collection_keys = elements_keys(named_collection_type)
-            type_hints = xtyping.get_type_hints(named_collection_type)
+            type_hints = typing_extensions.get_type_hints(named_collection_type)
             assert {*named_collection_keys} <= type_hints.keys(), (
                 "Mismatch between keys and type hints"
             )
@@ -331,7 +334,7 @@ def make_constructor_expr(
             }
 
         elif issubclass(actual_type, tuple) and (
-            tuple_args_hint := xtyping.get_args(named_collection_type_hint)
+            tuple_args_hint := typing.get_args(named_collection_type_hint)
         ):
             named_collection_type_alias = ""
             nested_types = {i: type_hint for i, type_hint in enumerate(tuple_args_hint)}

--- a/src/gt4py/next/otf/arguments.py
+++ b/src/gt4py/next/otf/arguments.py
@@ -11,23 +11,13 @@ from __future__ import annotations
 import abc
 import dataclasses
 import enum
+from collections.abc import Callable, Mapping
+from typing import Any, Generic, Hashable, Optional, Self, TypeAlias, TypeVar, cast, final
+
+from typing_extensions import TypeIs
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve.extended_typing import (
-    Any,
-    Callable,
-    Generic,
-    Hashable,
-    Mapping,
-    MaybeNestedInTuple,
-    Optional,
-    Self,
-    TypeAlias,
-    TypeIs,
-    TypeVar,
-    cast,
-    final,
-)
+from gt4py.eve.extra_typing import MaybeNestedInTuple
 from gt4py.next import common, errors, named_collections, utils
 from gt4py.next.type_system import type_info, type_specifications as ts, type_translation
 

--- a/src/gt4py/next/otf/compilation_tasks.py
+++ b/src/gt4py/next/otf/compilation_tasks.py
@@ -21,13 +21,13 @@ import dataclasses
 import os
 import pathlib
 import tempfile
+import typing
 import weakref
 from typing import Any, Callable
 
 import numpy as np
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping
 from gt4py.next import backend as gtx_backend, common, constructors
 from gt4py.next.otf import arguments, definitions as otf_definitions, runners, stages
 
@@ -118,7 +118,7 @@ def _offset_provider_with_file_refs(
     return {
         name: value
         if isinstance(value, common.Dimension)
-        else xtyping.cast(common.OffsetProviderElem, _ConnectivityFileRef(value))
+        else typing.cast(common.OffsetProviderElem, _ConnectivityFileRef(value))
         for name, value in offset_provider.items()
     }
 

--- a/src/gt4py/next/otf/compiled_program.py
+++ b/src/gt4py/next/otf/compiled_program.py
@@ -23,7 +23,7 @@ from collections.abc import Callable, Hashable, Sequence
 from typing import Any, Generic, TypeAlias, TypeVar
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping, utils as eve_utils
+from gt4py.eve import extra_typing, utils as eve_utils
 from gt4py.next import backend as gtx_backend, common, errors, utils as gtx_utils
 from gt4py.next.ffront import (
     stages as ffront_stages,
@@ -39,7 +39,7 @@ from gt4py.next.utils import tree_map
 
 T = TypeVar("T")
 
-ScalarOrTupleOfScalars: TypeAlias = xtyping.MaybeNestedInTuple[core_defs.Scalar]
+ScalarOrTupleOfScalars: TypeAlias = extra_typing.MaybeNestedInTuple[core_defs.Scalar]
 
 #: Content of the key: (*hashable_arg_descriptors, id(offset_provider), concrete_instantation_if_generic)
 CompiledProgramsKey: TypeAlias = tuple[tuple[Hashable, ...], int, str | None]
@@ -209,7 +209,7 @@ def _make_tuple_expr(el_exprs: list[str]) -> str:
 def _make_param_context_from_func_type(
     func_type: ts.FunctionType,
     type_map: Callable[[ts.TypeSpec], T] = lambda x: x,  # type: ignore[assignment, return-value]  # mypy not smart enough to narrow type for default
-) -> dict[str, xtyping.MaybeNestedInTuple[T]]:
+) -> dict[str, extra_typing.MaybeNestedInTuple[T]]:
     """
     Create a context to evaluate expressions in from a function type.
 

--- a/src/gt4py/next/otf/workflow.py
+++ b/src/gt4py/next/otf/workflow.py
@@ -13,12 +13,10 @@ import dataclasses
 import functools
 import pathlib
 import typing
-from typing import Any, Callable, Generic, Protocol, TypeVar
-
-from typing_extensions import Self
+from typing import Any, Callable, Generic, Protocol, Self, TypeVar
 
 from gt4py._core import filecache
-from gt4py.eve.extended_typing import OpaqueMutableMapping
+from gt4py.eve.extra_typing import OpaqueMutableMapping
 from gt4py.next import config, fingerprinting, utils
 
 

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_dataflow.py
@@ -31,7 +31,7 @@ from dace import nodes as dace_nodes, subsets as dace_subsets
 from dace.libraries import standard as dace_stdlib
 
 from gt4py import eve
-from gt4py.eve.extended_typing import MaybeNestedInTuple, NestedTuple
+from gt4py.eve.extra_typing import MaybeNestedInTuple, NestedTuple
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import (

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_domain.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_domain.py
@@ -15,7 +15,7 @@ import dace
 from dace import subsets as dace_subsets
 
 from gt4py import eve
-from gt4py.eve.extended_typing import MaybeNestedInTuple
+from gt4py.eve.extra_typing import MaybeNestedInTuple
 from gt4py.next import common as gtx_common
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import common_pattern_matcher as cpm, domain_utils

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_scan.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_scan.py
@@ -29,7 +29,7 @@ import dace
 from dace import nodes as dace_nodes, subsets as dace_subsets
 
 from gt4py import eve
-from gt4py.eve.extended_typing import MaybeNestedInTuple
+from gt4py.eve.extra_typing import MaybeNestedInTuple
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import (

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_types.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_types.py
@@ -16,7 +16,7 @@ from typing import Final, TypeAlias
 import dace
 from dace import nodes as dace_nodes, subsets as dace_subsets
 
-from gt4py.eve.extended_typing import MaybeNestedInTuple
+from gt4py.eve.extra_typing import MaybeNestedInTuple
 from gt4py.next import common as gtx_common
 from gt4py.next.iterator import builtins as gtir_builtins
 from gt4py.next.program_processors.runners.dace import sdfg_args as gtx_dace_args

--- a/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
+++ b/src/gt4py/next/program_processors/runners/dace/lowering/gtir_to_sdfg_utils.py
@@ -13,7 +13,7 @@ from typing import Dict, Final, Mapping, Optional, TypeVar
 import dace
 
 from gt4py import eve
-from gt4py.eve.extended_typing import NestedTuple
+from gt4py.eve.extra_typing import NestedTuple
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.iterator import ir as gtir
 from gt4py.next.iterator.ir_utils import ir_makers as im

--- a/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/auto_optimize.py
@@ -9,6 +9,7 @@
 """Fast access to the auto optimization on DaCe."""
 
 import enum
+import typing
 import warnings
 from typing import Any, Callable, Optional, Sequence, TypeAlias, Union
 
@@ -19,7 +20,6 @@ from dace.transformation import dataflow as dace_dataflow, pass_pipeline as dace
 from dace.transformation.auto import auto_optimize as dace_aoptimize
 from dace.transformation.passes import analysis as dace_analysis
 
-from gt4py.eve import extended_typing as xtyping
 from gt4py.next import common as gtx_common, utils as gtx_utils
 from gt4py.next.program_processors.runners.dace import (
     library_nodes as gtx_library_nodes,
@@ -1020,7 +1020,7 @@ def _gt_auto_post_processing(
             pass
 
         case _ as unreachable:
-            xtyping.assert_never(unreachable)
+            typing.assert_never(unreachable)
 
     if validate_all:
         sdfg.validate()

--- a/src/gt4py/next/program_processors/runners/dace/workflow/common.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/common.py
@@ -13,7 +13,7 @@ from typing import Any, Final, Generator, Optional, TypeAlias
 import dace
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping
+from gt4py.eve import extra_typing
 from gt4py.next import config as gtx_config
 from gt4py.next.otf.compilation import common as gtx_compilation_common
 
@@ -35,13 +35,13 @@ SDFG_ARG_METRIC_COMPUTE_TIME_DTYPE: Final[dace.dtypes.typeclass] = dace.float64
 
 
 ExternalWorkspace: TypeAlias = dict[
-    core_defs.DeviceType, xtyping.ArrayInterface | xtyping.CUDAArrayInterface
+    core_defs.DeviceType, extra_typing.ArrayInterface | extra_typing.CUDAArrayInterface
 ]
 """ Mapping from device types to array-like objects.
 
     The array-like objects must be accepted by `dace.dtypes.array_interface_ptr()`
-    as a workspace: a host array exposing `gt4py.eve.extended_typing.ArrayInterface`
-    or a device array exposing `gt4py.eve.extended_typing.CUDAArrayInterface`.
+    as a workspace: a host array exposing `gt4py.eve.extra_typing.ArrayInterface`
+    or a device array exposing `gt4py.eve.extra_typing.CUDAArrayInterface`.
 """
 
 

--- a/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
+++ b/src/gt4py/next/program_processors/runners/dace/workflow/compilation.py
@@ -21,7 +21,7 @@ import dace.codegen.compiler as dace_compiler
 import factory
 
 from gt4py._core import definitions as core_defs, locking
-from gt4py.eve import extended_typing as xtyping
+from gt4py.eve import extra_typing
 from gt4py.next import common, config, fingerprinting
 from gt4py.next.otf import code_specs, definitions, stages, workflow
 from gt4py.next.otf.compilation import cache as gtx_cache
@@ -88,7 +88,9 @@ def _map_storage_to_device(storage: dace.StorageType) -> core_defs.DeviceType:
 
 
 def _validate_external_workspace(
-    wsp: xtyping.ArrayInterface | xtyping.CUDAArrayInterface, storage: dace.StorageType, nbytes: int
+    wsp: extra_typing.ArrayInterface | extra_typing.CUDAArrayInterface,
+    storage: dace.StorageType,
+    nbytes: int,
 ) -> None:
     """Validate that the provided ``wsp`` workspace satisfies the requirements.
 
@@ -105,12 +107,12 @@ def _validate_external_workspace(
             accepted on a trust basis (their size can not be checked here).
     """
     if storage == dace.StorageType.GPU_Global:
-        if not xtyping.supports_cuda_array_interface(wsp):
+        if not extra_typing.supports_cuda_array_interface(wsp):
             raise TypeError(
                 f"External workspace for storage {storage!r} must expose `__cuda_array_interface__` (got {type(wsp).__name__!r})."
             )
     elif storage == dace.StorageType.CPU_Heap:
-        if not xtyping.supports_array_interface(wsp):
+        if not extra_typing.supports_array_interface(wsp):
             raise TypeError(
                 f"External workspace for storage {storage!r} must expose `__array_interface__` (got {type(wsp).__name__!r})."
             )

--- a/src/gt4py/next/type_system/type_info.py
+++ b/src/gt4py/next/type_system/type_info.py
@@ -12,9 +12,10 @@ from collections.abc import Callable, Collection, Iterable, Iterator
 from typing import Any, Final, Literal, Sequence, Type, TypeGuard, TypeVar, cast, overload
 
 import numpy as np
+import typing_extensions
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping, utils
+from gt4py.eve import utils
 from gt4py.next import common, utils as next_utils
 from gt4py.next.iterator.type_system import type_specifications as it_ts
 from gt4py.next.type_system import type_specifications as ts
@@ -936,7 +937,7 @@ def accepts_args(
 
 def needs_value_extraction(
     type_spec: ts.TypeSpec,
-) -> xtyping.TypeIs[ts.NamedCollectionType | ts.TupleType]:
+) -> typing_extensions.TypeIs[ts.NamedCollectionType | ts.TupleType]:
     return isinstance(type_spec, ts.NamedCollectionType) or (
         isinstance(type_spec, ts.TupleType)
         and any(needs_value_extraction(t) for t in type_spec.types)

--- a/src/gt4py/next/type_system/type_specifications.py
+++ b/src/gt4py/next/type_system/type_specifications.py
@@ -8,13 +8,10 @@
 
 from __future__ import annotations
 
+import typing
 from typing import Final, Iterator, Optional, Sequence, TypeVar
 
-from gt4py.eve import (
-    datamodels as eve_datamodels,
-    extended_typing as xtyping,
-    type_definitions as eve_types,
-)
+from gt4py.eve import datamodels as eve_datamodels, type_definitions as eve_types
 from gt4py.next import common
 
 
@@ -200,7 +197,7 @@ class NamedCollectionType(DataType):
 
 CollectionTypeSpecT = TypeVar("CollectionTypeSpecT", TupleType, NamedCollectionType)
 CollectionTypeSpec = TupleType | NamedCollectionType
-COLLECTION_TYPE_SPECS: Final[tuple[type[CollectionTypeSpec], ...]] = xtyping.get_args(
+COLLECTION_TYPE_SPECS: Final[tuple[type[CollectionTypeSpec], ...]] = typing.get_args(
     CollectionTypeSpec
 )
 

--- a/src/gt4py/next/type_system/type_translation.py
+++ b/src/gt4py/next/type_system/type_translation.py
@@ -25,7 +25,7 @@ import numpy as np
 import numpy.typing as npt
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping, utils as eve_utils
+from gt4py.eve import extra_typing, utils as eve_utils
 from gt4py.next import common, named_collections
 from gt4py.next.type_system import type_info, type_specifications as ts
 
@@ -80,7 +80,7 @@ def make_constructor_type(type_spec: ts.TypeSpec) -> ts.ConstructorType:
             pos_or_kw_args = {k: t for k, t in zip(type_spec.keys, type_spec.types)}
             kw_only_args = (
                 {f.name: pos_or_kw_args.pop(f.name) for f in dataclasses.fields(type_) if f.kw_only}
-                if issubclass(type_, xtyping.DataclassABC)
+                if issubclass(type_, extra_typing.DataclassABC)
                 else {}
             )
 
@@ -103,7 +103,7 @@ def make_type(type_: type) -> ts.TypeSpec:
         return ts.ScalarType(kind=get_scalar_kind(type_))
 
     if issubclass(type_, named_collections.CUSTOM_NAMED_COLLECTION_TYPES):
-        if issubclass(type_, xtyping.DataclassABC) and not issubclass(
+        if issubclass(type_, extra_typing.DataclassABC) and not issubclass(
             type_, named_collections.CustomDataclassNamedCollectionABC
         ):
             raise ValueError(
@@ -130,7 +130,7 @@ def make_type(type_: type) -> ts.TypeSpec:
 def _resolve_type_alias(type_hint: Any) -> Any:
     """Resolve a PEP 695 type alias, reporting its failures the way annotations do."""
     try:
-        return xtyping.eval_type_alias(type_hint)
+        return extra_typing.eval_type_alias(type_hint)
     except NameError as error:
         raise ValueError(
             f"Type annotation '{type_hint}' has undefined forward references."
@@ -156,7 +156,7 @@ def canonicalize_type_hint(
         type_hint = ForwardRef(type_hint)
     if isinstance(type_hint, ForwardRef):
         try:
-            type_hint = xtyping.eval_forward_ref(type_hint, globalns=globalns, localns=localns)
+            type_hint = extra_typing.eval_forward_ref(type_hint, globalns=globalns, localns=localns)
         except Exception as error:
             raise ValueError(
                 f"Type annotation '{type_hint}' has undefined forward references."
@@ -173,7 +173,7 @@ def canonicalize_type_hint(
             type_hint,
             collections.abc.Callable,  # type:ignore[arg-type] # see https://github.com/python/mypy/issues/14928
         ):
-            type_hint = xtyping.eval_forward_ref(type_hint, globalns=globalns, localns=localns)
+            type_hint = extra_typing.eval_forward_ref(type_hint, globalns=globalns, localns=localns)
         # An 'Annotated' annotation may in turn wrap a type alias
         type_hint = _resolve_type_alias(type_hint)
 
@@ -246,7 +246,9 @@ def from_type_hint(
             except Exception as error:
                 raise ValueError(f"Invalid callable annotations in '{type_hint}'.") from error
 
-            kwargs_info = [arg for arg in extra_args if isinstance(arg, xtyping.CallableKwargsInfo)]
+            kwargs_info = [
+                arg for arg in extra_args if isinstance(arg, extra_typing.CallableKwargsInfo)
+            ]
             if len(kwargs_info) != 1:
                 raise ValueError(f"Invalid callable annotations in '{type_hint}'.")
             kwargs = {
@@ -349,7 +351,7 @@ def from_value(value: Any) -> ts.TypeSpec:
         dtype = from_type_hint(value.dtype.scalar_type)
         assert isinstance(dtype, ts.ScalarType)
         symbol_type = ts.FieldType(dims=dims, dtype=dtype)
-    elif isinstance(value, tuple) and not isinstance(value, xtyping.TypedNamedTupleABC):
+    elif isinstance(value, tuple) and not isinstance(value, extra_typing.TypedNamedTupleABC):
         # Since the elements of the tuple might be one of the special cases
         # above, we can not resort to generic `infer_type` but need to do it
         # manually here. If we get rid of all the special cases this is
@@ -362,7 +364,7 @@ def from_value(value: Any) -> ts.TypeSpec:
     elif isinstance(value, PythonNamespaceObject):
         return NamespaceProxy(value)
     else:
-        type_ = xtyping.infer_type(value, annotate_callable_kwargs=True)
+        type_ = extra_typing.infer_type(value, annotate_callable_kwargs=True)
         symbol_type = from_type_hint(type_)
 
     if isinstance(symbol_type, (ts.DataType, ts.CallableType, ts.OffsetType, ts.DimensionType)):
@@ -413,8 +415,8 @@ def from_dtype(dtype: core_defs.DType) -> ts.ScalarType:
 
 # TODO(havogt): Could be extended to also accept `core_defs.DType`s as `type_`
 def unsafe_cast_to(
-    value: xtyping.MaybeNestedInTuple[core_defs.Scalar], type_: ts.TupleType | ts.ScalarType
-) -> xtyping.MaybeNestedInTuple[core_defs.Scalar]:
+    value: extra_typing.MaybeNestedInTuple[core_defs.Scalar], type_: ts.TupleType | ts.ScalarType
+) -> extra_typing.MaybeNestedInTuple[core_defs.Scalar]:
     """
     Converts `value` to the type specified by `type_`.
 

--- a/src/gt4py/storage/allocators.py
+++ b/src/gt4py/storage/allocators.py
@@ -15,25 +15,15 @@ import functools
 import math
 import operator
 import types
+from collections.abc import Buffer, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Generic, NewType, Optional, TypeAlias, TypeGuard, Union
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import Protocol
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping
-from gt4py.eve.extended_typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    NewType,
-    Optional,
-    Protocol,
-    Sequence,
-    TypeAlias,
-    TypeGuard,
-    Union,
-)
+from gt4py.eve import extra_typing
 
 
 try:
@@ -43,8 +33,10 @@ except ImportError:
 
 
 _NDBuffer: TypeAlias = Union[
-    # TODO: add `xtyping.Buffer` once we update typing_extensions
-    xtyping.ArrayInterface, xtyping.CUDAArrayInterface, xtyping.DLPackBuffer
+    Buffer,
+    extra_typing.ArrayInterface,
+    extra_typing.CUDAArrayInterface,
+    extra_typing.DLPackBuffer,
 ]
 
 #: Tuple of positive integers encoding a permutation of the dimensions, such that
@@ -107,21 +99,21 @@ class TensorBuffer(Generic[core_defs.DeviceTypeT, core_defs.ScalarT]):
         return len(self.shape)
 
     def __array__(self, dtype: Optional[npt.DTypeLike] = None, /) -> np.ndarray:
-        if not xtyping.supports_array(self.ndarray):
+        if not extra_typing.supports_array(self.ndarray):
             raise TypeError("Cannot export tensor buffer as NumPy array.")
 
         return self.ndarray.__array__(dtype)
 
     @property
     def __array_interface__(self) -> dict[str, Any]:
-        if not xtyping.supports_array_interface(self.ndarray):
+        if not extra_typing.supports_array_interface(self.ndarray):
             raise TypeError("Cannot export tensor buffer to NumPy array interface.")
 
         return self.ndarray.__array_interface__
 
     @property
     def __cuda_array_interface__(self) -> dict[str, Any]:
-        if not xtyping.supports_cuda_array_interface(self.ndarray):
+        if not extra_typing.supports_cuda_array_interface(self.ndarray):
             raise TypeError("Cannot export tensor buffer to CUDA array interface.")
 
         return self.ndarray.__cuda_array_interface__
@@ -131,7 +123,7 @@ class TensorBuffer(Generic[core_defs.DeviceTypeT, core_defs.ScalarT]):
             raise TypeError("Cannot export tensor buffer to DLPack.")
         return self.ndarray.__dlpack__(stream=stream)  # type: ignore[call-arg,arg-type]  # stream is not always supported
 
-    def __dlpack_device__(self) -> xtyping.DLPackDevice:
+    def __dlpack_device__(self) -> extra_typing.DLPackDevice:
         if not hasattr(self.ndarray, "__dlpack_device__"):
             raise TypeError("Cannot extract DLPack device from tensor buffer.")
         return self.ndarray.__dlpack_device__()
@@ -139,9 +131,9 @@ class TensorBuffer(Generic[core_defs.DeviceTypeT, core_defs.ScalarT]):
 
 if TYPE_CHECKING:
     # TensorBuffer should be compatible with all the expected buffer interfaces
-    __TensorBufferAsArrayInterfaceT: type[xtyping.ArrayInterface] = TensorBuffer
-    __TensorBufferAsCUDAArrayInterfaceT: type[xtyping.CUDAArrayInterface] = TensorBuffer
-    __TensorBufferAsDLPackBufferT: type[xtyping.DLPackBuffer] = TensorBuffer
+    __TensorBufferAsArrayInterfaceT: type[extra_typing.ArrayInterface] = TensorBuffer
+    __TensorBufferAsCUDAArrayInterfaceT: type[extra_typing.CUDAArrayInterface] = TensorBuffer
+    __TensorBufferAsDLPackBufferT: type[extra_typing.DLPackBuffer] = TensorBuffer
 
 
 class BufferAllocator(Protocol[core_defs.DeviceTypeT]):

--- a/src/gt4py/storage/cartesian/utils.py
+++ b/src/gt4py/storage/cartesian/utils.py
@@ -19,7 +19,7 @@ import numpy.typing as npt
 from numpy.typing import DTypeLike
 
 from gt4py._core import definitions as core_defs
-from gt4py.eve.extended_typing import ArrayInterface, CUDAArrayInterface
+from gt4py.eve.extra_typing import ArrayInterface, CUDAArrayInterface
 from gt4py.storage import allocators
 
 

--- a/tests/eve_tests/unit_tests/test_annotation_spelling.py
+++ b/tests/eve_tests/unit_tests/test_annotation_spelling.py
@@ -60,12 +60,7 @@ from typing import (  # noqa: UP035 [deprecated-import] deliberately exercising 
 
 import pytest
 
-from gt4py.eve import (
-    datamodels,
-    exceptions,
-    extended_typing as xtyping,
-    type_validation as type_val,
-)
+from gt4py.eve import datamodels, exceptions, extra_typing, type_validation as type_val
 
 # Imported directly on purpose: reaching these two through a datamodel is not enough.
 # 'get_partial_type_hints' strips 'Annotated' before a field annotation gets this far,
@@ -278,7 +273,7 @@ def observe_represented_types(annotation: Any, probes: tuple[Any, ...]) -> Any:
     # Compared as a set: the result is meant to be handed to 'isinstance()', and
     # 'typing' preserves the order the union members were written in, so
     # 'Optional[int]' and 'Union[None, int]' legitimately differ in order alone.
-    outcome = _outcome(lambda: xtyping.get_represented_types(annotation))
+    outcome = _outcome(lambda: extra_typing.get_represented_types(annotation))
     if outcome[0] == "value":
         return ("represented", "value", frozenset(outcome[2]))
     return ("represented", *outcome)
@@ -362,7 +357,7 @@ def test_string_annotation_rows_are_not_silently_vacuous() -> None:
         spelling.id
         for spelling in SPELLINGS
         if all(
-            xtyping.eval_forward_ref(_as_source(annotation), globalns=globals()) is annotation
+            extra_typing.eval_forward_ref(_as_source(annotation), globalns=globals()) is annotation
             for annotation in (spelling.legacy, spelling.modern)
         )
     }
@@ -392,7 +387,7 @@ def test_string_annotations_agree_with_live_objects(spelling: Spelling, funnel: 
         # PEP 563 resolves a string annotation against the *defining module's*
         # globals, so that is what gets passed here -- this module imports 'typing'
         # and 'collections.abc', exactly as a module writing those annotations would.
-        resolved = xtyping.eval_forward_ref(_as_source(annotation), globalns=globals())
+        resolved = extra_typing.eval_forward_ref(_as_source(annotation), globalns=globals())
         assert funnel(resolved, spelling.probes) == funnel(annotation, spelling.probes)
 
 
@@ -482,7 +477,7 @@ def test_get_partial_type_hints_strips_annotated_recursively() -> None:
         nested: list[Annotated[int, "meta"]]
         in_value: dict[str, Annotated[int, "meta"]]
 
-    hints = xtyping.get_partial_type_hints(_Holder)
+    hints = extra_typing.get_partial_type_hints(_Holder)
 
     assert hints["plain"] is int
     assert hints["nested"] == list[int]
@@ -495,15 +490,15 @@ def test_represented_types_of_literal_are_the_types_of_its_values() -> None:
     Recursing into them matches no branch and yields an empty tuple, which callers
     turn into an `isinstance()` argument -- making every check against it `False`.
     """
-    assert xtyping.get_represented_types(Literal[1, 2]) == (int,)
-    assert xtyping.get_represented_types(Literal["a", 1]) == (str, int)
-    assert xtyping.get_represented_types(Union[Literal["a"], int]) == (str, int)
+    assert extra_typing.get_represented_types(Literal[1, 2]) == (int,)
+    assert extra_typing.get_represented_types(Literal["a", 1]) == (str, int)
+    assert extra_typing.get_represented_types(Union[Literal["a"], int]) == (str, int)
 
 
 def test_represented_types_sees_through_annotated() -> None:
     """The metadata of an `Annotated` is not a represented type, and neither is the form."""
-    assert xtyping.get_represented_types(Annotated[int, "meta"]) == (int,)
-    assert xtyping.get_represented_types(Annotated[Optional[int], "meta"]) == (int, type(None))
+    assert extra_typing.get_represented_types(Annotated[int, "meta"]) == (int,)
+    assert extra_typing.get_represented_types(Annotated[Optional[int], "meta"]) == (int, type(None))
 
 
 @pytest.mark.parametrize(
@@ -551,7 +546,7 @@ def test_infer_type_passes_annotations_through_unchanged() -> None:
         Callable[[int], int],
         ModernAlias,
     ):
-        assert xtyping.infer_type(annotation) is annotation
+        assert extra_typing.infer_type(annotation) is annotation
 
 
 def test_infer_type_still_infers_the_type_of_runtime_values() -> None:
@@ -563,12 +558,12 @@ def test_infer_type_still_infers_the_type_of_runtime_values() -> None:
 
     class Generic_(typing.Generic[typing.TypeVar("_T")]): ...
 
-    assert xtyping.infer_type(3) is int
-    assert xtyping.infer_type("x") is str
-    assert xtyping.infer_type(None) is type(None)
-    assert xtyping.infer_type([1, 2]) == list[int]
-    assert xtyping.infer_type({"a": 1}) == dict[str, int]
-    assert xtyping.infer_type(Generic_()) is Generic_
+    assert extra_typing.infer_type(3) is int
+    assert extra_typing.infer_type("x") is str
+    assert extra_typing.infer_type(None) is type(None)
+    assert extra_typing.infer_type([1, 2]) == list[int]
+    assert extra_typing.infer_type({"a": 1}) == dict[str, int]
+    assert extra_typing.infer_type(Generic_()) is Generic_
 
 
 # -- Regressions from unwrapping transparent wrappers --
@@ -599,7 +594,7 @@ type _MutuallyWrappingB = Annotated[_MutuallyWrappingA, "b"]
 @pytest.mark.parametrize(
     "funnel",
     [
-        xtyping.get_represented_types,
+        extra_typing.get_represented_types,
         _is_strictly_immutable_type,
         lambda annotation: _make_type_converter(annotation, "<field>"),
     ],
@@ -637,11 +632,11 @@ def test_normalize_union_returns_identical_objects_for_normalized_input() -> Non
     invites -- would then see a spelling change that did not happen.
     """
     for annotation in (Optional[int], Union[int, str], int, None, list[int]):
-        assert xtyping.normalize_union(annotation) is annotation
+        assert extra_typing.normalize_union(annotation) is annotation
 
     # Genuine PEP 604 unions are rewritten before 3.14, and are already 'typing.Union'
     # from 3.14 on, so this is the one row whose identity legitimately varies.
-    assert xtyping.normalize_union(int | None) == Optional[int]
+    assert extra_typing.normalize_union(int | None) == Optional[int]
 
 
 def test_genuine_recursive_aliases_still_build() -> None:

--- a/tests/eve_tests/unit_tests/test_concepts.py
+++ b/tests/eve_tests/unit_tests/test_concepts.py
@@ -114,7 +114,7 @@ class TestNode:
             name: str
 
         class Parent(eve.Node):
-            targets: eve.extended_typing.NestedTuple[Target]
+            targets: eve.extra_typing.NestedTuple[Target]
 
         node = Parent(targets=(Target(name="a"), (Target(name="b"), (Target(name="c"),))))
 

--- a/tests/eve_tests/unit_tests/test_extra_typing.py
+++ b/tests/eve_tests/unit_tests/test_extra_typing.py
@@ -20,18 +20,16 @@ import typing
 import pytest
 import typing_extensions
 
-from gt4py.eve import extended_typing as xtyping
-from gt4py.eve.extended_typing import (
-    Annotated,
-    Any,
-    Callable,
-    ForwardRef,
-    Mapping,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
+from collections.abc import Callable, Mapping, Sequence
+from typing import Annotated, Any, ForwardRef, Optional, TypeVar, Union
+import typing
+import typing_extensions
+from gt4py.eve.extra_typing import (
+    supports_array_interface,
+    supports_cuda_array_interface,
+    supports_dlpack,
 )
+from gt4py.eve import extra_typing
 
 
 @pytest.fixture
@@ -108,7 +106,6 @@ class IncompleteClass:
 
 
 def test_supports_array_interface():
-    from gt4py.eve.extended_typing import supports_array_interface
 
     class ArrayInterface:
         __array_interface__ = "interface"
@@ -123,7 +120,6 @@ def test_supports_array_interface():
 
 
 def test_supports_cuda_array_interface():
-    from gt4py.eve.extended_typing import supports_cuda_array_interface
 
     class CudaArray:
         def __cuda_array_interface__(self):
@@ -139,7 +135,6 @@ def test_supports_cuda_array_interface():
 
 
 def test_supports_dlpack():
-    from gt4py.eve.extended_typing import supports_dlpack
 
     class DummyDLPackBuffer:
         def __dlpack__(self):
@@ -180,38 +175,38 @@ DEPRECATED_TYPING_ALIASES = [
 ]
 
 
-@pytest.mark.parametrize(["name", "replacement"], DEPRECATED_TYPING_ALIASES)
-def test_deprecated_typing_alias_is_not_exported(name, replacement):
-    # These names are still bound by the 'typing' / 'typing_extensions' star imports in
-    # 'extended_typing', and its module '__getattr__' would otherwise forward them. Pin
-    # the rejection: dropping the guard would not make the names disappear, it would
-    # silently resolve them to the deprecated 'typing' objects instead of the builtins.
-    with pytest.raises(AttributeError, match=f"'{name}' is a deprecated 'typing' alias"):
-        getattr(xtyping, name)
+def test_module_does_not_re_export_typing():
+    """`extra_typing` must export only definitions the standard modules do not provide.
 
-    assert replacement in str(pytest.raises(AttributeError, lambda: getattr(xtyping, name)).value)
+    This is the invariant the module exists to hold: it used to star-import `typing`
+    and `typing_extensions` and forward anything else through a module `__getattr__`,
+    which meant mypy could not check a single `extra_typing.X` reference (an unknown
+    name simply resolved to `Any`) and ruff could not see through it either. If a
+    re-export creeps back in, both of those go quiet again.
+    """
+    borrowed = (typing, typing_extensions, collections.abc, collections, contextlib, re)
+    re_exported = sorted(
+        name
+        for name in extra_typing.__all__
+        if any(
+            getattr(module, name, object()) is getattr(extra_typing, name) for module in borrowed
+        )
+    )
+    assert re_exported == [], (
+        f"'extra_typing' exports {re_exported}, which it does not define; import "
+        f"those from 'typing', 'typing_extensions' or 'collections.abc' at the use "
+        f"site instead."
+    )
 
-    with pytest.raises(ImportError):
-        exec(f"from gt4py.eve.extended_typing import {name}")
 
-    assert name not in dir(xtyping)
+def test_module_has_no_getattr_fallback():
+    """An unknown name must raise, not be forwarded to `typing`.
 
-
-@pytest.mark.parametrize(
-    ["name", "expected"],
-    [
-        ("Sequence", collections.abc.Sequence),
-        ("Callable", collections.abc.Callable),
-        ("AbstractSet", collections.abc.Set),
-        ("Match", re.Match),
-        ("ContextManager", contextlib.AbstractContextManager),
-        ("deque", collections.deque),
-    ],
-)
-def test_non_deprecated_aliases_are_still_re_exported(name, expected):
-    # Unlike the builtin generics above, these names are not deprecated -- only their
-    # 'typing' home is -- so 'extended_typing' keeps pointing them at the modern object.
-    assert getattr(xtyping, name) is expected
+    The forwarding `__getattr__` is what made every `extra_typing.X` reference
+    unverifiable: a typo resolved to `Any` and type-checked clean.
+    """
+    with pytest.raises(AttributeError):
+        extra_typing.ThisNameDoesNotExist
 
 
 @pytest.mark.parametrize(
@@ -229,21 +224,21 @@ def test_deprecated_typing_alias_still_resolves_in_forward_refs(name, replacemen
     expected_args = tuple(eval(a) for a in args.split(", "))
 
     for ref in (f"{name}[{args}]", f"typing.{name}[{args}]"):
-        resolved = xtyping.eval_forward_ref(ref)
+        resolved = extra_typing.eval_forward_ref(ref)
 
-        assert xtyping.get_origin(resolved) is getattr(builtins, replacement)
-        assert xtyping.get_args(resolved) == expected_args
+        assert typing.get_origin(resolved) is getattr(builtins, replacement)
+        assert typing.get_args(resolved) == expected_args
         # A builtin generic alias, not the deprecated 'typing._GenericAlias' object.
         assert type(resolved) is types.GenericAlias
 
     # An explicit 'globalns' is left alone, so the bare name is not injected there.
     with pytest.raises(NameError):
-        xtyping.eval_forward_ref(f"{name}[{args}]", globalns={})
+        extra_typing.eval_forward_ref(f"{name}[{args}]", globalns={})
 
 
 @pytest.mark.parametrize("t", (int, float, dict, tuple, frozenset, collections.abc.Mapping))
 def test_is_actual_valid_type(t):
-    assert xtyping.is_actual_type(t)
+    assert extra_typing.is_actual_type(t)
 
 
 @pytest.mark.parametrize(
@@ -258,7 +253,7 @@ def test_is_actual_valid_type(t):
     ),
 )
 def test_is_actual_wrong_type(t):
-    assert not xtyping.is_actual_type(t)
+    assert not extra_typing.is_actual_type(t)
 
 
 ACTUAL_TYPE_SAMPLES = [
@@ -279,30 +274,30 @@ ACTUAL_TYPE_SAMPLES = [
 
 @pytest.mark.parametrize(["instance", "expected"], ACTUAL_TYPE_SAMPLES)
 def test_get_actual_type(instance, expected):
-    assert xtyping.get_actual_type(instance) == expected
+    assert extra_typing.get_actual_type(instance) == expected
 
 
 def test_has_custom_hash_abc():
-    assert isinstance(4, xtyping.HasCustomHash)
-    assert isinstance(True, xtyping.HasCustomHash)
-    assert isinstance((), xtyping.HasCustomHash)
+    assert isinstance(4, extra_typing.HasCustomHash)
+    assert isinstance(True, extra_typing.HasCustomHash)
+    assert isinstance((), extra_typing.HasCustomHash)
 
     class A:
         def __hash__(self):
             return 3
 
-    assert isinstance(A(), xtyping.HasCustomHash)
+    assert isinstance(A(), extra_typing.HasCustomHash)
 
     # PEP-683 Immortal objects have custom hash
-    assert isinstance(None, xtyping.HasCustomHash) == (sys.version_info >= (3, 12))
+    assert isinstance(None, extra_typing.HasCustomHash) == (sys.version_info >= (3, 12))
 
     class B:
         __hash__ = None
 
-    assert not isinstance(B(), xtyping.HasCustomHash)
+    assert not isinstance(B(), extra_typing.HasCustomHash)
 
-    assert not isinstance(object(), xtyping.HasCustomHash)
-    assert not isinstance(type, xtyping.HasCustomHash)
+    assert not isinstance(object(), extra_typing.HasCustomHash)
+    assert not isinstance(type, extra_typing.HasCustomHash)
 
 
 def test_is_protocol():
@@ -312,28 +307,28 @@ def test_is_protocol():
     class NotProtocol(AProtocol):
         def do_something_else(self, value: float) -> float: ...
 
-    class AXProtocol(xtyping.Protocol):
+    class AXProtocol(typing_extensions.Protocol):
         A = 1
 
     class NotXProtocol(AXProtocol):
         A = 1
 
-    class AgainProtocol(AProtocol, xtyping.Protocol):
+    class AgainProtocol(AProtocol, typing_extensions.Protocol):
         def do_something_else(self, value: float) -> float: ...
 
-    assert xtyping.is_protocol(AProtocol)
-    assert xtyping.is_protocol(AXProtocol)
+    assert typing_extensions.is_protocol(AProtocol)
+    assert typing_extensions.is_protocol(AXProtocol)
 
-    assert not xtyping.is_protocol(NotProtocol)
-    assert not xtyping.is_protocol(NotXProtocol)
+    assert not typing_extensions.is_protocol(NotProtocol)
+    assert not typing_extensions.is_protocol(NotXProtocol)
 
-    assert xtyping.is_protocol(AgainProtocol)
+    assert typing_extensions.is_protocol(AgainProtocol)
 
 
 def test_get_partial_type_hints():
     def f1(a: int) -> float: ...
 
-    assert xtyping.get_partial_type_hints(f1) == {"a": int, "return": float}
+    assert extra_typing.get_partial_type_hints(f1) == {"a": int, "return": float}
 
     class MissingRef: ...
 
@@ -342,26 +337,28 @@ def test_get_partial_type_hints():
     # This is expected behavior because this test file uses
     # 'from __future__ import annotations' and therefore local
     # references cannot be automatically resolved
-    assert xtyping.get_partial_type_hints(f_partial) == {
+    assert extra_typing.get_partial_type_hints(f_partial) == {
         "a": int,
         "return": ForwardRef("MissingRef"),
     }
-    assert xtyping.get_partial_type_hints(f_partial, localns={"MissingRef": MissingRef}) == {
+    assert extra_typing.get_partial_type_hints(f_partial, localns={"MissingRef": MissingRef}) == {
         "a": int,
         "return": MissingRef,
     }
-    assert xtyping.get_partial_type_hints(f_partial, globalns={"MissingRef": int}) == {
+    assert extra_typing.get_partial_type_hints(f_partial, globalns={"MissingRef": int}) == {
         "a": int,
         "return": int,
     }
 
     def f_nested_partial(a: int) -> dict[str, MissingRef]: ...
 
-    assert xtyping.get_partial_type_hints(f_nested_partial) == {
+    assert extra_typing.get_partial_type_hints(f_nested_partial) == {
         "a": int,
         "return": ForwardRef("dict[str, MissingRef]"),
     }
-    assert xtyping.get_partial_type_hints(f_nested_partial, localns={"MissingRef": MissingRef}) == {
+    assert extra_typing.get_partial_type_hints(
+        f_nested_partial, localns={"MissingRef": MissingRef}
+    ) == {
         "a": int,
         "return": dict[str, MissingRef],
     }
@@ -369,33 +366,38 @@ def test_get_partial_type_hints():
     def f_annotated(a: Annotated[int, "Foo"]) -> float:  # type: ignore[name-defined]  # used to work, now mypy is going berserk for unknown reasons
         ...
 
-    assert xtyping.get_partial_type_hints(f_annotated) == {"a": int, "return": float}
-    assert xtyping.get_partial_type_hints(f_annotated, include_extras=True) == {
+    assert extra_typing.get_partial_type_hints(f_annotated) == {"a": int, "return": float}
+    assert extra_typing.get_partial_type_hints(f_annotated, include_extras=True) == {
         "a": Annotated[int, "Foo"],
         "return": float,
     }
-    assert xtyping.get_partial_type_hints(f_annotated, include_extras=True) != {
+    assert extra_typing.get_partial_type_hints(f_annotated, include_extras=True) != {
         "a": Annotated[int, "Bar"],
         "return": float,
     }
 
 
 def test_eval_forward_ref():
-    assert xtyping.eval_forward_ref("dict[str, tuple[int, float]]") == dict[str, tuple[int, float]]
     assert (
-        xtyping.eval_forward_ref(ForwardRef("dict[str, tuple[int, float]]"))
+        extra_typing.eval_forward_ref("dict[str, tuple[int, float]]")
+        == dict[str, tuple[int, float]]
+    )
+    assert (
+        extra_typing.eval_forward_ref(ForwardRef("dict[str, tuple[int, float]]"))
         == dict[str, tuple[int, float]]
     )
 
     class MissingRef: ...
 
     assert (
-        xtyping.eval_forward_ref("Callable[[int], MissingRef]", localns={"MissingRef": MissingRef})
+        extra_typing.eval_forward_ref(
+            "Callable[[int], MissingRef]", localns={"MissingRef": MissingRef}
+        )
         == Callable[[int], MissingRef]
     )
 
     assert (
-        xtyping.eval_forward_ref(
+        extra_typing.eval_forward_ref(
             "Callable[[int], MissingRef]",
             globalns={"Callable": Callable},
             localns={"MissingRef": MissingRef},
@@ -404,7 +406,7 @@ def test_eval_forward_ref():
     )
 
     assert (
-        ref := xtyping.eval_forward_ref(
+        ref := extra_typing.eval_forward_ref(
             "Callable[[Annotated[int, 'Foo']], MissingRef]",
             globalns={"Annotated": Annotated, "Callable": Callable},
             localns={"MissingRef": MissingRef},
@@ -412,7 +414,7 @@ def test_eval_forward_ref():
     ) == Callable[[int], MissingRef]
 
     assert (
-        xtyping.eval_forward_ref(
+        extra_typing.eval_forward_ref(
             "Callable[[Annotated[int, 'Foo']], MissingRef]",
             globalns={"Annotated": Annotated, "Callable": Callable},
             localns={"MissingRef": MissingRef},
@@ -423,34 +425,34 @@ def test_eval_forward_ref():
 
 
 def test_infer_type():
-    assert xtyping.infer_type(3) == int
+    assert extra_typing.infer_type(3) == int
 
-    assert xtyping.infer_type(None) is type(None)  # noqa: E721  # do not compare types
-    assert xtyping.infer_type(type(None)) is type(None)  # noqa: E721  # do not compare types
-    assert xtyping.infer_type(None, none_as_type=False) is None
-    assert xtyping.infer_type(type(None), none_as_type=False) is None
+    assert extra_typing.infer_type(None) is type(None)  # noqa: E721  # do not compare types
+    assert extra_typing.infer_type(type(None)) is type(None)  # noqa: E721  # do not compare types
+    assert extra_typing.infer_type(None, none_as_type=False) is None
+    assert extra_typing.infer_type(type(None), none_as_type=False) is None
 
-    assert xtyping.infer_type(dict[str, int]) == dict[str, int]
+    assert extra_typing.infer_type(dict[str, int]) == dict[str, int]
 
-    assert xtyping.infer_type({1, 2, 3}) == set[int]
-    assert xtyping.infer_type(frozenset({"1", "2", "3"})) == frozenset[str]
+    assert extra_typing.infer_type({1, 2, 3}) == set[int]
+    assert extra_typing.infer_type(frozenset({"1", "2", "3"})) == frozenset[str]
 
-    assert xtyping.infer_type({"a": [0], "b": [1]}) == dict[str, list[int]]
+    assert extra_typing.infer_type({"a": [0], "b": [1]}) == dict[str, list[int]]
 
-    assert xtyping.infer_type(str) == type[str]
+    assert extra_typing.infer_type(str) == type[str]
 
     class A: ...
 
-    assert xtyping.infer_type(A()) == A
-    assert xtyping.infer_type(A) == type[A]
+    assert extra_typing.infer_type(A()) == A
+    assert extra_typing.infer_type(A) == type[A]
 
     def f1(): ...
 
-    assert xtyping.infer_type(f1) == Callable[[], Any]
+    assert extra_typing.infer_type(f1) == Callable[[], Any]
 
     def f2(a: int, b: float) -> None: ...
 
-    assert xtyping.infer_type(f2) == Callable[[int, float], type(None)]
+    assert extra_typing.infer_type(f2) == Callable[[int, float], type(None)]
 
     def f3(
         a: dict[tuple[str, ...], list[int]],
@@ -459,7 +461,7 @@ def test_infer_type():
     ) -> Any: ...
 
     assert (
-        xtyping.infer_type(f3)
+        extra_typing.infer_type(f3)
         == Callable[
             [
                 dict[tuple[str, ...], list[int]],
@@ -472,11 +474,12 @@ def test_infer_type():
 
     def f4(a: int, b: float, *, foo: tuple[str, ...] = ()) -> None: ...
 
-    assert xtyping.infer_type(f4) == Callable[[int, float], type(None)]
+    assert extra_typing.infer_type(f4) == Callable[[int, float], type(None)]
     assert (
-        xtyping.infer_type(f4, annotate_callable_kwargs=True)
+        extra_typing.infer_type(f4, annotate_callable_kwargs=True)
         == Annotated[
-            Callable[[int, float], type(None)], xtyping.CallableKwargsInfo({"foo": tuple[str, ...]})
+            Callable[[int, float], type(None)],
+            extra_typing.CallableKwargsInfo({"foo": tuple[str, ...]}),
         ]
     )
 
@@ -485,11 +488,11 @@ def test_is_single_dispatch_callable():
     import functools
 
     # `functools.singledispatch` results (and wrappers exposing `dispatch`/`register`).
-    assert xtyping.is_single_dispatch_callable(functools.singledispatch(lambda _: None))
+    assert extra_typing.is_single_dispatch_callable(functools.singledispatch(lambda _: None))
 
     # Plain callables and non-callables are rejected.
-    assert not xtyping.is_single_dispatch_callable(lambda _: None)
-    assert not xtyping.is_single_dispatch_callable(42)
+    assert not extra_typing.is_single_dispatch_callable(lambda _: None)
+    assert not extra_typing.is_single_dispatch_callable(42)
 
 
 # -- PEP 695 type aliases --
@@ -507,23 +510,23 @@ def test_is_type_alias():
     # Both the native 'typing' class and the 'typing_extensions' backport have to be
     # recognized: they are distinct classes and a native alias is not an instance
     # of the backport.
-    assert xtyping.is_type_alias(SampleIntAlias)
-    assert xtyping.is_type_alias(typing_extensions.TypeAliasType("Backported", str))
+    assert extra_typing.is_type_alias(SampleIntAlias)
+    assert extra_typing.is_type_alias(typing_extensions.TypeAliasType("Backported", str))
 
-    assert not xtyping.is_type_alias(int)
-    assert not xtyping.is_type_alias(list[int])
-    assert not xtyping.is_type_alias(SampleGenericAlias[int])
+    assert not extra_typing.is_type_alias(int)
+    assert not extra_typing.is_type_alias(list[int])
+    assert not extra_typing.is_type_alias(SampleGenericAlias[int])
 
 
 def test_eval_type_alias():
-    assert xtyping.eval_type_alias(SampleIntAlias) is int
-    assert xtyping.eval_type_alias(SampleChainedAlias) is int
-    assert xtyping.eval_type_alias(SampleGenericAlias[int]) == tuple[int, int]
+    assert extra_typing.eval_type_alias(SampleIntAlias) is int
+    assert extra_typing.eval_type_alias(SampleChainedAlias) is int
+    assert extra_typing.eval_type_alias(SampleGenericAlias[int]) == tuple[int, int]
 
 
 def test_eval_type_alias_passes_through_non_aliases():
-    for annotation in (int, list[int], xtyping.Any, None):
-        assert xtyping.eval_type_alias(annotation) is annotation
+    for annotation in (int, list[int], typing.Any, None):
+        assert extra_typing.eval_type_alias(annotation) is annotation
 
 
 def test_eval_type_alias_with_undefined_value():
@@ -531,16 +534,16 @@ def test_eval_type_alias_with_undefined_value():
     type LazyAlias = _defined_later  # noqa: F821 [undefined-name]  # defined below
 
     with pytest.raises(NameError):
-        xtyping.eval_type_alias(LazyAlias)
+        extra_typing.eval_type_alias(LazyAlias)
 
     _defined_later = int
 
-    assert xtyping.eval_type_alias(LazyAlias) is int
+    assert extra_typing.eval_type_alias(LazyAlias) is int
 
 
 def test_eval_type_alias_with_recursive_alias():
     with pytest.raises(TypeError, match="recursive definition"):
-        xtyping.eval_type_alias(SampleRecursiveAlias)
+        extra_typing.eval_type_alias(SampleRecursiveAlias)
 
 
 def test_eval_type_alias_with_alias_recursing_through_a_container():
@@ -549,12 +552,12 @@ def test_eval_type_alias_with_alias_recursing_through_a_container():
     # so it resolves instead of being reported as a cycle. The alias is still present
     # in the result, so consumers walking it have to break the recursion themselves.
     assert (
-        xtyping.eval_type_alias(SampleNestedTupleAlias[int])
+        extra_typing.eval_type_alias(SampleNestedTupleAlias[int])
         == tuple[int | SampleNestedTupleAlias[int], ...]
     )
     assert (
-        xtyping.eval_type_alias(xtyping.NestedTuple[int])
-        == tuple[int | xtyping.NestedTuple[int], ...]
+        extra_typing.eval_type_alias(extra_typing.NestedTuple[int])
+        == tuple[int | extra_typing.NestedTuple[int], ...]
     )
 
 
@@ -563,14 +566,14 @@ def test_eval_type_alias_with_mutually_recursive_aliases():
     # depth bound would have to say: a cycle repeats an alias, so it is detected as
     # soon as one is seen twice, however long the cycle is.
     with pytest.raises(TypeError, match="'SampleMutualAliasA' cannot be resolved.*recursive"):
-        xtyping.eval_type_alias(SampleMutualAliasA)
+        extra_typing.eval_type_alias(SampleMutualAliasA)
 
 
 def test_eval_type_alias_with_diverging_generic_alias():
     # A parametrized alias which grows on every step never repeats an annotation, so
     # the visited-alias check cannot see it and the depth bound is what stops it.
     with pytest.raises(TypeError, match="nested too deeply"):
-        xtyping.eval_type_alias(SampleDivergingGenericAlias[int])
+        extra_typing.eval_type_alias(SampleDivergingGenericAlias[int])
 
 
 def test_eval_type_alias_with_failing_value():
@@ -582,7 +585,7 @@ def test_eval_type_alias_with_failing_value():
     _empty_module = types.ModuleType("_empty_module")
 
     with pytest.raises(TypeError, match="'BrokenAlias' cannot be resolved") as exc_info:
-        xtyping.eval_type_alias(BrokenAlias)
+        extra_typing.eval_type_alias(BrokenAlias)
 
     # The actual cause is kept, both in the message and as the chained exception.
     assert "missing_attribute" in str(exc_info.value)
@@ -601,24 +604,24 @@ type SampleNestedUnionAlias = SampleUnionAlias | int
 
 
 def test_get_represented_types():
-    assert xtyping.get_represented_types(int) == (int,)
-    assert xtyping.get_represented_types(Union[SampleReprA, SampleReprB]) == (
+    assert extra_typing.get_represented_types(int) == (int,)
+    assert extra_typing.get_represented_types(Union[SampleReprA, SampleReprB]) == (
         SampleReprA,
         SampleReprB,
     )
-    assert xtyping.get_represented_types(SampleReprA | SampleReprB) == (
+    assert extra_typing.get_represented_types(SampleReprA | SampleReprB) == (
         SampleReprA,
         SampleReprB,
     )
-    assert xtyping.get_represented_types(list[int]) == (list,)
+    assert extra_typing.get_represented_types(list[int]) == (list,)
 
 
 def test_get_represented_types_resolves_type_aliases():
     # An unresolved alias would silently yield an empty tuple, which turns every
     # downstream 'isinstance()' check against the result into a constant 'False'.
-    assert xtyping.get_represented_types(SampleIntAlias) == (int,)
-    assert xtyping.get_represented_types(SampleUnionAlias) == (SampleReprA, SampleReprB)
-    assert xtyping.get_represented_types(SampleNestedUnionAlias) == (
+    assert extra_typing.get_represented_types(SampleIntAlias) == (int,)
+    assert extra_typing.get_represented_types(SampleUnionAlias) == (SampleReprA, SampleReprB)
+    assert extra_typing.get_represented_types(SampleNestedUnionAlias) == (
         SampleReprA,
         SampleReprB,
         int,
@@ -628,15 +631,15 @@ def test_get_represented_types_resolves_type_aliases():
 def test_get_represented_types_with_alias_recursing_through_a_container():
     # The recursion stops at the container, since generic annotations are represented
     # by their origin and are not walked any further.
-    assert xtyping.get_represented_types(SampleNestedTupleAlias[int]) == (tuple,)
-    assert xtyping.get_represented_types(xtyping.NestedTuple) == (tuple,)
-    assert xtyping.get_represented_types(xtyping.NestedTuple[int]) == (tuple,)
-    assert xtyping.get_represented_types(xtyping.MaybeNestedInTuple[int]) == (int, tuple)
+    assert extra_typing.get_represented_types(SampleNestedTupleAlias[int]) == (tuple,)
+    assert extra_typing.get_represented_types(extra_typing.NestedTuple) == (tuple,)
+    assert extra_typing.get_represented_types(extra_typing.NestedTuple[int]) == (tuple,)
+    assert extra_typing.get_represented_types(extra_typing.MaybeNestedInTuple[int]) == (int, tuple)
 
 
 def test_get_represented_types_with_alias_nested_in_annotation():
-    assert xtyping.get_represented_types(Optional[SampleIntAlias]) == (int, type(None))
-    assert xtyping.get_represented_types(Union[SampleUnionAlias, int]) == (
+    assert extra_typing.get_represented_types(Optional[SampleIntAlias]) == (int, type(None))
+    assert extra_typing.get_represented_types(Union[SampleUnionAlias, int]) == (
         SampleReprA,
         SampleReprB,
         int,

--- a/tests/eve_tests/unit_tests/test_traits.py
+++ b/tests/eve_tests/unit_tests/test_traits.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from gt4py import eve
-from gt4py.eve.extended_typing import Any, ClassVar
+from typing import Any, ClassVar
 
 from .. import definitions
 

--- a/tests/eve_tests/unit_tests/test_type_validation.py
+++ b/tests/eve_tests/unit_tests/test_type_validation.py
@@ -15,20 +15,12 @@ from frozendict import frozendict
 
 import pytest
 
-from gt4py.eve import (
-    extended_typing as xtyping,
-    type_validation as type_val,
-)
-from gt4py.eve.extended_typing import (
-    Any,
-    Callable,
-    Final,
-    ForwardRef,
-    Optional,
-    Sequence,
-    SourceTypeAnnotation,
-    Union,
-)
+from collections.abc import Callable, Sequence
+from typing import Any, Final, ForwardRef, Optional, Union
+import typing
+from gt4py.eve.extra_typing import SourceTypeAnnotation
+from gt4py.eve import extra_typing
+from gt4py.eve import type_validation as type_val
 
 
 VALIDATORS: Final[list[Callable]] = [type_val.simple_type_validator]
@@ -235,20 +227,26 @@ SAMPLE_TYPE_DEFINITIONS.extend(
             None,
         ),
         (
-            xtyping.NestedTuple[int],
+            extra_typing.NestedTuple[int],
             ((), (1, 2), (1, (2, (3, 4)), ())),
             (1, [1], (1, "2"), (1, [2])),
             None,
             None,
         ),
         (
-            xtyping.NestedList[int],
+            extra_typing.NestedList[int],
             ([], [1, 2], [1, [2, [3, 4]], []]),
             (1, (1,), [1, "2"], [1, (2,)]),
             None,
             None,
         ),
-        (xtyping.MaybeNestedInTuple[int], (1, (), (1, (2, 3))), ("1", [1], (1, "2")), None, None),
+        (
+            extra_typing.MaybeNestedInTuple[int],
+            (1, (), (1, (2, 3))),
+            ("1", [1], (1, "2")),
+            None,
+            None,
+        ),
     ]
 )
 
@@ -339,7 +337,7 @@ def test_simple_validation_particularities():
     lenient_validator(True)
 
     # not supported annotations
-    InvalidAnnotation = xtyping.TypeGuard[str]
+    InvalidAnnotation = typing.TypeGuard[str]
     assert (
         type_val.simple_type_validator_factory(InvalidAnnotation, "value", required=False) is None
     )

--- a/tests/next_tests/artifacts/custom_named_collections.py
+++ b/tests/next_tests/artifacts/custom_named_collections.py
@@ -14,7 +14,8 @@ from typing import NamedTuple, Final, Protocol, TypeVar
 import dataclasses
 
 from gt4py import next as gtx
-from gt4py.eve.extended_typing import NestedTuple, Self
+from typing import Self
+from gt4py.eve.extra_typing import NestedTuple
 from gt4py.next import common, Dimension, Field, float32, float64, Dims, named_collections
 from gt4py.next.type_system import type_specifications as ts
 

--- a/tests/next_tests/integration_tests/cases.py
+++ b/tests/next_tests/integration_tests/cases.py
@@ -31,8 +31,8 @@ import pytest
 
 import gt4py.next as gtx
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping
-from gt4py.eve.extended_typing import Self
+from typing import Self
+import typing_extensions
 from gt4py.next import (
     backend as next_backend,
     common,
@@ -645,7 +645,7 @@ def get_param_types(
         raise ValueError(
             f"test cases do not support '{type(fieldview_prog)}' with empty .definition attribute (as you would get from .as_program())."
         )
-    annotations = xtyping.get_type_hints(fieldview_prog.definition)
+    annotations = typing_extensions.get_type_hints(fieldview_prog.definition)
     return {
         name: type_translation.from_type_hint(type_hint) for name, type_hint in annotations.items()
     }

--- a/tests/next_tests/unit_tests/otf_tests/test_arguments.py
+++ b/tests/next_tests/unit_tests/otf_tests/test_arguments.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 import pytest
 
-from gt4py.eve.extended_typing import NestedTuple
+from gt4py.eve.extra_typing import NestedTuple
 from gt4py.next import common
 from gt4py.next import named_collections
 from gt4py.next.type_system import type_specifications as ts, type_translation as tt

--- a/tests/next_tests/unit_tests/test_containers.py
+++ b/tests/next_tests/unit_tests/test_containers.py
@@ -13,7 +13,7 @@ import dataclasses
 import pytest
 
 from gt4py import next as gtx
-from gt4py.eve.extended_typing import NestedTuple
+from gt4py.eve.extra_typing import NestedTuple
 from gt4py.next import common, Field, named_collections
 
 from next_tests.artifacts import custom_named_collections as cnc

--- a/tests/next_tests/unit_tests/type_system_tests/test_type_translation.py
+++ b/tests/next_tests/unit_tests/type_system_tests/test_type_translation.py
@@ -16,7 +16,8 @@ import pytest
 import gt4py.next as gtx
 from gt4py import eve
 from gt4py._core import definitions as core_defs
-from gt4py.eve import extended_typing as xtyping, utils as eve_utils
+from gt4py.eve import extra_typing
+from gt4py.eve import utils as eve_utils
 from gt4py.next import common
 from gt4py.next.type_system import type_specifications as ts, type_translation
 from gt4py.next import constructors
@@ -106,7 +107,7 @@ def _make_type_string_for_container(cls: type) -> str:
         ),
         (
             typing.Annotated[
-                typing.Callable[["float", int], int], xtyping.CallableKwargsInfo(data={})
+                typing.Callable[["float", int], int], extra_typing.CallableKwargsInfo(data={})
             ],
             ts.FunctionType(
                 pos_only_args=[


### PR DESCRIPTION
`extended_typing` star-imported `typing` and `typing_extensions`, re-exported 115 of
their names, and forwarded anything else through a module `__getattr__`. It is replaced
by `extra_typing`, holding only the definitions the standard modules do not provide;
call sites now import from `typing`, `typing_extensions` or `collections.abc` directly.

Not just tidying — the re-export layer suppressed both static checkers. A module
`__getattr__` is unmodellable, so mypy typed everything reached through it as `Any`:
249 `xtyping.<name>` references across 53 distinct names, in the module that defines
the project's type infrastructure.

```console
$ mypy -c 'from gt4py.eve import extended_typing as xtyping; reveal_type(xtyping.TotallyMadeUpSymbol)'
note: Revealed type is "Any"
Success: no issues found in 1 source file
```

Restoring checking surfaced two real findings, both fixed here: a
`type: ignore[type-abstract]` in `next/embedded/operators.py` that sat on the closing
paren instead of the argument and so had never applied, and an unused ignore that
survived only via this module's `warn_unused_ignores` override. ruff needed its own
escape hatch, `typing-modules = ['gt4py.eve.extended_typing']`, without which `UP045`
stops firing on names imported from the module; that setting and the mypy override are
both deleted, so later work analyses plain imports natively.

Destinations were chosen by the identity of each symbol's current binding, not by
whether `typing` has the name — `extended_typing` rebinds the container protocols to
`collections.abc`, so the naive test would have introduced 7 deprecated PEP 585
spellings. Of the 83 symbols in use: 39 are `extra_typing`'s own, 32 go to `typing`, 7
to `collections.abc`, 5 stay on `typing_extensions`.

Seven symbols are bound to the `typing_extensions` version *and* differ from the
`typing` one, so each was a decision rather than a rewrite. `get_type_hints` stays
because `eve` runs every annotation through it and the two differ on `Annotated` / PEP
695 / PEP 649; `Protocol` and `runtime_checkable` stay because `next/common.py` checks
four `@runtime_checkable` protocols on hot paths, and keeping the current
implementation is the no-behaviour-change choice. `TypeVar`, `TypeVarTuple`, `ParamSpec`
and `NamedTuple` move to `typing`, their divergences (PEP 696 `default=`, generic
namedtuples) being unused or verified here. The reasoning is repeated in the
`extra_typing` docstring.

The subtle part: `eval_forward_ref` resolved references against this module's own
`globals()` when given no namespace, which worked only because the star imports put
every typing name there. `datamodels/core.py` calls it that way inside
`_is_strictly_immutable_type`, wrapped in `except Exception: return False` — so
deleting the star imports would not have crashed, it would have quietly started
reporting `frozen="strict"` datamodels with string annotations as *not* immutable. The
namespace is now built explicitly. Old and new were differential-tested while both
existed: 312/312 identical across 13 public functions, 27/27 on forward references.

`extra_typing` declares `__all__` of its own 61 definitions, and two tests assert what
made the old module unverifiable: nothing in `__all__` is a re-export, and there is no
`__getattr__` fallback.

Falling out of the same work: closes the `# TODO: add xtyping.Buffer once we update
typing_extensions` in `storage/allocators.py`; moves `Self` to `typing`; adds
`./scripts/run check typing-extensions-usage`, which reports `typing_extensions`
imports a raised Python floor makes redundant, flagging only names where `typing`
provides the identical object.

The call-site rewrite was a deterministic codemod driven by the destination map, which
aborts on any unmapped symbol rather than guessing.

Verified on 3.12, 3.13 and 3.14: 848 passed + 57 doctests each. `next` / `storage` /
`cartesian` unit tests: 3057 passed, 108 skipped, 13 xfailed. `pre-commit run
--all-files` clean, including mypy and tach. Not run locally: the backend matrix.

`gt4py.eve.extended_typing` is removed outright, with no compatibility shim. The
module is private: it is not in `gt4py.eve.__all__` and no user documentation refers
to it. A forwarding shim would in any case have to keep the module `__getattr__` that
blinds the checkers, which is the hole this removes. Worth a release-note line, as the
comparable change in 1.2.1 got.
