### PR TITLE
feat[next]: JAX support for connectivities and premap

### DIFF
--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -320,11 +320,6 @@ class NdArrayField(
                 connectivity = connectivity.as_connectivity_field()
             assert isinstance(connectivity, common.Connectivity)
 
-            # Current implementation relies on skip_value == -1:
-            # if we assume the indexed array has at least one element,
-            # we wrap around without out of bounds access
-            assert connectivity.skip_value is None or connectivity.skip_value == -1
-
             conn_fields.append(connectivity)
             codomains_counter[connectivity.codomain] += 1
 
@@ -988,18 +983,27 @@ def _make_reduction(
         assert common.is_neighbor_table(offset_definition)
         new_domain = common.Domain(*[nr for nr in field.domain if nr.dim != axis])
 
-        broadcast_slice = tuple(
-            slice(None) if d in [axis, offset_definition.domain.dims[0]] else xp.newaxis
-            for d in field.domain.dims
-        )
-        masked_array = xp.where(
-            xp.asarray(offset_definition.ndarray[broadcast_slice]) != common._DEFAULT_SKIP_VALUE,
-            field.ndarray,
-            initial_value_op(field),
-        )
+        if offset_definition.skip_value is None:
+            values = field.ndarray
+        else:
+            table_domain = common.Domain(*(field.domain[d] for d in offset_definition.domain.dims))
+            table = (
+                offset_definition
+                if table_domain == offset_definition.domain
+                else offset_definition.restrict(table_domain)
+            ).ndarray
+            broadcast_slice = tuple(
+                slice(None) if d in offset_definition.domain.dims else xp.newaxis
+                for d in field.domain.dims
+            )
+            values = xp.where(
+                xp.asarray(table[broadcast_slice]) != offset_definition.skip_value,
+                field.ndarray,
+                initial_value_op(field),
+            )
 
         return field.__class__.from_array(
-            getattr(xp, array_builtin_name)(masked_array, axis=reduce_dim_index), domain=new_domain
+            getattr(xp, array_builtin_name)(values, axis=reduce_dim_index), domain=new_domain
         )
 
     _builtin_op.__name__ = builtin_name

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -581,8 +581,7 @@ class NdArrayConnectivityField(
             assert isinstance(image_range, common.UnitRange)
             assert common.UnitRange.is_finite(image_range)
 
-            xp = self.array_ns
-            slices = _hyperslice(self._ndarray, image_range, xp, self.skip_value)
+            slices = self._image_slices(image_range)
             if slices is None:
                 raise ValueError("Restriction generates non-contiguous or empty dimensions.")
 
@@ -590,6 +589,37 @@ class NdArrayConnectivityField(
             self._cache[cache_key] = new_domain
 
         return new_domain
+
+    @property
+    def _index_table(self) -> core_defs.NDArrayObject:
+        """The table whose contents `inverse_image` inspects."""
+        return self._ndarray
+
+    @functools.cached_property
+    def _image_bounds(self) -> Optional[tuple[int, int, tuple[slice, ...]]]:
+        """`(min, max, support)` of the non-skip entries, `None` if there are none."""
+        xp = self.array_ns
+        table = self._index_table
+        if self.skip_value is None:
+            return int(xp.min(table)), int(xp.max(table)), tuple(slice(0, n) for n in table.shape)
+        valid = table != self.skip_value
+        if not xp.any(valid):
+            return None
+        support = tuple(slice(int(xp.min(i)), int(xp.max(i)) + 1) for i in xp.nonzero(valid))
+        return int(xp.min(table[valid])), int(xp.max(table[valid])), support
+
+    def _image_slices(self, image_range: common.UnitRange) -> Optional[tuple[slice, ...]]:
+        if (bounds := self._image_bounds) is not None:
+            value_min, value_max, support = bounds
+            # with the skip value inside the range, skip-only rows would be selected as well
+            skip_selected = self.skip_value is not None and self.skip_value in image_range
+            if (
+                image_range.start <= value_min
+                and value_max < image_range.stop
+                and not skip_selected
+            ):
+                return support
+        return _hyperslice(self._index_table, image_range, self.array_ns, self.skip_value)
 
     def restrict(self, index: common.AnyIndexSpec) -> NdArrayConnectivityField:
         cache_key = (id(self.ndarray), self.domain, index)
@@ -1089,9 +1119,38 @@ if jnp:
 
             object.__setattr__(self, "_ndarray", self._ndarray.at[target_slice].set(value))  # type: ignore[attr-defined] # `NDArrayObject` typing is not complete
 
+    class _TableHandle:
+        """Trace-time reference to a connectivity table, compared by buffer identity."""
+
+        __slots__ = ("table",)
+
+        def __init__(self, table: core_defs.NDArrayObject) -> None:
+            self.table = table
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, _TableHandle) and self.table is other.table
+
+        def __hash__(self) -> int:
+            return id(self.table)
+
+    _JaxConnectivityAuxData: TypeAlias = tuple[
+        common.Domain, common.Dimension, Optional[core_defs.IntegralScalar], Optional[_TableHandle]
+    ]
+
     @dataclasses.dataclass(frozen=True, eq=False)
     class JaxArrayConnectivityField(NdArrayConnectivityField):
         array_ns: ClassVar[ModuleType] = jnp
+        _table_handle: Optional[_TableHandle] = None
+
+        @property
+        def _index_table(self) -> core_defs.NDArrayObject:
+            if self._table_handle is not None and isinstance(self._ndarray, jax.core.Tracer):
+                return self._table_handle.table
+            return self._ndarray
+
+        def _image_slices(self, image_range: common.UnitRange) -> Optional[tuple[slice, ...]]:
+            with jax.ensure_compile_time_eval():
+                return super()._image_slices(image_range)
 
     common._field.register(jnp.ndarray, JaxArrayField.from_array)
     common._connectivity.register(jnp.ndarray, JaxArrayConnectivityField.from_array)
@@ -1114,6 +1173,34 @@ if jnp:
         JaxArrayField,  # type: ignore[type-abstract, unused-ignore] # only reported when 'jax' is installed, see '_unflatten_jax_field'
         _flatten_jax_field,
         _unflatten_jax_field,
+    )
+
+    def _flatten_jax_connectivity(
+        connectivity: JaxArrayConnectivityField,
+    ) -> tuple[tuple[core_defs.NDArrayObject], _JaxConnectivityAuxData]:
+        table = connectivity._ndarray
+        handle = (
+            connectivity._table_handle
+            if isinstance(table, jax.core.Tracer)
+            else _TableHandle(table)
+        )
+        return (table,), (
+            connectivity.domain,
+            connectivity.codomain,
+            connectivity.skip_value,
+            handle,
+        )
+
+    def _unflatten_jax_connectivity(
+        aux_data: _JaxConnectivityAuxData, children: tuple[core_defs.NDArrayObject]
+    ) -> JaxArrayConnectivityField:
+        domain, codomain, skip_value, handle = aux_data
+        return JaxArrayConnectivityField(domain, children[0], codomain, skip_value, handle)
+
+    jax.tree_util.register_pytree_node(
+        JaxArrayConnectivityField,  # type: ignore[type-abstract, unused-ignore] # see '_unflatten_jax_field'
+        _flatten_jax_connectivity,
+        _unflatten_jax_connectivity,
     )
 
 

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -592,12 +592,11 @@ class NdArrayConnectivityField(
 
     @property
     def _index_table(self) -> core_defs.NDArrayObject:
-        """The table whose contents `inverse_image` inspects."""
         return self._ndarray
 
     @functools.cached_property
     def _image_bounds(self) -> Optional[tuple[int, int, tuple[slice, ...]]]:
-        """`(min, max, support)` of the non-skip entries, `None` if there are none."""
+        """Smallest value, largest value and bounding hyperslice of the non-skip entries."""
         xp = self.array_ns
         table = self._index_table
         if self.skip_value is None:

--- a/src/gt4py/next/embedded/nd_array_field.py
+++ b/src/gt4py/next/embedded/nd_array_field.py
@@ -669,16 +669,18 @@ def _gather_premap(data: NdArrayField, *connectivities: common.GatherConnectivit
 
     # one index array per original field dimension (the connectivity's, or identity), broadcast over
     # the output domain and shifted to 0-based buffer indices, then a single advanced-index gather
-    take_indices = tuple(
-        (
-            _connectivity_index_array(conn_by_codomain[dim], new_domain, xp)
-            if dim in conn_by_codomain
-            else _identity_index_array(new_domain, dim, xp)
-        )
-        - data.domain[dim].unit_range.start
-        for dim in data.domain.dims
-    )
-    new_buffer = data._ndarray[take_indices]
+    def take_index(dim: common.Dimension) -> core_defs.NDArrayObject:
+        start = data.domain[dim].unit_range.start
+        if (conn := conn_by_codomain.get(dim)) is None:
+            return _identity_index_array(new_domain, dim, xp) - start
+        indices = _connectivity_index_array(conn, new_domain, xp)
+        if conn.skip_value is not None:
+            # a wrapped-around skip index is harmless for the primal, but under autodiff its
+            # cotangent would flow into whichever element it happens to hit
+            indices = xp.where(indices == conn.skip_value, start, indices)
+        return indices - start
+
+    new_buffer = data._ndarray[tuple(take_index(dim) for dim in data.domain.dims)]
     return data.__class__.from_array(new_buffer, domain=new_domain, dtype=data.dtype)
 
 

--- a/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
+++ b/tests/next_tests/integration_tests/feature_tests/ffront_tests/test_external_local_field.py
@@ -118,14 +118,20 @@ def test_write_local_field(unstructured_case):
     def testee(inp: gtx.Field[[Edge], int32]) -> gtx.Field[[Vertex, V2EDim], int32]:
         return inp(V2E)
 
-    out = unstructured_case.as_field(
-        [Vertex, V2EDim], np.zeros_like(unstructured_case.offset_provider["V2E"].asnumpy())
-    )
+    v2e = unstructured_case.offset_provider["V2E"]
+    v2e_table = v2e.asnumpy()
+    out = unstructured_case.as_field([Vertex, V2EDim], np.zeros_like(v2e_table))
     inp = cases.allocate(unstructured_case, testee, "inp")()
+    valid = v2e_table != v2e.skip_value
+
+    def allclose_at_valid_entries(ref, out):
+        return np.allclose(ref[valid], out[valid])
+
     cases.verify(
         unstructured_case,
         testee,
         inp,
         out=out,
-        ref=inp.asnumpy()[unstructured_case.offset_provider["V2E"].asnumpy()],
+        ref=inp.asnumpy()[v2e_table],
+        comparison=allclose_at_valid_entries,
     )

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -9,6 +9,7 @@
 import math
 import operator
 import pickle
+import re
 from typing import Callable, Iterable, Optional
 
 import numpy as np
@@ -1874,3 +1875,171 @@ def test_jax_grad_through_premap_with_skip_values():
 
     np.testing.assert_allclose(loss(x), 9.0)
     np.testing.assert_allclose(jax.grad(loss)(x), [0.25, 1.0 / 6.0, 0.125, 0.0])
+
+
+def _skip_value_e2v_table(num_vertices: int) -> np.ndarray:
+    """Two edges per vertex, both entries equal, every seventh second entry a skip value."""
+    vertex = np.arange(4 * num_vertices) // 2
+    table = np.stack([vertex, vertex], axis=1).astype(np.int32)
+    table[::7, 1] = -1
+    return table
+
+
+@pytest.mark.parametrize("skip_value", [None, -1])
+def test_inverse_image_bounds_shortcut_matches_hyperslice(skip_value):
+    rng = np.random.default_rng(0)
+    high = 6
+    covering_cases = 0
+    for _ in range(150):
+        table = rng.integers(-1 if skip_value is not None else 0, high, size=(4, 3))
+        conn = common._connectivity(
+            table,
+            codomain=D0,
+            domain=common.domain({D1: (0, 4), D2: (0, 3)}),
+            skip_value=skip_value,
+        )
+        for start in range(-1, high):
+            for stop in range(start + 1, high + 1):
+                image_range = UnitRange(start, stop)
+                expected = nd_array_field._hyperslice(table, image_range, np, skip_value)
+                if expected is None:
+                    with pytest.raises(ValueError, match="non-contiguous or empty"):
+                        conn.inverse_image(image_range)
+                else:
+                    assert conn.inverse_image(image_range) == conn.domain.slice_at[expected]
+                    valid = table[table != skip_value] if skip_value is not None else table
+                    covering_cases += bool(np.all((valid >= start) & (valid < stop)))
+    assert covering_cases > 0
+
+
+def test_inverse_image_range_containing_skip_value_selects_skip_only_rows():
+    conn = common._connectivity(
+        np.asarray([[0, 1], [-1, -1]]),
+        codomain=D0,
+        domain=common.domain({D1: (0, 2), D2: (0, 2)}),
+        skip_value=-1,
+    )
+
+    assert conn.inverse_image(UnitRange(0, 2)) == common.domain({D1: (0, 1), D2: (0, 2)})
+    assert conn.inverse_image(UnitRange(-1, 2)) == common.domain({D1: (0, 2), D2: (0, 2)})
+
+
+@pytest.mark.requires_jax
+def test_jax_connectivity_pytree_roundtrip():
+    import jax
+
+    V = Dimension("V")
+    E = Dimension("E")
+    E2VDim = Dimension("E2V", kind=DimensionKind.LOCAL)
+    domain = common.domain({E: (0, 2), E2VDim: (0, 2)})
+    table = jax.numpy.asarray([[0, 1], [2, -1]], dtype=np.int32)
+    conn = common._connectivity(table, codomain=V, domain=domain, skip_value=-1)
+
+    children, treedef = jax.tree_util.tree_flatten(conn)
+    assert len(children) == 1
+    assert children[0] is table
+
+    restored = jax.tree_util.tree_unflatten(treedef, children)
+    assert isinstance(restored, nd_array_field.JaxArrayConnectivityField)
+    assert restored.domain == domain
+    assert restored.codomain == V
+    assert restored.skip_value == -1
+    assert restored.inverse_image(UnitRange(0, 2)) == common.domain({E: (0, 1), E2VDim: (0, 2)})
+
+    same_table = common._connectivity(table, codomain=V, domain=domain, skip_value=-1)
+    assert jax.tree_util.tree_structure(same_table) == treedef
+    copied_table = common._connectivity(
+        jax.numpy.array(table, copy=True), codomain=V, domain=domain, skip_value=-1
+    )
+    assert jax.tree_util.tree_structure(copied_table) != treedef
+
+
+@pytest.mark.requires_jax
+@pytest.mark.parametrize("num_field_vertices", [300, 600], ids=["narrowing", "covering"])
+def test_jax_jit_premap_with_connectivity_argument(num_field_vertices):
+    import jax
+
+    V = Dimension("V")
+    E = Dimension("E")
+    E2VDim = Dimension("E2V", kind=DimensionKind.LOCAL)
+    table = _skip_value_e2v_table(300)
+    conn_domain = common.domain({E: (0, table.shape[0]), E2VDim: (0, 2)})
+    field_domain = common.domain({V: (0, num_field_vertices)})
+
+    def premap_and_reduce(field, conn):
+        with embedded_context.update(offset_provider={"E2V": conn}):
+            return fbuiltins.neighbor_sum(field.premap(conn), axis=E2VDim)
+
+    expected = premap_and_reduce(
+        common._field(np.arange(num_field_vertices, dtype=np.float64), domain=field_domain),
+        common._connectivity(table, codomain=V, domain=conn_domain, skip_value=-1),
+    )
+
+    jitted = jax.jit(premap_and_reduce)
+    field = common._field(
+        jax.numpy.arange(num_field_vertices, dtype=np.float64), domain=field_domain
+    )
+    conn = common._connectivity(
+        jax.numpy.asarray(table), codomain=V, domain=conn_domain, skip_value=-1
+    )
+    result = jitted(field, conn)
+
+    assert result.domain == expected.domain
+    np.testing.assert_allclose(result.asnumpy(), expected.asnumpy())
+
+    stablehlo = jitted.lower(field, conn).as_text()
+    main_arguments = re.search(r"@main\(([^)]*)\)", stablehlo).group(1)
+    assert f"tensor<{table.shape[0]}x2xi32>" in main_arguments
+    assert "dense<[" not in stablehlo  # the table is not inlined as a constant
+
+
+@pytest.mark.requires_jax
+def test_jax_jit_retraces_per_connectivity_buffer():
+    import jax
+
+    V = Dimension("V")
+    E = Dimension("E")
+    E2VDim = Dimension("E2V", kind=DimensionKind.LOCAL)
+    table = jax.numpy.asarray(_skip_value_e2v_table(8))
+    conn_domain = common.domain({E: (0, table.shape[0]), E2VDim: (0, 2)})
+    field = common._field(jax.numpy.arange(8, dtype=np.float64), domain=common.domain({V: (0, 8)}))
+    traces = 0
+
+    @jax.jit
+    def premap(field, conn):
+        nonlocal traces
+        traces += 1
+        return field.premap(conn)
+
+    conn = common._connectivity(table, codomain=V, domain=conn_domain, skip_value=-1)
+    premap(field, conn)
+    premap(field, conn)
+    assert traces == 1
+
+    premap(field, common._connectivity(table, codomain=V, domain=conn_domain, skip_value=-1))
+    assert traces == 1
+
+    premap(
+        field,
+        common._connectivity(
+            jax.numpy.array(table, copy=True), codomain=V, domain=conn_domain, skip_value=-1
+        ),
+    )
+    assert traces == 2
+
+
+@pytest.mark.requires_jax
+def test_jax_jit_premap_non_contiguous_inverse_image_raises():
+    import jax
+
+    V = Dimension("V")
+    E = Dimension("E")
+    conn = common._connectivity(
+        jax.numpy.asarray([0, 5, 1], dtype=np.int32),
+        codomain=V,
+        domain=common.domain({E: (0, 3)}),
+    )
+    field = common._field(jax.numpy.arange(3, dtype=np.float64), domain=common.domain({V: (0, 3)}))
+
+    with pytest.raises(ValueError, match="non-contiguous"):
+        jax.jit(lambda field, conn: field.premap(conn))(field, conn)

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -1886,7 +1886,17 @@ def _skip_value_e2v_table(num_vertices: int) -> np.ndarray:
 
 
 @pytest.mark.parametrize("skip_value", [None, -1])
-def test_inverse_image_bounds_shortcut_matches_hyperslice(skip_value):
+def test_inverse_image_bounds_shortcut_matches_hyperslice(skip_value, monkeypatch):
+    hyperslice = nd_array_field._hyperslice
+    hyperslice_calls = 0
+
+    def counting_hyperslice(*args, **kwargs):
+        nonlocal hyperslice_calls
+        hyperslice_calls += 1
+        return hyperslice(*args, **kwargs)
+
+    monkeypatch.setattr(nd_array_field, "_hyperslice", counting_hyperslice)
+
     rng = np.random.default_rng(0)
     high = 6
     covering_cases = 0
@@ -1901,14 +1911,19 @@ def test_inverse_image_bounds_shortcut_matches_hyperslice(skip_value):
         for start in range(-1, high):
             for stop in range(start + 1, high + 1):
                 image_range = UnitRange(start, stop)
-                expected = nd_array_field._hyperslice(table, image_range, np, skip_value)
+                expected = hyperslice(table, image_range, np, skip_value)
+                valid = table[table != skip_value] if skip_value is not None else table
+                covering = valid.size > 0 and bool(np.all((valid >= start) & (valid < stop)))
+                covering &= skip_value is None or skip_value not in image_range
+                calls_before = hyperslice_calls
                 if expected is None:
                     with pytest.raises(ValueError, match="non-contiguous or empty"):
                         conn.inverse_image(image_range)
                 else:
                     assert conn.inverse_image(image_range) == conn.domain.slice_at[expected]
-                    valid = table[table != skip_value] if skip_value is not None else table
-                    covering_cases += bool(np.all((valid >= start) & (valid < stop)))
+                # the shortcut answers exactly the covering cases without scanning the table
+                assert (hyperslice_calls == calls_before) == covering
+                covering_cases += covering
     assert covering_cases > 0
 
 

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -25,7 +25,11 @@ from gt4py.next.common import (
     NamedRange,
     UnitRange,
 )
-from gt4py.next.embedded import exceptions as embedded_exceptions, nd_array_field
+from gt4py.next.embedded import (
+    context as embedded_context,
+    exceptions as embedded_exceptions,
+    nd_array_field,
+)
 from gt4py.next.embedded.nd_array_field import _get_slices_from_domain_slice
 from gt4py.next.ffront import fbuiltins
 from gt4py.next.ffront.experimental import as_offset
@@ -1825,3 +1829,29 @@ def test_jax_traced_array_dispatch():
         return common._connectivity(arr, codomain=D0, domain=codomain).ndarray
 
     np.testing.assert_array_equal(jax.jit(make_connectivity)(offsets), offsets)
+
+
+@pytest.mark.requires_jax
+def test_jax_grad_through_premap_with_skip_values():
+    import jax
+
+    V = Dimension("V")
+    E = Dimension("E")
+    E2VDim = Dimension("E2V", kind=DimensionKind.LOCAL)
+    e2v = common._connectivity(
+        jax.numpy.asarray([[0, 1], [2, -1]], dtype=np.int32),
+        codomain=V,
+        domain=common.domain({E: (0, 2), E2VDim: (0, 2)}),
+        skip_value=-1,
+    )
+
+    def loss(x):
+        field = common._field(x, domain=common.domain({V: (0, 4)}))
+        with embedded_context.update(offset_provider={"E2V": e2v}):
+            result = fbuiltins.neighbor_sum(fbuiltins.sqrt(field.premap(e2v)), axis=E2VDim)
+        return jax.numpy.sum(result.ndarray)
+
+    x = jax.numpy.asarray([4.0, 9.0, 16.0, -1.0])
+
+    np.testing.assert_allclose(loss(x), 9.0)
+    np.testing.assert_allclose(jax.grad(loss)(x), [0.25, 1.0 / 6.0, 0.125, 0.0])

--- a/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
+++ b/tests/next_tests/unit_tests/embedded_tests/test_nd_array_field.py
@@ -1764,6 +1764,25 @@ def test_concat(fields_data, dim, expected_data, expect_error):
         np.testing.assert_allclose(result.asnumpy(), expected_array)
 
 
+def test_neighbor_sum_after_narrowing_premap():
+    V = Dimension("V")
+    E = Dimension("E")
+    E2VDim = Dimension("E2V", kind=DimensionKind.LOCAL)
+    e2v = common._connectivity(
+        np.asarray([[0, 1], [2, -1], [4, 5], [6, 7]]),
+        codomain=V,
+        domain=common.domain({E: (0, 4), E2VDim: (0, 2)}),
+        skip_value=-1,
+    )
+    v_field = common._field(np.arange(1.0, 5.0), domain=common.domain({V: (0, 4)}))
+
+    with embedded_context.update(offset_provider={"E2V": e2v}):
+        result = fbuiltins.neighbor_sum(v_field.premap(e2v), axis=E2VDim)
+
+    assert result.domain == common.domain({E: (0, 2)})
+    np.testing.assert_array_equal(result.asnumpy(), [3.0, 3.0])
+
+
 @pytest.mark.requires_jax
 def test_jax_jit_field_arguments():
     import jax


### PR DESCRIPTION
## Description

Implements [gt4py_knowledge#25](https://github.com/GridTools/gt4py_knowledge/pull/25): `premap` with unstructured connectivities under `jax.jit`.

- `JaxArrayConnectivityField` is registered as a pytree node. The neighbor table is the traced child, so it is a runtime argument of the compiled program instead of an inlined constant. The aux data carries the domain, codomain, skip value and a handle to the same buffer compared by identity; `inverse_image` reads the concrete table through the handle under `jax.ensure_compile_time_eval()`, so domain inference narrows under `jit` exactly as it does eagerly. Retracing happens per table buffer: a new wrapper around the same buffer does not retrace, a new buffer does.
- `inverse_image` answers image ranges that cover all non-skip entries from cached table bounds `(min, max, support)` instead of scanning the table, guarded by the skip value not lying in the range.
- Two pre-existing embedded defects fixed as their own commits:
  - `_gather_premap` let the `-1` skip value wrap around to a real element; harmless for the primal, but under `jax.grad` its cotangent flowed into that element (NaN gradients). Skip indices are now mapped to the field's domain start before the gather. The `skip_value == -1` assertion in `premap` is gone with it.
  - `neighbor_sum` after a narrowing `premap` broadcast the full table against the narrowed field (fails on NumPy too). The reduction now restricts the table to the field's domain and masks with the connectivity's own skip value.
- `test_write_local_field[skip_value_mesh]` (embedded-only) compared against NumPy's wrap-around value at skip positions; it now compares valid entries only.

Out of scope, as in the proposal: `shard_map`/distributed, and a mesh object owning connectivities.

Measured against jax 0.11.0: `PyTreeDef.__hash__` still ignores custom-node aux data, closure constants are still inlined by default, `ensure_compile_time_eval` now works under `lax.scan` (it did not at 0.6.2), and `make_jaxpr(...).consts` no longer lists a closed-over table (it only shows up in the lowered module), so the tests check the StableHLO `@main` signature instead.

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/) folder.
