### PR TITLE
test[next]: un-shadow the duplicate test_annotated_assign

### DIFF
--- a/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
+++ b/tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py
@@ -632,7 +632,7 @@ def test_broken_if():
     assert result == expected
 
 
-def test_annotated_assign():
+def test_annotation_applies_to_next_assign():
     result = ast.unparse(
         ssaify_string(
             """


### PR DESCRIPTION
## Problem

`tests/next_tests/unit_tests/ffront_tests/ast_passes_tests/test_single_static_assign.py` defines `test_annotated_assign` **twice** at module level, with different bodies:

- **L111** — an annotated assignment that carries a value:
  ```python
  a: int = 5
  ```
  asserting `a{SEP}0: int = 5`, with the docstring *"The name of type annotations should not be treated as an assignment target."*

- **L635** — a bare annotation applying to the next assignment:
  ```python
  a: int # annotations always apply to the next assignment
  a = a + 1
  ```
  asserting `a{SEP}0: int` / `a{SEP}0 = a + 1`.

The second binding shadows the first, so pytest only ever collects one of them. The file has 30 `def test_` at module level but collects 29:

```
$ pytest --collect-only -q test_single_static_assign.py
29 tests collected
```

The L111 case — annotated assign **with** a value — is currently never exercised. It is a distinct case from its neighbour `test_empty_annotated_assign` (L123), which covers a bare annotation between two assignments.

`ruff check` does not catch this (F811) because `.pre-commit-config.yaml` excludes `^(tests/|docs/|examples/)` from the `ruff-check` hook.

## Fix

Renames the second definition to `test_annotation_applies_to_next_assign`, taking the name from its own inline comment, and leaves `test_annotated_assign` on the L111 body that actually tests an annotated *assignment*. One line changed.

## Verification

Both tests were run against the real `SingleStaticAssignPass` (the upstream `src/gt4py/next/ffront/ast_passes/single_static_assign.py`, with only `fbuiltins.TYPE_BUILTIN_NAMES` supplied, to keep the check dependency-free):

| | collected | result |
|---|---|---|
| before | 29 | `29 passed` |
| after | 30 | `30 passed` |

So the restored test passes as written — this only adds the missing coverage, it does not turn CI red.

Also checked: `ruff format --diff` reports *"1 file already formatted"* both before and after, and `ruff check --select F811` goes from 1 error to clean.

Happy to flip which of the two keeps the `test_annotated_assign` name, or to use a different name for the renamed one, if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
