### PR TITLE
test[cartesian]: un-shadow the duplicate test_enum_runtime

### DIFF
--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py
@@ -1893,7 +1893,7 @@ def test_enum_runtime(backend):
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)
-def test_enum_runtime(backend):
+def test_bool_runtime(backend):
 
     @gtscript.stencil(backend=backend)
     def the_stencil(out_field: Field[int], done: bool):  # type: ignore


### PR DESCRIPTION
## Summary

`test_enum_runtime` is defined **twice** at module level in
`tests/cartesian_tests/integration_tests/multi_feature_tests/test_code_generation.py`
(L1868 and L1896). Since Python keeps only the last binding of a name, pytest
collects a single `test_enum_runtime` and the **first** definition is silently
dropped and never runs.

The first (shadowed) definition is the one that actually exercises the
`@gtscript.enum MyEnum` runtime parameter — enum comparison (`order < MyEnum.A`)
and multi-interval enum assignment, asserting the output equals
`MyEnum.A/B/C.value`. That coverage is currently lost.

The second definition takes a `done: bool` parameter and tests a **boolean**
runtime argument, so it is really a separate test that was mis-named. This PR
renames it to `test_bool_runtime` so both tests are collected and run.

## Verification

AST scan of the file:

| | total module-level `test_` defs | unique names (pytest collects) |
|---|---|---|
| before | 60 | 59 (`test_enum_runtime` duplicated) |
| after  | 60 | 60 |

Change is a single-line rename; no test logic is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
