### PR TITLE
fix[next]: resolve closure variable references by value

### DIFF
--- a/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
+++ b/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
@@ -8,12 +8,36 @@
 
 import dataclasses
 import enum
+import re
+import types
 from typing import Any
 
 import gt4py.next.ffront.field_operator_ast as foast
-from gt4py.eve import NodeTranslator, traits
+from gt4py._core import definitions as core_defs
+from gt4py.eve import NodeTranslator, concepts, traits
 from gt4py.next import errors
+from gt4py.next.ffront import dialect_ast_enums, experimental, fbuiltins, gtcallable
+from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.type_system import type_translation
+
+
+_BUILTINS_BY_NAME: dict[str, Any] = {
+    **fbuiltins.BUILTINS,
+    **{name: getattr(experimental, name) for name in experimental.EXPERIMENTAL_FUN_BUILTIN_NAMES},
+}
+_BUILTIN_NAME_BY_ID: dict[int, str] = {id(value): name for name, value in _BUILTINS_BY_NAME.items()}
+
+
+def _canonical_name(value: Any) -> str | None:
+    """Name under which `value` is known to the later passes, or `None` if it has none."""
+    name = _BUILTIN_NAME_BY_ID.get(id(value))
+    if name is not None and _BUILTINS_BY_NAME[name] is value:
+        return name
+    if isinstance(value, gtcallable.GTCallable) and (
+        definition := getattr(value, "definition", None)
+    ):
+        return re.sub(r"\W", "_", f"{definition.__module__}.{definition.__qualname__}")
+    return None
 
 
 @dataclasses.dataclass
@@ -22,11 +46,18 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
     Replace references to closure variables or their attributes with constants.
 
     `Name` nodes that refer to closure variables are replaced by `Constant`
