### PR TITLE
fix[next]: guard on `inline_let_params` values, not keys, in `InlineDynamicShifts`

### DIFF
--- a/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
+++ b/src/gt4py/next/iterator/transforms/inline_dynamic_shifts.py
@@ -59,7 +59,7 @@ class InlineDynamicShifts(eve.NodeTranslator, eve.VisitorWithSymbolTableTrait):
                     if ref in inline_let_params and is_dynamic_shift_arg:
                         inline_let_params[ref] = True
 
-            if any(inline_let_params):
+            if any(inline_let_params.values()):
                 node = inline_lambdas.inline_lambda(
                     node, eligible_params=list(inline_let_params.values())
                 )


### PR DESCRIPTION
## Description

`visit_FunCall` built a `dict[str, bool]` of which let-bound parameters feed a dynamically
shifted argument, then gated on `any(inline_let_params)` — which iterates the dict's **keys**.
The keys are `SymbolName`s, constrained to `^[a-zA-Z_]\w*$` and therefore never falsy, so the
guard was equivalent to `len(node.fun.params) > 0` and discarded the per-parameter information
just computed. The correct values were still passed to `eligible_params`.

The change is inert on well-formed IR: `inline_lambda` re-checks the same predicate and returns
`node` unchanged when no parameter is eligible, so the spurious calls did nothing. The only
behavioural difference is that an arity-mismatched (malformed) `let` no longer trips
`inline_lambda`'s arity assert.

Verified by instrumenting the guard to record both readings and compare the resulting IR, at
two independent levels — at the guard site, and by running the whole pipeline twice per program
and diffing the final `itir.Program`. Across the `roundtrip` integration suite the guard is
reached 20 times and the old form is wrong at every one of them; no program's IR differs. A
deliberately mis-specified control arm was used to confirm both comparisons do report a
difference when one exists.

Fixes #2849.

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  - No test added: the change is inert on well-formed IR, so there is nothing a test could
    assert. The only observable difference needs invalid IR as input, which is the wrong shape
    for a regression test.
- [x] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  - N/A, no design decision.

https://claude.ai/code/session_01R5u3nT8NcM4RovwvaxYfjh