### PR TITLE
fix[next-dace]: fix memlet issues discovered with dace v2.0.0-alpha7

### DIFF
--- a/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
@@ -1116,7 +1116,10 @@ class LoopBlocking(dace_transformation.SingleStateTransformation):
                         new_out_conn,
                         in_edge.dst,
                         in_edge.dst_conn,
-                        copy.deepcopy(in_edge.data),
+                        dace.Memlet(
+                            data=in_edge.data.data,
+                            subset=in_edge.data.get_src_subset(in_edge, state),
+                        ),
                     )
                     inner_entry.add_in_connector(new_in_conn)
                     inner_entry.add_out_connector(new_out_conn)
@@ -1152,7 +1155,10 @@ class LoopBlocking(dace_transformation.SingleStateTransformation):
                 "OUT_" + edge_conn,
                 outer_exit,
                 in_edge.dst_conn,
-                copy.deepcopy(in_edge.data),
+                dace.Memlet(
+                    data=in_edge.data.data,
+                    subset=in_edge.data.get_dst_subset(in_edge, state),
+                ),
             )
             inner_exit.add_in_connector("IN_" + edge_conn)
             inner_exit.add_out_connector("OUT_" + edge_conn)

--- a/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
+++ b/src/gt4py/next/program_processors/runners/dace/transformations/loop_blocking.py
@@ -1118,7 +1118,9 @@ class LoopBlocking(dace_transformation.SingleStateTransformation):
                         in_edge.dst_conn,
                         dace.Memlet(
                             data=in_edge.data.data,
-                            subset=in_edge.data.get_src_subset(in_edge, state),
+                            subset=dace_subsets.Range(
+                                in_edge.data.get_src_subset(in_edge, state).ndrange()
+                            ),
                         ),
                     )
                     inner_entry.add_in_connector(new_in_conn)
@@ -1157,7 +1159,9 @@ class LoopBlocking(dace_transformation.SingleStateTransformation):
                 in_edge.dst_conn,
                 dace.Memlet(
                     data=in_edge.data.data,
-                    subset=in_edge.data.get_dst_subset(in_edge, state),
+                    subset=dace_subsets.Range(
+                        in_edge.data.get_dst_subset(in_edge, state).ndrange()
+                    ),
                 ),
             )
             inner_exit.add_in_connector("IN_" + edge_conn)

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_concat_where_replacer.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_concat_where_replacer.py
@@ -888,7 +888,7 @@ def _make_concat_where_global_read(
         state.add_edge(c, None, tlet, "__in0", dace.Memlet(f"c[{scalar_access}]"))
         state.add_edge(tlet, "__out", d, None, dace.Memlet("d[5]"))
     else:
-        state.add_edge(c, None, d, None, dace.Memlet(f"c[{scalar_access}]"))
+        state.add_edge(c, None, d, None, dace.Memlet("d[5]", other_subset=str(scalar_access)))
 
     sdfg.validate()
 

--- a/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_loop_blocking.py
+++ b/tests/next_tests/unit_tests/program_processor_tests/runners_tests/dace_tests/transformation_tests/test_loop_blocking.py
@@ -1503,7 +1503,7 @@ def _make_loop_blocking_output_access_node(
     state.add_edge(me, "OUT_A", tlet, "__in", dace.Memlet("A[__i0]"))
     me.add_scope_connectors("A")
     state.add_edge(tlet, "__out", t, None, dace.Memlet("t[0]"))
-    state.add_edge(t, None, mx, "IN_B", dace.Memlet("B[__i0, __i1]"))
+    state.add_edge(t, None, mx, "IN_B", dace.Memlet("B[__i0, __i1]", other_subset="0"))
     state.add_edge(mx, "OUT_B", B, None, dace.Memlet("B[0:40, 0:10]"))
     mx.add_scope_connectors("B")
 


### PR DESCRIPTION
Some tests started to fail after bumping the dace version to v2.0.0-alpha7. The issues belong to the test code, which contained incomplete and/or malformed memlet subsets.

After fixing the tests, another issue was discovered in loop-blocking transformation, also related to memlet subsets.