-     nodes. `Attribute` nodes that refer to attributes of closure variables
-     are recursively replaced by `Constant` nodes.
+    nodes. `Attribute` nodes that refer to attributes of closure variables
+    are recursively replaced by `Constant` nodes.
+
+    References that reach a value through a module (`np.pi`, `gtx.where`,
+    `helpers.helper`) or refer to a builtin under another name are resolved by
+    value: scalars become `Constant`s, builtins and `GTCallable`s become a
+    `Name` of a canonical, value-derived symbol that is added to `closure_vars`
+    and to the function's closure variable symbols.
     """
 
     closure_vars: dict[str, Any]
+    _added_closure_vars: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     @classmethod
     def apply(
@@ -34,25 +65,48 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
     ) -> foast.FunctionDefinition:
         return cls(closure_vars=closure_vars).visit(node)
 
+    def _closure_value(
+        self,
+        node: foast.Expr,
+        current_closure_vars: list[foast.Symbol],
+        symtable: dict[str, foast.Symbol],
+    ) -> Any:
+        """Python value of a closure variable reference, resolved through module attributes."""
+        if isinstance(node, foast.Name):
+            if node.id in symtable and symtable[node.id] in current_closure_vars:
+                return self.closure_vars[node.id]
+        elif isinstance(node, foast.Attribute):
+            base = self._closure_value(node.value, current_closure_vars, symtable)
+            if isinstance(base, types.ModuleType):
+                if not hasattr(base, node.attr):
+                    raise errors.MissingAttributeError(node.location, node.attr)
+                return getattr(base, node.attr)
+        return _MISSING
+
     def visit_Name(
         self,
         node: foast.Name,
-        current_closure_vars: dict[str, Any],
+        current_closure_vars: list[foast.Symbol],
         symtable: dict[str, foast.Symbol],
         **kwargs: Any,
     ) -> foast.Name | foast.Constant:
-        if node.id in symtable:
-            definition = symtable[node.id]
-            if definition in current_closure_vars:
-                value = self.closure_vars[node.id]
-                if isinstance(value, type_translation.ConstantPythonNamespaceObject):
-                    return foast.Constant(value=value, location=node.location)
+        value = self._closure_value(node, current_closure_vars, symtable)
+        if isinstance(value, type_translation.ConstantPythonNamespaceObject):
+            return foast.Constant(value=value, location=node.location)
+        if (name := _canonical_name(value)) is not None and name != node.id:
+            return self._reference(name, value, node.location, symtable)
         return node
 
     def visit_Attribute(
-        self, node: foast.Attribute, **kwargs: Any
-    ) -> foast.Constant | foast.Attribute:
-        value = self.visit(node.value, **kwargs)
+        self,
+        node: foast.Attribute,
+        current_closure_vars: list[foast.Symbol],
+        symtable: dict[str, foast.Symbol],
+        **kwargs: Any,
+    ) -> foast.Constant | foast.Attribute | foast.Name:
+        value = self.visit(
+            node.value, current_closure_vars=current_closure_vars, symtable=symtable, **kwargs
+        )
         if isinstance(value, foast.Constant):
             if hasattr(value.value, node.attr):
                 const_value = getattr(value.value, node.attr)
@@ -60,9 +114,64 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
                     const_value = const_value.value
                 return foast.Constant(value=const_value, location=node.location)
             raise errors.MissingAttributeError(node.location, node.attr)
+        if isinstance(node.value, (foast.Name, foast.Attribute)):
+            leaf = self._closure_value(node, current_closure_vars, symtable)
+            if (name := _canonical_name(leaf)) is not None:
+                return self._reference(name, leaf, node.location, symtable)
+            if core_defs.is_scalar_type(leaf):
+                return foast.Constant(value=leaf, location=node.location)
         return node
+
+    def _reference(
+        self,
+        name: str,
+        value: Any,
+        location: concepts.SourceLocation,
+        symtable: dict[str, foast.Symbol],
+    ) -> foast.Name:
+        if name in self.closure_vars:
+            if self.closure_vars[name] is not value:
+                raise errors.DSLError(
+                    location,
+                    f"Reference resolves to '{name}', which is bound to a different value in the "
+                    "closure of this function.",
+                )
+        elif any(ssa.original_name(symbol) == name for symbol in symtable):
+            raise errors.DSLError(
+                location,
+                f"Reference resolves to '{name}', which is shadowed by a local variable or "
+                "parameter of the same name.",
+            )
+        else:
+            self.closure_vars[name] = value
+            self._added_closure_vars[name] = value
+        return foast.Name(id=name, location=location)
 
     def visit_FunctionDefinition(
         self, node: foast.FunctionDefinition, **kwargs: Any
     ) -> foast.FunctionDefinition:
-        return self.generic_visit(node, current_closure_vars=node.closure_vars, **kwargs)
+        new_node: foast.FunctionDefinition = self.generic_visit(
+            node, current_closure_vars=node.closure_vars, **kwargs
+        )
+        if not self._added_closure_vars:
+            return new_node
+        new_symbols: list[foast.Symbol] = [
+            foast.Symbol(
+                id=name,
+                type=type_translation.from_value(value),
+                namespace=dialect_ast_enums.Namespace.CLOSURE,
+                location=new_node.location,
+            )
+            for name, value in self._added_closure_vars.items()
+        ]
+        return foast.FunctionDefinition(
+            id=new_node.id,
+            params=new_node.params,
+            body=new_node.body,
+            closure_vars=[*new_node.closure_vars, *new_symbols],
+            type=new_node.type,
+            location=new_node.location,
+        )
+
+
+_MISSING = object()

--- a/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
+++ b/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
@@ -8,7 +8,7 @@
 
 import dataclasses
 import enum
-import re
+import hashlib
 import types
 from typing import Any
 
@@ -21,16 +21,14 @@ from gt4py.next.ffront.ast_passes import single_static_assign as ssa
 from gt4py.next.type_system import type_translation
 
 
-_BUILTINS_BY_NAME: dict[str, Any] = {
+_BUILTINS: dict[str, Any] = {
     **fbuiltins.BUILTINS,
     **{name: getattr(experimental, name) for name in experimental.EXPERIMENTAL_FUN_BUILTIN_NAMES},
 }
-_BUILTIN_NAME_BY_ID: dict[int, str] = {id(value): name for name, value in _BUILTINS_BY_NAME.items()}
 
 
 def _builtin_name(value: Any) -> str | None:
-    name = _BUILTIN_NAME_BY_ID.get(id(value))
-    return name if name is not None and _BUILTINS_BY_NAME[name] is value else None
+    return next((name for name, builtin in _BUILTINS.items() if builtin is value), None)
 
 
 def _operator_name(value: Any) -> str | None:
@@ -38,7 +36,8 @@ def _operator_name(value: Any) -> str | None:
     if isinstance(value, gtcallable.GTCallable) and (
         definition := getattr(value, "definition", None)
     ):
-        return re.sub(r"\W", "_", f"{definition.__module__}.{definition.__qualname__}")
+        key = f"{definition.__code__.co_filename}:{definition.__qualname__}".encode()
+        return f"{definition.__name__}_{hashlib.sha256(key).hexdigest()[:8]}"
     return None
 
 
@@ -147,8 +146,8 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
         elif self.closure_vars[name] is not value:
             raise errors.DSLError(
                 location,
-                f"Reference resolves to '{name}', which is bound to a different value in the "
-                "closure of this function.",
+                f"Reference resolves to '{name}', but '{name}' already refers to a different "
+                "value in this function.",
             )
         return foast.Name(id=name, location=location)
 

--- a/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
+++ b/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
@@ -28,11 +28,13 @@ _BUILTINS_BY_NAME: dict[str, Any] = {
 _BUILTIN_NAME_BY_ID: dict[int, str] = {id(value): name for name, value in _BUILTINS_BY_NAME.items()}
 
 
-def _canonical_name(value: Any) -> str | None:
-    """Name under which `value` is known to the later passes, or `None` if it has none."""
+def _builtin_name(value: Any) -> str | None:
     name = _BUILTIN_NAME_BY_ID.get(id(value))
-    if name is not None and _BUILTINS_BY_NAME[name] is value:
-        return name
+    return name if name is not None and _BUILTINS_BY_NAME[name] is value else None
+
+
+def _operator_name(value: Any) -> str | None:
+    """A symbol name for a `GTCallable` reached through a module, derived from its definition."""
     if isinstance(value, gtcallable.GTCallable) and (
         definition := getattr(value, "definition", None)
     ):
@@ -93,8 +95,8 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
         value = self._closure_value(node, current_closure_vars, symtable)
         if isinstance(value, type_translation.ConstantPythonNamespaceObject):
             return foast.Constant(value=value, location=node.location)
-        if (name := _canonical_name(value)) is not None and name != node.id:
-            return self._reference(name, value, node.location, symtable)
+        if (name := _builtin_name(value)) is not None and name != node.id:
+            return self._reference(name, value, node.location, current_closure_vars, symtable)
         return node
 
     def visit_Attribute(
@@ -116,8 +118,8 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
             raise errors.MissingAttributeError(node.location, node.attr)
         if isinstance(node.value, (foast.Name, foast.Attribute)):
             leaf = self._closure_value(node, current_closure_vars, symtable)
-            if (name := _canonical_name(leaf)) is not None:
-                return self._reference(name, leaf, node.location, symtable)
+            if (name := _builtin_name(leaf) or _operator_name(leaf)) is not None:
+                return self._reference(name, leaf, node.location, current_closure_vars, symtable)
             if core_defs.is_scalar_type(leaf):
                 return foast.Constant(value=leaf, location=node.location)
         return node
@@ -127,24 +129,27 @@ class ClosureVarFolding(NodeTranslator, traits.VisitorWithSymbolTableTrait):
         name: str,
         value: Any,
         location: concepts.SourceLocation,
+        current_closure_vars: list[foast.Symbol],
         symtable: dict[str, foast.Symbol],
     ) -> foast.Name:
-        if name in self.closure_vars:
-            if self.closure_vars[name] is not value:
-                raise errors.DSLError(
-                    location,
-                    f"Reference resolves to '{name}', which is bound to a different value in the "
-                    "closure of this function.",
-                )
-        elif any(ssa.original_name(symbol) == name for symbol in symtable):
+        if any(
+            ssa.original_name(symbol) == name and symtable[symbol] not in current_closure_vars
+            for symbol in symtable
+        ):
             raise errors.DSLError(
                 location,
                 f"Reference resolves to '{name}', which is shadowed by a local variable or "
                 "parameter of the same name.",
             )
-        else:
+        if name not in self.closure_vars:
             self.closure_vars[name] = value
             self._added_closure_vars[name] = value
+        elif self.closure_vars[name] is not value:
+            raise errors.DSLError(
+                location,
+                f"Reference resolves to '{name}', which is bound to a different value in the "
+                "closure of this function.",
+            )
         return foast.Name(id=name, location=location)
 
     def visit_FunctionDefinition(

--- a/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
+++ b/src/gt4py/next/ffront/foast_passes/closure_var_folding.py
@@ -36,9 +36,15 @@ def _operator_name(value: Any) -> str | None:
     if isinstance(value, gtcallable.GTCallable) and (
         definition := getattr(value, "definition", None)
     ):
-        key = f"{definition.__code__.co_filename}:{definition.__qualname__}".encode()
-        return f"{definition.__name__}_{hashlib.sha256(key).hexdigest()[:8]}"
+        return _operator_name_from_definition(definition)
     return None
+
+
+def _operator_name_from_definition(definition: types.FunctionType) -> str:
+    # derived from the import path, not the file path, so the symbol (and with it the IR and
+    # the on-disk cache keys) is the same for every checkout of the same code
+    key = f"{definition.__module__}.{definition.__qualname__}".encode()
+    return f"{definition.__name__}_{hashlib.sha256(key).hexdigest()[:8]}"
 
 
 @dataclasses.dataclass

--- a/src/gt4py/next/ffront/past_passes/linters.py
+++ b/src/gt4py/next/ffront/past_passes/linters.py
@@ -8,27 +8,9 @@
 
 from typing import Any
 
-from gt4py.next.ffront import gtcallable, stages as ffront_stages, transform_utils
+from gt4py.next.ffront import stages as ffront_stages
 from gt4py.next.ffront.stages import ConcretePASTProgramDef, PASTProgramDef
 from gt4py.next.otf import toolchain, workflow
-
-
-def lint_misnamed_functions(
-    inp: ffront_stages.PASTProgramDef,
-) -> ffront_stages.PASTProgramDef:
-    function_closure_vars = transform_utils._filter_closure_vars_by_type(
-        inp.closure_vars, gtcallable.GTCallable
-    )
-    misnamed_functions = [
-        f"{name} vs. {func.__gt_itir__().id}"
-        for name, func in function_closure_vars.items()
-        if name != func.__gt_itir__().id
-    ]
-    if misnamed_functions:
-        raise RuntimeError(
-            f"The following symbols resolve to a function with a mismatching name: {','.join(misnamed_functions)}."
-        )
-    return inp
 
 
 def lint_undefined_symbols(
@@ -48,7 +30,7 @@ def linter_factory(
     cached: bool = True, adapter: bool = True
 ) -> workflow.Workflow[PASTProgramDef, PASTProgramDef]:
     wf: workflow.Workflow[PASTProgramDef, PASTProgramDef] = workflow.StepSequence(
-        (lint_misnamed_functions, lint_undefined_symbols)
+        (lint_undefined_symbols,)
     )
     if cached:
         wf = workflow.CachedStep.in_memory(

--- a/src/gt4py/next/ffront/past_to_itir.py
+++ b/src/gt4py/next/ffront/past_to_itir.py
@@ -82,7 +82,7 @@ def past_to_gtir(inp: ConcretePASTProgramDef) -> definitions.CompilableProgramDe
 
     gt_callables = transform_utils._filter_closure_vars_by_type(
         all_closure_vars, gtcallable.GTCallable
-    ).values()
+    )
 
     # FIXME[#1582](tehrengruber): remove after refactoring to GTIR
     # TODO(ricoh): The following calls to .__gt_itir__, which will use whatever
@@ -90,8 +90,14 @@ def past_to_gtir(inp: ConcretePASTProgramDef) -> definitions.CompilableProgramDe
     #  we should use the current toolchain to lower these to ITIR. This will require
     #  making this step aware of the toolchain it is called by (it can be part of multiple).
     lowered_funcs = []
-    for gt_callable in gt_callables:
-        lowered_funcs.append(gt_callable.__gt_gtir__())
+    for name, gt_callable in gt_callables.items():
+        lowered_func = gt_callable.__gt_gtir__()
+        if lowered_func.id != name:
+            # a callable is registered under each name it is referenced by, e.g. an alias
+            lowered_func = itir.FunctionDefinition(
+                id=name, params=lowered_func.params, expr=lowered_func.expr
+            )
+        lowered_funcs.append(lowered_func)
 
     itir_program = ProgramLowering.apply(
         inp.data.past_node, function_definitions=lowered_funcs, grid_type=grid_type

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_closure_vars.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_closure_vars.py
@@ -6,42 +6,141 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import types
+
 import numpy as np
+import pytest
 
 import gt4py.next as gtx
+from gt4py.next import errors, where
 
 from next_tests.integration_tests import cases
 from next_tests.integration_tests.cases import cartesian_case
-from next_tests.integration_tests.cases_utils import (
-    exec_alloc_descriptor,
-)
+from next_tests.integration_tests.cases_utils import exec_alloc_descriptor
 
 
-def test_constant_closure_vars_with_frozen_namespace(cartesian_case):
-    from gt4py.eve.utils import FrozenNamespace
+def test_module_prefixed_builtin(cartesian_case):
+    @gtx.field_operator
+    def select(a: cases.IFloatField, b: cases.IFloatField) -> cases.IFloatField:
+        return gtx.where(a > b, a, b)
 
-    constants = FrozenNamespace(PI=np.float64(3.142), E=np.float64(2.718))
+    cases.verify_with_default_data(cartesian_case, select, ref=lambda a, b: np.where(a > b, a, b))
+
+
+def test_aliased_builtin(cartesian_case):
+    my_where = where
 
     @gtx.field_operator
-    def consume_constants(input: cases.IFloatField) -> cases.IFloatField:
-        return constants.PI * constants.E * input
+    def select(a: cases.IFloatField, b: cases.IFloatField) -> cases.IFloatField:
+        return my_where(a > b, a, b)
 
-    cases.verify_with_default_data(
-        cartesian_case, consume_constants, ref=lambda input: constants.PI * constants.E * input
+    cases.verify_with_default_data(cartesian_case, select, ref=lambda a, b: np.where(a > b, a, b))
+
+
+def test_module_prefixed_type_constructor(cartesian_case):
+    @gtx.field_operator
+    def shifted(a: cases.IFloatField) -> cases.IFloatField:
+        return a + gtx.float64(1)
+
+    cases.verify_with_default_data(cartesian_case, shifted, ref=lambda a: a + 1.0)
+
+
+def test_module_attribute_scalar_constant(cartesian_case):
+    @gtx.field_operator
+    def offset_by_pi(a: cases.IFloatField) -> cases.IFloatField:
+        return a + np.pi
+
+    cases.verify_with_default_data(cartesian_case, offset_by_pi, ref=lambda a: a + np.pi)
+
+
+@gtx.field_operator
+def _increment(a: cases.IFloatField) -> cases.IFloatField:
+    return a + 1.0
+
+
+@gtx.field_operator
+def _double(a: cases.IFloatField) -> cases.IFloatField:
+    return a + a
+
+
+#: stand-in for a real helper module ('import helpers')
+helpers_module = types.ModuleType("helpers_module")
+helpers_module.increment = _increment
+#: stand-in for a second module defining an operator with the same definition name
+other_helpers_module = types.ModuleType("other_helpers_module")
+other_helpers_module.increment = _double
+
+increment_alias = _increment
+
+
+def test_module_prefixed_field_operator(cartesian_case):
+    @gtx.field_operator
+    def wrapper(a: cases.IFloatField) -> cases.IFloatField:
+        return helpers_module.increment(a)
+
+    cases.verify_with_default_data(cartesian_case, wrapper, ref=lambda a: a + 1.0)
+
+
+def test_aliased_field_operator(cartesian_case):
+    @gtx.field_operator
+    def wrapper(a: cases.IFloatField) -> cases.IFloatField:
+        return increment_alias(a)
+
+    cases.verify_with_default_data(cartesian_case, wrapper, ref=lambda a: a + 1.0)
+
+
+def test_same_field_operator_under_two_names(cartesian_case):
+    also_increment = increment_alias
+
+    @gtx.field_operator
+    def wrapper(a: cases.IFloatField) -> cases.IFloatField:
+        return increment_alias(a) + also_increment(a)
+
+    cases.verify_with_default_data(cartesian_case, wrapper, ref=lambda a: 2 * (a + 1.0))
+
+
+def test_same_named_field_operators_from_different_modules(cartesian_case):
+    @gtx.field_operator
+    def use_first(a: cases.IFloatField) -> cases.IFloatField:
+        return helpers_module.increment(a)
+
+    @gtx.field_operator
+    def use_second(a: cases.IFloatField) -> cases.IFloatField:
+        return other_helpers_module.increment(a)
+
+    @gtx.program
+    def prog(a: cases.IFloatField, out1: cases.IFloatField, out2: cases.IFloatField):
+        use_first(a, out=out1)
+        use_second(a, out=out2)
+
+    a = cases.allocate(cartesian_case, prog, "a")()
+    out1 = cases.allocate(cartesian_case, prog, "out1")()
+    out2 = cases.allocate(cartesian_case, prog, "out2")()
+    cases.verify(
+        cartesian_case,
+        prog,
+        a,
+        out1,
+        out2,
+        inout=(out1, out2),
+        ref=(a.asnumpy() + 1.0, a.asnumpy() + a.asnumpy()),
     )
 
 
-def test_constant_closure_vars_with_enums(cartesian_case):
-    import enum
+def test_aliased_field_operator_in_program(cartesian_case):
+    @gtx.program
+    def prog(a: cases.IFloatField, out: cases.IFloatField):
+        increment_alias(a, out=out)
 
-    class Constants(np.float64, enum.Enum):
-        PI = 3.142
-        E = 2.718
+    a = cases.allocate(cartesian_case, prog, "a")()
+    out = cases.allocate(cartesian_case, prog, "out")()
+    cases.verify(cartesian_case, prog, a, out, inout=out, ref=a.asnumpy() + 1.0)
 
-    @gtx.field_operator
-    def consume_constants(input: cases.IFloatField) -> cases.IFloatField:
-        return Constants.PI * Constants.E * input
 
-    cases.verify_with_default_data(
-        cartesian_case, consume_constants, ref=lambda input: Constants.PI * Constants.E * input
-    )
+def test_module_prefixed_builtin_shadowed_by_local_error():
+    with pytest.raises(errors.DSLError, match="shadowed"):
+
+        @gtx.field_operator
+        def select(a: cases.IFloatField, b: cases.IFloatField) -> cases.IFloatField:
+            where = a > b
+            return gtx.where(where, a, b)

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_closure_vars.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_closure_vars.py
@@ -19,6 +19,36 @@ from next_tests.integration_tests.cases import cartesian_case
 from next_tests.integration_tests.cases_utils import exec_alloc_descriptor
 
 
+def test_constant_closure_vars_with_frozen_namespace(cartesian_case):
+    from gt4py.eve.utils import FrozenNamespace
+
+    constants = FrozenNamespace(PI=np.float64(3.142), E=np.float64(2.718))
+
+    @gtx.field_operator
+    def consume_constants(input: cases.IFloatField) -> cases.IFloatField:
+        return constants.PI * constants.E * input
+
+    cases.verify_with_default_data(
+        cartesian_case, consume_constants, ref=lambda input: constants.PI * constants.E * input
+    )
+
+
+def test_constant_closure_vars_with_enums(cartesian_case):
+    import enum
+
+    class Constants(np.float64, enum.Enum):
+        PI = 3.142
+        E = 2.718
+
+    @gtx.field_operator
+    def consume_constants(input: cases.IFloatField) -> cases.IFloatField:
+        return Constants.PI * Constants.E * input
+
+    cases.verify_with_default_data(
+        cartesian_case, consume_constants, ref=lambda input: Constants.PI * Constants.E * input
+    )
+
+
 def test_module_prefixed_builtin(cartesian_case):
     @gtx.field_operator
     def select(a: cases.IFloatField, b: cases.IFloatField) -> cases.IFloatField:

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_import_from_mod.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_import_from_mod.py
@@ -54,16 +54,32 @@ def test_import_dims_module(cartesian_case):
     cases.verify(cartesian_case, mod_prog, f, isize, ksize, out=out, ref=expected)
 
 
+def test_import_module_prefixed_builtin(cartesian_case):
+    @gtx.field_operator
+    def mod_op(f: cases.IField) -> cases.IKField:
+        f_i_k = gtx.broadcast(f, (cases.IDim, cases.KDim))
+        return f_i_k
+
+    f = cases.allocate(cartesian_case, mod_op, "f")()
+    out = cases.allocate(cartesian_case, mod_op, cases.RETURN)()
+    ref = np.reshape(np.repeat(f.asnumpy(), out.shape[1], axis=0), out.shape)
+    cases.verify(cartesian_case, mod_op, f, out=out, ref=ref)
+
+
+def test_import_module_prefixed_field_operator(cartesian_case):
+    from ....artifacts.dummy_package import dummy_module
+
+    @gtx.field_operator
+    def field_op(f: cases.IKField) -> cases.IKField:
+        f_new = dummy_module.field_op_sample(f)
+        return f_new
+
+    cases.verify_with_default_data(cartesian_case, field_op, ref=lambda f: f)
+
+
 # TODO: these set of features should be allowed as module imports in a later PR
 def test_import_module_errors_future_allowed(cartesian_case):
     from ....artifacts.dummy_package import dummy_module
-
-    with pytest.raises(gtx.errors.DSLError):
-
-        @gtx.field_operator
-        def field_op(f: cases.IField):
-            f_i_k = gtx.broadcast(f, (cases.IDim, cases.KDim))
-            return f_i_k
 
     with pytest.raises(gtx.errors.DSLError):
 
@@ -73,17 +89,6 @@ def test_import_module_errors_future_allowed(cartesian_case):
             return astype(f, type_)
 
     with pytest.raises(gtx.errors.DSLError):
-
-        @gtx.field_operator
-        def field_op(f: cases.IField):
-            f_new = dummy_module.field_op_sample(f)
-            return f_new
-
-    with pytest.raises(gtx.errors.DSLError):
-
-        @gtx.field_operator
-        def field_op(f: cases.IField):
-            return f
 
         @gtx.program
         def field_op(f: cases.IField):

--- a/tests/next_tests/unit_tests/ffront_tests/test_closure_var_folding.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_closure_var_folding.py
@@ -94,6 +94,21 @@ def test_module_prefixed_operator_gets_a_synthesized_name():
         assert name in _closure_symbol_ids(node)
 
 
+def test_synthesized_operator_name_does_not_depend_on_the_source_path():
+    definition = helper.definition
+    moved = types.FunctionType(
+        definition.__code__.replace(co_filename="/elsewhere/checkout/helpers.py"),
+        definition.__globals__,
+    )
+    assert (moved.__module__, moved.__qualname__) == (
+        definition.__module__,
+        definition.__qualname__,
+    )
+    assert closure_var_folding._operator_name_from_definition(
+        moved
+    ) == closure_var_folding._operator_name(helper)
+
+
 def test_module_scalar_attribute_is_folded():
     def testee(a: IField) -> IField:
         return a * np.pi

--- a/tests/next_tests/unit_tests/ffront_tests/test_closure_var_folding.py
+++ b/tests/next_tests/unit_tests/ffront_tests/test_closure_var_folding.py
@@ -1,0 +1,102 @@
+# GT4Py - GridTools Framework
+#
+# Copyright (c) 2014-2024, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import types
+
+import numpy as np
+
+import gt4py.next as gtx
+import gt4py.next.ffront.field_operator_ast as foast
+from gt4py.next import Dims, Dimension, float64, where
+from gt4py.next.ffront.foast_passes import closure_var_folding
+from gt4py.next.ffront.func_to_foast import FieldOperatorParser
+
+
+I = Dimension("I")
+IField = gtx.Field[Dims[I], float64]
+BField = gtx.Field[Dims[I], bool]
+
+
+@gtx.field_operator
+def helper(a: IField) -> IField:
+    return a + 1.0
+
+
+helper_alias = helper
+my_where = where
+helpers = types.ModuleType("helpers")
+helpers.helper = helper
+more_helpers = types.ModuleType("more_helpers")
+more_helpers.also_helper = helper
+
+
+def _parse(func):
+    return FieldOperatorParser.apply_to_function(func)
+
+
+def _callee(node) -> str:
+    return node.pre_walk_values().if_isinstance(foast.Call).to_list()[0].func.id
+
+
+def _closure_symbol_ids(node) -> set[str]:
+    return {symbol.id for symbol in node.closure_vars}
+
+
+def test_direct_reference_is_kept():
+    def testee(a: IField) -> IField:
+        return helper(a)
+
+    assert _callee(_parse(testee)) == "helper"
+
+
+def test_aliased_reference_is_kept():
+    def testee(a: IField) -> IField:
+        return helper_alias(a)
+
+    assert _callee(_parse(testee)) == "helper_alias"
+
+
+def test_module_prefixed_builtin_is_canonicalized():
+    def testee(cond: BField, a: IField, b: IField) -> IField:
+        return gtx.where(cond, a, b)
+
+    node = _parse(testee)
+    assert _callee(node) == "where"
+    assert "where" in _closure_symbol_ids(node)
+
+
+def test_aliased_builtin_is_canonicalized():
+    def testee(cond: BField, a: IField, b: IField) -> IField:
+        return my_where(cond, a, b)
+
+    node = _parse(testee)
+    assert _callee(node) == "where"
+    assert "where" in _closure_symbol_ids(node)
+
+
+def test_module_prefixed_operator_gets_a_synthesized_name():
+    def testee(a: IField) -> IField:
+        return helpers.helper(a)
+
+    def other_testee(a: IField) -> IField:
+        return more_helpers.also_helper(a)
+
+    name = closure_var_folding._operator_name(helper)
+    assert name.startswith("helper_") and name.isidentifier()
+    for func in (testee, other_testee):
+        node = _parse(func)
+        assert _callee(node) == name
+        assert name in _closure_symbol_ids(node)
+
+
+def test_module_scalar_attribute_is_folded():
+    def testee(a: IField) -> IField:
+        return a * np.pi
+
+    constants = _parse(testee).pre_walk_values().if_isinstance(foast.Constant).to_list()
+    assert [c.value for c in constants] == [np.pi]


### PR DESCRIPTION
References to builtins and field operators are recognized by their source-level name in the later frontend passes, so a builtin referenced through a module (`gtx.where`) or under an alias (`my_where = where`), an operator referenced through a module (`helpers.helper`) or under an alias (`helper as h2`), and a scalar module attribute (`np.pi`) all failed, most of them with internal errors late in the pipeline.

Extend `ClosureVarFolding` to resolve such references by value: scalar module attributes are folded into constants, builtins are rewritten to their builtin name, and module-prefixed operators to a name derived from the operator's definition, registered as additional closure variables. The program lowering registers each callable under every name it is referenced by, which makes aliases work without rewriting and retires the misnamed-function lint.