### PR TITLE
refactor[cartesian]: remove unused list of `missing_api_parameters` from OIR -> TreeIR

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -345,9 +345,7 @@ class OIRToTreeIR(eve.NodeVisitor):
             ignore_horizontal_mask=True,
         )
 
-        missing_api_parameters: list[str] = [p.name for p in self._api_signature]
         for param in node.params:
-            missing_api_parameters.remove(param.name)
             if isinstance(param, oir.ScalarDecl):
                 containers[param.name] = data.Scalar(
                     dtype=utils.data_type_to_dace_typeclass(param.dtype),


### PR DESCRIPTION
## Description

Building the TreeIR from OIR builds a list of "missing api parameters" and then does nothing with it. I chose to remove it. We could  also raise in case missing parameters are detected. I have no recollection why we have this. @FlorianDeconinck do you remember? Is this somehow related to https://github.com/GridTools/gt4py/issues/2083?

## Requirements

- [ ] All fixes and/or new features come with corresponding tests.
  N/A
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
  N/A
