### PR TITLE
fix[next]: register jax.core.Tracer for embedded field dispatch on jax >= 0.11

### DIFF
--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -1089,6 +1089,10 @@ if jnp:
 
     common._field.register(jnp.ndarray, JaxArrayField.from_array)
     common._connectivity.register(jnp.ndarray, JaxArrayConnectivityField.from_array)
+    # jax >= 0.11: 'Tracer' is no longer a subclass of 'jax.Array' (only 'isinstance' says so, via
+    # 'ArrayMeta.__instancecheck__'), and 'singledispatch' resolves on the class hierarchy.
+    common._field.register(jax.core.Tracer, JaxArrayField.from_array)
+    common._connectivity.register(jax.core.Tracer, JaxArrayConnectivityField.from_array)
 
     def _flatten_jax_field(
         field: JaxArrayField,

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -1801,3 +1801,27 @@ def test_jax_pytree_roundtrip():
     )
     # the domain is part of the tree structure, hence a domain change forces a 'jax.jit' retrace
     assert jax.tree_util.tree_structure(other_field) != treedef
+
+
+@pytest.mark.requires_jax
+def test_jax_traced_array_dispatch():
+    import jax
+
+    domain = common.domain({D0: (0, 3)})
+    x = jax.numpy.arange(3, dtype=np.float64)
+
+    def loss(arr):
+        field = common._field(arr, domain=domain)
+        assert isinstance(field, nd_array_field.JaxArrayField)
+        return jax.numpy.sum((field * field).ndarray)
+
+    np.testing.assert_allclose(jax.grad(loss)(x), 2.0 * x.__array__())
+    np.testing.assert_allclose(jax.jit(loss)(x), loss(x))
+
+    offsets = jax.numpy.asarray([[2, 0], [1, 2]])
+    codomain = common.domain({D0: (0, 2), D1: (0, 2)})
+
+    def make_connectivity(arr):
+        return common._connectivity(arr, codomain=D0, domain=codomain).ndarray
+
+    np.testing.assert_array_equal(jax.jit(make_connectivity)(offsets), offsets)


### PR DESCRIPTION
`common._field` / `common._connectivity` are `functools.singledispatch` functions; the embedded JAX backend registers them for `jnp.ndarray` (which is `jax.Array`). Since jax 0.11 `jax.Array` is built by a metaclass (`ArrayMeta`) and `jax.core.Tracer` is no longer in its MRO; only `isinstance()` still reports a tracer as a `jax.Array`, via `ArrayMeta.__instancecheck__`. `singledispatch` resolves on the class hierarchy, so constructing a field from a traced array (inside `jax.jit`, `jax.grad`, `jax.lax.scan`, ...) falls through to the base implementation and raises a bare `NotImplementedError`.

Fix: additionally register `jax.core.Tracer`. On older jax, where `Tracer` already subclasses `jax.Array`, the extra registration resolves to the same implementation and is a no-op.